### PR TITLE
Allow Conversion handler to return errors

### DIFF
--- a/v2/api/appconfiguration/v1api20220501/configuration_store_types_gen.go
+++ b/v2/api/appconfiguration/v1api20220501/configuration_store_types_gen.go
@@ -409,7 +409,7 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ConfigurationStore_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if store.Identity != nil {
 		identity_ARM, err := (*store.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -419,16 +419,16 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if store.Location != nil {
 		location := *store.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if store.CreateMode != nil ||
 		store.DisableLocalAuth != nil ||
 		store.EnablePurgeProtection != nil ||
@@ -466,7 +466,7 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.SoftDeleteRetentionInDays = &softDeleteRetentionInDays
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if store.Sku != nil {
 		sku_ARM, err := (*store.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -476,7 +476,7 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if store.SystemData != nil {
 		systemData_ARM, err := (*store.SystemData).ConvertToARM(resolved)
 		if err != nil {
@@ -486,7 +486,7 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if store.Tags != nil {
 		result.Tags = make(map[string]string, len(store.Tags))
 		for key, value := range store.Tags {
@@ -508,10 +508,10 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConfigurationStore_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	store.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -520,7 +520,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -529,7 +529,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnablePurgeProtection’:
+	// Set property "EnablePurgeProtection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePurgeProtection != nil {
@@ -538,7 +538,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -552,7 +552,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ResourceIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -563,18 +563,18 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		store.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		store.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	store.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -583,7 +583,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -594,7 +594,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		store.Sku = &sku
 	}
 
-	// Set property ‘SoftDeleteRetentionInDays’:
+	// Set property "SoftDeleteRetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoftDeleteRetentionInDays != nil {
@@ -603,7 +603,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -614,7 +614,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		store.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		store.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1158,9 +1158,9 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConfigurationStore_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -1169,7 +1169,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘CreationDate’:
+	// Set property "CreationDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationDate != nil {
@@ -1178,7 +1178,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -1187,7 +1187,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘EnablePurgeProtection’:
+	// Set property "EnablePurgeProtection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePurgeProtection != nil {
@@ -1196,7 +1196,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1210,7 +1210,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Endpoint’:
+	// Set property "Endpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Endpoint != nil {
@@ -1219,13 +1219,13 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		store.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ResourceIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1236,19 +1236,19 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		store.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		store.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		store.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1261,7 +1261,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1270,7 +1270,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1279,7 +1279,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1290,7 +1290,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		store.Sku = &sku
 	}
 
-	// Set property ‘SoftDeleteRetentionInDays’:
+	// Set property "SoftDeleteRetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoftDeleteRetentionInDays != nil {
@@ -1299,7 +1299,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1310,7 +1310,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		store.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		store.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1318,7 +1318,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		store.Type = &typeVar
@@ -1726,7 +1726,7 @@ func (properties *EncryptionProperties) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &EncryptionProperties_ARM{}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if properties.KeyVaultProperties != nil {
 		keyVaultProperties_ARM, err := (*properties.KeyVaultProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -1750,7 +1750,7 @@ func (properties *EncryptionProperties) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -1851,7 +1851,7 @@ func (properties *EncryptionProperties_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties_STATUS
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -1933,7 +1933,7 @@ func (reference *PrivateEndpointConnectionReference_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnectionReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
@@ -1993,13 +1993,13 @@ func (identity *ResourceIdentity) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ResourceIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -2024,13 +2024,13 @@ func (identity *ResourceIdentity) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -2171,25 +2171,25 @@ func (identity *ResourceIdentity_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2309,7 +2309,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -2329,7 +2329,7 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -2398,7 +2398,7 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -2467,37 +2467,37 @@ func (data *SystemData) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &SystemData_ARM{}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if data.CreatedAt != nil {
 		createdAt := *data.CreatedAt
 		result.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if data.CreatedBy != nil {
 		createdBy := *data.CreatedBy
 		result.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if data.CreatedByType != nil {
 		createdByType := *data.CreatedByType
 		result.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if data.LastModifiedAt != nil {
 		lastModifiedAt := *data.LastModifiedAt
 		result.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if data.LastModifiedBy != nil {
 		lastModifiedBy := *data.LastModifiedBy
 		result.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if data.LastModifiedByType != nil {
 		lastModifiedByType := *data.LastModifiedByType
 		result.LastModifiedByType = &lastModifiedByType
@@ -2517,37 +2517,37 @@ func (data *SystemData) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -2706,37 +2706,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -3108,13 +3108,13 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘IdentityClientId’:
+	// Set property "IdentityClientId":
 	if properties.IdentityClientId != nil {
 		identityClientId := *properties.IdentityClientId
 		result.IdentityClientId = &identityClientId
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if properties.KeyIdentifier != nil {
 		keyIdentifier := *properties.KeyIdentifier
 		result.KeyIdentifier = &keyIdentifier
@@ -3134,13 +3134,13 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IdentityClientId’:
+	// Set property "IdentityClientId":
 	if typedInput.IdentityClientId != nil {
 		identityClientId := *typedInput.IdentityClientId
 		properties.IdentityClientId = &identityClientId
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
@@ -3221,13 +3221,13 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IdentityClientId’:
+	// Set property "IdentityClientId":
 	if typedInput.IdentityClientId != nil {
 		identityClientId := *typedInput.IdentityClientId
 		properties.IdentityClientId = &identityClientId
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
@@ -3329,13 +3329,13 @@ func (identity *UserIdentity_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId

--- a/v2/api/appconfiguration/v1beta20220501/configuration_store_types_gen.go
+++ b/v2/api/appconfiguration/v1beta20220501/configuration_store_types_gen.go
@@ -387,7 +387,7 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ConfigurationStore_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if store.Identity != nil {
 		identity_ARM, err := (*store.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -397,16 +397,16 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if store.Location != nil {
 		location := *store.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if store.CreateMode != nil ||
 		store.DisableLocalAuth != nil ||
 		store.EnablePurgeProtection != nil ||
@@ -444,7 +444,7 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.SoftDeleteRetentionInDays = &softDeleteRetentionInDays
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if store.Sku != nil {
 		sku_ARM, err := (*store.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -454,7 +454,7 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if store.SystemData != nil {
 		systemData_ARM, err := (*store.SystemData).ConvertToARM(resolved)
 		if err != nil {
@@ -464,7 +464,7 @@ func (store *ConfigurationStore_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if store.Tags != nil {
 		result.Tags = make(map[string]string, len(store.Tags))
 		for key, value := range store.Tags {
@@ -486,10 +486,10 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConfigurationStore_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	store.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -498,7 +498,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -507,7 +507,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnablePurgeProtection’:
+	// Set property "EnablePurgeProtection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePurgeProtection != nil {
@@ -516,7 +516,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -530,7 +530,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ResourceIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -541,18 +541,18 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		store.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		store.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	store.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -561,7 +561,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -572,7 +572,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		store.Sku = &sku
 	}
 
-	// Set property ‘SoftDeleteRetentionInDays’:
+	// Set property "SoftDeleteRetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoftDeleteRetentionInDays != nil {
@@ -581,7 +581,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -592,7 +592,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		store.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		store.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1000,9 +1000,9 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConfigurationStore_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -1011,7 +1011,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘CreationDate’:
+	// Set property "CreationDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationDate != nil {
@@ -1020,7 +1020,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -1029,7 +1029,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘EnablePurgeProtection’:
+	// Set property "EnablePurgeProtection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePurgeProtection != nil {
@@ -1038,7 +1038,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1052,7 +1052,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Endpoint’:
+	// Set property "Endpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Endpoint != nil {
@@ -1061,13 +1061,13 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		store.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ResourceIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1078,19 +1078,19 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		store.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		store.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		store.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1103,7 +1103,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1112,7 +1112,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1121,7 +1121,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1132,7 +1132,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		store.Sku = &sku
 	}
 
-	// Set property ‘SoftDeleteRetentionInDays’:
+	// Set property "SoftDeleteRetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoftDeleteRetentionInDays != nil {
@@ -1141,7 +1141,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1152,7 +1152,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		store.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		store.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1160,7 +1160,7 @@ func (store *ConfigurationStore_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		store.Type = &typeVar
@@ -1577,7 +1577,7 @@ func (properties *EncryptionProperties) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &EncryptionProperties_ARM{}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if properties.KeyVaultProperties != nil {
 		keyVaultProperties_ARM, err := (*properties.KeyVaultProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -1601,7 +1601,7 @@ func (properties *EncryptionProperties) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -1682,7 +1682,7 @@ func (properties *EncryptionProperties_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties_STATUS
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -1763,7 +1763,7 @@ func (reference *PrivateEndpointConnectionReference_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnectionReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
@@ -1817,13 +1817,13 @@ func (identity *ResourceIdentity) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ResourceIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -1848,13 +1848,13 @@ func (identity *ResourceIdentity) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -1957,25 +1957,25 @@ func (identity *ResourceIdentity_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2094,7 +2094,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -2114,7 +2114,7 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -2172,7 +2172,7 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -2230,37 +2230,37 @@ func (data *SystemData) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &SystemData_ARM{}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if data.CreatedAt != nil {
 		createdAt := *data.CreatedAt
 		result.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if data.CreatedBy != nil {
 		createdBy := *data.CreatedBy
 		result.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if data.CreatedByType != nil {
 		createdByType := *data.CreatedByType
 		result.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if data.LastModifiedAt != nil {
 		lastModifiedAt := *data.LastModifiedAt
 		result.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if data.LastModifiedBy != nil {
 		lastModifiedBy := *data.LastModifiedBy
 		result.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if data.LastModifiedByType != nil {
 		lastModifiedByType := *data.LastModifiedByType
 		result.LastModifiedByType = &lastModifiedByType
@@ -2280,37 +2280,37 @@ func (data *SystemData) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -2423,37 +2423,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -2822,13 +2822,13 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘IdentityClientId’:
+	// Set property "IdentityClientId":
 	if properties.IdentityClientId != nil {
 		identityClientId := *properties.IdentityClientId
 		result.IdentityClientId = &identityClientId
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if properties.KeyIdentifier != nil {
 		keyIdentifier := *properties.KeyIdentifier
 		result.KeyIdentifier = &keyIdentifier
@@ -2848,13 +2848,13 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IdentityClientId’:
+	// Set property "IdentityClientId":
 	if typedInput.IdentityClientId != nil {
 		identityClientId := *typedInput.IdentityClientId
 		properties.IdentityClientId = &identityClientId
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
@@ -2919,13 +2919,13 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IdentityClientId’:
+	// Set property "IdentityClientId":
 	if typedInput.IdentityClientId != nil {
 		identityClientId := *typedInput.IdentityClientId
 		properties.IdentityClientId = &identityClientId
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
@@ -3024,13 +3024,13 @@ func (identity *UserIdentity_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId

--- a/v2/api/authorization/v1api20200801preview/role_assignment_types_gen.go
+++ b/v2/api/authorization/v1api20200801preview/role_assignment_types_gen.go
@@ -368,10 +368,10 @@ func (assignment *RoleAssignment_Spec) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &RoleAssignment_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if assignment.Condition != nil ||
 		assignment.ConditionVersion != nil ||
 		assignment.DelegatedManagedIdentityResourceId != nil ||
@@ -437,10 +437,10 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoleAssignment_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	assignment.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Condition’:
+	// Set property "Condition":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Condition != nil {
@@ -449,7 +449,7 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘ConditionVersion’:
+	// Set property "ConditionVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConditionVersion != nil {
@@ -458,7 +458,7 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DelegatedManagedIdentityResourceId’:
+	// Set property "DelegatedManagedIdentityResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DelegatedManagedIdentityResourceId != nil {
@@ -467,7 +467,7 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -476,10 +476,10 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	assignment.Owner = &owner
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalId != nil {
@@ -488,9 +488,9 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘PrincipalIdFromConfig’
+	// no assignment for property "PrincipalIdFromConfig"
 
-	// Set property ‘PrincipalType’:
+	// Set property "PrincipalType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalType != nil {
@@ -499,7 +499,7 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘RoleDefinitionReference’
+	// no assignment for property "RoleDefinitionReference"
 
 	// No error
 	return nil
@@ -846,7 +846,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoleAssignment_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Condition’:
+	// Set property "Condition":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Condition != nil {
@@ -855,7 +855,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘ConditionVersion’:
+	// Set property "ConditionVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConditionVersion != nil {
@@ -864,9 +864,9 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedBy != nil {
@@ -875,7 +875,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedOn != nil {
@@ -884,7 +884,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘DelegatedManagedIdentityResourceId’:
+	// Set property "DelegatedManagedIdentityResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DelegatedManagedIdentityResourceId != nil {
@@ -893,7 +893,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -902,19 +902,19 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		assignment.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		assignment.Name = &name
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalId != nil {
@@ -923,7 +923,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘PrincipalType’:
+	// Set property "PrincipalType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalType != nil {
@@ -932,7 +932,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘RoleDefinitionId’:
+	// Set property "RoleDefinitionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RoleDefinitionId != nil {
@@ -941,7 +941,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Scope’:
+	// Set property "Scope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Scope != nil {
@@ -950,13 +950,13 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		assignment.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedBy’:
+	// Set property "UpdatedBy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedBy != nil {
@@ -965,7 +965,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘UpdatedOn’:
+	// Set property "UpdatedOn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedOn != nil {

--- a/v2/api/authorization/v1beta20200801preview/role_assignment_types_gen.go
+++ b/v2/api/authorization/v1beta20200801preview/role_assignment_types_gen.go
@@ -351,10 +351,10 @@ func (assignment *RoleAssignment_Spec) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &RoleAssignment_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if assignment.Condition != nil ||
 		assignment.ConditionVersion != nil ||
 		assignment.DelegatedManagedIdentityResourceId != nil ||
@@ -420,10 +420,10 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoleAssignment_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	assignment.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Condition’:
+	// Set property "Condition":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Condition != nil {
@@ -432,7 +432,7 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘ConditionVersion’:
+	// Set property "ConditionVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConditionVersion != nil {
@@ -441,7 +441,7 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DelegatedManagedIdentityResourceId’:
+	// Set property "DelegatedManagedIdentityResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DelegatedManagedIdentityResourceId != nil {
@@ -450,7 +450,7 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -459,10 +459,10 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	assignment.Owner = &owner
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalId != nil {
@@ -471,9 +471,9 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘PrincipalIdFromConfig’
+	// no assignment for property "PrincipalIdFromConfig"
 
-	// Set property ‘PrincipalType’:
+	// Set property "PrincipalType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalType != nil {
@@ -482,7 +482,7 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘RoleDefinitionReference’
+	// no assignment for property "RoleDefinitionReference"
 
 	// No error
 	return nil
@@ -760,7 +760,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoleAssignment_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Condition’:
+	// Set property "Condition":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Condition != nil {
@@ -769,7 +769,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘ConditionVersion’:
+	// Set property "ConditionVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConditionVersion != nil {
@@ -778,9 +778,9 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedBy != nil {
@@ -789,7 +789,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedOn != nil {
@@ -798,7 +798,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘DelegatedManagedIdentityResourceId’:
+	// Set property "DelegatedManagedIdentityResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DelegatedManagedIdentityResourceId != nil {
@@ -807,7 +807,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -816,19 +816,19 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		assignment.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		assignment.Name = &name
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalId != nil {
@@ -837,7 +837,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘PrincipalType’:
+	// Set property "PrincipalType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalType != nil {
@@ -846,7 +846,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘RoleDefinitionId’:
+	// Set property "RoleDefinitionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RoleDefinitionId != nil {
@@ -855,7 +855,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Scope’:
+	// Set property "Scope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Scope != nil {
@@ -864,13 +864,13 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		assignment.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedBy’:
+	// Set property "UpdatedBy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedBy != nil {
@@ -879,7 +879,7 @@ func (assignment *RoleAssignment_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘UpdatedOn’:
+	// Set property "UpdatedOn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedOn != nil {

--- a/v2/api/batch/v1api20210101/batch_account_types_gen.go
+++ b/v2/api/batch/v1api20210101/batch_account_types_gen.go
@@ -367,7 +367,7 @@ func (account *BatchAccount_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &BatchAccount_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if account.Identity != nil {
 		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -377,16 +377,16 @@ func (account *BatchAccount_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if account.Location != nil {
 		location := *account.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if account.AutoStorage != nil ||
 		account.Encryption != nil ||
 		account.KeyVaultReference != nil ||
@@ -427,7 +427,7 @@ func (account *BatchAccount_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if account.Tags != nil {
 		result.Tags = make(map[string]string, len(account.Tags))
 		for key, value := range account.Tags {
@@ -449,7 +449,7 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BatchAccount_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoStorage’:
+	// Set property "AutoStorage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoStorage != nil {
@@ -463,10 +463,10 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	account.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -480,7 +480,7 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 BatchAccountIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -491,7 +491,7 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		account.Identity = &identity
 	}
 
-	// Set property ‘KeyVaultReference’:
+	// Set property "KeyVaultReference":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVaultReference != nil {
@@ -505,16 +505,16 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	account.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PoolAllocationMode’:
+	// Set property "PoolAllocationMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PoolAllocationMode != nil {
@@ -523,7 +523,7 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -532,7 +532,7 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1002,7 +1002,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BatchAccount_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountEndpoint’:
+	// Set property "AccountEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccountEndpoint != nil {
@@ -1011,7 +1011,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ActiveJobAndJobScheduleQuota’:
+	// Set property "ActiveJobAndJobScheduleQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ActiveJobAndJobScheduleQuota != nil {
@@ -1020,7 +1020,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AutoStorage’:
+	// Set property "AutoStorage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoStorage != nil {
@@ -1034,9 +1034,9 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DedicatedCoreQuota’:
+	// Set property "DedicatedCoreQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DedicatedCoreQuota != nil {
@@ -1045,7 +1045,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DedicatedCoreQuotaPerVMFamily’:
+	// Set property "DedicatedCoreQuotaPerVMFamily":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DedicatedCoreQuotaPerVMFamily {
@@ -1058,7 +1058,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DedicatedCoreQuotaPerVMFamilyEnforced’:
+	// Set property "DedicatedCoreQuotaPerVMFamilyEnforced":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DedicatedCoreQuotaPerVMFamilyEnforced != nil {
@@ -1067,7 +1067,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1081,13 +1081,13 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		account.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 BatchAccountIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1098,7 +1098,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		account.Identity = &identity
 	}
 
-	// Set property ‘KeyVaultReference’:
+	// Set property "KeyVaultReference":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVaultReference != nil {
@@ -1112,13 +1112,13 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘LowPriorityCoreQuota’:
+	// Set property "LowPriorityCoreQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LowPriorityCoreQuota != nil {
@@ -1127,13 +1127,13 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		account.Name = &name
 	}
 
-	// Set property ‘PoolAllocationMode’:
+	// Set property "PoolAllocationMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PoolAllocationMode != nil {
@@ -1142,7 +1142,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘PoolQuota’:
+	// Set property "PoolQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PoolQuota != nil {
@@ -1151,7 +1151,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1164,7 +1164,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1173,7 +1173,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1182,7 +1182,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1190,7 +1190,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		account.Type = &typeVar
@@ -1537,7 +1537,7 @@ func (properties *AutoStorageBaseProperties) ConvertToARM(resolved genruntime.Co
 	}
 	result := &AutoStorageBaseProperties_ARM{}
 
-	// Set property ‘StorageAccountId’:
+	// Set property "StorageAccountId":
 	if properties.StorageAccountReference != nil {
 		storageAccountReferenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.StorageAccountReference)
 		if err != nil {
@@ -1561,7 +1561,7 @@ func (properties *AutoStorageBaseProperties) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoStorageBaseProperties_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘StorageAccountReference’
+	// no assignment for property "StorageAccountReference"
 
 	// No error
 	return nil
@@ -1644,13 +1644,13 @@ func (properties *AutoStorageProperties_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoStorageProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LastKeySync’:
+	// Set property "LastKeySync":
 	if typedInput.LastKeySync != nil {
 		lastKeySync := *typedInput.LastKeySync
 		properties.LastKeySync = &lastKeySync
 	}
 
-	// Set property ‘StorageAccountId’:
+	// Set property "StorageAccountId":
 	if typedInput.StorageAccountId != nil {
 		storageAccountId := *typedInput.StorageAccountId
 		properties.StorageAccountId = &storageAccountId
@@ -1717,13 +1717,13 @@ func (identity *BatchAccountIdentity) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &BatchAccountIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -1748,13 +1748,13 @@ func (identity *BatchAccountIdentity) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BatchAccountIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -1895,25 +1895,25 @@ func (identity *BatchAccountIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BatchAccountIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]BatchAccountIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2047,13 +2047,13 @@ func (properties *EncryptionProperties) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &EncryptionProperties_ARM{}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if properties.KeySource != nil {
 		keySource := *properties.KeySource
 		result.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if properties.KeyVaultProperties != nil {
 		keyVaultProperties_ARM, err := (*properties.KeyVaultProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -2077,13 +2077,13 @@ func (properties *EncryptionProperties) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		properties.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -2212,13 +2212,13 @@ func (properties *EncryptionProperties_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		properties.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties_STATUS
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -2316,7 +2316,7 @@ func (reference *KeyVaultReference) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &KeyVaultReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -2326,7 +2326,7 @@ func (reference *KeyVaultReference) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Id = &reference1
 	}
 
-	// Set property ‘Url’:
+	// Set property "Url":
 	if reference.Url != nil {
 		url := *reference.Url
 		result.Url = &url
@@ -2346,9 +2346,9 @@ func (reference *KeyVaultReference) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultReference_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘Url’:
+	// Set property "Url":
 	if typedInput.Url != nil {
 		url := *typedInput.Url
 		reference.Url = &url
@@ -2444,13 +2444,13 @@ func (reference *KeyVaultReference_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
 	}
 
-	// Set property ‘Url’:
+	// Set property "Url":
 	if typedInput.Url != nil {
 		url := *typedInput.Url
 		reference.Url = &url
@@ -2532,7 +2532,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -2611,13 +2611,13 @@ func (quota *VirtualMachineFamilyCoreQuota_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineFamilyCoreQuota_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CoreQuota’:
+	// Set property "CoreQuota":
 	if typedInput.CoreQuota != nil {
 		coreQuota := *typedInput.CoreQuota
 		quota.CoreQuota = &coreQuota
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		quota.Name = &name
@@ -2684,13 +2684,13 @@ func (identities *BatchAccountIdentity_UserAssignedIdentities_STATUS) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BatchAccountIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -2770,7 +2770,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if properties.KeyIdentifier != nil {
 		keyIdentifier := *properties.KeyIdentifier
 		result.KeyIdentifier = &keyIdentifier
@@ -2790,7 +2790,7 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
@@ -2864,7 +2864,7 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier

--- a/v2/api/batch/v1beta20210101/batch_account_types_gen.go
+++ b/v2/api/batch/v1beta20210101/batch_account_types_gen.go
@@ -350,7 +350,7 @@ func (account *BatchAccount_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &BatchAccount_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if account.Identity != nil {
 		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -360,16 +360,16 @@ func (account *BatchAccount_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if account.Location != nil {
 		location := *account.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if account.AutoStorage != nil ||
 		account.Encryption != nil ||
 		account.KeyVaultReference != nil ||
@@ -410,7 +410,7 @@ func (account *BatchAccount_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if account.Tags != nil {
 		result.Tags = make(map[string]string, len(account.Tags))
 		for key, value := range account.Tags {
@@ -432,7 +432,7 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BatchAccount_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoStorage’:
+	// Set property "AutoStorage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoStorage != nil {
@@ -446,10 +446,10 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	account.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -463,7 +463,7 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 BatchAccountIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -474,7 +474,7 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		account.Identity = &identity
 	}
 
-	// Set property ‘KeyVaultReference’:
+	// Set property "KeyVaultReference":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVaultReference != nil {
@@ -488,16 +488,16 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	account.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PoolAllocationMode’:
+	// Set property "PoolAllocationMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PoolAllocationMode != nil {
@@ -506,7 +506,7 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -515,7 +515,7 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -864,7 +864,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BatchAccount_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountEndpoint’:
+	// Set property "AccountEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccountEndpoint != nil {
@@ -873,7 +873,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ActiveJobAndJobScheduleQuota’:
+	// Set property "ActiveJobAndJobScheduleQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ActiveJobAndJobScheduleQuota != nil {
@@ -882,7 +882,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AutoStorage’:
+	// Set property "AutoStorage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoStorage != nil {
@@ -896,9 +896,9 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DedicatedCoreQuota’:
+	// Set property "DedicatedCoreQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DedicatedCoreQuota != nil {
@@ -907,7 +907,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DedicatedCoreQuotaPerVMFamily’:
+	// Set property "DedicatedCoreQuotaPerVMFamily":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DedicatedCoreQuotaPerVMFamily {
@@ -920,7 +920,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DedicatedCoreQuotaPerVMFamilyEnforced’:
+	// Set property "DedicatedCoreQuotaPerVMFamilyEnforced":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DedicatedCoreQuotaPerVMFamilyEnforced != nil {
@@ -929,7 +929,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -943,13 +943,13 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		account.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 BatchAccountIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -960,7 +960,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		account.Identity = &identity
 	}
 
-	// Set property ‘KeyVaultReference’:
+	// Set property "KeyVaultReference":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVaultReference != nil {
@@ -974,13 +974,13 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘LowPriorityCoreQuota’:
+	// Set property "LowPriorityCoreQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LowPriorityCoreQuota != nil {
@@ -989,13 +989,13 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		account.Name = &name
 	}
 
-	// Set property ‘PoolAllocationMode’:
+	// Set property "PoolAllocationMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PoolAllocationMode != nil {
@@ -1004,7 +1004,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘PoolQuota’:
+	// Set property "PoolQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PoolQuota != nil {
@@ -1013,7 +1013,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1026,7 +1026,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1035,7 +1035,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1044,7 +1044,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1052,7 +1052,7 @@ func (account *BatchAccount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		account.Type = &typeVar
@@ -1398,7 +1398,7 @@ func (properties *AutoStorageBaseProperties) ConvertToARM(resolved genruntime.Co
 	}
 	result := &AutoStorageBaseProperties_ARM{}
 
-	// Set property ‘StorageAccountId’:
+	// Set property "StorageAccountId":
 	if properties.StorageAccountReference != nil {
 		storageAccountReferenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.StorageAccountReference)
 		if err != nil {
@@ -1422,7 +1422,7 @@ func (properties *AutoStorageBaseProperties) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoStorageBaseProperties_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘StorageAccountReference’
+	// no assignment for property "StorageAccountReference"
 
 	// No error
 	return nil
@@ -1487,13 +1487,13 @@ func (properties *AutoStorageProperties_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoStorageProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LastKeySync’:
+	// Set property "LastKeySync":
 	if typedInput.LastKeySync != nil {
 		lastKeySync := *typedInput.LastKeySync
 		properties.LastKeySync = &lastKeySync
 	}
 
-	// Set property ‘StorageAccountId’:
+	// Set property "StorageAccountId":
 	if typedInput.StorageAccountId != nil {
 		storageAccountId := *typedInput.StorageAccountId
 		properties.StorageAccountId = &storageAccountId
@@ -1554,13 +1554,13 @@ func (identity *BatchAccountIdentity) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &BatchAccountIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -1585,13 +1585,13 @@ func (identity *BatchAccountIdentity) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BatchAccountIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -1694,25 +1694,25 @@ func (identity *BatchAccountIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BatchAccountIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]BatchAccountIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -1844,13 +1844,13 @@ func (properties *EncryptionProperties) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &EncryptionProperties_ARM{}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if properties.KeySource != nil {
 		keySource := *properties.KeySource
 		result.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if properties.KeyVaultProperties != nil {
 		keyVaultProperties_ARM, err := (*properties.KeyVaultProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -1874,13 +1874,13 @@ func (properties *EncryptionProperties) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		properties.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -1978,13 +1978,13 @@ func (properties *EncryptionProperties_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		properties.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties_STATUS
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -2080,7 +2080,7 @@ func (reference *KeyVaultReference) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &KeyVaultReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -2090,7 +2090,7 @@ func (reference *KeyVaultReference) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Id = &reference1
 	}
 
-	// Set property ‘Url’:
+	// Set property "Url":
 	if reference.Url != nil {
 		url := *reference.Url
 		result.Url = &url
@@ -2110,9 +2110,9 @@ func (reference *KeyVaultReference) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultReference_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘Url’:
+	// Set property "Url":
 	if typedInput.Url != nil {
 		url := *typedInput.Url
 		reference.Url = &url
@@ -2187,13 +2187,13 @@ func (reference *KeyVaultReference_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
 	}
 
-	// Set property ‘Url’:
+	// Set property "Url":
 	if typedInput.Url != nil {
 		url := *typedInput.Url
 		reference.Url = &url
@@ -2274,7 +2274,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -2350,13 +2350,13 @@ func (quota *VirtualMachineFamilyCoreQuota_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineFamilyCoreQuota_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CoreQuota’:
+	// Set property "CoreQuota":
 	if typedInput.CoreQuota != nil {
 		coreQuota := *typedInput.CoreQuota
 		quota.CoreQuota = &coreQuota
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		quota.Name = &name
@@ -2421,13 +2421,13 @@ func (identities *BatchAccountIdentity_UserAssignedIdentities_STATUS) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BatchAccountIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -2504,7 +2504,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if properties.KeyIdentifier != nil {
 		keyIdentifier := *properties.KeyIdentifier
 		result.KeyIdentifier = &keyIdentifier
@@ -2524,7 +2524,7 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
@@ -2582,7 +2582,7 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier

--- a/v2/api/cache/v1api20201201/redis_firewall_rule_types_gen.go
+++ b/v2/api/cache/v1api20201201/redis_firewall_rule_types_gen.go
@@ -339,10 +339,10 @@ func (rule *Redis_FirewallRule_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &Redis_FirewallRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.EndIP != nil || rule.StartIP != nil {
 		result.Properties = &RedisFirewallRuleProperties_ARM{}
 	}
@@ -369,10 +369,10 @@ func (rule *Redis_FirewallRule_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_FirewallRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EndIP’:
+	// Set property "EndIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIP != nil {
@@ -381,10 +381,10 @@ func (rule *Redis_FirewallRule_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘StartIP’:
+	// Set property "StartIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIP != nil {
@@ -613,9 +613,9 @@ func (rule *Redis_FirewallRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_FirewallRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EndIP’:
+	// Set property "EndIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIP != nil {
@@ -624,19 +624,19 @@ func (rule *Redis_FirewallRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘StartIP’:
+	// Set property "StartIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIP != nil {
@@ -645,7 +645,7 @@ func (rule *Redis_FirewallRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/cache/v1api20201201/redis_linked_server_types_gen.go
+++ b/v2/api/cache/v1api20201201/redis_linked_server_types_gen.go
@@ -343,10 +343,10 @@ func (server *Redis_LinkedServer_Spec) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &Redis_LinkedServer_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if server.LinkedRedisCacheLocation != nil ||
 		server.LinkedRedisCacheReference != nil ||
 		server.ServerRole != nil {
@@ -383,10 +383,10 @@ func (server *Redis_LinkedServer_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_LinkedServer_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	server.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘LinkedRedisCacheLocation’:
+	// Set property "LinkedRedisCacheLocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinkedRedisCacheLocation != nil {
@@ -395,12 +395,12 @@ func (server *Redis_LinkedServer_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘LinkedRedisCacheReference’
+	// no assignment for property "LinkedRedisCacheReference"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ServerRole’:
+	// Set property "ServerRole":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServerRole != nil {
@@ -674,15 +674,15 @@ func (server *Redis_LinkedServer_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_LinkedServer_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		server.Id = &id
 	}
 
-	// Set property ‘LinkedRedisCacheId’:
+	// Set property "LinkedRedisCacheId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinkedRedisCacheId != nil {
@@ -691,7 +691,7 @@ func (server *Redis_LinkedServer_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘LinkedRedisCacheLocation’:
+	// Set property "LinkedRedisCacheLocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinkedRedisCacheLocation != nil {
@@ -700,13 +700,13 @@ func (server *Redis_LinkedServer_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		server.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -715,7 +715,7 @@ func (server *Redis_LinkedServer_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘ServerRole’:
+	// Set property "ServerRole":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServerRole != nil {
@@ -724,7 +724,7 @@ func (server *Redis_LinkedServer_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		server.Type = &typeVar

--- a/v2/api/cache/v1api20201201/redis_patch_schedule_types_gen.go
+++ b/v2/api/cache/v1api20201201/redis_patch_schedule_types_gen.go
@@ -324,10 +324,10 @@ func (schedule *Redis_PatchSchedule_Spec) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &Redis_PatchSchedule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if schedule.ScheduleEntries != nil {
 		result.Properties = &ScheduleEntries_ARM{}
 	}
@@ -353,10 +353,10 @@ func (schedule *Redis_PatchSchedule_Spec) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_PatchSchedule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	schedule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ScheduleEntries’:
+	// Set property "ScheduleEntries":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ScheduleEntries {
@@ -616,27 +616,27 @@ func (schedule *Redis_PatchSchedule_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_PatchSchedule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		schedule.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		schedule.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		schedule.Name = &name
 	}
 
-	// Set property ‘ScheduleEntries’:
+	// Set property "ScheduleEntries":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ScheduleEntries {
@@ -649,7 +649,7 @@ func (schedule *Redis_PatchSchedule_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		schedule.Type = &typeVar
@@ -771,19 +771,19 @@ func (entry *ScheduleEntry) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &ScheduleEntry_ARM{}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if entry.DayOfWeek != nil {
 		dayOfWeek := *entry.DayOfWeek
 		result.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	if entry.MaintenanceWindow != nil {
 		maintenanceWindow := *entry.MaintenanceWindow
 		result.MaintenanceWindow = &maintenanceWindow
 	}
 
-	// Set property ‘StartHourUtc’:
+	// Set property "StartHourUtc":
 	if entry.StartHourUtc != nil {
 		startHourUtc := *entry.StartHourUtc
 		result.StartHourUtc = &startHourUtc
@@ -803,19 +803,19 @@ func (entry *ScheduleEntry) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduleEntry_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		entry.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	if typedInput.MaintenanceWindow != nil {
 		maintenanceWindow := *typedInput.MaintenanceWindow
 		entry.MaintenanceWindow = &maintenanceWindow
 	}
 
-	// Set property ‘StartHourUtc’:
+	// Set property "StartHourUtc":
 	if typedInput.StartHourUtc != nil {
 		startHourUtc := *typedInput.StartHourUtc
 		entry.StartHourUtc = &startHourUtc
@@ -923,19 +923,19 @@ func (entry *ScheduleEntry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduleEntry_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		entry.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	if typedInput.MaintenanceWindow != nil {
 		maintenanceWindow := *typedInput.MaintenanceWindow
 		entry.MaintenanceWindow = &maintenanceWindow
 	}
 
-	// Set property ‘StartHourUtc’:
+	// Set property "StartHourUtc":
 	if typedInput.StartHourUtc != nil {
 		startHourUtc := *typedInput.StartHourUtc
 		entry.StartHourUtc = &startHourUtc

--- a/v2/api/cache/v1api20201201/redis_types_gen.go
+++ b/v2/api/cache/v1api20201201/redis_types_gen.go
@@ -419,16 +419,16 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &Redis_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if redis.Location != nil {
 		location := *redis.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if redis.EnableNonSslPort != nil ||
 		redis.MinimumTlsVersion != nil ||
 		redis.PublicNetworkAccess != nil ||
@@ -506,7 +506,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if redis.Tags != nil {
 		result.Tags = make(map[string]string, len(redis.Tags))
 		for key, value := range redis.Tags {
@@ -514,7 +514,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range redis.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -533,10 +533,10 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	redis.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EnableNonSslPort’:
+	// Set property "EnableNonSslPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNonSslPort != nil {
@@ -545,13 +545,13 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		redis.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -560,12 +560,12 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	redis.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -574,7 +574,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘RedisConfiguration’:
+	// Set property "RedisConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedisConfiguration != nil {
@@ -588,7 +588,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘RedisVersion’:
+	// Set property "RedisVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedisVersion != nil {
@@ -597,7 +597,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ReplicasPerMaster’:
+	// Set property "ReplicasPerMaster":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicasPerMaster != nil {
@@ -606,7 +606,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ReplicasPerPrimary’:
+	// Set property "ReplicasPerPrimary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicasPerPrimary != nil {
@@ -615,7 +615,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ShardCount’:
+	// Set property "ShardCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ShardCount != nil {
@@ -624,7 +624,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -638,7 +638,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘StaticIP’:
+	// Set property "StaticIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StaticIP != nil {
@@ -647,9 +647,9 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// no assignment for property ‘SubnetReference’
+	// no assignment for property "SubnetReference"
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		redis.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -657,7 +657,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘TenantSettings’:
+	// Set property "TenantSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantSettings != nil {
@@ -668,7 +668,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		redis.Zones = append(redis.Zones, item)
 	}
@@ -1232,9 +1232,9 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EnableNonSslPort’:
+	// Set property "EnableNonSslPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNonSslPort != nil {
@@ -1243,7 +1243,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -1252,13 +1252,13 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		redis.Id = &id
 	}
 
-	// Set property ‘Instances’:
+	// Set property "Instances":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Instances {
@@ -1271,7 +1271,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘LinkedServers’:
+	// Set property "LinkedServers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LinkedServers {
@@ -1284,13 +1284,13 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		redis.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -1299,13 +1299,13 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		redis.Name = &name
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Port != nil {
@@ -1314,7 +1314,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1327,7 +1327,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1336,7 +1336,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1345,7 +1345,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘RedisConfiguration’:
+	// Set property "RedisConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedisConfiguration != nil {
@@ -1359,7 +1359,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘RedisVersion’:
+	// Set property "RedisVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedisVersion != nil {
@@ -1368,7 +1368,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘ReplicasPerMaster’:
+	// Set property "ReplicasPerMaster":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicasPerMaster != nil {
@@ -1377,7 +1377,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘ReplicasPerPrimary’:
+	// Set property "ReplicasPerPrimary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicasPerPrimary != nil {
@@ -1386,7 +1386,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘ShardCount’:
+	// Set property "ShardCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ShardCount != nil {
@@ -1395,7 +1395,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -1409,7 +1409,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘SslPort’:
+	// Set property "SslPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SslPort != nil {
@@ -1418,7 +1418,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘StaticIP’:
+	// Set property "StaticIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StaticIP != nil {
@@ -1427,7 +1427,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘SubnetId’:
+	// Set property "SubnetId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SubnetId != nil {
@@ -1436,7 +1436,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		redis.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1444,7 +1444,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘TenantSettings’:
+	// Set property "TenantSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantSettings != nil {
@@ -1455,13 +1455,13 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		redis.Type = &typeVar
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		redis.Zones = append(redis.Zones, item)
 	}
@@ -1836,7 +1836,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -1942,7 +1942,7 @@ func (configuration *RedisCreateProperties_RedisConfiguration) ConvertToARM(reso
 	}
 	result := &RedisCreateProperties_RedisConfiguration_ARM{}
 
-	// Set property ‘AdditionalProperties’:
+	// Set property "AdditionalProperties":
 	if configuration.AdditionalProperties != nil {
 		result.AdditionalProperties = make(map[string]string, len(configuration.AdditionalProperties))
 		for key, value := range configuration.AdditionalProperties {
@@ -1950,73 +1950,73 @@ func (configuration *RedisCreateProperties_RedisConfiguration) ConvertToARM(reso
 		}
 	}
 
-	// Set property ‘AofBackupEnabled’:
+	// Set property "AofBackupEnabled":
 	if configuration.AofBackupEnabled != nil {
 		aofBackupEnabled := *configuration.AofBackupEnabled
 		result.AofBackupEnabled = &aofBackupEnabled
 	}
 
-	// Set property ‘AofStorageConnectionString0’:
+	// Set property "AofStorageConnectionString0":
 	if configuration.AofStorageConnectionString0 != nil {
 		aofStorageConnectionString0 := *configuration.AofStorageConnectionString0
 		result.AofStorageConnectionString0 = &aofStorageConnectionString0
 	}
 
-	// Set property ‘AofStorageConnectionString1’:
+	// Set property "AofStorageConnectionString1":
 	if configuration.AofStorageConnectionString1 != nil {
 		aofStorageConnectionString1 := *configuration.AofStorageConnectionString1
 		result.AofStorageConnectionString1 = &aofStorageConnectionString1
 	}
 
-	// Set property ‘Authnotrequired’:
+	// Set property "Authnotrequired":
 	if configuration.Authnotrequired != nil {
 		authnotrequired := *configuration.Authnotrequired
 		result.Authnotrequired = &authnotrequired
 	}
 
-	// Set property ‘MaxfragmentationmemoryReserved’:
+	// Set property "MaxfragmentationmemoryReserved":
 	if configuration.MaxfragmentationmemoryReserved != nil {
 		maxfragmentationmemoryReserved := *configuration.MaxfragmentationmemoryReserved
 		result.MaxfragmentationmemoryReserved = &maxfragmentationmemoryReserved
 	}
 
-	// Set property ‘MaxmemoryDelta’:
+	// Set property "MaxmemoryDelta":
 	if configuration.MaxmemoryDelta != nil {
 		maxmemoryDelta := *configuration.MaxmemoryDelta
 		result.MaxmemoryDelta = &maxmemoryDelta
 	}
 
-	// Set property ‘MaxmemoryPolicy’:
+	// Set property "MaxmemoryPolicy":
 	if configuration.MaxmemoryPolicy != nil {
 		maxmemoryPolicy := *configuration.MaxmemoryPolicy
 		result.MaxmemoryPolicy = &maxmemoryPolicy
 	}
 
-	// Set property ‘MaxmemoryReserved’:
+	// Set property "MaxmemoryReserved":
 	if configuration.MaxmemoryReserved != nil {
 		maxmemoryReserved := *configuration.MaxmemoryReserved
 		result.MaxmemoryReserved = &maxmemoryReserved
 	}
 
-	// Set property ‘RdbBackupEnabled’:
+	// Set property "RdbBackupEnabled":
 	if configuration.RdbBackupEnabled != nil {
 		rdbBackupEnabled := *configuration.RdbBackupEnabled
 		result.RdbBackupEnabled = &rdbBackupEnabled
 	}
 
-	// Set property ‘RdbBackupFrequency’:
+	// Set property "RdbBackupFrequency":
 	if configuration.RdbBackupFrequency != nil {
 		rdbBackupFrequency := *configuration.RdbBackupFrequency
 		result.RdbBackupFrequency = &rdbBackupFrequency
 	}
 
-	// Set property ‘RdbBackupMaxSnapshotCount’:
+	// Set property "RdbBackupMaxSnapshotCount":
 	if configuration.RdbBackupMaxSnapshotCount != nil {
 		rdbBackupMaxSnapshotCount := *configuration.RdbBackupMaxSnapshotCount
 		result.RdbBackupMaxSnapshotCount = &rdbBackupMaxSnapshotCount
 	}
 
-	// Set property ‘RdbStorageConnectionString’:
+	// Set property "RdbStorageConnectionString":
 	if configuration.RdbStorageConnectionString != nil {
 		rdbStorageConnectionString := *configuration.RdbStorageConnectionString
 		result.RdbStorageConnectionString = &rdbStorageConnectionString
@@ -2036,7 +2036,7 @@ func (configuration *RedisCreateProperties_RedisConfiguration) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisCreateProperties_RedisConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalProperties’:
+	// Set property "AdditionalProperties":
 	if typedInput.AdditionalProperties != nil {
 		configuration.AdditionalProperties = make(map[string]string, len(typedInput.AdditionalProperties))
 		for key, value := range typedInput.AdditionalProperties {
@@ -2044,73 +2044,73 @@ func (configuration *RedisCreateProperties_RedisConfiguration) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘AofBackupEnabled’:
+	// Set property "AofBackupEnabled":
 	if typedInput.AofBackupEnabled != nil {
 		aofBackupEnabled := *typedInput.AofBackupEnabled
 		configuration.AofBackupEnabled = &aofBackupEnabled
 	}
 
-	// Set property ‘AofStorageConnectionString0’:
+	// Set property "AofStorageConnectionString0":
 	if typedInput.AofStorageConnectionString0 != nil {
 		aofStorageConnectionString0 := *typedInput.AofStorageConnectionString0
 		configuration.AofStorageConnectionString0 = &aofStorageConnectionString0
 	}
 
-	// Set property ‘AofStorageConnectionString1’:
+	// Set property "AofStorageConnectionString1":
 	if typedInput.AofStorageConnectionString1 != nil {
 		aofStorageConnectionString1 := *typedInput.AofStorageConnectionString1
 		configuration.AofStorageConnectionString1 = &aofStorageConnectionString1
 	}
 
-	// Set property ‘Authnotrequired’:
+	// Set property "Authnotrequired":
 	if typedInput.Authnotrequired != nil {
 		authnotrequired := *typedInput.Authnotrequired
 		configuration.Authnotrequired = &authnotrequired
 	}
 
-	// Set property ‘MaxfragmentationmemoryReserved’:
+	// Set property "MaxfragmentationmemoryReserved":
 	if typedInput.MaxfragmentationmemoryReserved != nil {
 		maxfragmentationmemoryReserved := *typedInput.MaxfragmentationmemoryReserved
 		configuration.MaxfragmentationmemoryReserved = &maxfragmentationmemoryReserved
 	}
 
-	// Set property ‘MaxmemoryDelta’:
+	// Set property "MaxmemoryDelta":
 	if typedInput.MaxmemoryDelta != nil {
 		maxmemoryDelta := *typedInput.MaxmemoryDelta
 		configuration.MaxmemoryDelta = &maxmemoryDelta
 	}
 
-	// Set property ‘MaxmemoryPolicy’:
+	// Set property "MaxmemoryPolicy":
 	if typedInput.MaxmemoryPolicy != nil {
 		maxmemoryPolicy := *typedInput.MaxmemoryPolicy
 		configuration.MaxmemoryPolicy = &maxmemoryPolicy
 	}
 
-	// Set property ‘MaxmemoryReserved’:
+	// Set property "MaxmemoryReserved":
 	if typedInput.MaxmemoryReserved != nil {
 		maxmemoryReserved := *typedInput.MaxmemoryReserved
 		configuration.MaxmemoryReserved = &maxmemoryReserved
 	}
 
-	// Set property ‘RdbBackupEnabled’:
+	// Set property "RdbBackupEnabled":
 	if typedInput.RdbBackupEnabled != nil {
 		rdbBackupEnabled := *typedInput.RdbBackupEnabled
 		configuration.RdbBackupEnabled = &rdbBackupEnabled
 	}
 
-	// Set property ‘RdbBackupFrequency’:
+	// Set property "RdbBackupFrequency":
 	if typedInput.RdbBackupFrequency != nil {
 		rdbBackupFrequency := *typedInput.RdbBackupFrequency
 		configuration.RdbBackupFrequency = &rdbBackupFrequency
 	}
 
-	// Set property ‘RdbBackupMaxSnapshotCount’:
+	// Set property "RdbBackupMaxSnapshotCount":
 	if typedInput.RdbBackupMaxSnapshotCount != nil {
 		rdbBackupMaxSnapshotCount := *typedInput.RdbBackupMaxSnapshotCount
 		configuration.RdbBackupMaxSnapshotCount = &rdbBackupMaxSnapshotCount
 	}
 
-	// Set property ‘RdbStorageConnectionString’:
+	// Set property "RdbStorageConnectionString":
 	if typedInput.RdbStorageConnectionString != nil {
 		rdbStorageConnectionString := *typedInput.RdbStorageConnectionString
 		configuration.RdbStorageConnectionString = &rdbStorageConnectionString
@@ -2302,37 +2302,37 @@ func (details *RedisInstanceDetails_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisInstanceDetails_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IsMaster’:
+	// Set property "IsMaster":
 	if typedInput.IsMaster != nil {
 		isMaster := *typedInput.IsMaster
 		details.IsMaster = &isMaster
 	}
 
-	// Set property ‘IsPrimary’:
+	// Set property "IsPrimary":
 	if typedInput.IsPrimary != nil {
 		isPrimary := *typedInput.IsPrimary
 		details.IsPrimary = &isPrimary
 	}
 
-	// Set property ‘NonSslPort’:
+	// Set property "NonSslPort":
 	if typedInput.NonSslPort != nil {
 		nonSslPort := *typedInput.NonSslPort
 		details.NonSslPort = &nonSslPort
 	}
 
-	// Set property ‘ShardId’:
+	// Set property "ShardId":
 	if typedInput.ShardId != nil {
 		shardId := *typedInput.ShardId
 		details.ShardId = &shardId
 	}
 
-	// Set property ‘SslPort’:
+	// Set property "SslPort":
 	if typedInput.SslPort != nil {
 		sslPort := *typedInput.SslPort
 		details.SslPort = &sslPort
 	}
 
-	// Set property ‘Zone’:
+	// Set property "Zone":
 	if typedInput.Zone != nil {
 		zone := *typedInput.Zone
 		details.Zone = &zone
@@ -2441,7 +2441,7 @@ func (server *RedisLinkedServer_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisLinkedServer_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		server.Id = &id
@@ -2626,7 +2626,7 @@ func (configuration *RedisProperties_RedisConfiguration_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisProperties_RedisConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalProperties’:
+	// Set property "AdditionalProperties":
 	if typedInput.AdditionalProperties != nil {
 		configuration.AdditionalProperties = make(map[string]string, len(typedInput.AdditionalProperties))
 		for key, value := range typedInput.AdditionalProperties {
@@ -2634,85 +2634,85 @@ func (configuration *RedisProperties_RedisConfiguration_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘AofBackupEnabled’:
+	// Set property "AofBackupEnabled":
 	if typedInput.AofBackupEnabled != nil {
 		aofBackupEnabled := *typedInput.AofBackupEnabled
 		configuration.AofBackupEnabled = &aofBackupEnabled
 	}
 
-	// Set property ‘AofStorageConnectionString0’:
+	// Set property "AofStorageConnectionString0":
 	if typedInput.AofStorageConnectionString0 != nil {
 		aofStorageConnectionString0 := *typedInput.AofStorageConnectionString0
 		configuration.AofStorageConnectionString0 = &aofStorageConnectionString0
 	}
 
-	// Set property ‘AofStorageConnectionString1’:
+	// Set property "AofStorageConnectionString1":
 	if typedInput.AofStorageConnectionString1 != nil {
 		aofStorageConnectionString1 := *typedInput.AofStorageConnectionString1
 		configuration.AofStorageConnectionString1 = &aofStorageConnectionString1
 	}
 
-	// Set property ‘Authnotrequired’:
+	// Set property "Authnotrequired":
 	if typedInput.Authnotrequired != nil {
 		authnotrequired := *typedInput.Authnotrequired
 		configuration.Authnotrequired = &authnotrequired
 	}
 
-	// Set property ‘Maxclients’:
+	// Set property "Maxclients":
 	if typedInput.Maxclients != nil {
 		maxclients := *typedInput.Maxclients
 		configuration.Maxclients = &maxclients
 	}
 
-	// Set property ‘MaxfragmentationmemoryReserved’:
+	// Set property "MaxfragmentationmemoryReserved":
 	if typedInput.MaxfragmentationmemoryReserved != nil {
 		maxfragmentationmemoryReserved := *typedInput.MaxfragmentationmemoryReserved
 		configuration.MaxfragmentationmemoryReserved = &maxfragmentationmemoryReserved
 	}
 
-	// Set property ‘MaxmemoryDelta’:
+	// Set property "MaxmemoryDelta":
 	if typedInput.MaxmemoryDelta != nil {
 		maxmemoryDelta := *typedInput.MaxmemoryDelta
 		configuration.MaxmemoryDelta = &maxmemoryDelta
 	}
 
-	// Set property ‘MaxmemoryPolicy’:
+	// Set property "MaxmemoryPolicy":
 	if typedInput.MaxmemoryPolicy != nil {
 		maxmemoryPolicy := *typedInput.MaxmemoryPolicy
 		configuration.MaxmemoryPolicy = &maxmemoryPolicy
 	}
 
-	// Set property ‘MaxmemoryReserved’:
+	// Set property "MaxmemoryReserved":
 	if typedInput.MaxmemoryReserved != nil {
 		maxmemoryReserved := *typedInput.MaxmemoryReserved
 		configuration.MaxmemoryReserved = &maxmemoryReserved
 	}
 
-	// Set property ‘RdbBackupEnabled’:
+	// Set property "RdbBackupEnabled":
 	if typedInput.RdbBackupEnabled != nil {
 		rdbBackupEnabled := *typedInput.RdbBackupEnabled
 		configuration.RdbBackupEnabled = &rdbBackupEnabled
 	}
 
-	// Set property ‘RdbBackupFrequency’:
+	// Set property "RdbBackupFrequency":
 	if typedInput.RdbBackupFrequency != nil {
 		rdbBackupFrequency := *typedInput.RdbBackupFrequency
 		configuration.RdbBackupFrequency = &rdbBackupFrequency
 	}
 
-	// Set property ‘RdbBackupMaxSnapshotCount’:
+	// Set property "RdbBackupMaxSnapshotCount":
 	if typedInput.RdbBackupMaxSnapshotCount != nil {
 		rdbBackupMaxSnapshotCount := *typedInput.RdbBackupMaxSnapshotCount
 		configuration.RdbBackupMaxSnapshotCount = &rdbBackupMaxSnapshotCount
 	}
 
-	// Set property ‘RdbStorageConnectionString’:
+	// Set property "RdbStorageConnectionString":
 	if typedInput.RdbStorageConnectionString != nil {
 		rdbStorageConnectionString := *typedInput.RdbStorageConnectionString
 		configuration.RdbStorageConnectionString = &rdbStorageConnectionString
 	}
 
-	// Set property ‘ZonalConfiguration’:
+	// Set property "ZonalConfiguration":
 	if typedInput.ZonalConfiguration != nil {
 		zonalConfiguration := *typedInput.ZonalConfiguration
 		configuration.ZonalConfiguration = &zonalConfiguration
@@ -2860,19 +2860,19 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sku.Capacity != nil {
 		capacity := *sku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if sku.Family != nil {
 		family := *sku.Family
 		result.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -2892,19 +2892,19 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -3028,19 +3028,19 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name

--- a/v2/api/cache/v1api20210301/redis_enterprise_database_types_gen.go
+++ b/v2/api/cache/v1api20210301/redis_enterprise_database_types_gen.go
@@ -350,10 +350,10 @@ func (database *RedisEnterprise_Database_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &RedisEnterprise_Database_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.ClientProtocol != nil ||
 		database.ClusteringPolicy != nil ||
 		database.EvictionPolicy != nil ||
@@ -408,10 +408,10 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisEnterprise_Database_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘ClientProtocol’:
+	// Set property "ClientProtocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientProtocol != nil {
@@ -420,7 +420,7 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ClusteringPolicy’:
+	// Set property "ClusteringPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClusteringPolicy != nil {
@@ -429,7 +429,7 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EvictionPolicy != nil {
@@ -438,7 +438,7 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Modules’:
+	// Set property "Modules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Modules {
@@ -451,10 +451,10 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Persistence’:
+	// Set property "Persistence":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Persistence != nil {
@@ -468,7 +468,7 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Port != nil {
@@ -871,7 +871,7 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisEnterprise_Database_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientProtocol’:
+	// Set property "ClientProtocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientProtocol != nil {
@@ -880,7 +880,7 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ClusteringPolicy’:
+	// Set property "ClusteringPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClusteringPolicy != nil {
@@ -889,9 +889,9 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EvictionPolicy != nil {
@@ -900,13 +900,13 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Modules’:
+	// Set property "Modules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Modules {
@@ -919,13 +919,13 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘Persistence’:
+	// Set property "Persistence":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Persistence != nil {
@@ -939,7 +939,7 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Port != nil {
@@ -948,7 +948,7 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -957,7 +957,7 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ResourceState’:
+	// Set property "ResourceState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceState != nil {
@@ -966,7 +966,7 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar
@@ -1245,13 +1245,13 @@ func (module *Module) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &Module_ARM{}
 
-	// Set property ‘Args’:
+	// Set property "Args":
 	if module.Args != nil {
 		args := *module.Args
 		result.Args = &args
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if module.Name != nil {
 		name := *module.Name
 		result.Name = &name
@@ -1271,13 +1271,13 @@ func (module *Module) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Module_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Args’:
+	// Set property "Args":
 	if typedInput.Args != nil {
 		args := *typedInput.Args
 		module.Args = &args
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		module.Name = &name
@@ -1361,19 +1361,19 @@ func (module *Module_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Module_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Args’:
+	// Set property "Args":
 	if typedInput.Args != nil {
 		args := *typedInput.Args
 		module.Args = &args
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		module.Name = &name
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		module.Version = &version
@@ -1448,25 +1448,25 @@ func (persistence *Persistence) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &Persistence_ARM{}
 
-	// Set property ‘AofEnabled’:
+	// Set property "AofEnabled":
 	if persistence.AofEnabled != nil {
 		aofEnabled := *persistence.AofEnabled
 		result.AofEnabled = &aofEnabled
 	}
 
-	// Set property ‘AofFrequency’:
+	// Set property "AofFrequency":
 	if persistence.AofFrequency != nil {
 		aofFrequency := *persistence.AofFrequency
 		result.AofFrequency = &aofFrequency
 	}
 
-	// Set property ‘RdbEnabled’:
+	// Set property "RdbEnabled":
 	if persistence.RdbEnabled != nil {
 		rdbEnabled := *persistence.RdbEnabled
 		result.RdbEnabled = &rdbEnabled
 	}
 
-	// Set property ‘RdbFrequency’:
+	// Set property "RdbFrequency":
 	if persistence.RdbFrequency != nil {
 		rdbFrequency := *persistence.RdbFrequency
 		result.RdbFrequency = &rdbFrequency
@@ -1486,25 +1486,25 @@ func (persistence *Persistence) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Persistence_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AofEnabled’:
+	// Set property "AofEnabled":
 	if typedInput.AofEnabled != nil {
 		aofEnabled := *typedInput.AofEnabled
 		persistence.AofEnabled = &aofEnabled
 	}
 
-	// Set property ‘AofFrequency’:
+	// Set property "AofFrequency":
 	if typedInput.AofFrequency != nil {
 		aofFrequency := *typedInput.AofFrequency
 		persistence.AofFrequency = &aofFrequency
 	}
 
-	// Set property ‘RdbEnabled’:
+	// Set property "RdbEnabled":
 	if typedInput.RdbEnabled != nil {
 		rdbEnabled := *typedInput.RdbEnabled
 		persistence.RdbEnabled = &rdbEnabled
 	}
 
-	// Set property ‘RdbFrequency’:
+	// Set property "RdbFrequency":
 	if typedInput.RdbFrequency != nil {
 		rdbFrequency := *typedInput.RdbFrequency
 		persistence.RdbFrequency = &rdbFrequency
@@ -1669,25 +1669,25 @@ func (persistence *Persistence_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Persistence_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AofEnabled’:
+	// Set property "AofEnabled":
 	if typedInput.AofEnabled != nil {
 		aofEnabled := *typedInput.AofEnabled
 		persistence.AofEnabled = &aofEnabled
 	}
 
-	// Set property ‘AofFrequency’:
+	// Set property "AofFrequency":
 	if typedInput.AofFrequency != nil {
 		aofFrequency := *typedInput.AofFrequency
 		persistence.AofFrequency = &aofFrequency
 	}
 
-	// Set property ‘RdbEnabled’:
+	// Set property "RdbEnabled":
 	if typedInput.RdbEnabled != nil {
 		rdbEnabled := *typedInput.RdbEnabled
 		persistence.RdbEnabled = &rdbEnabled
 	}
 
-	// Set property ‘RdbFrequency’:
+	// Set property "RdbFrequency":
 	if typedInput.RdbFrequency != nil {
 		rdbFrequency := *typedInput.RdbFrequency
 		persistence.RdbFrequency = &rdbFrequency

--- a/v2/api/cache/v1api20210301/redis_enterprise_types_gen.go
+++ b/v2/api/cache/v1api20210301/redis_enterprise_types_gen.go
@@ -353,16 +353,16 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &RedisEnterprise_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if enterprise.Location != nil {
 		location := *enterprise.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if enterprise.MinimumTlsVersion != nil {
 		result.Properties = &ClusterProperties_ARM{}
 	}
@@ -371,7 +371,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.MinimumTlsVersion = &minimumTlsVersion
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if enterprise.Sku != nil {
 		sku_ARM, err := (*enterprise.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -381,7 +381,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if enterprise.Tags != nil {
 		result.Tags = make(map[string]string, len(enterprise.Tags))
 		for key, value := range enterprise.Tags {
@@ -389,7 +389,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range enterprise.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -408,16 +408,16 @@ func (enterprise *RedisEnterprise_Spec) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisEnterprise_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	enterprise.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		enterprise.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -426,10 +426,10 @@ func (enterprise *RedisEnterprise_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	enterprise.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -440,7 +440,7 @@ func (enterprise *RedisEnterprise_Spec) PopulateFromARM(owner genruntime.Arbitra
 		enterprise.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		enterprise.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -448,7 +448,7 @@ func (enterprise *RedisEnterprise_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		enterprise.Zones = append(enterprise.Zones, item)
 	}
@@ -768,9 +768,9 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisEnterprise_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -779,19 +779,19 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		enterprise.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		enterprise.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -800,13 +800,13 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		enterprise.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -819,7 +819,7 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -828,7 +828,7 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘RedisVersion’:
+	// Set property "RedisVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedisVersion != nil {
@@ -837,7 +837,7 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘ResourceState’:
+	// Set property "ResourceState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceState != nil {
@@ -846,7 +846,7 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -857,7 +857,7 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		enterprise.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		enterprise.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -865,13 +865,13 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		enterprise.Type = &typeVar
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		enterprise.Zones = append(enterprise.Zones, item)
 	}
@@ -1103,7 +1103,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -1192,13 +1192,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sku.Capacity != nil {
 		capacity := *sku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -1218,13 +1218,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -1321,13 +1321,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name

--- a/v2/api/cache/v1beta20201201/redis_firewall_rule_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_firewall_rule_types_gen.go
@@ -336,10 +336,10 @@ func (rule *Redis_FirewallRule_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &Redis_FirewallRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.EndIP != nil || rule.StartIP != nil {
 		result.Properties = &RedisFirewallRuleProperties_ARM{}
 	}
@@ -366,10 +366,10 @@ func (rule *Redis_FirewallRule_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_FirewallRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EndIP’:
+	// Set property "EndIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIP != nil {
@@ -378,10 +378,10 @@ func (rule *Redis_FirewallRule_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘StartIP’:
+	// Set property "StartIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIP != nil {
@@ -587,9 +587,9 @@ func (rule *Redis_FirewallRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_FirewallRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EndIP’:
+	// Set property "EndIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIP != nil {
@@ -598,19 +598,19 @@ func (rule *Redis_FirewallRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘StartIP’:
+	// Set property "StartIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIP != nil {
@@ -619,7 +619,7 @@ func (rule *Redis_FirewallRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/cache/v1beta20201201/redis_linked_server_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_linked_server_types_gen.go
@@ -339,10 +339,10 @@ func (server *Redis_LinkedServer_Spec) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &Redis_LinkedServer_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if server.LinkedRedisCacheLocation != nil ||
 		server.LinkedRedisCacheReference != nil ||
 		server.ServerRole != nil {
@@ -379,10 +379,10 @@ func (server *Redis_LinkedServer_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_LinkedServer_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	server.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘LinkedRedisCacheLocation’:
+	// Set property "LinkedRedisCacheLocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinkedRedisCacheLocation != nil {
@@ -391,12 +391,12 @@ func (server *Redis_LinkedServer_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘LinkedRedisCacheReference’
+	// no assignment for property "LinkedRedisCacheReference"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ServerRole’:
+	// Set property "ServerRole":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServerRole != nil {
@@ -630,15 +630,15 @@ func (server *Redis_LinkedServer_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_LinkedServer_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		server.Id = &id
 	}
 
-	// Set property ‘LinkedRedisCacheId’:
+	// Set property "LinkedRedisCacheId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinkedRedisCacheId != nil {
@@ -647,7 +647,7 @@ func (server *Redis_LinkedServer_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘LinkedRedisCacheLocation’:
+	// Set property "LinkedRedisCacheLocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinkedRedisCacheLocation != nil {
@@ -656,13 +656,13 @@ func (server *Redis_LinkedServer_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		server.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -671,7 +671,7 @@ func (server *Redis_LinkedServer_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘ServerRole’:
+	// Set property "ServerRole":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServerRole != nil {
@@ -680,7 +680,7 @@ func (server *Redis_LinkedServer_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		server.Type = &typeVar

--- a/v2/api/cache/v1beta20201201/redis_patch_schedule_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_patch_schedule_types_gen.go
@@ -322,10 +322,10 @@ func (schedule *Redis_PatchSchedule_Spec) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &Redis_PatchSchedule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if schedule.ScheduleEntries != nil {
 		result.Properties = &ScheduleEntries_ARM{}
 	}
@@ -351,10 +351,10 @@ func (schedule *Redis_PatchSchedule_Spec) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_PatchSchedule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	schedule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ScheduleEntries’:
+	// Set property "ScheduleEntries":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ScheduleEntries {
@@ -579,27 +579,27 @@ func (schedule *Redis_PatchSchedule_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_PatchSchedule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		schedule.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		schedule.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		schedule.Name = &name
 	}
 
-	// Set property ‘ScheduleEntries’:
+	// Set property "ScheduleEntries":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ScheduleEntries {
@@ -612,7 +612,7 @@ func (schedule *Redis_PatchSchedule_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		schedule.Type = &typeVar
@@ -730,19 +730,19 @@ func (entry *ScheduleEntry) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &ScheduleEntry_ARM{}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if entry.DayOfWeek != nil {
 		dayOfWeek := *entry.DayOfWeek
 		result.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	if entry.MaintenanceWindow != nil {
 		maintenanceWindow := *entry.MaintenanceWindow
 		result.MaintenanceWindow = &maintenanceWindow
 	}
 
-	// Set property ‘StartHourUtc’:
+	// Set property "StartHourUtc":
 	if entry.StartHourUtc != nil {
 		startHourUtc := *entry.StartHourUtc
 		result.StartHourUtc = &startHourUtc
@@ -762,19 +762,19 @@ func (entry *ScheduleEntry) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduleEntry_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		entry.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	if typedInput.MaintenanceWindow != nil {
 		maintenanceWindow := *typedInput.MaintenanceWindow
 		entry.MaintenanceWindow = &maintenanceWindow
 	}
 
-	// Set property ‘StartHourUtc’:
+	// Set property "StartHourUtc":
 	if typedInput.StartHourUtc != nil {
 		startHourUtc := *typedInput.StartHourUtc
 		entry.StartHourUtc = &startHourUtc
@@ -856,19 +856,19 @@ func (entry *ScheduleEntry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduleEntry_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		entry.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	if typedInput.MaintenanceWindow != nil {
 		maintenanceWindow := *typedInput.MaintenanceWindow
 		entry.MaintenanceWindow = &maintenanceWindow
 	}
 
-	// Set property ‘StartHourUtc’:
+	// Set property "StartHourUtc":
 	if typedInput.StartHourUtc != nil {
 		startHourUtc := *typedInput.StartHourUtc
 		entry.StartHourUtc = &startHourUtc

--- a/v2/api/cache/v1beta20201201/redis_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_types_gen.go
@@ -383,16 +383,16 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &Redis_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if redis.Location != nil {
 		location := *redis.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if redis.EnableNonSslPort != nil ||
 		redis.MinimumTlsVersion != nil ||
 		redis.PublicNetworkAccess != nil ||
@@ -470,7 +470,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if redis.Tags != nil {
 		result.Tags = make(map[string]string, len(redis.Tags))
 		for key, value := range redis.Tags {
@@ -478,7 +478,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range redis.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -497,10 +497,10 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	redis.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EnableNonSslPort’:
+	// Set property "EnableNonSslPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNonSslPort != nil {
@@ -509,13 +509,13 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		redis.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -524,12 +524,12 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	redis.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -538,7 +538,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘RedisConfiguration’:
+	// Set property "RedisConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedisConfiguration != nil {
@@ -552,7 +552,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘RedisVersion’:
+	// Set property "RedisVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedisVersion != nil {
@@ -561,7 +561,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ReplicasPerMaster’:
+	// Set property "ReplicasPerMaster":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicasPerMaster != nil {
@@ -570,7 +570,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ReplicasPerPrimary’:
+	// Set property "ReplicasPerPrimary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicasPerPrimary != nil {
@@ -579,7 +579,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ShardCount’:
+	// Set property "ShardCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ShardCount != nil {
@@ -588,7 +588,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -602,7 +602,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘StaticIP’:
+	// Set property "StaticIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StaticIP != nil {
@@ -611,9 +611,9 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// no assignment for property ‘SubnetReference’
+	// no assignment for property "SubnetReference"
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		redis.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -621,7 +621,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘TenantSettings’:
+	// Set property "TenantSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantSettings != nil {
@@ -632,7 +632,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		redis.Zones = append(redis.Zones, item)
 	}
@@ -1042,9 +1042,9 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Redis_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EnableNonSslPort’:
+	// Set property "EnableNonSslPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNonSslPort != nil {
@@ -1053,7 +1053,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -1062,13 +1062,13 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		redis.Id = &id
 	}
 
-	// Set property ‘Instances’:
+	// Set property "Instances":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Instances {
@@ -1081,7 +1081,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘LinkedServers’:
+	// Set property "LinkedServers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LinkedServers {
@@ -1094,13 +1094,13 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		redis.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -1109,13 +1109,13 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		redis.Name = &name
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Port != nil {
@@ -1124,7 +1124,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1137,7 +1137,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1146,7 +1146,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1155,7 +1155,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘RedisConfiguration’:
+	// Set property "RedisConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedisConfiguration != nil {
@@ -1169,7 +1169,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘RedisVersion’:
+	// Set property "RedisVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedisVersion != nil {
@@ -1178,7 +1178,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘ReplicasPerMaster’:
+	// Set property "ReplicasPerMaster":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicasPerMaster != nil {
@@ -1187,7 +1187,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘ReplicasPerPrimary’:
+	// Set property "ReplicasPerPrimary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicasPerPrimary != nil {
@@ -1196,7 +1196,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘ShardCount’:
+	// Set property "ShardCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ShardCount != nil {
@@ -1205,7 +1205,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -1219,7 +1219,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘SslPort’:
+	// Set property "SslPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SslPort != nil {
@@ -1228,7 +1228,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘StaticIP’:
+	// Set property "StaticIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StaticIP != nil {
@@ -1237,7 +1237,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘SubnetId’:
+	// Set property "SubnetId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SubnetId != nil {
@@ -1246,7 +1246,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		redis.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1254,7 +1254,7 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘TenantSettings’:
+	// Set property "TenantSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantSettings != nil {
@@ -1265,13 +1265,13 @@ func (redis *Redis_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		redis.Type = &typeVar
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		redis.Zones = append(redis.Zones, item)
 	}
@@ -1644,7 +1644,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -1730,7 +1730,7 @@ func (configuration *RedisCreateProperties_RedisConfiguration) ConvertToARM(reso
 	}
 	result := &RedisCreateProperties_RedisConfiguration_ARM{}
 
-	// Set property ‘AdditionalProperties’:
+	// Set property "AdditionalProperties":
 	if configuration.AdditionalProperties != nil {
 		result.AdditionalProperties = make(map[string]string, len(configuration.AdditionalProperties))
 		for key, value := range configuration.AdditionalProperties {
@@ -1738,73 +1738,73 @@ func (configuration *RedisCreateProperties_RedisConfiguration) ConvertToARM(reso
 		}
 	}
 
-	// Set property ‘AofBackupEnabled’:
+	// Set property "AofBackupEnabled":
 	if configuration.AofBackupEnabled != nil {
 		aofBackupEnabled := *configuration.AofBackupEnabled
 		result.AofBackupEnabled = &aofBackupEnabled
 	}
 
-	// Set property ‘AofStorageConnectionString0’:
+	// Set property "AofStorageConnectionString0":
 	if configuration.AofStorageConnectionString0 != nil {
 		aofStorageConnectionString0 := *configuration.AofStorageConnectionString0
 		result.AofStorageConnectionString0 = &aofStorageConnectionString0
 	}
 
-	// Set property ‘AofStorageConnectionString1’:
+	// Set property "AofStorageConnectionString1":
 	if configuration.AofStorageConnectionString1 != nil {
 		aofStorageConnectionString1 := *configuration.AofStorageConnectionString1
 		result.AofStorageConnectionString1 = &aofStorageConnectionString1
 	}
 
-	// Set property ‘Authnotrequired’:
+	// Set property "Authnotrequired":
 	if configuration.Authnotrequired != nil {
 		authnotrequired := *configuration.Authnotrequired
 		result.Authnotrequired = &authnotrequired
 	}
 
-	// Set property ‘MaxfragmentationmemoryReserved’:
+	// Set property "MaxfragmentationmemoryReserved":
 	if configuration.MaxfragmentationmemoryReserved != nil {
 		maxfragmentationmemoryReserved := *configuration.MaxfragmentationmemoryReserved
 		result.MaxfragmentationmemoryReserved = &maxfragmentationmemoryReserved
 	}
 
-	// Set property ‘MaxmemoryDelta’:
+	// Set property "MaxmemoryDelta":
 	if configuration.MaxmemoryDelta != nil {
 		maxmemoryDelta := *configuration.MaxmemoryDelta
 		result.MaxmemoryDelta = &maxmemoryDelta
 	}
 
-	// Set property ‘MaxmemoryPolicy’:
+	// Set property "MaxmemoryPolicy":
 	if configuration.MaxmemoryPolicy != nil {
 		maxmemoryPolicy := *configuration.MaxmemoryPolicy
 		result.MaxmemoryPolicy = &maxmemoryPolicy
 	}
 
-	// Set property ‘MaxmemoryReserved’:
+	// Set property "MaxmemoryReserved":
 	if configuration.MaxmemoryReserved != nil {
 		maxmemoryReserved := *configuration.MaxmemoryReserved
 		result.MaxmemoryReserved = &maxmemoryReserved
 	}
 
-	// Set property ‘RdbBackupEnabled’:
+	// Set property "RdbBackupEnabled":
 	if configuration.RdbBackupEnabled != nil {
 		rdbBackupEnabled := *configuration.RdbBackupEnabled
 		result.RdbBackupEnabled = &rdbBackupEnabled
 	}
 
-	// Set property ‘RdbBackupFrequency’:
+	// Set property "RdbBackupFrequency":
 	if configuration.RdbBackupFrequency != nil {
 		rdbBackupFrequency := *configuration.RdbBackupFrequency
 		result.RdbBackupFrequency = &rdbBackupFrequency
 	}
 
-	// Set property ‘RdbBackupMaxSnapshotCount’:
+	// Set property "RdbBackupMaxSnapshotCount":
 	if configuration.RdbBackupMaxSnapshotCount != nil {
 		rdbBackupMaxSnapshotCount := *configuration.RdbBackupMaxSnapshotCount
 		result.RdbBackupMaxSnapshotCount = &rdbBackupMaxSnapshotCount
 	}
 
-	// Set property ‘RdbStorageConnectionString’:
+	// Set property "RdbStorageConnectionString":
 	if configuration.RdbStorageConnectionString != nil {
 		rdbStorageConnectionString := *configuration.RdbStorageConnectionString
 		result.RdbStorageConnectionString = &rdbStorageConnectionString
@@ -1824,7 +1824,7 @@ func (configuration *RedisCreateProperties_RedisConfiguration) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisCreateProperties_RedisConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalProperties’:
+	// Set property "AdditionalProperties":
 	if typedInput.AdditionalProperties != nil {
 		configuration.AdditionalProperties = make(map[string]string, len(typedInput.AdditionalProperties))
 		for key, value := range typedInput.AdditionalProperties {
@@ -1832,73 +1832,73 @@ func (configuration *RedisCreateProperties_RedisConfiguration) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘AofBackupEnabled’:
+	// Set property "AofBackupEnabled":
 	if typedInput.AofBackupEnabled != nil {
 		aofBackupEnabled := *typedInput.AofBackupEnabled
 		configuration.AofBackupEnabled = &aofBackupEnabled
 	}
 
-	// Set property ‘AofStorageConnectionString0’:
+	// Set property "AofStorageConnectionString0":
 	if typedInput.AofStorageConnectionString0 != nil {
 		aofStorageConnectionString0 := *typedInput.AofStorageConnectionString0
 		configuration.AofStorageConnectionString0 = &aofStorageConnectionString0
 	}
 
-	// Set property ‘AofStorageConnectionString1’:
+	// Set property "AofStorageConnectionString1":
 	if typedInput.AofStorageConnectionString1 != nil {
 		aofStorageConnectionString1 := *typedInput.AofStorageConnectionString1
 		configuration.AofStorageConnectionString1 = &aofStorageConnectionString1
 	}
 
-	// Set property ‘Authnotrequired’:
+	// Set property "Authnotrequired":
 	if typedInput.Authnotrequired != nil {
 		authnotrequired := *typedInput.Authnotrequired
 		configuration.Authnotrequired = &authnotrequired
 	}
 
-	// Set property ‘MaxfragmentationmemoryReserved’:
+	// Set property "MaxfragmentationmemoryReserved":
 	if typedInput.MaxfragmentationmemoryReserved != nil {
 		maxfragmentationmemoryReserved := *typedInput.MaxfragmentationmemoryReserved
 		configuration.MaxfragmentationmemoryReserved = &maxfragmentationmemoryReserved
 	}
 
-	// Set property ‘MaxmemoryDelta’:
+	// Set property "MaxmemoryDelta":
 	if typedInput.MaxmemoryDelta != nil {
 		maxmemoryDelta := *typedInput.MaxmemoryDelta
 		configuration.MaxmemoryDelta = &maxmemoryDelta
 	}
 
-	// Set property ‘MaxmemoryPolicy’:
+	// Set property "MaxmemoryPolicy":
 	if typedInput.MaxmemoryPolicy != nil {
 		maxmemoryPolicy := *typedInput.MaxmemoryPolicy
 		configuration.MaxmemoryPolicy = &maxmemoryPolicy
 	}
 
-	// Set property ‘MaxmemoryReserved’:
+	// Set property "MaxmemoryReserved":
 	if typedInput.MaxmemoryReserved != nil {
 		maxmemoryReserved := *typedInput.MaxmemoryReserved
 		configuration.MaxmemoryReserved = &maxmemoryReserved
 	}
 
-	// Set property ‘RdbBackupEnabled’:
+	// Set property "RdbBackupEnabled":
 	if typedInput.RdbBackupEnabled != nil {
 		rdbBackupEnabled := *typedInput.RdbBackupEnabled
 		configuration.RdbBackupEnabled = &rdbBackupEnabled
 	}
 
-	// Set property ‘RdbBackupFrequency’:
+	// Set property "RdbBackupFrequency":
 	if typedInput.RdbBackupFrequency != nil {
 		rdbBackupFrequency := *typedInput.RdbBackupFrequency
 		configuration.RdbBackupFrequency = &rdbBackupFrequency
 	}
 
-	// Set property ‘RdbBackupMaxSnapshotCount’:
+	// Set property "RdbBackupMaxSnapshotCount":
 	if typedInput.RdbBackupMaxSnapshotCount != nil {
 		rdbBackupMaxSnapshotCount := *typedInput.RdbBackupMaxSnapshotCount
 		configuration.RdbBackupMaxSnapshotCount = &rdbBackupMaxSnapshotCount
 	}
 
-	// Set property ‘RdbStorageConnectionString’:
+	// Set property "RdbStorageConnectionString":
 	if typedInput.RdbStorageConnectionString != nil {
 		rdbStorageConnectionString := *typedInput.RdbStorageConnectionString
 		configuration.RdbStorageConnectionString = &rdbStorageConnectionString
@@ -2033,37 +2033,37 @@ func (details *RedisInstanceDetails_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisInstanceDetails_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IsMaster’:
+	// Set property "IsMaster":
 	if typedInput.IsMaster != nil {
 		isMaster := *typedInput.IsMaster
 		details.IsMaster = &isMaster
 	}
 
-	// Set property ‘IsPrimary’:
+	// Set property "IsPrimary":
 	if typedInput.IsPrimary != nil {
 		isPrimary := *typedInput.IsPrimary
 		details.IsPrimary = &isPrimary
 	}
 
-	// Set property ‘NonSslPort’:
+	// Set property "NonSslPort":
 	if typedInput.NonSslPort != nil {
 		nonSslPort := *typedInput.NonSslPort
 		details.NonSslPort = &nonSslPort
 	}
 
-	// Set property ‘ShardId’:
+	// Set property "ShardId":
 	if typedInput.ShardId != nil {
 		shardId := *typedInput.ShardId
 		details.ShardId = &shardId
 	}
 
-	// Set property ‘SslPort’:
+	// Set property "SslPort":
 	if typedInput.SslPort != nil {
 		sslPort := *typedInput.SslPort
 		details.SslPort = &sslPort
 	}
 
-	// Set property ‘Zone’:
+	// Set property "Zone":
 	if typedInput.Zone != nil {
 		zone := *typedInput.Zone
 		details.Zone = &zone
@@ -2171,7 +2171,7 @@ func (server *RedisLinkedServer_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisLinkedServer_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		server.Id = &id
@@ -2334,7 +2334,7 @@ func (configuration *RedisProperties_RedisConfiguration_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisProperties_RedisConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalProperties’:
+	// Set property "AdditionalProperties":
 	if typedInput.AdditionalProperties != nil {
 		configuration.AdditionalProperties = make(map[string]string, len(typedInput.AdditionalProperties))
 		for key, value := range typedInput.AdditionalProperties {
@@ -2342,85 +2342,85 @@ func (configuration *RedisProperties_RedisConfiguration_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘AofBackupEnabled’:
+	// Set property "AofBackupEnabled":
 	if typedInput.AofBackupEnabled != nil {
 		aofBackupEnabled := *typedInput.AofBackupEnabled
 		configuration.AofBackupEnabled = &aofBackupEnabled
 	}
 
-	// Set property ‘AofStorageConnectionString0’:
+	// Set property "AofStorageConnectionString0":
 	if typedInput.AofStorageConnectionString0 != nil {
 		aofStorageConnectionString0 := *typedInput.AofStorageConnectionString0
 		configuration.AofStorageConnectionString0 = &aofStorageConnectionString0
 	}
 
-	// Set property ‘AofStorageConnectionString1’:
+	// Set property "AofStorageConnectionString1":
 	if typedInput.AofStorageConnectionString1 != nil {
 		aofStorageConnectionString1 := *typedInput.AofStorageConnectionString1
 		configuration.AofStorageConnectionString1 = &aofStorageConnectionString1
 	}
 
-	// Set property ‘Authnotrequired’:
+	// Set property "Authnotrequired":
 	if typedInput.Authnotrequired != nil {
 		authnotrequired := *typedInput.Authnotrequired
 		configuration.Authnotrequired = &authnotrequired
 	}
 
-	// Set property ‘Maxclients’:
+	// Set property "Maxclients":
 	if typedInput.Maxclients != nil {
 		maxclients := *typedInput.Maxclients
 		configuration.Maxclients = &maxclients
 	}
 
-	// Set property ‘MaxfragmentationmemoryReserved’:
+	// Set property "MaxfragmentationmemoryReserved":
 	if typedInput.MaxfragmentationmemoryReserved != nil {
 		maxfragmentationmemoryReserved := *typedInput.MaxfragmentationmemoryReserved
 		configuration.MaxfragmentationmemoryReserved = &maxfragmentationmemoryReserved
 	}
 
-	// Set property ‘MaxmemoryDelta’:
+	// Set property "MaxmemoryDelta":
 	if typedInput.MaxmemoryDelta != nil {
 		maxmemoryDelta := *typedInput.MaxmemoryDelta
 		configuration.MaxmemoryDelta = &maxmemoryDelta
 	}
 
-	// Set property ‘MaxmemoryPolicy’:
+	// Set property "MaxmemoryPolicy":
 	if typedInput.MaxmemoryPolicy != nil {
 		maxmemoryPolicy := *typedInput.MaxmemoryPolicy
 		configuration.MaxmemoryPolicy = &maxmemoryPolicy
 	}
 
-	// Set property ‘MaxmemoryReserved’:
+	// Set property "MaxmemoryReserved":
 	if typedInput.MaxmemoryReserved != nil {
 		maxmemoryReserved := *typedInput.MaxmemoryReserved
 		configuration.MaxmemoryReserved = &maxmemoryReserved
 	}
 
-	// Set property ‘RdbBackupEnabled’:
+	// Set property "RdbBackupEnabled":
 	if typedInput.RdbBackupEnabled != nil {
 		rdbBackupEnabled := *typedInput.RdbBackupEnabled
 		configuration.RdbBackupEnabled = &rdbBackupEnabled
 	}
 
-	// Set property ‘RdbBackupFrequency’:
+	// Set property "RdbBackupFrequency":
 	if typedInput.RdbBackupFrequency != nil {
 		rdbBackupFrequency := *typedInput.RdbBackupFrequency
 		configuration.RdbBackupFrequency = &rdbBackupFrequency
 	}
 
-	// Set property ‘RdbBackupMaxSnapshotCount’:
+	// Set property "RdbBackupMaxSnapshotCount":
 	if typedInput.RdbBackupMaxSnapshotCount != nil {
 		rdbBackupMaxSnapshotCount := *typedInput.RdbBackupMaxSnapshotCount
 		configuration.RdbBackupMaxSnapshotCount = &rdbBackupMaxSnapshotCount
 	}
 
-	// Set property ‘RdbStorageConnectionString’:
+	// Set property "RdbStorageConnectionString":
 	if typedInput.RdbStorageConnectionString != nil {
 		rdbStorageConnectionString := *typedInput.RdbStorageConnectionString
 		configuration.RdbStorageConnectionString = &rdbStorageConnectionString
 	}
 
-	// Set property ‘ZonalConfiguration’:
+	// Set property "ZonalConfiguration":
 	if typedInput.ZonalConfiguration != nil {
 		zonalConfiguration := *typedInput.ZonalConfiguration
 		configuration.ZonalConfiguration = &zonalConfiguration
@@ -2564,19 +2564,19 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sku.Capacity != nil {
 		capacity := *sku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if sku.Family != nil {
 		family := *sku.Family
 		result.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -2596,19 +2596,19 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -2700,19 +2700,19 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name

--- a/v2/api/cache/v1beta20210301/redis_enterprise_database_types_gen.go
+++ b/v2/api/cache/v1beta20210301/redis_enterprise_database_types_gen.go
@@ -336,10 +336,10 @@ func (database *RedisEnterprise_Database_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &RedisEnterprise_Database_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.ClientProtocol != nil ||
 		database.ClusteringPolicy != nil ||
 		database.EvictionPolicy != nil ||
@@ -394,10 +394,10 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisEnterprise_Database_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘ClientProtocol’:
+	// Set property "ClientProtocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientProtocol != nil {
@@ -406,7 +406,7 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ClusteringPolicy’:
+	// Set property "ClusteringPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClusteringPolicy != nil {
@@ -415,7 +415,7 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EvictionPolicy != nil {
@@ -424,7 +424,7 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Modules’:
+	// Set property "Modules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Modules {
@@ -437,10 +437,10 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Persistence’:
+	// Set property "Persistence":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Persistence != nil {
@@ -454,7 +454,7 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Port != nil {
@@ -771,7 +771,7 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisEnterprise_Database_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientProtocol’:
+	// Set property "ClientProtocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientProtocol != nil {
@@ -780,7 +780,7 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ClusteringPolicy’:
+	// Set property "ClusteringPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClusteringPolicy != nil {
@@ -789,9 +789,9 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EvictionPolicy != nil {
@@ -800,13 +800,13 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Modules’:
+	// Set property "Modules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Modules {
@@ -819,13 +819,13 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘Persistence’:
+	// Set property "Persistence":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Persistence != nil {
@@ -839,7 +839,7 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Port != nil {
@@ -848,7 +848,7 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -857,7 +857,7 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ResourceState’:
+	// Set property "ResourceState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceState != nil {
@@ -866,7 +866,7 @@ func (database *RedisEnterprise_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar
@@ -1152,13 +1152,13 @@ func (module *Module) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &Module_ARM{}
 
-	// Set property ‘Args’:
+	// Set property "Args":
 	if module.Args != nil {
 		args := *module.Args
 		result.Args = &args
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if module.Name != nil {
 		name := *module.Name
 		result.Name = &name
@@ -1178,13 +1178,13 @@ func (module *Module) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Module_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Args’:
+	// Set property "Args":
 	if typedInput.Args != nil {
 		args := *typedInput.Args
 		module.Args = &args
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		module.Name = &name
@@ -1250,19 +1250,19 @@ func (module *Module_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Module_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Args’:
+	// Set property "Args":
 	if typedInput.Args != nil {
 		args := *typedInput.Args
 		module.Args = &args
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		module.Name = &name
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		module.Version = &version
@@ -1330,25 +1330,25 @@ func (persistence *Persistence) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &Persistence_ARM{}
 
-	// Set property ‘AofEnabled’:
+	// Set property "AofEnabled":
 	if persistence.AofEnabled != nil {
 		aofEnabled := *persistence.AofEnabled
 		result.AofEnabled = &aofEnabled
 	}
 
-	// Set property ‘AofFrequency’:
+	// Set property "AofFrequency":
 	if persistence.AofFrequency != nil {
 		aofFrequency := *persistence.AofFrequency
 		result.AofFrequency = &aofFrequency
 	}
 
-	// Set property ‘RdbEnabled’:
+	// Set property "RdbEnabled":
 	if persistence.RdbEnabled != nil {
 		rdbEnabled := *persistence.RdbEnabled
 		result.RdbEnabled = &rdbEnabled
 	}
 
-	// Set property ‘RdbFrequency’:
+	// Set property "RdbFrequency":
 	if persistence.RdbFrequency != nil {
 		rdbFrequency := *persistence.RdbFrequency
 		result.RdbFrequency = &rdbFrequency
@@ -1368,25 +1368,25 @@ func (persistence *Persistence) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Persistence_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AofEnabled’:
+	// Set property "AofEnabled":
 	if typedInput.AofEnabled != nil {
 		aofEnabled := *typedInput.AofEnabled
 		persistence.AofEnabled = &aofEnabled
 	}
 
-	// Set property ‘AofFrequency’:
+	// Set property "AofFrequency":
 	if typedInput.AofFrequency != nil {
 		aofFrequency := *typedInput.AofFrequency
 		persistence.AofFrequency = &aofFrequency
 	}
 
-	// Set property ‘RdbEnabled’:
+	// Set property "RdbEnabled":
 	if typedInput.RdbEnabled != nil {
 		rdbEnabled := *typedInput.RdbEnabled
 		persistence.RdbEnabled = &rdbEnabled
 	}
 
-	// Set property ‘RdbFrequency’:
+	// Set property "RdbFrequency":
 	if typedInput.RdbFrequency != nil {
 		rdbFrequency := *typedInput.RdbFrequency
 		persistence.RdbFrequency = &rdbFrequency
@@ -1505,25 +1505,25 @@ func (persistence *Persistence_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Persistence_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AofEnabled’:
+	// Set property "AofEnabled":
 	if typedInput.AofEnabled != nil {
 		aofEnabled := *typedInput.AofEnabled
 		persistence.AofEnabled = &aofEnabled
 	}
 
-	// Set property ‘AofFrequency’:
+	// Set property "AofFrequency":
 	if typedInput.AofFrequency != nil {
 		aofFrequency := *typedInput.AofFrequency
 		persistence.AofFrequency = &aofFrequency
 	}
 
-	// Set property ‘RdbEnabled’:
+	// Set property "RdbEnabled":
 	if typedInput.RdbEnabled != nil {
 		rdbEnabled := *typedInput.RdbEnabled
 		persistence.RdbEnabled = &rdbEnabled
 	}
 
-	// Set property ‘RdbFrequency’:
+	// Set property "RdbFrequency":
 	if typedInput.RdbFrequency != nil {
 		rdbFrequency := *typedInput.RdbFrequency
 		persistence.RdbFrequency = &rdbFrequency

--- a/v2/api/cache/v1beta20210301/redis_enterprise_types_gen.go
+++ b/v2/api/cache/v1beta20210301/redis_enterprise_types_gen.go
@@ -345,16 +345,16 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &RedisEnterprise_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if enterprise.Location != nil {
 		location := *enterprise.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if enterprise.MinimumTlsVersion != nil {
 		result.Properties = &ClusterProperties_ARM{}
 	}
@@ -363,7 +363,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.MinimumTlsVersion = &minimumTlsVersion
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if enterprise.Sku != nil {
 		sku_ARM, err := (*enterprise.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -373,7 +373,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if enterprise.Tags != nil {
 		result.Tags = make(map[string]string, len(enterprise.Tags))
 		for key, value := range enterprise.Tags {
@@ -381,7 +381,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range enterprise.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -400,16 +400,16 @@ func (enterprise *RedisEnterprise_Spec) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisEnterprise_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	enterprise.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		enterprise.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -418,10 +418,10 @@ func (enterprise *RedisEnterprise_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	enterprise.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -432,7 +432,7 @@ func (enterprise *RedisEnterprise_Spec) PopulateFromARM(owner genruntime.Arbitra
 		enterprise.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		enterprise.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -440,7 +440,7 @@ func (enterprise *RedisEnterprise_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		enterprise.Zones = append(enterprise.Zones, item)
 	}
@@ -698,9 +698,9 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RedisEnterprise_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -709,19 +709,19 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		enterprise.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		enterprise.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -730,13 +730,13 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		enterprise.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -749,7 +749,7 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -758,7 +758,7 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘RedisVersion’:
+	// Set property "RedisVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedisVersion != nil {
@@ -767,7 +767,7 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘ResourceState’:
+	// Set property "ResourceState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceState != nil {
@@ -776,7 +776,7 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -787,7 +787,7 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		enterprise.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		enterprise.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -795,13 +795,13 @@ func (enterprise *RedisEnterprise_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		enterprise.Type = &typeVar
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		enterprise.Zones = append(enterprise.Zones, item)
 	}
@@ -1034,7 +1034,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -1120,13 +1120,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sku.Capacity != nil {
 		capacity := *sku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -1146,13 +1146,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -1227,13 +1227,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name

--- a/v2/api/cdn/v1api20210601/profile_types_gen.go
+++ b/v2/api/cdn/v1api20210601/profile_types_gen.go
@@ -353,16 +353,16 @@ func (profile *Profile_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &Profile_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if profile.Location != nil {
 		location := *profile.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if profile.OriginResponseTimeoutSeconds != nil {
 		result.Properties = &ProfileProperties_ARM{}
 	}
@@ -371,7 +371,7 @@ func (profile *Profile_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.OriginResponseTimeoutSeconds = &originResponseTimeoutSeconds
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if profile.Sku != nil {
 		sku_ARM, err := (*profile.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -381,7 +381,7 @@ func (profile *Profile_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if profile.Tags != nil {
 		result.Tags = make(map[string]string, len(profile.Tags))
 		for key, value := range profile.Tags {
@@ -403,16 +403,16 @@ func (profile *Profile_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Profile_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	profile.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		profile.Location = &location
 	}
 
-	// Set property ‘OriginResponseTimeoutSeconds’:
+	// Set property "OriginResponseTimeoutSeconds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginResponseTimeoutSeconds != nil {
@@ -421,10 +421,10 @@ func (profile *Profile_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	profile.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -435,7 +435,7 @@ func (profile *Profile_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		profile.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		profile.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -746,9 +746,9 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Profile_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘FrontDoorId’:
+	// Set property "FrontDoorId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontDoorId != nil {
@@ -757,31 +757,31 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		profile.Id = &id
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		profile.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		profile.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘OriginResponseTimeoutSeconds’:
+	// Set property "OriginResponseTimeoutSeconds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginResponseTimeoutSeconds != nil {
@@ -790,7 +790,7 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -799,7 +799,7 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ResourceState’:
+	// Set property "ResourceState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceState != nil {
@@ -808,7 +808,7 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -819,7 +819,7 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -830,7 +830,7 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		profile.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -838,7 +838,7 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
@@ -1062,7 +1062,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -1082,7 +1082,7 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -1189,7 +1189,7 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -1273,37 +1273,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType

--- a/v2/api/cdn/v1api20210601/profiles_endpoint_types_gen.go
+++ b/v2/api/cdn/v1api20210601/profiles_endpoint_types_gen.go
@@ -401,16 +401,16 @@ func (endpoint *Profiles_Endpoint_Spec) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &Profiles_Endpoint_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if endpoint.Location != nil {
 		location := *endpoint.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if endpoint.ContentTypesToCompress != nil ||
 		endpoint.DefaultOriginGroup != nil ||
 		endpoint.DeliveryPolicy != nil ||
@@ -517,7 +517,7 @@ func (endpoint *Profiles_Endpoint_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.WebApplicationFirewallPolicyLink = &webApplicationFirewallPolicyLink
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if endpoint.Tags != nil {
 		result.Tags = make(map[string]string, len(endpoint.Tags))
 		for key, value := range endpoint.Tags {
@@ -539,10 +539,10 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Profiles_Endpoint_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	endpoint.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘ContentTypesToCompress’:
+	// Set property "ContentTypesToCompress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ContentTypesToCompress {
@@ -550,7 +550,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘DefaultOriginGroup’:
+	// Set property "DefaultOriginGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultOriginGroup != nil {
@@ -564,7 +564,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘DeliveryPolicy’:
+	// Set property "DeliveryPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeliveryPolicy != nil {
@@ -578,7 +578,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘GeoFilters’:
+	// Set property "GeoFilters":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.GeoFilters {
@@ -591,7 +591,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘IsCompressionEnabled’:
+	// Set property "IsCompressionEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsCompressionEnabled != nil {
@@ -600,7 +600,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘IsHttpAllowed’:
+	// Set property "IsHttpAllowed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHttpAllowed != nil {
@@ -609,7 +609,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘IsHttpsAllowed’:
+	// Set property "IsHttpsAllowed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHttpsAllowed != nil {
@@ -618,13 +618,13 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		endpoint.Location = &location
 	}
 
-	// Set property ‘OptimizationType’:
+	// Set property "OptimizationType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OptimizationType != nil {
@@ -633,7 +633,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘OriginGroups’:
+	// Set property "OriginGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.OriginGroups {
@@ -646,7 +646,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘OriginHostHeader’:
+	// Set property "OriginHostHeader":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginHostHeader != nil {
@@ -655,7 +655,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘OriginPath’:
+	// Set property "OriginPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginPath != nil {
@@ -664,7 +664,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Origins’:
+	// Set property "Origins":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Origins {
@@ -677,10 +677,10 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	endpoint.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ProbePath’:
+	// Set property "ProbePath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProbePath != nil {
@@ -689,7 +689,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘QueryStringCachingBehavior’:
+	// Set property "QueryStringCachingBehavior":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.QueryStringCachingBehavior != nil {
@@ -698,7 +698,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		endpoint.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -706,7 +706,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘UrlSigningKeys’:
+	// Set property "UrlSigningKeys":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.UrlSigningKeys {
@@ -719,7 +719,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘WebApplicationFirewallPolicyLink’:
+	// Set property "WebApplicationFirewallPolicyLink":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WebApplicationFirewallPolicyLink != nil {
@@ -1511,9 +1511,9 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Profiles_Endpoint_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ContentTypesToCompress’:
+	// Set property "ContentTypesToCompress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ContentTypesToCompress {
@@ -1521,7 +1521,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘CustomDomains’:
+	// Set property "CustomDomains":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CustomDomains {
@@ -1534,7 +1534,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘DefaultOriginGroup’:
+	// Set property "DefaultOriginGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultOriginGroup != nil {
@@ -1548,7 +1548,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘DeliveryPolicy’:
+	// Set property "DeliveryPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeliveryPolicy != nil {
@@ -1562,7 +1562,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘GeoFilters’:
+	// Set property "GeoFilters":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.GeoFilters {
@@ -1575,7 +1575,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -1584,13 +1584,13 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		endpoint.Id = &id
 	}
 
-	// Set property ‘IsCompressionEnabled’:
+	// Set property "IsCompressionEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsCompressionEnabled != nil {
@@ -1599,7 +1599,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘IsHttpAllowed’:
+	// Set property "IsHttpAllowed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHttpAllowed != nil {
@@ -1608,7 +1608,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘IsHttpsAllowed’:
+	// Set property "IsHttpsAllowed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHttpsAllowed != nil {
@@ -1617,19 +1617,19 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		endpoint.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		endpoint.Name = &name
 	}
 
-	// Set property ‘OptimizationType’:
+	// Set property "OptimizationType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OptimizationType != nil {
@@ -1638,7 +1638,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘OriginGroups’:
+	// Set property "OriginGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.OriginGroups {
@@ -1651,7 +1651,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘OriginHostHeader’:
+	// Set property "OriginHostHeader":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginHostHeader != nil {
@@ -1660,7 +1660,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘OriginPath’:
+	// Set property "OriginPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginPath != nil {
@@ -1669,7 +1669,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Origins’:
+	// Set property "Origins":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Origins {
@@ -1682,7 +1682,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘ProbePath’:
+	// Set property "ProbePath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProbePath != nil {
@@ -1691,7 +1691,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1700,7 +1700,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘QueryStringCachingBehavior’:
+	// Set property "QueryStringCachingBehavior":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.QueryStringCachingBehavior != nil {
@@ -1709,7 +1709,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘ResourceState’:
+	// Set property "ResourceState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceState != nil {
@@ -1718,7 +1718,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1729,7 +1729,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		endpoint.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		endpoint.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1737,13 +1737,13 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		endpoint.Type = &typeVar
 	}
 
-	// Set property ‘UrlSigningKeys’:
+	// Set property "UrlSigningKeys":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.UrlSigningKeys {
@@ -1756,7 +1756,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘WebApplicationFirewallPolicyLink’:
+	// Set property "WebApplicationFirewallPolicyLink":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WebApplicationFirewallPolicyLink != nil {
@@ -2278,7 +2278,7 @@ func (domain *DeepCreatedCustomDomain_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeepCreatedCustomDomain_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -2287,13 +2287,13 @@ func (domain *DeepCreatedCustomDomain_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		domain.Name = &name
 	}
 
-	// Set property ‘ValidationData’:
+	// Set property "ValidationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ValidationData != nil {
@@ -2412,13 +2412,13 @@ func (origin *DeepCreatedOrigin) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &DeepCreatedOrigin_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if origin.Name != nil {
 		name := *origin.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if origin.Enabled != nil ||
 		origin.HostName != nil ||
 		origin.HttpPort != nil ||
@@ -2499,7 +2499,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeepCreatedOrigin_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Enabled != nil {
@@ -2508,7 +2508,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -2517,7 +2517,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘HttpPort’:
+	// Set property "HttpPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpPort != nil {
@@ -2526,7 +2526,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘HttpsPort’:
+	// Set property "HttpsPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpsPort != nil {
@@ -2535,13 +2535,13 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		origin.Name = &name
 	}
 
-	// Set property ‘OriginHostHeader’:
+	// Set property "OriginHostHeader":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginHostHeader != nil {
@@ -2550,7 +2550,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -2559,7 +2559,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PrivateLinkAlias’:
+	// Set property "PrivateLinkAlias":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkAlias != nil {
@@ -2568,7 +2568,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PrivateLinkApprovalMessage’:
+	// Set property "PrivateLinkApprovalMessage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkApprovalMessage != nil {
@@ -2577,11 +2577,11 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// no assignment for property ‘PrivateLinkLocationReference’
+	// no assignment for property "PrivateLinkLocationReference"
 
-	// no assignment for property ‘PrivateLinkResourceReference’
+	// no assignment for property "PrivateLinkResourceReference"
 
-	// Set property ‘Weight’:
+	// Set property "Weight":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Weight != nil {
@@ -2891,7 +2891,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeepCreatedOrigin_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Enabled != nil {
@@ -2900,7 +2900,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -2909,7 +2909,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘HttpPort’:
+	// Set property "HttpPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpPort != nil {
@@ -2918,7 +2918,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘HttpsPort’:
+	// Set property "HttpsPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpsPort != nil {
@@ -2927,13 +2927,13 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		origin.Name = &name
 	}
 
-	// Set property ‘OriginHostHeader’:
+	// Set property "OriginHostHeader":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginHostHeader != nil {
@@ -2942,7 +2942,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -2951,7 +2951,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘PrivateEndpointStatus’:
+	// Set property "PrivateEndpointStatus":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateEndpointStatus != nil {
@@ -2960,7 +2960,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘PrivateLinkAlias’:
+	// Set property "PrivateLinkAlias":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkAlias != nil {
@@ -2969,7 +2969,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘PrivateLinkApprovalMessage’:
+	// Set property "PrivateLinkApprovalMessage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkApprovalMessage != nil {
@@ -2978,7 +2978,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘PrivateLinkLocation’:
+	// Set property "PrivateLinkLocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkLocation != nil {
@@ -2987,7 +2987,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘PrivateLinkResourceId’:
+	// Set property "PrivateLinkResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkResourceId != nil {
@@ -2996,7 +2996,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Weight’:
+	// Set property "Weight":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Weight != nil {
@@ -3165,13 +3165,13 @@ func (group *DeepCreatedOriginGroup) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &DeepCreatedOriginGroup_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if group.Name != nil {
 		name := *group.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if group.HealthProbeSettings != nil ||
 		group.Origins != nil ||
 		group.ResponseBasedOriginErrorDetectionSettings != nil ||
@@ -3220,7 +3220,7 @@ func (group *DeepCreatedOriginGroup) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeepCreatedOriginGroup_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HealthProbeSettings’:
+	// Set property "HealthProbeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HealthProbeSettings != nil {
@@ -3234,13 +3234,13 @@ func (group *DeepCreatedOriginGroup) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		group.Name = &name
 	}
 
-	// Set property ‘Origins’:
+	// Set property "Origins":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Origins {
@@ -3253,7 +3253,7 @@ func (group *DeepCreatedOriginGroup) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ResponseBasedOriginErrorDetectionSettings’:
+	// Set property "ResponseBasedOriginErrorDetectionSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResponseBasedOriginErrorDetectionSettings != nil {
@@ -3267,7 +3267,7 @@ func (group *DeepCreatedOriginGroup) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TrafficRestorationTimeToHealedOrNewEndpointsInMinutes’:
+	// Set property "TrafficRestorationTimeToHealedOrNewEndpointsInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes != nil {
@@ -3505,7 +3505,7 @@ func (group *DeepCreatedOriginGroup_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeepCreatedOriginGroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HealthProbeSettings’:
+	// Set property "HealthProbeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HealthProbeSettings != nil {
@@ -3519,13 +3519,13 @@ func (group *DeepCreatedOriginGroup_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		group.Name = &name
 	}
 
-	// Set property ‘Origins’:
+	// Set property "Origins":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Origins {
@@ -3538,7 +3538,7 @@ func (group *DeepCreatedOriginGroup_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘ResponseBasedOriginErrorDetectionSettings’:
+	// Set property "ResponseBasedOriginErrorDetectionSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResponseBasedOriginErrorDetectionSettings != nil {
@@ -3552,7 +3552,7 @@ func (group *DeepCreatedOriginGroup_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘TrafficRestorationTimeToHealedOrNewEndpointsInMinutes’:
+	// Set property "TrafficRestorationTimeToHealedOrNewEndpointsInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes != nil {
@@ -3702,13 +3702,13 @@ func (policy *EndpointProperties_DeliveryPolicy) ConvertToARM(resolved genruntim
 	}
 	result := &EndpointProperties_DeliveryPolicy_ARM{}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if policy.Description != nil {
 		description := *policy.Description
 		result.Description = &description
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range policy.Rules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3731,13 +3731,13 @@ func (policy *EndpointProperties_DeliveryPolicy) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EndpointProperties_DeliveryPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		policy.Description = &description
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		var item1 DeliveryRule
 		err := item1.PopulateFromARM(owner, item)
@@ -3866,13 +3866,13 @@ func (policy *EndpointProperties_DeliveryPolicy_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EndpointProperties_DeliveryPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		policy.Description = &description
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		var item1 DeliveryRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3986,7 +3986,7 @@ func (link *EndpointProperties_WebApplicationFirewallPolicyLink) ConvertToARM(re
 	}
 	result := &EndpointProperties_WebApplicationFirewallPolicyLink_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if link.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*link.Reference)
 		if err != nil {
@@ -4010,7 +4010,7 @@ func (link *EndpointProperties_WebApplicationFirewallPolicyLink) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EndpointProperties_WebApplicationFirewallPolicyLink_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -4089,7 +4089,7 @@ func (link *EndpointProperties_WebApplicationFirewallPolicyLink_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EndpointProperties_WebApplicationFirewallPolicyLink_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		link.Id = &id
@@ -4152,18 +4152,18 @@ func (filter *GeoFilter) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &GeoFilter_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if filter.Action != nil {
 		action := *filter.Action
 		result.Action = &action
 	}
 
-	// Set property ‘CountryCodes’:
+	// Set property "CountryCodes":
 	for _, item := range filter.CountryCodes {
 		result.CountryCodes = append(result.CountryCodes, item)
 	}
 
-	// Set property ‘RelativePath’:
+	// Set property "RelativePath":
 	if filter.RelativePath != nil {
 		relativePath := *filter.RelativePath
 		result.RelativePath = &relativePath
@@ -4183,18 +4183,18 @@ func (filter *GeoFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GeoFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		filter.Action = &action
 	}
 
-	// Set property ‘CountryCodes’:
+	// Set property "CountryCodes":
 	for _, item := range typedInput.CountryCodes {
 		filter.CountryCodes = append(filter.CountryCodes, item)
 	}
 
-	// Set property ‘RelativePath’:
+	// Set property "RelativePath":
 	if typedInput.RelativePath != nil {
 		relativePath := *typedInput.RelativePath
 		filter.RelativePath = &relativePath
@@ -4302,18 +4302,18 @@ func (filter *GeoFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GeoFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		filter.Action = &action
 	}
 
-	// Set property ‘CountryCodes’:
+	// Set property "CountryCodes":
 	for _, item := range typedInput.CountryCodes {
 		filter.CountryCodes = append(filter.CountryCodes, item)
 	}
 
-	// Set property ‘RelativePath’:
+	// Set property "RelativePath":
 	if typedInput.RelativePath != nil {
 		relativePath := *typedInput.RelativePath
 		filter.RelativePath = &relativePath
@@ -4437,7 +4437,7 @@ func (reference *ResourceReference) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ResourceReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -4461,7 +4461,7 @@ func (reference *ResourceReference) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceReference_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -4541,7 +4541,7 @@ func (reference *ResourceReference_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
@@ -4601,13 +4601,13 @@ func (signingKey *UrlSigningKey) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &UrlSigningKey_ARM{}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	if signingKey.KeyId != nil {
 		keyId := *signingKey.KeyId
 		result.KeyId = &keyId
 	}
 
-	// Set property ‘KeySourceParameters’:
+	// Set property "KeySourceParameters":
 	if signingKey.KeySourceParameters != nil {
 		keySourceParameters_ARM, err := (*signingKey.KeySourceParameters).ConvertToARM(resolved)
 		if err != nil {
@@ -4631,13 +4631,13 @@ func (signingKey *UrlSigningKey) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningKey_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	if typedInput.KeyId != nil {
 		keyId := *typedInput.KeyId
 		signingKey.KeyId = &keyId
 	}
 
-	// Set property ‘KeySourceParameters’:
+	// Set property "KeySourceParameters":
 	if typedInput.KeySourceParameters != nil {
 		var keySourceParameters1 KeyVaultSigningKeyParameters
 		err := keySourceParameters1.PopulateFromARM(owner, *typedInput.KeySourceParameters)
@@ -4751,13 +4751,13 @@ func (signingKey *UrlSigningKey_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	if typedInput.KeyId != nil {
 		keyId := *typedInput.KeyId
 		signingKey.KeyId = &keyId
 	}
 
-	// Set property ‘KeySourceParameters’:
+	// Set property "KeySourceParameters":
 	if typedInput.KeySourceParameters != nil {
 		var keySourceParameters1 KeyVaultSigningKeyParameters_STATUS
 		err := keySourceParameters1.PopulateFromARM(owner, *typedInput.KeySourceParameters)
@@ -4853,7 +4853,7 @@ func (rule *DeliveryRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &DeliveryRule_ARM{}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	for _, item := range rule.Actions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4862,7 +4862,7 @@ func (rule *DeliveryRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Actions = append(result.Actions, *item_ARM.(*DeliveryRuleAction_ARM))
 	}
 
-	// Set property ‘Conditions’:
+	// Set property "Conditions":
 	for _, item := range rule.Conditions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4871,13 +4871,13 @@ func (rule *DeliveryRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Conditions = append(result.Conditions, *item_ARM.(*DeliveryRuleCondition_ARM))
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if rule.Name != nil {
 		name := *rule.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if rule.Order != nil {
 		order := *rule.Order
 		result.Order = &order
@@ -4897,7 +4897,7 @@ func (rule *DeliveryRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	for _, item := range typedInput.Actions {
 		var item1 DeliveryRuleAction
 		err := item1.PopulateFromARM(owner, item)
@@ -4907,7 +4907,7 @@ func (rule *DeliveryRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		rule.Actions = append(rule.Actions, item1)
 	}
 
-	// Set property ‘Conditions’:
+	// Set property "Conditions":
 	for _, item := range typedInput.Conditions {
 		var item1 DeliveryRuleCondition
 		err := item1.PopulateFromARM(owner, item)
@@ -4917,13 +4917,13 @@ func (rule *DeliveryRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		rule.Conditions = append(rule.Conditions, item1)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if typedInput.Order != nil {
 		order := *typedInput.Order
 		rule.Order = &order
@@ -5120,7 +5120,7 @@ func (rule *DeliveryRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	for _, item := range typedInput.Actions {
 		var item1 DeliveryRuleAction_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5130,15 +5130,15 @@ func (rule *DeliveryRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		rule.Actions = append(rule.Actions, item1)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if typedInput.Order != nil {
 		order := *typedInput.Order
 		rule.Order = &order
@@ -5296,25 +5296,25 @@ func (parameters *HealthProbeParameters) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &HealthProbeParameters_ARM{}
 
-	// Set property ‘ProbeIntervalInSeconds’:
+	// Set property "ProbeIntervalInSeconds":
 	if parameters.ProbeIntervalInSeconds != nil {
 		probeIntervalInSeconds := *parameters.ProbeIntervalInSeconds
 		result.ProbeIntervalInSeconds = &probeIntervalInSeconds
 	}
 
-	// Set property ‘ProbePath’:
+	// Set property "ProbePath":
 	if parameters.ProbePath != nil {
 		probePath := *parameters.ProbePath
 		result.ProbePath = &probePath
 	}
 
-	// Set property ‘ProbeProtocol’:
+	// Set property "ProbeProtocol":
 	if parameters.ProbeProtocol != nil {
 		probeProtocol := *parameters.ProbeProtocol
 		result.ProbeProtocol = &probeProtocol
 	}
 
-	// Set property ‘ProbeRequestType’:
+	// Set property "ProbeRequestType":
 	if parameters.ProbeRequestType != nil {
 		probeRequestType := *parameters.ProbeRequestType
 		result.ProbeRequestType = &probeRequestType
@@ -5334,25 +5334,25 @@ func (parameters *HealthProbeParameters) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HealthProbeParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ProbeIntervalInSeconds’:
+	// Set property "ProbeIntervalInSeconds":
 	if typedInput.ProbeIntervalInSeconds != nil {
 		probeIntervalInSeconds := *typedInput.ProbeIntervalInSeconds
 		parameters.ProbeIntervalInSeconds = &probeIntervalInSeconds
 	}
 
-	// Set property ‘ProbePath’:
+	// Set property "ProbePath":
 	if typedInput.ProbePath != nil {
 		probePath := *typedInput.ProbePath
 		parameters.ProbePath = &probePath
 	}
 
-	// Set property ‘ProbeProtocol’:
+	// Set property "ProbeProtocol":
 	if typedInput.ProbeProtocol != nil {
 		probeProtocol := *typedInput.ProbeProtocol
 		parameters.ProbeProtocol = &probeProtocol
 	}
 
-	// Set property ‘ProbeRequestType’:
+	// Set property "ProbeRequestType":
 	if typedInput.ProbeRequestType != nil {
 		probeRequestType := *typedInput.ProbeRequestType
 		parameters.ProbeRequestType = &probeRequestType
@@ -5502,25 +5502,25 @@ func (parameters *HealthProbeParameters_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HealthProbeParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ProbeIntervalInSeconds’:
+	// Set property "ProbeIntervalInSeconds":
 	if typedInput.ProbeIntervalInSeconds != nil {
 		probeIntervalInSeconds := *typedInput.ProbeIntervalInSeconds
 		parameters.ProbeIntervalInSeconds = &probeIntervalInSeconds
 	}
 
-	// Set property ‘ProbePath’:
+	// Set property "ProbePath":
 	if typedInput.ProbePath != nil {
 		probePath := *typedInput.ProbePath
 		parameters.ProbePath = &probePath
 	}
 
-	// Set property ‘ProbeProtocol’:
+	// Set property "ProbeProtocol":
 	if typedInput.ProbeProtocol != nil {
 		probeProtocol := *typedInput.ProbeProtocol
 		parameters.ProbeProtocol = &probeProtocol
 	}
 
-	// Set property ‘ProbeRequestType’:
+	// Set property "ProbeRequestType":
 	if typedInput.ProbeRequestType != nil {
 		probeRequestType := *typedInput.ProbeRequestType
 		parameters.ProbeRequestType = &probeRequestType
@@ -5632,37 +5632,37 @@ func (parameters *KeyVaultSigningKeyParameters) ConvertToARM(resolved genruntime
 	}
 	result := &KeyVaultSigningKeyParameters_ARM{}
 
-	// Set property ‘ResourceGroupName’:
+	// Set property "ResourceGroupName":
 	if parameters.ResourceGroupName != nil {
 		resourceGroupName := *parameters.ResourceGroupName
 		result.ResourceGroupName = &resourceGroupName
 	}
 
-	// Set property ‘SecretName’:
+	// Set property "SecretName":
 	if parameters.SecretName != nil {
 		secretName := *parameters.SecretName
 		result.SecretName = &secretName
 	}
 
-	// Set property ‘SecretVersion’:
+	// Set property "SecretVersion":
 	if parameters.SecretVersion != nil {
 		secretVersion := *parameters.SecretVersion
 		result.SecretVersion = &secretVersion
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if parameters.SubscriptionId != nil {
 		subscriptionId := *parameters.SubscriptionId
 		result.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
 	}
 
-	// Set property ‘VaultName’:
+	// Set property "VaultName":
 	if parameters.VaultName != nil {
 		vaultName := *parameters.VaultName
 		result.VaultName = &vaultName
@@ -5682,37 +5682,37 @@ func (parameters *KeyVaultSigningKeyParameters) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultSigningKeyParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ResourceGroupName’:
+	// Set property "ResourceGroupName":
 	if typedInput.ResourceGroupName != nil {
 		resourceGroupName := *typedInput.ResourceGroupName
 		parameters.ResourceGroupName = &resourceGroupName
 	}
 
-	// Set property ‘SecretName’:
+	// Set property "SecretName":
 	if typedInput.SecretName != nil {
 		secretName := *typedInput.SecretName
 		parameters.SecretName = &secretName
 	}
 
-	// Set property ‘SecretVersion’:
+	// Set property "SecretVersion":
 	if typedInput.SecretVersion != nil {
 		secretVersion := *typedInput.SecretVersion
 		parameters.SecretVersion = &secretVersion
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		parameters.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
 	}
 
-	// Set property ‘VaultName’:
+	// Set property "VaultName":
 	if typedInput.VaultName != nil {
 		vaultName := *typedInput.VaultName
 		parameters.VaultName = &vaultName
@@ -5854,37 +5854,37 @@ func (parameters *KeyVaultSigningKeyParameters_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultSigningKeyParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ResourceGroupName’:
+	// Set property "ResourceGroupName":
 	if typedInput.ResourceGroupName != nil {
 		resourceGroupName := *typedInput.ResourceGroupName
 		parameters.ResourceGroupName = &resourceGroupName
 	}
 
-	// Set property ‘SecretName’:
+	// Set property "SecretName":
 	if typedInput.SecretName != nil {
 		secretName := *typedInput.SecretName
 		parameters.SecretName = &secretName
 	}
 
-	// Set property ‘SecretVersion’:
+	// Set property "SecretVersion":
 	if typedInput.SecretVersion != nil {
 		secretVersion := *typedInput.SecretVersion
 		parameters.SecretVersion = &secretVersion
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		parameters.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
 	}
 
-	// Set property ‘VaultName’:
+	// Set property "VaultName":
 	if typedInput.VaultName != nil {
 		vaultName := *typedInput.VaultName
 		parameters.VaultName = &vaultName
@@ -5998,7 +5998,7 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters) ConvertToARM(reso
 	}
 	result := &ResponseBasedOriginErrorDetectionParameters_ARM{}
 
-	// Set property ‘HttpErrorRanges’:
+	// Set property "HttpErrorRanges":
 	for _, item := range parameters.HttpErrorRanges {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -6007,13 +6007,13 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters) ConvertToARM(reso
 		result.HttpErrorRanges = append(result.HttpErrorRanges, *item_ARM.(*HttpErrorRangeParameters_ARM))
 	}
 
-	// Set property ‘ResponseBasedDetectedErrorTypes’:
+	// Set property "ResponseBasedDetectedErrorTypes":
 	if parameters.ResponseBasedDetectedErrorTypes != nil {
 		responseBasedDetectedErrorTypes := *parameters.ResponseBasedDetectedErrorTypes
 		result.ResponseBasedDetectedErrorTypes = &responseBasedDetectedErrorTypes
 	}
 
-	// Set property ‘ResponseBasedFailoverThresholdPercentage’:
+	// Set property "ResponseBasedFailoverThresholdPercentage":
 	if parameters.ResponseBasedFailoverThresholdPercentage != nil {
 		responseBasedFailoverThresholdPercentage := *parameters.ResponseBasedFailoverThresholdPercentage
 		result.ResponseBasedFailoverThresholdPercentage = &responseBasedFailoverThresholdPercentage
@@ -6033,7 +6033,7 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResponseBasedOriginErrorDetectionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpErrorRanges’:
+	// Set property "HttpErrorRanges":
 	for _, item := range typedInput.HttpErrorRanges {
 		var item1 HttpErrorRangeParameters
 		err := item1.PopulateFromARM(owner, item)
@@ -6043,13 +6043,13 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters) PopulateFromARM(o
 		parameters.HttpErrorRanges = append(parameters.HttpErrorRanges, item1)
 	}
 
-	// Set property ‘ResponseBasedDetectedErrorTypes’:
+	// Set property "ResponseBasedDetectedErrorTypes":
 	if typedInput.ResponseBasedDetectedErrorTypes != nil {
 		responseBasedDetectedErrorTypes := *typedInput.ResponseBasedDetectedErrorTypes
 		parameters.ResponseBasedDetectedErrorTypes = &responseBasedDetectedErrorTypes
 	}
 
-	// Set property ‘ResponseBasedFailoverThresholdPercentage’:
+	// Set property "ResponseBasedFailoverThresholdPercentage":
 	if typedInput.ResponseBasedFailoverThresholdPercentage != nil {
 		responseBasedFailoverThresholdPercentage := *typedInput.ResponseBasedFailoverThresholdPercentage
 		parameters.ResponseBasedFailoverThresholdPercentage = &responseBasedFailoverThresholdPercentage
@@ -6218,7 +6218,7 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters_STATUS) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResponseBasedOriginErrorDetectionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpErrorRanges’:
+	// Set property "HttpErrorRanges":
 	for _, item := range typedInput.HttpErrorRanges {
 		var item1 HttpErrorRangeParameters_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6228,13 +6228,13 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters_STATUS) PopulateFr
 		parameters.HttpErrorRanges = append(parameters.HttpErrorRanges, item1)
 	}
 
-	// Set property ‘ResponseBasedDetectedErrorTypes’:
+	// Set property "ResponseBasedDetectedErrorTypes":
 	if typedInput.ResponseBasedDetectedErrorTypes != nil {
 		responseBasedDetectedErrorTypes := *typedInput.ResponseBasedDetectedErrorTypes
 		parameters.ResponseBasedDetectedErrorTypes = &responseBasedDetectedErrorTypes
 	}
 
-	// Set property ‘ResponseBasedFailoverThresholdPercentage’:
+	// Set property "ResponseBasedFailoverThresholdPercentage":
 	if typedInput.ResponseBasedFailoverThresholdPercentage != nil {
 		responseBasedFailoverThresholdPercentage := *typedInput.ResponseBasedFailoverThresholdPercentage
 		parameters.ResponseBasedFailoverThresholdPercentage = &responseBasedFailoverThresholdPercentage
@@ -6364,7 +6364,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &DeliveryRuleAction_ARM{}
 
-	// Set property ‘CacheExpiration’:
+	// Set property "CacheExpiration":
 	if action.CacheExpiration != nil {
 		cacheExpiration_ARM, err := (*action.CacheExpiration).ConvertToARM(resolved)
 		if err != nil {
@@ -6374,7 +6374,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.CacheExpiration = &cacheExpiration
 	}
 
-	// Set property ‘CacheKeyQueryString’:
+	// Set property "CacheKeyQueryString":
 	if action.CacheKeyQueryString != nil {
 		cacheKeyQueryString_ARM, err := (*action.CacheKeyQueryString).ConvertToARM(resolved)
 		if err != nil {
@@ -6384,7 +6384,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.CacheKeyQueryString = &cacheKeyQueryString
 	}
 
-	// Set property ‘ModifyRequestHeader’:
+	// Set property "ModifyRequestHeader":
 	if action.ModifyRequestHeader != nil {
 		modifyRequestHeader_ARM, err := (*action.ModifyRequestHeader).ConvertToARM(resolved)
 		if err != nil {
@@ -6394,7 +6394,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.ModifyRequestHeader = &modifyRequestHeader
 	}
 
-	// Set property ‘ModifyResponseHeader’:
+	// Set property "ModifyResponseHeader":
 	if action.ModifyResponseHeader != nil {
 		modifyResponseHeader_ARM, err := (*action.ModifyResponseHeader).ConvertToARM(resolved)
 		if err != nil {
@@ -6404,7 +6404,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.ModifyResponseHeader = &modifyResponseHeader
 	}
 
-	// Set property ‘OriginGroupOverride’:
+	// Set property "OriginGroupOverride":
 	if action.OriginGroupOverride != nil {
 		originGroupOverride_ARM, err := (*action.OriginGroupOverride).ConvertToARM(resolved)
 		if err != nil {
@@ -6414,7 +6414,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.OriginGroupOverride = &originGroupOverride
 	}
 
-	// Set property ‘RouteConfigurationOverride’:
+	// Set property "RouteConfigurationOverride":
 	if action.RouteConfigurationOverride != nil {
 		routeConfigurationOverride_ARM, err := (*action.RouteConfigurationOverride).ConvertToARM(resolved)
 		if err != nil {
@@ -6424,7 +6424,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.RouteConfigurationOverride = &routeConfigurationOverride
 	}
 
-	// Set property ‘UrlRedirect’:
+	// Set property "UrlRedirect":
 	if action.UrlRedirect != nil {
 		urlRedirect_ARM, err := (*action.UrlRedirect).ConvertToARM(resolved)
 		if err != nil {
@@ -6434,7 +6434,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.UrlRedirect = &urlRedirect
 	}
 
-	// Set property ‘UrlRewrite’:
+	// Set property "UrlRewrite":
 	if action.UrlRewrite != nil {
 		urlRewrite_ARM, err := (*action.UrlRewrite).ConvertToARM(resolved)
 		if err != nil {
@@ -6444,7 +6444,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.UrlRewrite = &urlRewrite
 	}
 
-	// Set property ‘UrlSigning’:
+	// Set property "UrlSigning":
 	if action.UrlSigning != nil {
 		urlSigning_ARM, err := (*action.UrlSigning).ConvertToARM(resolved)
 		if err != nil {
@@ -6468,7 +6468,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheExpiration’:
+	// Set property "CacheExpiration":
 	if typedInput.CacheExpiration != nil {
 		var cacheExpiration1 DeliveryRuleCacheExpirationAction
 		err := cacheExpiration1.PopulateFromARM(owner, *typedInput.CacheExpiration)
@@ -6479,7 +6479,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.CacheExpiration = &cacheExpiration
 	}
 
-	// Set property ‘CacheKeyQueryString’:
+	// Set property "CacheKeyQueryString":
 	if typedInput.CacheKeyQueryString != nil {
 		var cacheKeyQueryString1 DeliveryRuleCacheKeyQueryStringAction
 		err := cacheKeyQueryString1.PopulateFromARM(owner, *typedInput.CacheKeyQueryString)
@@ -6490,7 +6490,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.CacheKeyQueryString = &cacheKeyQueryString
 	}
 
-	// Set property ‘ModifyRequestHeader’:
+	// Set property "ModifyRequestHeader":
 	if typedInput.ModifyRequestHeader != nil {
 		var modifyRequestHeader1 DeliveryRuleRequestHeaderAction
 		err := modifyRequestHeader1.PopulateFromARM(owner, *typedInput.ModifyRequestHeader)
@@ -6501,7 +6501,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.ModifyRequestHeader = &modifyRequestHeader
 	}
 
-	// Set property ‘ModifyResponseHeader’:
+	// Set property "ModifyResponseHeader":
 	if typedInput.ModifyResponseHeader != nil {
 		var modifyResponseHeader1 DeliveryRuleResponseHeaderAction
 		err := modifyResponseHeader1.PopulateFromARM(owner, *typedInput.ModifyResponseHeader)
@@ -6512,7 +6512,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.ModifyResponseHeader = &modifyResponseHeader
 	}
 
-	// Set property ‘OriginGroupOverride’:
+	// Set property "OriginGroupOverride":
 	if typedInput.OriginGroupOverride != nil {
 		var originGroupOverride1 OriginGroupOverrideAction
 		err := originGroupOverride1.PopulateFromARM(owner, *typedInput.OriginGroupOverride)
@@ -6523,7 +6523,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.OriginGroupOverride = &originGroupOverride
 	}
 
-	// Set property ‘RouteConfigurationOverride’:
+	// Set property "RouteConfigurationOverride":
 	if typedInput.RouteConfigurationOverride != nil {
 		var routeConfigurationOverride1 DeliveryRuleRouteConfigurationOverrideAction
 		err := routeConfigurationOverride1.PopulateFromARM(owner, *typedInput.RouteConfigurationOverride)
@@ -6534,7 +6534,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.RouteConfigurationOverride = &routeConfigurationOverride
 	}
 
-	// Set property ‘UrlRedirect’:
+	// Set property "UrlRedirect":
 	if typedInput.UrlRedirect != nil {
 		var urlRedirect1 UrlRedirectAction
 		err := urlRedirect1.PopulateFromARM(owner, *typedInput.UrlRedirect)
@@ -6545,7 +6545,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.UrlRedirect = &urlRedirect
 	}
 
-	// Set property ‘UrlRewrite’:
+	// Set property "UrlRewrite":
 	if typedInput.UrlRewrite != nil {
 		var urlRewrite1 UrlRewriteAction
 		err := urlRewrite1.PopulateFromARM(owner, *typedInput.UrlRewrite)
@@ -6556,7 +6556,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.UrlRewrite = &urlRewrite
 	}
 
-	// Set property ‘UrlSigning’:
+	// Set property "UrlSigning":
 	if typedInput.UrlSigning != nil {
 		var urlSigning1 UrlSigningAction
 		err := urlSigning1.PopulateFromARM(owner, *typedInput.UrlSigning)
@@ -6969,7 +6969,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheExpiration’:
+	// Set property "CacheExpiration":
 	if typedInput.CacheExpiration != nil {
 		var cacheExpiration1 DeliveryRuleCacheExpirationAction_STATUS
 		err := cacheExpiration1.PopulateFromARM(owner, *typedInput.CacheExpiration)
@@ -6980,7 +6980,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.CacheExpiration = &cacheExpiration
 	}
 
-	// Set property ‘CacheKeyQueryString’:
+	// Set property "CacheKeyQueryString":
 	if typedInput.CacheKeyQueryString != nil {
 		var cacheKeyQueryString1 DeliveryRuleCacheKeyQueryStringAction_STATUS
 		err := cacheKeyQueryString1.PopulateFromARM(owner, *typedInput.CacheKeyQueryString)
@@ -6991,7 +6991,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.CacheKeyQueryString = &cacheKeyQueryString
 	}
 
-	// Set property ‘ModifyRequestHeader’:
+	// Set property "ModifyRequestHeader":
 	if typedInput.ModifyRequestHeader != nil {
 		var modifyRequestHeader1 DeliveryRuleRequestHeaderAction_STATUS
 		err := modifyRequestHeader1.PopulateFromARM(owner, *typedInput.ModifyRequestHeader)
@@ -7002,7 +7002,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.ModifyRequestHeader = &modifyRequestHeader
 	}
 
-	// Set property ‘ModifyResponseHeader’:
+	// Set property "ModifyResponseHeader":
 	if typedInput.ModifyResponseHeader != nil {
 		var modifyResponseHeader1 DeliveryRuleResponseHeaderAction_STATUS
 		err := modifyResponseHeader1.PopulateFromARM(owner, *typedInput.ModifyResponseHeader)
@@ -7013,7 +7013,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.ModifyResponseHeader = &modifyResponseHeader
 	}
 
-	// Set property ‘OriginGroupOverride’:
+	// Set property "OriginGroupOverride":
 	if typedInput.OriginGroupOverride != nil {
 		var originGroupOverride1 OriginGroupOverrideAction_STATUS
 		err := originGroupOverride1.PopulateFromARM(owner, *typedInput.OriginGroupOverride)
@@ -7024,7 +7024,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.OriginGroupOverride = &originGroupOverride
 	}
 
-	// Set property ‘RouteConfigurationOverride’:
+	// Set property "RouteConfigurationOverride":
 	if typedInput.RouteConfigurationOverride != nil {
 		var routeConfigurationOverride1 DeliveryRuleRouteConfigurationOverrideAction_STATUS
 		err := routeConfigurationOverride1.PopulateFromARM(owner, *typedInput.RouteConfigurationOverride)
@@ -7035,7 +7035,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.RouteConfigurationOverride = &routeConfigurationOverride
 	}
 
-	// Set property ‘UrlRedirect’:
+	// Set property "UrlRedirect":
 	if typedInput.UrlRedirect != nil {
 		var urlRedirect1 UrlRedirectAction_STATUS
 		err := urlRedirect1.PopulateFromARM(owner, *typedInput.UrlRedirect)
@@ -7046,7 +7046,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.UrlRedirect = &urlRedirect
 	}
 
-	// Set property ‘UrlRewrite’:
+	// Set property "UrlRewrite":
 	if typedInput.UrlRewrite != nil {
 		var urlRewrite1 UrlRewriteAction_STATUS
 		err := urlRewrite1.PopulateFromARM(owner, *typedInput.UrlRewrite)
@@ -7057,7 +7057,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.UrlRewrite = &urlRewrite
 	}
 
-	// Set property ‘UrlSigning’:
+	// Set property "UrlSigning":
 	if typedInput.UrlSigning != nil {
 		var urlSigning1 UrlSigningAction_STATUS
 		err := urlSigning1.PopulateFromARM(owner, *typedInput.UrlSigning)
@@ -7380,7 +7380,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &DeliveryRuleCondition_ARM{}
 
-	// Set property ‘ClientPort’:
+	// Set property "ClientPort":
 	if condition.ClientPort != nil {
 		clientPort_ARM, err := (*condition.ClientPort).ConvertToARM(resolved)
 		if err != nil {
@@ -7390,7 +7390,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.ClientPort = &clientPort
 	}
 
-	// Set property ‘Cookies’:
+	// Set property "Cookies":
 	if condition.Cookies != nil {
 		cookies_ARM, err := (*condition.Cookies).ConvertToARM(resolved)
 		if err != nil {
@@ -7400,7 +7400,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.Cookies = &cookies
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	if condition.HostName != nil {
 		hostName_ARM, err := (*condition.HostName).ConvertToARM(resolved)
 		if err != nil {
@@ -7410,7 +7410,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.HostName = &hostName
 	}
 
-	// Set property ‘HttpVersion’:
+	// Set property "HttpVersion":
 	if condition.HttpVersion != nil {
 		httpVersion_ARM, err := (*condition.HttpVersion).ConvertToARM(resolved)
 		if err != nil {
@@ -7420,7 +7420,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.HttpVersion = &httpVersion
 	}
 
-	// Set property ‘IsDevice’:
+	// Set property "IsDevice":
 	if condition.IsDevice != nil {
 		isDevice_ARM, err := (*condition.IsDevice).ConvertToARM(resolved)
 		if err != nil {
@@ -7430,7 +7430,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.IsDevice = &isDevice
 	}
 
-	// Set property ‘PostArgs’:
+	// Set property "PostArgs":
 	if condition.PostArgs != nil {
 		postArgs_ARM, err := (*condition.PostArgs).ConvertToARM(resolved)
 		if err != nil {
@@ -7440,7 +7440,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.PostArgs = &postArgs
 	}
 
-	// Set property ‘QueryString’:
+	// Set property "QueryString":
 	if condition.QueryString != nil {
 		queryString_ARM, err := (*condition.QueryString).ConvertToARM(resolved)
 		if err != nil {
@@ -7450,7 +7450,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.QueryString = &queryString
 	}
 
-	// Set property ‘RemoteAddress’:
+	// Set property "RemoteAddress":
 	if condition.RemoteAddress != nil {
 		remoteAddress_ARM, err := (*condition.RemoteAddress).ConvertToARM(resolved)
 		if err != nil {
@@ -7460,7 +7460,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.RemoteAddress = &remoteAddress
 	}
 
-	// Set property ‘RequestBody’:
+	// Set property "RequestBody":
 	if condition.RequestBody != nil {
 		requestBody_ARM, err := (*condition.RequestBody).ConvertToARM(resolved)
 		if err != nil {
@@ -7470,7 +7470,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.RequestBody = &requestBody
 	}
 
-	// Set property ‘RequestHeader’:
+	// Set property "RequestHeader":
 	if condition.RequestHeader != nil {
 		requestHeader_ARM, err := (*condition.RequestHeader).ConvertToARM(resolved)
 		if err != nil {
@@ -7480,7 +7480,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.RequestHeader = &requestHeader
 	}
 
-	// Set property ‘RequestMethod’:
+	// Set property "RequestMethod":
 	if condition.RequestMethod != nil {
 		requestMethod_ARM, err := (*condition.RequestMethod).ConvertToARM(resolved)
 		if err != nil {
@@ -7490,7 +7490,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.RequestMethod = &requestMethod
 	}
 
-	// Set property ‘RequestScheme’:
+	// Set property "RequestScheme":
 	if condition.RequestScheme != nil {
 		requestScheme_ARM, err := (*condition.RequestScheme).ConvertToARM(resolved)
 		if err != nil {
@@ -7500,7 +7500,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.RequestScheme = &requestScheme
 	}
 
-	// Set property ‘RequestUri’:
+	// Set property "RequestUri":
 	if condition.RequestUri != nil {
 		requestUri_ARM, err := (*condition.RequestUri).ConvertToARM(resolved)
 		if err != nil {
@@ -7510,7 +7510,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.RequestUri = &requestUri
 	}
 
-	// Set property ‘ServerPort’:
+	// Set property "ServerPort":
 	if condition.ServerPort != nil {
 		serverPort_ARM, err := (*condition.ServerPort).ConvertToARM(resolved)
 		if err != nil {
@@ -7520,7 +7520,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.ServerPort = &serverPort
 	}
 
-	// Set property ‘SocketAddr’:
+	// Set property "SocketAddr":
 	if condition.SocketAddr != nil {
 		socketAddr_ARM, err := (*condition.SocketAddr).ConvertToARM(resolved)
 		if err != nil {
@@ -7530,7 +7530,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.SocketAddr = &socketAddr
 	}
 
-	// Set property ‘SslProtocol’:
+	// Set property "SslProtocol":
 	if condition.SslProtocol != nil {
 		sslProtocol_ARM, err := (*condition.SslProtocol).ConvertToARM(resolved)
 		if err != nil {
@@ -7540,7 +7540,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.SslProtocol = &sslProtocol
 	}
 
-	// Set property ‘UrlFileExtension’:
+	// Set property "UrlFileExtension":
 	if condition.UrlFileExtension != nil {
 		urlFileExtension_ARM, err := (*condition.UrlFileExtension).ConvertToARM(resolved)
 		if err != nil {
@@ -7550,7 +7550,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.UrlFileExtension = &urlFileExtension
 	}
 
-	// Set property ‘UrlFileName’:
+	// Set property "UrlFileName":
 	if condition.UrlFileName != nil {
 		urlFileName_ARM, err := (*condition.UrlFileName).ConvertToARM(resolved)
 		if err != nil {
@@ -7560,7 +7560,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.UrlFileName = &urlFileName
 	}
 
-	// Set property ‘UrlPath’:
+	// Set property "UrlPath":
 	if condition.UrlPath != nil {
 		urlPath_ARM, err := (*condition.UrlPath).ConvertToARM(resolved)
 		if err != nil {
@@ -7584,7 +7584,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientPort’:
+	// Set property "ClientPort":
 	if typedInput.ClientPort != nil {
 		var clientPort1 DeliveryRuleClientPortCondition
 		err := clientPort1.PopulateFromARM(owner, *typedInput.ClientPort)
@@ -7595,7 +7595,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.ClientPort = &clientPort
 	}
 
-	// Set property ‘Cookies’:
+	// Set property "Cookies":
 	if typedInput.Cookies != nil {
 		var cookies1 DeliveryRuleCookiesCondition
 		err := cookies1.PopulateFromARM(owner, *typedInput.Cookies)
@@ -7606,7 +7606,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.Cookies = &cookies
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	if typedInput.HostName != nil {
 		var hostName1 DeliveryRuleHostNameCondition
 		err := hostName1.PopulateFromARM(owner, *typedInput.HostName)
@@ -7617,7 +7617,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.HostName = &hostName
 	}
 
-	// Set property ‘HttpVersion’:
+	// Set property "HttpVersion":
 	if typedInput.HttpVersion != nil {
 		var httpVersion1 DeliveryRuleHttpVersionCondition
 		err := httpVersion1.PopulateFromARM(owner, *typedInput.HttpVersion)
@@ -7628,7 +7628,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.HttpVersion = &httpVersion
 	}
 
-	// Set property ‘IsDevice’:
+	// Set property "IsDevice":
 	if typedInput.IsDevice != nil {
 		var isDevice1 DeliveryRuleIsDeviceCondition
 		err := isDevice1.PopulateFromARM(owner, *typedInput.IsDevice)
@@ -7639,7 +7639,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.IsDevice = &isDevice
 	}
 
-	// Set property ‘PostArgs’:
+	// Set property "PostArgs":
 	if typedInput.PostArgs != nil {
 		var postArgs1 DeliveryRulePostArgsCondition
 		err := postArgs1.PopulateFromARM(owner, *typedInput.PostArgs)
@@ -7650,7 +7650,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.PostArgs = &postArgs
 	}
 
-	// Set property ‘QueryString’:
+	// Set property "QueryString":
 	if typedInput.QueryString != nil {
 		var queryString1 DeliveryRuleQueryStringCondition
 		err := queryString1.PopulateFromARM(owner, *typedInput.QueryString)
@@ -7661,7 +7661,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.QueryString = &queryString
 	}
 
-	// Set property ‘RemoteAddress’:
+	// Set property "RemoteAddress":
 	if typedInput.RemoteAddress != nil {
 		var remoteAddress1 DeliveryRuleRemoteAddressCondition
 		err := remoteAddress1.PopulateFromARM(owner, *typedInput.RemoteAddress)
@@ -7672,7 +7672,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.RemoteAddress = &remoteAddress
 	}
 
-	// Set property ‘RequestBody’:
+	// Set property "RequestBody":
 	if typedInput.RequestBody != nil {
 		var requestBody1 DeliveryRuleRequestBodyCondition
 		err := requestBody1.PopulateFromARM(owner, *typedInput.RequestBody)
@@ -7683,7 +7683,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.RequestBody = &requestBody
 	}
 
-	// Set property ‘RequestHeader’:
+	// Set property "RequestHeader":
 	if typedInput.RequestHeader != nil {
 		var requestHeader1 DeliveryRuleRequestHeaderCondition
 		err := requestHeader1.PopulateFromARM(owner, *typedInput.RequestHeader)
@@ -7694,7 +7694,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.RequestHeader = &requestHeader
 	}
 
-	// Set property ‘RequestMethod’:
+	// Set property "RequestMethod":
 	if typedInput.RequestMethod != nil {
 		var requestMethod1 DeliveryRuleRequestMethodCondition
 		err := requestMethod1.PopulateFromARM(owner, *typedInput.RequestMethod)
@@ -7705,7 +7705,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.RequestMethod = &requestMethod
 	}
 
-	// Set property ‘RequestScheme’:
+	// Set property "RequestScheme":
 	if typedInput.RequestScheme != nil {
 		var requestScheme1 DeliveryRuleRequestSchemeCondition
 		err := requestScheme1.PopulateFromARM(owner, *typedInput.RequestScheme)
@@ -7716,7 +7716,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.RequestScheme = &requestScheme
 	}
 
-	// Set property ‘RequestUri’:
+	// Set property "RequestUri":
 	if typedInput.RequestUri != nil {
 		var requestUri1 DeliveryRuleRequestUriCondition
 		err := requestUri1.PopulateFromARM(owner, *typedInput.RequestUri)
@@ -7727,7 +7727,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.RequestUri = &requestUri
 	}
 
-	// Set property ‘ServerPort’:
+	// Set property "ServerPort":
 	if typedInput.ServerPort != nil {
 		var serverPort1 DeliveryRuleServerPortCondition
 		err := serverPort1.PopulateFromARM(owner, *typedInput.ServerPort)
@@ -7738,7 +7738,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.ServerPort = &serverPort
 	}
 
-	// Set property ‘SocketAddr’:
+	// Set property "SocketAddr":
 	if typedInput.SocketAddr != nil {
 		var socketAddr1 DeliveryRuleSocketAddrCondition
 		err := socketAddr1.PopulateFromARM(owner, *typedInput.SocketAddr)
@@ -7749,7 +7749,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.SocketAddr = &socketAddr
 	}
 
-	// Set property ‘SslProtocol’:
+	// Set property "SslProtocol":
 	if typedInput.SslProtocol != nil {
 		var sslProtocol1 DeliveryRuleSslProtocolCondition
 		err := sslProtocol1.PopulateFromARM(owner, *typedInput.SslProtocol)
@@ -7760,7 +7760,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.SslProtocol = &sslProtocol
 	}
 
-	// Set property ‘UrlFileExtension’:
+	// Set property "UrlFileExtension":
 	if typedInput.UrlFileExtension != nil {
 		var urlFileExtension1 DeliveryRuleUrlFileExtensionCondition
 		err := urlFileExtension1.PopulateFromARM(owner, *typedInput.UrlFileExtension)
@@ -7771,7 +7771,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.UrlFileExtension = &urlFileExtension
 	}
 
-	// Set property ‘UrlFileName’:
+	// Set property "UrlFileName":
 	if typedInput.UrlFileName != nil {
 		var urlFileName1 DeliveryRuleUrlFileNameCondition
 		err := urlFileName1.PopulateFromARM(owner, *typedInput.UrlFileName)
@@ -7782,7 +7782,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.UrlFileName = &urlFileName
 	}
 
-	// Set property ‘UrlPath’:
+	// Set property "UrlPath":
 	if typedInput.UrlPath != nil {
 		var urlPath1 DeliveryRuleUrlPathCondition
 		err := urlPath1.PopulateFromARM(owner, *typedInput.UrlPath)
@@ -8585,7 +8585,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientPort’:
+	// Set property "ClientPort":
 	if typedInput.ClientPort != nil {
 		var clientPort1 DeliveryRuleClientPortCondition_STATUS
 		err := clientPort1.PopulateFromARM(owner, *typedInput.ClientPort)
@@ -8596,7 +8596,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.ClientPort = &clientPort
 	}
 
-	// Set property ‘Cookies’:
+	// Set property "Cookies":
 	if typedInput.Cookies != nil {
 		var cookies1 DeliveryRuleCookiesCondition_STATUS
 		err := cookies1.PopulateFromARM(owner, *typedInput.Cookies)
@@ -8607,7 +8607,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.Cookies = &cookies
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	if typedInput.HostName != nil {
 		var hostName1 DeliveryRuleHostNameCondition_STATUS
 		err := hostName1.PopulateFromARM(owner, *typedInput.HostName)
@@ -8618,7 +8618,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.HostName = &hostName
 	}
 
-	// Set property ‘HttpVersion’:
+	// Set property "HttpVersion":
 	if typedInput.HttpVersion != nil {
 		var httpVersion1 DeliveryRuleHttpVersionCondition_STATUS
 		err := httpVersion1.PopulateFromARM(owner, *typedInput.HttpVersion)
@@ -8629,7 +8629,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.HttpVersion = &httpVersion
 	}
 
-	// Set property ‘IsDevice’:
+	// Set property "IsDevice":
 	if typedInput.IsDevice != nil {
 		var isDevice1 DeliveryRuleIsDeviceCondition_STATUS
 		err := isDevice1.PopulateFromARM(owner, *typedInput.IsDevice)
@@ -8640,7 +8640,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.IsDevice = &isDevice
 	}
 
-	// Set property ‘PostArgs’:
+	// Set property "PostArgs":
 	if typedInput.PostArgs != nil {
 		var postArgs1 DeliveryRulePostArgsCondition_STATUS
 		err := postArgs1.PopulateFromARM(owner, *typedInput.PostArgs)
@@ -8651,7 +8651,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.PostArgs = &postArgs
 	}
 
-	// Set property ‘QueryString’:
+	// Set property "QueryString":
 	if typedInput.QueryString != nil {
 		var queryString1 DeliveryRuleQueryStringCondition_STATUS
 		err := queryString1.PopulateFromARM(owner, *typedInput.QueryString)
@@ -8662,7 +8662,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.QueryString = &queryString
 	}
 
-	// Set property ‘RemoteAddress’:
+	// Set property "RemoteAddress":
 	if typedInput.RemoteAddress != nil {
 		var remoteAddress1 DeliveryRuleRemoteAddressCondition_STATUS
 		err := remoteAddress1.PopulateFromARM(owner, *typedInput.RemoteAddress)
@@ -8673,7 +8673,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.RemoteAddress = &remoteAddress
 	}
 
-	// Set property ‘RequestBody’:
+	// Set property "RequestBody":
 	if typedInput.RequestBody != nil {
 		var requestBody1 DeliveryRuleRequestBodyCondition_STATUS
 		err := requestBody1.PopulateFromARM(owner, *typedInput.RequestBody)
@@ -8684,7 +8684,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.RequestBody = &requestBody
 	}
 
-	// Set property ‘RequestHeader’:
+	// Set property "RequestHeader":
 	if typedInput.RequestHeader != nil {
 		var requestHeader1 DeliveryRuleRequestHeaderCondition_STATUS
 		err := requestHeader1.PopulateFromARM(owner, *typedInput.RequestHeader)
@@ -8695,7 +8695,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.RequestHeader = &requestHeader
 	}
 
-	// Set property ‘RequestMethod’:
+	// Set property "RequestMethod":
 	if typedInput.RequestMethod != nil {
 		var requestMethod1 DeliveryRuleRequestMethodCondition_STATUS
 		err := requestMethod1.PopulateFromARM(owner, *typedInput.RequestMethod)
@@ -8706,7 +8706,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.RequestMethod = &requestMethod
 	}
 
-	// Set property ‘RequestScheme’:
+	// Set property "RequestScheme":
 	if typedInput.RequestScheme != nil {
 		var requestScheme1 DeliveryRuleRequestSchemeCondition_STATUS
 		err := requestScheme1.PopulateFromARM(owner, *typedInput.RequestScheme)
@@ -8717,7 +8717,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.RequestScheme = &requestScheme
 	}
 
-	// Set property ‘RequestUri’:
+	// Set property "RequestUri":
 	if typedInput.RequestUri != nil {
 		var requestUri1 DeliveryRuleRequestUriCondition_STATUS
 		err := requestUri1.PopulateFromARM(owner, *typedInput.RequestUri)
@@ -8728,7 +8728,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.RequestUri = &requestUri
 	}
 
-	// Set property ‘ServerPort’:
+	// Set property "ServerPort":
 	if typedInput.ServerPort != nil {
 		var serverPort1 DeliveryRuleServerPortCondition_STATUS
 		err := serverPort1.PopulateFromARM(owner, *typedInput.ServerPort)
@@ -8739,7 +8739,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.ServerPort = &serverPort
 	}
 
-	// Set property ‘SocketAddr’:
+	// Set property "SocketAddr":
 	if typedInput.SocketAddr != nil {
 		var socketAddr1 DeliveryRuleSocketAddrCondition_STATUS
 		err := socketAddr1.PopulateFromARM(owner, *typedInput.SocketAddr)
@@ -8750,7 +8750,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.SocketAddr = &socketAddr
 	}
 
-	// Set property ‘SslProtocol’:
+	// Set property "SslProtocol":
 	if typedInput.SslProtocol != nil {
 		var sslProtocol1 DeliveryRuleSslProtocolCondition_STATUS
 		err := sslProtocol1.PopulateFromARM(owner, *typedInput.SslProtocol)
@@ -8761,7 +8761,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.SslProtocol = &sslProtocol
 	}
 
-	// Set property ‘UrlFileExtension’:
+	// Set property "UrlFileExtension":
 	if typedInput.UrlFileExtension != nil {
 		var urlFileExtension1 DeliveryRuleUrlFileExtensionCondition_STATUS
 		err := urlFileExtension1.PopulateFromARM(owner, *typedInput.UrlFileExtension)
@@ -8772,7 +8772,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.UrlFileExtension = &urlFileExtension
 	}
 
-	// Set property ‘UrlFileName’:
+	// Set property "UrlFileName":
 	if typedInput.UrlFileName != nil {
 		var urlFileName1 DeliveryRuleUrlFileNameCondition_STATUS
 		err := urlFileName1.PopulateFromARM(owner, *typedInput.UrlFileName)
@@ -8783,7 +8783,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.UrlFileName = &urlFileName
 	}
 
-	// Set property ‘UrlPath’:
+	// Set property "UrlPath":
 	if typedInput.UrlPath != nil {
 		var urlPath1 DeliveryRuleUrlPathCondition_STATUS
 		err := urlPath1.PopulateFromARM(owner, *typedInput.UrlPath)
@@ -9333,13 +9333,13 @@ func (parameters *HttpErrorRangeParameters) ConvertToARM(resolved genruntime.Con
 	}
 	result := &HttpErrorRangeParameters_ARM{}
 
-	// Set property ‘Begin’:
+	// Set property "Begin":
 	if parameters.Begin != nil {
 		begin := *parameters.Begin
 		result.Begin = &begin
 	}
 
-	// Set property ‘End’:
+	// Set property "End":
 	if parameters.End != nil {
 		end := *parameters.End
 		result.End = &end
@@ -9359,13 +9359,13 @@ func (parameters *HttpErrorRangeParameters) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HttpErrorRangeParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Begin’:
+	// Set property "Begin":
 	if typedInput.Begin != nil {
 		begin := *typedInput.Begin
 		parameters.Begin = &begin
 	}
 
-	// Set property ‘End’:
+	// Set property "End":
 	if typedInput.End != nil {
 		end := *typedInput.End
 		parameters.End = &end
@@ -9476,13 +9476,13 @@ func (parameters *HttpErrorRangeParameters_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HttpErrorRangeParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Begin’:
+	// Set property "Begin":
 	if typedInput.Begin != nil {
 		begin := *typedInput.Begin
 		parameters.Begin = &begin
 	}
 
-	// Set property ‘End’:
+	// Set property "End":
 	if typedInput.End != nil {
 		end := *typedInput.End
 		parameters.End = &end
@@ -9572,12 +9572,12 @@ func (action *DeliveryRuleCacheExpirationAction) ConvertToARM(resolved genruntim
 	}
 	result := &DeliveryRuleCacheExpirationAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -9601,10 +9601,10 @@ func (action *DeliveryRuleCacheExpirationAction) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCacheExpirationAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 CacheExpirationActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -9731,10 +9731,10 @@ func (action *DeliveryRuleCacheExpirationAction_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCacheExpirationAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 CacheExpirationActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -9831,12 +9831,12 @@ func (action *DeliveryRuleCacheKeyQueryStringAction) ConvertToARM(resolved genru
 	}
 	result := &DeliveryRuleCacheKeyQueryStringAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -9860,10 +9860,10 @@ func (action *DeliveryRuleCacheKeyQueryStringAction) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCacheKeyQueryStringAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 CacheKeyQueryStringActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -9990,10 +9990,10 @@ func (action *DeliveryRuleCacheKeyQueryStringAction_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCacheKeyQueryStringAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 CacheKeyQueryStringActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10090,12 +10090,12 @@ func (condition *DeliveryRuleClientPortCondition) ConvertToARM(resolved genrunti
 	}
 	result := &DeliveryRuleClientPortCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -10119,10 +10119,10 @@ func (condition *DeliveryRuleClientPortCondition) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleClientPortCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 ClientPortMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10249,10 +10249,10 @@ func (condition *DeliveryRuleClientPortCondition_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleClientPortCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 ClientPortMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10349,12 +10349,12 @@ func (condition *DeliveryRuleCookiesCondition) ConvertToARM(resolved genruntime.
 	}
 	result := &DeliveryRuleCookiesCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -10378,10 +10378,10 @@ func (condition *DeliveryRuleCookiesCondition) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCookiesCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 CookiesMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10508,10 +10508,10 @@ func (condition *DeliveryRuleCookiesCondition_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCookiesCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 CookiesMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10608,12 +10608,12 @@ func (condition *DeliveryRuleHostNameCondition) ConvertToARM(resolved genruntime
 	}
 	result := &DeliveryRuleHostNameCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -10637,10 +10637,10 @@ func (condition *DeliveryRuleHostNameCondition) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleHostNameCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HostNameMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10767,10 +10767,10 @@ func (condition *DeliveryRuleHostNameCondition_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleHostNameCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HostNameMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10867,12 +10867,12 @@ func (condition *DeliveryRuleHttpVersionCondition) ConvertToARM(resolved genrunt
 	}
 	result := &DeliveryRuleHttpVersionCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -10896,10 +10896,10 @@ func (condition *DeliveryRuleHttpVersionCondition) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleHttpVersionCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HttpVersionMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11026,10 +11026,10 @@ func (condition *DeliveryRuleHttpVersionCondition_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleHttpVersionCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HttpVersionMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11126,12 +11126,12 @@ func (condition *DeliveryRuleIsDeviceCondition) ConvertToARM(resolved genruntime
 	}
 	result := &DeliveryRuleIsDeviceCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -11155,10 +11155,10 @@ func (condition *DeliveryRuleIsDeviceCondition) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleIsDeviceCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 IsDeviceMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11285,10 +11285,10 @@ func (condition *DeliveryRuleIsDeviceCondition_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleIsDeviceCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 IsDeviceMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11385,12 +11385,12 @@ func (condition *DeliveryRulePostArgsCondition) ConvertToARM(resolved genruntime
 	}
 	result := &DeliveryRulePostArgsCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -11414,10 +11414,10 @@ func (condition *DeliveryRulePostArgsCondition) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRulePostArgsCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 PostArgsMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11544,10 +11544,10 @@ func (condition *DeliveryRulePostArgsCondition_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRulePostArgsCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 PostArgsMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11644,12 +11644,12 @@ func (condition *DeliveryRuleQueryStringCondition) ConvertToARM(resolved genrunt
 	}
 	result := &DeliveryRuleQueryStringCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -11673,10 +11673,10 @@ func (condition *DeliveryRuleQueryStringCondition) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleQueryStringCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 QueryStringMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11803,10 +11803,10 @@ func (condition *DeliveryRuleQueryStringCondition_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleQueryStringCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 QueryStringMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11903,12 +11903,12 @@ func (condition *DeliveryRuleRemoteAddressCondition) ConvertToARM(resolved genru
 	}
 	result := &DeliveryRuleRemoteAddressCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -11932,10 +11932,10 @@ func (condition *DeliveryRuleRemoteAddressCondition) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRemoteAddressCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RemoteAddressMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12062,10 +12062,10 @@ func (condition *DeliveryRuleRemoteAddressCondition_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRemoteAddressCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RemoteAddressMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12162,12 +12162,12 @@ func (condition *DeliveryRuleRequestBodyCondition) ConvertToARM(resolved genrunt
 	}
 	result := &DeliveryRuleRequestBodyCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -12191,10 +12191,10 @@ func (condition *DeliveryRuleRequestBodyCondition) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestBodyCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestBodyMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12321,10 +12321,10 @@ func (condition *DeliveryRuleRequestBodyCondition_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestBodyCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestBodyMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12421,12 +12421,12 @@ func (action *DeliveryRuleRequestHeaderAction) ConvertToARM(resolved genruntime.
 	}
 	result := &DeliveryRuleRequestHeaderAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -12450,10 +12450,10 @@ func (action *DeliveryRuleRequestHeaderAction) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestHeaderAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HeaderActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12580,10 +12580,10 @@ func (action *DeliveryRuleRequestHeaderAction_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestHeaderAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HeaderActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12680,12 +12680,12 @@ func (condition *DeliveryRuleRequestHeaderCondition) ConvertToARM(resolved genru
 	}
 	result := &DeliveryRuleRequestHeaderCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -12709,10 +12709,10 @@ func (condition *DeliveryRuleRequestHeaderCondition) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestHeaderCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestHeaderMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12839,10 +12839,10 @@ func (condition *DeliveryRuleRequestHeaderCondition_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestHeaderCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestHeaderMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12939,12 +12939,12 @@ func (condition *DeliveryRuleRequestMethodCondition) ConvertToARM(resolved genru
 	}
 	result := &DeliveryRuleRequestMethodCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -12968,10 +12968,10 @@ func (condition *DeliveryRuleRequestMethodCondition) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestMethodCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestMethodMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13098,10 +13098,10 @@ func (condition *DeliveryRuleRequestMethodCondition_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestMethodCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestMethodMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13198,12 +13198,12 @@ func (condition *DeliveryRuleRequestSchemeCondition) ConvertToARM(resolved genru
 	}
 	result := &DeliveryRuleRequestSchemeCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -13227,10 +13227,10 @@ func (condition *DeliveryRuleRequestSchemeCondition) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestSchemeCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestSchemeMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13357,10 +13357,10 @@ func (condition *DeliveryRuleRequestSchemeCondition_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestSchemeCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestSchemeMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13457,12 +13457,12 @@ func (condition *DeliveryRuleRequestUriCondition) ConvertToARM(resolved genrunti
 	}
 	result := &DeliveryRuleRequestUriCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -13486,10 +13486,10 @@ func (condition *DeliveryRuleRequestUriCondition) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestUriCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestUriMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13616,10 +13616,10 @@ func (condition *DeliveryRuleRequestUriCondition_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestUriCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestUriMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13716,12 +13716,12 @@ func (action *DeliveryRuleResponseHeaderAction) ConvertToARM(resolved genruntime
 	}
 	result := &DeliveryRuleResponseHeaderAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -13745,10 +13745,10 @@ func (action *DeliveryRuleResponseHeaderAction) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleResponseHeaderAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HeaderActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13875,10 +13875,10 @@ func (action *DeliveryRuleResponseHeaderAction_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleResponseHeaderAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HeaderActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13975,12 +13975,12 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction) ConvertToARM(resolve
 	}
 	result := &DeliveryRuleRouteConfigurationOverrideAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -14004,10 +14004,10 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRouteConfigurationOverrideAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RouteConfigurationOverrideActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -14134,10 +14134,10 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRouteConfigurationOverrideAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RouteConfigurationOverrideActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -14234,12 +14234,12 @@ func (condition *DeliveryRuleServerPortCondition) ConvertToARM(resolved genrunti
 	}
 	result := &DeliveryRuleServerPortCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -14263,10 +14263,10 @@ func (condition *DeliveryRuleServerPortCondition) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleServerPortCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 ServerPortMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -14393,10 +14393,10 @@ func (condition *DeliveryRuleServerPortCondition_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleServerPortCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 ServerPortMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -14493,12 +14493,12 @@ func (condition *DeliveryRuleSocketAddrCondition) ConvertToARM(resolved genrunti
 	}
 	result := &DeliveryRuleSocketAddrCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -14522,10 +14522,10 @@ func (condition *DeliveryRuleSocketAddrCondition) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleSocketAddrCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 SocketAddrMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -14652,10 +14652,10 @@ func (condition *DeliveryRuleSocketAddrCondition_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleSocketAddrCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 SocketAddrMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -14752,12 +14752,12 @@ func (condition *DeliveryRuleSslProtocolCondition) ConvertToARM(resolved genrunt
 	}
 	result := &DeliveryRuleSslProtocolCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -14781,10 +14781,10 @@ func (condition *DeliveryRuleSslProtocolCondition) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleSslProtocolCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 SslProtocolMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -14911,10 +14911,10 @@ func (condition *DeliveryRuleSslProtocolCondition_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleSslProtocolCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 SslProtocolMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -15011,12 +15011,12 @@ func (condition *DeliveryRuleUrlFileExtensionCondition) ConvertToARM(resolved ge
 	}
 	result := &DeliveryRuleUrlFileExtensionCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -15040,10 +15040,10 @@ func (condition *DeliveryRuleUrlFileExtensionCondition) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleUrlFileExtensionCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlFileExtensionMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -15170,10 +15170,10 @@ func (condition *DeliveryRuleUrlFileExtensionCondition_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleUrlFileExtensionCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlFileExtensionMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -15270,12 +15270,12 @@ func (condition *DeliveryRuleUrlFileNameCondition) ConvertToARM(resolved genrunt
 	}
 	result := &DeliveryRuleUrlFileNameCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -15299,10 +15299,10 @@ func (condition *DeliveryRuleUrlFileNameCondition) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleUrlFileNameCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlFileNameMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -15429,10 +15429,10 @@ func (condition *DeliveryRuleUrlFileNameCondition_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleUrlFileNameCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlFileNameMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -15529,12 +15529,12 @@ func (condition *DeliveryRuleUrlPathCondition) ConvertToARM(resolved genruntime.
 	}
 	result := &DeliveryRuleUrlPathCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -15558,10 +15558,10 @@ func (condition *DeliveryRuleUrlPathCondition) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleUrlPathCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlPathMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -15688,10 +15688,10 @@ func (condition *DeliveryRuleUrlPathCondition_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleUrlPathCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlPathMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -15788,12 +15788,12 @@ func (action *OriginGroupOverrideAction) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &OriginGroupOverrideAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -15817,10 +15817,10 @@ func (action *OriginGroupOverrideAction) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OriginGroupOverrideAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 OriginGroupOverrideActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -15947,10 +15947,10 @@ func (action *OriginGroupOverrideAction_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OriginGroupOverrideAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 OriginGroupOverrideActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -16047,12 +16047,12 @@ func (action *UrlRedirectAction) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &UrlRedirectAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -16076,10 +16076,10 @@ func (action *UrlRedirectAction) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRedirectAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlRedirectActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -16206,10 +16206,10 @@ func (action *UrlRedirectAction_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRedirectAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlRedirectActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -16306,12 +16306,12 @@ func (action *UrlRewriteAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &UrlRewriteAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -16335,10 +16335,10 @@ func (action *UrlRewriteAction) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRewriteAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlRewriteActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -16465,10 +16465,10 @@ func (action *UrlRewriteAction_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRewriteAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlRewriteActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -16565,12 +16565,12 @@ func (action *UrlSigningAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &UrlSigningAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -16594,10 +16594,10 @@ func (action *UrlSigningAction) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlSigningActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -16724,10 +16724,10 @@ func (action *UrlSigningAction_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlSigningActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -16831,25 +16831,25 @@ func (parameters *CacheExpirationActionParameters) ConvertToARM(resolved genrunt
 	}
 	result := &CacheExpirationActionParameters_ARM{}
 
-	// Set property ‘CacheBehavior’:
+	// Set property "CacheBehavior":
 	if parameters.CacheBehavior != nil {
 		cacheBehavior := *parameters.CacheBehavior
 		result.CacheBehavior = &cacheBehavior
 	}
 
-	// Set property ‘CacheDuration’:
+	// Set property "CacheDuration":
 	if parameters.CacheDuration != nil {
 		cacheDuration := *parameters.CacheDuration
 		result.CacheDuration = &cacheDuration
 	}
 
-	// Set property ‘CacheType’:
+	// Set property "CacheType":
 	if parameters.CacheType != nil {
 		cacheType := *parameters.CacheType
 		result.CacheType = &cacheType
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -16869,25 +16869,25 @@ func (parameters *CacheExpirationActionParameters) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CacheExpirationActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheBehavior’:
+	// Set property "CacheBehavior":
 	if typedInput.CacheBehavior != nil {
 		cacheBehavior := *typedInput.CacheBehavior
 		parameters.CacheBehavior = &cacheBehavior
 	}
 
-	// Set property ‘CacheDuration’:
+	// Set property "CacheDuration":
 	if typedInput.CacheDuration != nil {
 		cacheDuration := *typedInput.CacheDuration
 		parameters.CacheDuration = &cacheDuration
 	}
 
-	// Set property ‘CacheType’:
+	// Set property "CacheType":
 	if typedInput.CacheType != nil {
 		cacheType := *typedInput.CacheType
 		parameters.CacheType = &cacheType
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -17035,25 +17035,25 @@ func (parameters *CacheExpirationActionParameters_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CacheExpirationActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheBehavior’:
+	// Set property "CacheBehavior":
 	if typedInput.CacheBehavior != nil {
 		cacheBehavior := *typedInput.CacheBehavior
 		parameters.CacheBehavior = &cacheBehavior
 	}
 
-	// Set property ‘CacheDuration’:
+	// Set property "CacheDuration":
 	if typedInput.CacheDuration != nil {
 		cacheDuration := *typedInput.CacheDuration
 		parameters.CacheDuration = &cacheDuration
 	}
 
-	// Set property ‘CacheType’:
+	// Set property "CacheType":
 	if typedInput.CacheType != nil {
 		cacheType := *typedInput.CacheType
 		parameters.CacheType = &cacheType
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -17162,19 +17162,19 @@ func (parameters *CacheKeyQueryStringActionParameters) ConvertToARM(resolved gen
 	}
 	result := &CacheKeyQueryStringActionParameters_ARM{}
 
-	// Set property ‘QueryParameters’:
+	// Set property "QueryParameters":
 	if parameters.QueryParameters != nil {
 		queryParameters := *parameters.QueryParameters
 		result.QueryParameters = &queryParameters
 	}
 
-	// Set property ‘QueryStringBehavior’:
+	// Set property "QueryStringBehavior":
 	if parameters.QueryStringBehavior != nil {
 		queryStringBehavior := *parameters.QueryStringBehavior
 		result.QueryStringBehavior = &queryStringBehavior
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -17194,19 +17194,19 @@ func (parameters *CacheKeyQueryStringActionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CacheKeyQueryStringActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘QueryParameters’:
+	// Set property "QueryParameters":
 	if typedInput.QueryParameters != nil {
 		queryParameters := *typedInput.QueryParameters
 		parameters.QueryParameters = &queryParameters
 	}
 
-	// Set property ‘QueryStringBehavior’:
+	// Set property "QueryStringBehavior":
 	if typedInput.QueryStringBehavior != nil {
 		queryStringBehavior := *typedInput.QueryStringBehavior
 		parameters.QueryStringBehavior = &queryStringBehavior
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -17327,19 +17327,19 @@ func (parameters *CacheKeyQueryStringActionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CacheKeyQueryStringActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘QueryParameters’:
+	// Set property "QueryParameters":
 	if typedInput.QueryParameters != nil {
 		queryParameters := *typedInput.QueryParameters
 		parameters.QueryParameters = &queryParameters
 	}
 
-	// Set property ‘QueryStringBehavior’:
+	// Set property "QueryStringBehavior":
 	if typedInput.QueryStringBehavior != nil {
 		queryStringBehavior := *typedInput.QueryStringBehavior
 		parameters.QueryStringBehavior = &queryStringBehavior
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -17438,29 +17438,29 @@ func (parameters *ClientPortMatchConditionParameters) ConvertToARM(resolved genr
 	}
 	result := &ClientPortMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -17480,29 +17480,29 @@ func (parameters *ClientPortMatchConditionParameters) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ClientPortMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -17693,29 +17693,29 @@ func (parameters *ClientPortMatchConditionParameters_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ClientPortMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -17859,35 +17859,35 @@ func (parameters *CookiesMatchConditionParameters) ConvertToARM(resolved genrunt
 	}
 	result := &CookiesMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if parameters.Selector != nil {
 		selector := *parameters.Selector
 		result.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -17907,35 +17907,35 @@ func (parameters *CookiesMatchConditionParameters) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CookiesMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if typedInput.Selector != nil {
 		selector := *typedInput.Selector
 		parameters.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -18138,35 +18138,35 @@ func (parameters *CookiesMatchConditionParameters_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CookiesMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if typedInput.Selector != nil {
 		selector := *typedInput.Selector
 		parameters.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -18527,25 +18527,25 @@ func (parameters *HeaderActionParameters) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &HeaderActionParameters_ARM{}
 
-	// Set property ‘HeaderAction’:
+	// Set property "HeaderAction":
 	if parameters.HeaderAction != nil {
 		headerAction := *parameters.HeaderAction
 		result.HeaderAction = &headerAction
 	}
 
-	// Set property ‘HeaderName’:
+	// Set property "HeaderName":
 	if parameters.HeaderName != nil {
 		headerName := *parameters.HeaderName
 		result.HeaderName = &headerName
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if parameters.Value != nil {
 		value := *parameters.Value
 		result.Value = &value
@@ -18565,25 +18565,25 @@ func (parameters *HeaderActionParameters) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HeaderActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HeaderAction’:
+	// Set property "HeaderAction":
 	if typedInput.HeaderAction != nil {
 		headerAction := *typedInput.HeaderAction
 		parameters.HeaderAction = &headerAction
 	}
 
-	// Set property ‘HeaderName’:
+	// Set property "HeaderName":
 	if typedInput.HeaderName != nil {
 		headerName := *typedInput.HeaderName
 		parameters.HeaderName = &headerName
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		parameters.Value = &value
@@ -18716,25 +18716,25 @@ func (parameters *HeaderActionParameters_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HeaderActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HeaderAction’:
+	// Set property "HeaderAction":
 	if typedInput.HeaderAction != nil {
 		headerAction := *typedInput.HeaderAction
 		parameters.HeaderAction = &headerAction
 	}
 
-	// Set property ‘HeaderName’:
+	// Set property "HeaderName":
 	if typedInput.HeaderName != nil {
 		headerName := *typedInput.HeaderName
 		parameters.HeaderName = &headerName
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		parameters.Value = &value
@@ -18839,29 +18839,29 @@ func (parameters *HostNameMatchConditionParameters) ConvertToARM(resolved genrun
 	}
 	result := &HostNameMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -18881,29 +18881,29 @@ func (parameters *HostNameMatchConditionParameters) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HostNameMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -19094,29 +19094,29 @@ func (parameters *HostNameMatchConditionParameters_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HostNameMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -19257,29 +19257,29 @@ func (parameters *HttpVersionMatchConditionParameters) ConvertToARM(resolved gen
 	}
 	result := &HttpVersionMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -19299,29 +19299,29 @@ func (parameters *HttpVersionMatchConditionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HttpVersionMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -19512,29 +19512,29 @@ func (parameters *HttpVersionMatchConditionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HttpVersionMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -19675,29 +19675,29 @@ func (parameters *IsDeviceMatchConditionParameters) ConvertToARM(resolved genrun
 	}
 	result := &IsDeviceMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -19717,29 +19717,29 @@ func (parameters *IsDeviceMatchConditionParameters) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IsDeviceMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -19961,29 +19961,29 @@ func (parameters *IsDeviceMatchConditionParameters_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IsDeviceMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -20144,7 +20144,7 @@ func (parameters *OriginGroupOverrideActionParameters) ConvertToARM(resolved gen
 	}
 	result := &OriginGroupOverrideActionParameters_ARM{}
 
-	// Set property ‘OriginGroup’:
+	// Set property "OriginGroup":
 	if parameters.OriginGroup != nil {
 		originGroup_ARM, err := (*parameters.OriginGroup).ConvertToARM(resolved)
 		if err != nil {
@@ -20154,7 +20154,7 @@ func (parameters *OriginGroupOverrideActionParameters) ConvertToARM(resolved gen
 		result.OriginGroup = &originGroup
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -20174,7 +20174,7 @@ func (parameters *OriginGroupOverrideActionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OriginGroupOverrideActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘OriginGroup’:
+	// Set property "OriginGroup":
 	if typedInput.OriginGroup != nil {
 		var originGroup1 ResourceReference
 		err := originGroup1.PopulateFromARM(owner, *typedInput.OriginGroup)
@@ -20185,7 +20185,7 @@ func (parameters *OriginGroupOverrideActionParameters) PopulateFromARM(owner gen
 		parameters.OriginGroup = &originGroup
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -20306,7 +20306,7 @@ func (parameters *OriginGroupOverrideActionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OriginGroupOverrideActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘OriginGroup’:
+	// Set property "OriginGroup":
 	if typedInput.OriginGroup != nil {
 		var originGroup1 ResourceReference_STATUS
 		err := originGroup1.PopulateFromARM(owner, *typedInput.OriginGroup)
@@ -20317,7 +20317,7 @@ func (parameters *OriginGroupOverrideActionParameters_STATUS) PopulateFromARM(ow
 		parameters.OriginGroup = &originGroup
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -20421,35 +20421,35 @@ func (parameters *PostArgsMatchConditionParameters) ConvertToARM(resolved genrun
 	}
 	result := &PostArgsMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if parameters.Selector != nil {
 		selector := *parameters.Selector
 		result.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -20469,35 +20469,35 @@ func (parameters *PostArgsMatchConditionParameters) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PostArgsMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if typedInput.Selector != nil {
 		selector := *typedInput.Selector
 		parameters.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -20700,35 +20700,35 @@ func (parameters *PostArgsMatchConditionParameters_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PostArgsMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if typedInput.Selector != nil {
 		selector := *typedInput.Selector
 		parameters.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -20875,29 +20875,29 @@ func (parameters *QueryStringMatchConditionParameters) ConvertToARM(resolved gen
 	}
 	result := &QueryStringMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -20917,29 +20917,29 @@ func (parameters *QueryStringMatchConditionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected QueryStringMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -21130,29 +21130,29 @@ func (parameters *QueryStringMatchConditionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected QueryStringMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -21294,29 +21294,29 @@ func (parameters *RemoteAddressMatchConditionParameters) ConvertToARM(resolved g
 	}
 	result := &RemoteAddressMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -21336,29 +21336,29 @@ func (parameters *RemoteAddressMatchConditionParameters) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RemoteAddressMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -21550,29 +21550,29 @@ func (parameters *RemoteAddressMatchConditionParameters_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RemoteAddressMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -21713,29 +21713,29 @@ func (parameters *RequestBodyMatchConditionParameters) ConvertToARM(resolved gen
 	}
 	result := &RequestBodyMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -21755,29 +21755,29 @@ func (parameters *RequestBodyMatchConditionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestBodyMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -21968,29 +21968,29 @@ func (parameters *RequestBodyMatchConditionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestBodyMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -22134,35 +22134,35 @@ func (parameters *RequestHeaderMatchConditionParameters) ConvertToARM(resolved g
 	}
 	result := &RequestHeaderMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if parameters.Selector != nil {
 		selector := *parameters.Selector
 		result.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -22182,35 +22182,35 @@ func (parameters *RequestHeaderMatchConditionParameters) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestHeaderMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if typedInput.Selector != nil {
 		selector := *typedInput.Selector
 		parameters.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -22413,35 +22413,35 @@ func (parameters *RequestHeaderMatchConditionParameters_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestHeaderMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if typedInput.Selector != nil {
 		selector := *typedInput.Selector
 		parameters.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -22588,29 +22588,29 @@ func (parameters *RequestMethodMatchConditionParameters) ConvertToARM(resolved g
 	}
 	result := &RequestMethodMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -22630,29 +22630,29 @@ func (parameters *RequestMethodMatchConditionParameters) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestMethodMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -22874,29 +22874,29 @@ func (parameters *RequestMethodMatchConditionParameters_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestMethodMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -23057,29 +23057,29 @@ func (parameters *RequestSchemeMatchConditionParameters) ConvertToARM(resolved g
 	}
 	result := &RequestSchemeMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -23099,29 +23099,29 @@ func (parameters *RequestSchemeMatchConditionParameters) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestSchemeMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -23343,29 +23343,29 @@ func (parameters *RequestSchemeMatchConditionParameters_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestSchemeMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -23526,29 +23526,29 @@ func (parameters *RequestUriMatchConditionParameters) ConvertToARM(resolved genr
 	}
 	result := &RequestUriMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -23568,29 +23568,29 @@ func (parameters *RequestUriMatchConditionParameters) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestUriMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -23781,29 +23781,29 @@ func (parameters *RequestUriMatchConditionParameters_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestUriMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -23939,7 +23939,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) ConvertToARM(resol
 	}
 	result := &RouteConfigurationOverrideActionParameters_ARM{}
 
-	// Set property ‘CacheConfiguration’:
+	// Set property "CacheConfiguration":
 	if parameters.CacheConfiguration != nil {
 		cacheConfiguration_ARM, err := (*parameters.CacheConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -23949,7 +23949,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) ConvertToARM(resol
 		result.CacheConfiguration = &cacheConfiguration
 	}
 
-	// Set property ‘OriginGroupOverride’:
+	// Set property "OriginGroupOverride":
 	if parameters.OriginGroupOverride != nil {
 		originGroupOverride_ARM, err := (*parameters.OriginGroupOverride).ConvertToARM(resolved)
 		if err != nil {
@@ -23959,7 +23959,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) ConvertToARM(resol
 		result.OriginGroupOverride = &originGroupOverride
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -23979,7 +23979,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteConfigurationOverrideActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheConfiguration’:
+	// Set property "CacheConfiguration":
 	if typedInput.CacheConfiguration != nil {
 		var cacheConfiguration1 CacheConfiguration
 		err := cacheConfiguration1.PopulateFromARM(owner, *typedInput.CacheConfiguration)
@@ -23990,7 +23990,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) PopulateFromARM(ow
 		parameters.CacheConfiguration = &cacheConfiguration
 	}
 
-	// Set property ‘OriginGroupOverride’:
+	// Set property "OriginGroupOverride":
 	if typedInput.OriginGroupOverride != nil {
 		var originGroupOverride1 OriginGroupOverride
 		err := originGroupOverride1.PopulateFromARM(owner, *typedInput.OriginGroupOverride)
@@ -24001,7 +24001,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) PopulateFromARM(ow
 		parameters.OriginGroupOverride = &originGroupOverride
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -24163,7 +24163,7 @@ func (parameters *RouteConfigurationOverrideActionParameters_STATUS) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteConfigurationOverrideActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheConfiguration’:
+	// Set property "CacheConfiguration":
 	if typedInput.CacheConfiguration != nil {
 		var cacheConfiguration1 CacheConfiguration_STATUS
 		err := cacheConfiguration1.PopulateFromARM(owner, *typedInput.CacheConfiguration)
@@ -24174,7 +24174,7 @@ func (parameters *RouteConfigurationOverrideActionParameters_STATUS) PopulateFro
 		parameters.CacheConfiguration = &cacheConfiguration
 	}
 
-	// Set property ‘OriginGroupOverride’:
+	// Set property "OriginGroupOverride":
 	if typedInput.OriginGroupOverride != nil {
 		var originGroupOverride1 OriginGroupOverride_STATUS
 		err := originGroupOverride1.PopulateFromARM(owner, *typedInput.OriginGroupOverride)
@@ -24185,7 +24185,7 @@ func (parameters *RouteConfigurationOverrideActionParameters_STATUS) PopulateFro
 		parameters.OriginGroupOverride = &originGroupOverride
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -24310,29 +24310,29 @@ func (parameters *ServerPortMatchConditionParameters) ConvertToARM(resolved genr
 	}
 	result := &ServerPortMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -24352,29 +24352,29 @@ func (parameters *ServerPortMatchConditionParameters) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPortMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -24565,29 +24565,29 @@ func (parameters *ServerPortMatchConditionParameters_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPortMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -24728,29 +24728,29 @@ func (parameters *SocketAddrMatchConditionParameters) ConvertToARM(resolved genr
 	}
 	result := &SocketAddrMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -24770,29 +24770,29 @@ func (parameters *SocketAddrMatchConditionParameters) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SocketAddrMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -24983,29 +24983,29 @@ func (parameters *SocketAddrMatchConditionParameters_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SocketAddrMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -25146,29 +25146,29 @@ func (parameters *SslProtocolMatchConditionParameters) ConvertToARM(resolved gen
 	}
 	result := &SslProtocolMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -25188,29 +25188,29 @@ func (parameters *SslProtocolMatchConditionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SslProtocolMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -25432,29 +25432,29 @@ func (parameters *SslProtocolMatchConditionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SslProtocolMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -25615,29 +25615,29 @@ func (parameters *UrlFileExtensionMatchConditionParameters) ConvertToARM(resolve
 	}
 	result := &UrlFileExtensionMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -25657,29 +25657,29 @@ func (parameters *UrlFileExtensionMatchConditionParameters) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlFileExtensionMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -25870,29 +25870,29 @@ func (parameters *UrlFileExtensionMatchConditionParameters_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlFileExtensionMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -26033,29 +26033,29 @@ func (parameters *UrlFileNameMatchConditionParameters) ConvertToARM(resolved gen
 	}
 	result := &UrlFileNameMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -26075,29 +26075,29 @@ func (parameters *UrlFileNameMatchConditionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlFileNameMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -26288,29 +26288,29 @@ func (parameters *UrlFileNameMatchConditionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlFileNameMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -26451,29 +26451,29 @@ func (parameters *UrlPathMatchConditionParameters) ConvertToARM(resolved genrunt
 	}
 	result := &UrlPathMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -26493,29 +26493,29 @@ func (parameters *UrlPathMatchConditionParameters) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlPathMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -26706,29 +26706,29 @@ func (parameters *UrlPathMatchConditionParameters_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlPathMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -26888,43 +26888,43 @@ func (parameters *UrlRedirectActionParameters) ConvertToARM(resolved genruntime.
 	}
 	result := &UrlRedirectActionParameters_ARM{}
 
-	// Set property ‘CustomFragment’:
+	// Set property "CustomFragment":
 	if parameters.CustomFragment != nil {
 		customFragment := *parameters.CustomFragment
 		result.CustomFragment = &customFragment
 	}
 
-	// Set property ‘CustomHostname’:
+	// Set property "CustomHostname":
 	if parameters.CustomHostname != nil {
 		customHostname := *parameters.CustomHostname
 		result.CustomHostname = &customHostname
 	}
 
-	// Set property ‘CustomPath’:
+	// Set property "CustomPath":
 	if parameters.CustomPath != nil {
 		customPath := *parameters.CustomPath
 		result.CustomPath = &customPath
 	}
 
-	// Set property ‘CustomQueryString’:
+	// Set property "CustomQueryString":
 	if parameters.CustomQueryString != nil {
 		customQueryString := *parameters.CustomQueryString
 		result.CustomQueryString = &customQueryString
 	}
 
-	// Set property ‘DestinationProtocol’:
+	// Set property "DestinationProtocol":
 	if parameters.DestinationProtocol != nil {
 		destinationProtocol := *parameters.DestinationProtocol
 		result.DestinationProtocol = &destinationProtocol
 	}
 
-	// Set property ‘RedirectType’:
+	// Set property "RedirectType":
 	if parameters.RedirectType != nil {
 		redirectType := *parameters.RedirectType
 		result.RedirectType = &redirectType
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -26944,43 +26944,43 @@ func (parameters *UrlRedirectActionParameters) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRedirectActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomFragment’:
+	// Set property "CustomFragment":
 	if typedInput.CustomFragment != nil {
 		customFragment := *typedInput.CustomFragment
 		parameters.CustomFragment = &customFragment
 	}
 
-	// Set property ‘CustomHostname’:
+	// Set property "CustomHostname":
 	if typedInput.CustomHostname != nil {
 		customHostname := *typedInput.CustomHostname
 		parameters.CustomHostname = &customHostname
 	}
 
-	// Set property ‘CustomPath’:
+	// Set property "CustomPath":
 	if typedInput.CustomPath != nil {
 		customPath := *typedInput.CustomPath
 		parameters.CustomPath = &customPath
 	}
 
-	// Set property ‘CustomQueryString’:
+	// Set property "CustomQueryString":
 	if typedInput.CustomQueryString != nil {
 		customQueryString := *typedInput.CustomQueryString
 		parameters.CustomQueryString = &customQueryString
 	}
 
-	// Set property ‘DestinationProtocol’:
+	// Set property "DestinationProtocol":
 	if typedInput.DestinationProtocol != nil {
 		destinationProtocol := *typedInput.DestinationProtocol
 		parameters.DestinationProtocol = &destinationProtocol
 	}
 
-	// Set property ‘RedirectType’:
+	// Set property "RedirectType":
 	if typedInput.RedirectType != nil {
 		redirectType := *typedInput.RedirectType
 		parameters.RedirectType = &redirectType
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -27168,43 +27168,43 @@ func (parameters *UrlRedirectActionParameters_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRedirectActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomFragment’:
+	// Set property "CustomFragment":
 	if typedInput.CustomFragment != nil {
 		customFragment := *typedInput.CustomFragment
 		parameters.CustomFragment = &customFragment
 	}
 
-	// Set property ‘CustomHostname’:
+	// Set property "CustomHostname":
 	if typedInput.CustomHostname != nil {
 		customHostname := *typedInput.CustomHostname
 		parameters.CustomHostname = &customHostname
 	}
 
-	// Set property ‘CustomPath’:
+	// Set property "CustomPath":
 	if typedInput.CustomPath != nil {
 		customPath := *typedInput.CustomPath
 		parameters.CustomPath = &customPath
 	}
 
-	// Set property ‘CustomQueryString’:
+	// Set property "CustomQueryString":
 	if typedInput.CustomQueryString != nil {
 		customQueryString := *typedInput.CustomQueryString
 		parameters.CustomQueryString = &customQueryString
 	}
 
-	// Set property ‘DestinationProtocol’:
+	// Set property "DestinationProtocol":
 	if typedInput.DestinationProtocol != nil {
 		destinationProtocol := *typedInput.DestinationProtocol
 		parameters.DestinationProtocol = &destinationProtocol
 	}
 
-	// Set property ‘RedirectType’:
+	// Set property "RedirectType":
 	if typedInput.RedirectType != nil {
 		redirectType := *typedInput.RedirectType
 		parameters.RedirectType = &redirectType
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -27345,25 +27345,25 @@ func (parameters *UrlRewriteActionParameters) ConvertToARM(resolved genruntime.C
 	}
 	result := &UrlRewriteActionParameters_ARM{}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	if parameters.Destination != nil {
 		destination := *parameters.Destination
 		result.Destination = &destination
 	}
 
-	// Set property ‘PreserveUnmatchedPath’:
+	// Set property "PreserveUnmatchedPath":
 	if parameters.PreserveUnmatchedPath != nil {
 		preserveUnmatchedPath := *parameters.PreserveUnmatchedPath
 		result.PreserveUnmatchedPath = &preserveUnmatchedPath
 	}
 
-	// Set property ‘SourcePattern’:
+	// Set property "SourcePattern":
 	if parameters.SourcePattern != nil {
 		sourcePattern := *parameters.SourcePattern
 		result.SourcePattern = &sourcePattern
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -27383,25 +27383,25 @@ func (parameters *UrlRewriteActionParameters) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRewriteActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	if typedInput.Destination != nil {
 		destination := *typedInput.Destination
 		parameters.Destination = &destination
 	}
 
-	// Set property ‘PreserveUnmatchedPath’:
+	// Set property "PreserveUnmatchedPath":
 	if typedInput.PreserveUnmatchedPath != nil {
 		preserveUnmatchedPath := *typedInput.PreserveUnmatchedPath
 		parameters.PreserveUnmatchedPath = &preserveUnmatchedPath
 	}
 
-	// Set property ‘SourcePattern’:
+	// Set property "SourcePattern":
 	if typedInput.SourcePattern != nil {
 		sourcePattern := *typedInput.SourcePattern
 		parameters.SourcePattern = &sourcePattern
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -27535,25 +27535,25 @@ func (parameters *UrlRewriteActionParameters_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRewriteActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	if typedInput.Destination != nil {
 		destination := *typedInput.Destination
 		parameters.Destination = &destination
 	}
 
-	// Set property ‘PreserveUnmatchedPath’:
+	// Set property "PreserveUnmatchedPath":
 	if typedInput.PreserveUnmatchedPath != nil {
 		preserveUnmatchedPath := *typedInput.PreserveUnmatchedPath
 		parameters.PreserveUnmatchedPath = &preserveUnmatchedPath
 	}
 
-	// Set property ‘SourcePattern’:
+	// Set property "SourcePattern":
 	if typedInput.SourcePattern != nil {
 		sourcePattern := *typedInput.SourcePattern
 		parameters.SourcePattern = &sourcePattern
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -27660,13 +27660,13 @@ func (parameters *UrlSigningActionParameters) ConvertToARM(resolved genruntime.C
 	}
 	result := &UrlSigningActionParameters_ARM{}
 
-	// Set property ‘Algorithm’:
+	// Set property "Algorithm":
 	if parameters.Algorithm != nil {
 		algorithm := *parameters.Algorithm
 		result.Algorithm = &algorithm
 	}
 
-	// Set property ‘ParameterNameOverride’:
+	// Set property "ParameterNameOverride":
 	for _, item := range parameters.ParameterNameOverride {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -27675,7 +27675,7 @@ func (parameters *UrlSigningActionParameters) ConvertToARM(resolved genruntime.C
 		result.ParameterNameOverride = append(result.ParameterNameOverride, *item_ARM.(*UrlSigningParamIdentifier_ARM))
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -27695,13 +27695,13 @@ func (parameters *UrlSigningActionParameters) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Algorithm’:
+	// Set property "Algorithm":
 	if typedInput.Algorithm != nil {
 		algorithm := *typedInput.Algorithm
 		parameters.Algorithm = &algorithm
 	}
 
-	// Set property ‘ParameterNameOverride’:
+	// Set property "ParameterNameOverride":
 	for _, item := range typedInput.ParameterNameOverride {
 		var item1 UrlSigningParamIdentifier
 		err := item1.PopulateFromARM(owner, item)
@@ -27711,7 +27711,7 @@ func (parameters *UrlSigningActionParameters) PopulateFromARM(owner genruntime.A
 		parameters.ParameterNameOverride = append(parameters.ParameterNameOverride, item1)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -27877,13 +27877,13 @@ func (parameters *UrlSigningActionParameters_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Algorithm’:
+	// Set property "Algorithm":
 	if typedInput.Algorithm != nil {
 		algorithm := *typedInput.Algorithm
 		parameters.Algorithm = &algorithm
 	}
 
-	// Set property ‘ParameterNameOverride’:
+	// Set property "ParameterNameOverride":
 	for _, item := range typedInput.ParameterNameOverride {
 		var item1 UrlSigningParamIdentifier_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -27893,7 +27893,7 @@ func (parameters *UrlSigningActionParameters_STATUS) PopulateFromARM(owner genru
 		parameters.ParameterNameOverride = append(parameters.ParameterNameOverride, item1)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -28025,31 +28025,31 @@ func (configuration *CacheConfiguration) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &CacheConfiguration_ARM{}
 
-	// Set property ‘CacheBehavior’:
+	// Set property "CacheBehavior":
 	if configuration.CacheBehavior != nil {
 		cacheBehavior := *configuration.CacheBehavior
 		result.CacheBehavior = &cacheBehavior
 	}
 
-	// Set property ‘CacheDuration’:
+	// Set property "CacheDuration":
 	if configuration.CacheDuration != nil {
 		cacheDuration := *configuration.CacheDuration
 		result.CacheDuration = &cacheDuration
 	}
 
-	// Set property ‘IsCompressionEnabled’:
+	// Set property "IsCompressionEnabled":
 	if configuration.IsCompressionEnabled != nil {
 		isCompressionEnabled := *configuration.IsCompressionEnabled
 		result.IsCompressionEnabled = &isCompressionEnabled
 	}
 
-	// Set property ‘QueryParameters’:
+	// Set property "QueryParameters":
 	if configuration.QueryParameters != nil {
 		queryParameters := *configuration.QueryParameters
 		result.QueryParameters = &queryParameters
 	}
 
-	// Set property ‘QueryStringCachingBehavior’:
+	// Set property "QueryStringCachingBehavior":
 	if configuration.QueryStringCachingBehavior != nil {
 		queryStringCachingBehavior := *configuration.QueryStringCachingBehavior
 		result.QueryStringCachingBehavior = &queryStringCachingBehavior
@@ -28069,31 +28069,31 @@ func (configuration *CacheConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CacheConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheBehavior’:
+	// Set property "CacheBehavior":
 	if typedInput.CacheBehavior != nil {
 		cacheBehavior := *typedInput.CacheBehavior
 		configuration.CacheBehavior = &cacheBehavior
 	}
 
-	// Set property ‘CacheDuration’:
+	// Set property "CacheDuration":
 	if typedInput.CacheDuration != nil {
 		cacheDuration := *typedInput.CacheDuration
 		configuration.CacheDuration = &cacheDuration
 	}
 
-	// Set property ‘IsCompressionEnabled’:
+	// Set property "IsCompressionEnabled":
 	if typedInput.IsCompressionEnabled != nil {
 		isCompressionEnabled := *typedInput.IsCompressionEnabled
 		configuration.IsCompressionEnabled = &isCompressionEnabled
 	}
 
-	// Set property ‘QueryParameters’:
+	// Set property "QueryParameters":
 	if typedInput.QueryParameters != nil {
 		queryParameters := *typedInput.QueryParameters
 		configuration.QueryParameters = &queryParameters
 	}
 
-	// Set property ‘QueryStringCachingBehavior’:
+	// Set property "QueryStringCachingBehavior":
 	if typedInput.QueryStringCachingBehavior != nil {
 		queryStringCachingBehavior := *typedInput.QueryStringCachingBehavior
 		configuration.QueryStringCachingBehavior = &queryStringCachingBehavior
@@ -28259,31 +28259,31 @@ func (configuration *CacheConfiguration_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CacheConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheBehavior’:
+	// Set property "CacheBehavior":
 	if typedInput.CacheBehavior != nil {
 		cacheBehavior := *typedInput.CacheBehavior
 		configuration.CacheBehavior = &cacheBehavior
 	}
 
-	// Set property ‘CacheDuration’:
+	// Set property "CacheDuration":
 	if typedInput.CacheDuration != nil {
 		cacheDuration := *typedInput.CacheDuration
 		configuration.CacheDuration = &cacheDuration
 	}
 
-	// Set property ‘IsCompressionEnabled’:
+	// Set property "IsCompressionEnabled":
 	if typedInput.IsCompressionEnabled != nil {
 		isCompressionEnabled := *typedInput.IsCompressionEnabled
 		configuration.IsCompressionEnabled = &isCompressionEnabled
 	}
 
-	// Set property ‘QueryParameters’:
+	// Set property "QueryParameters":
 	if typedInput.QueryParameters != nil {
 		queryParameters := *typedInput.QueryParameters
 		configuration.QueryParameters = &queryParameters
 	}
 
-	// Set property ‘QueryStringCachingBehavior’:
+	// Set property "QueryStringCachingBehavior":
 	if typedInput.QueryStringCachingBehavior != nil {
 		queryStringCachingBehavior := *typedInput.QueryStringCachingBehavior
 		configuration.QueryStringCachingBehavior = &queryStringCachingBehavior
@@ -28654,13 +28654,13 @@ func (override *OriginGroupOverride) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &OriginGroupOverride_ARM{}
 
-	// Set property ‘ForwardingProtocol’:
+	// Set property "ForwardingProtocol":
 	if override.ForwardingProtocol != nil {
 		forwardingProtocol := *override.ForwardingProtocol
 		result.ForwardingProtocol = &forwardingProtocol
 	}
 
-	// Set property ‘OriginGroup’:
+	// Set property "OriginGroup":
 	if override.OriginGroup != nil {
 		originGroup_ARM, err := (*override.OriginGroup).ConvertToARM(resolved)
 		if err != nil {
@@ -28684,13 +28684,13 @@ func (override *OriginGroupOverride) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OriginGroupOverride_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ForwardingProtocol’:
+	// Set property "ForwardingProtocol":
 	if typedInput.ForwardingProtocol != nil {
 		forwardingProtocol := *typedInput.ForwardingProtocol
 		override.ForwardingProtocol = &forwardingProtocol
 	}
 
-	// Set property ‘OriginGroup’:
+	// Set property "OriginGroup":
 	if typedInput.OriginGroup != nil {
 		var originGroup1 ResourceReference
 		err := originGroup1.PopulateFromARM(owner, *typedInput.OriginGroup)
@@ -28818,13 +28818,13 @@ func (override *OriginGroupOverride_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OriginGroupOverride_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ForwardingProtocol’:
+	// Set property "ForwardingProtocol":
 	if typedInput.ForwardingProtocol != nil {
 		forwardingProtocol := *typedInput.ForwardingProtocol
 		override.ForwardingProtocol = &forwardingProtocol
 	}
 
-	// Set property ‘OriginGroup’:
+	// Set property "OriginGroup":
 	if typedInput.OriginGroup != nil {
 		var originGroup1 ResourceReference_STATUS
 		err := originGroup1.PopulateFromARM(owner, *typedInput.OriginGroup)
@@ -29562,13 +29562,13 @@ func (identifier *UrlSigningParamIdentifier) ConvertToARM(resolved genruntime.Co
 	}
 	result := &UrlSigningParamIdentifier_ARM{}
 
-	// Set property ‘ParamIndicator’:
+	// Set property "ParamIndicator":
 	if identifier.ParamIndicator != nil {
 		paramIndicator := *identifier.ParamIndicator
 		result.ParamIndicator = &paramIndicator
 	}
 
-	// Set property ‘ParamName’:
+	// Set property "ParamName":
 	if identifier.ParamName != nil {
 		paramName := *identifier.ParamName
 		result.ParamName = &paramName
@@ -29588,13 +29588,13 @@ func (identifier *UrlSigningParamIdentifier) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningParamIdentifier_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ParamIndicator’:
+	// Set property "ParamIndicator":
 	if typedInput.ParamIndicator != nil {
 		paramIndicator := *typedInput.ParamIndicator
 		identifier.ParamIndicator = &paramIndicator
 	}
 
-	// Set property ‘ParamName’:
+	// Set property "ParamName":
 	if typedInput.ParamName != nil {
 		paramName := *typedInput.ParamName
 		identifier.ParamName = &paramName
@@ -29690,13 +29690,13 @@ func (identifier *UrlSigningParamIdentifier_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningParamIdentifier_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ParamIndicator’:
+	// Set property "ParamIndicator":
 	if typedInput.ParamIndicator != nil {
 		paramIndicator := *typedInput.ParamIndicator
 		identifier.ParamIndicator = &paramIndicator
 	}
 
-	// Set property ‘ParamName’:
+	// Set property "ParamName":
 	if typedInput.ParamName != nil {
 		paramName := *typedInput.ParamName
 		identifier.ParamName = &paramName

--- a/v2/api/cdn/v1beta20210601/profile_types_gen.go
+++ b/v2/api/cdn/v1beta20210601/profile_types_gen.go
@@ -346,16 +346,16 @@ func (profile *Profile_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &Profile_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if profile.Location != nil {
 		location := *profile.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if profile.OriginResponseTimeoutSeconds != nil {
 		result.Properties = &ProfileProperties_ARM{}
 	}
@@ -364,7 +364,7 @@ func (profile *Profile_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.OriginResponseTimeoutSeconds = &originResponseTimeoutSeconds
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if profile.Sku != nil {
 		sku_ARM, err := (*profile.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -374,7 +374,7 @@ func (profile *Profile_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if profile.Tags != nil {
 		result.Tags = make(map[string]string, len(profile.Tags))
 		for key, value := range profile.Tags {
@@ -396,16 +396,16 @@ func (profile *Profile_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Profile_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	profile.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		profile.Location = &location
 	}
 
-	// Set property ‘OriginResponseTimeoutSeconds’:
+	// Set property "OriginResponseTimeoutSeconds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginResponseTimeoutSeconds != nil {
@@ -414,10 +414,10 @@ func (profile *Profile_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	profile.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -428,7 +428,7 @@ func (profile *Profile_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		profile.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		profile.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -680,9 +680,9 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Profile_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘FrontDoorId’:
+	// Set property "FrontDoorId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontDoorId != nil {
@@ -691,31 +691,31 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		profile.Id = &id
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		profile.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		profile.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘OriginResponseTimeoutSeconds’:
+	// Set property "OriginResponseTimeoutSeconds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginResponseTimeoutSeconds != nil {
@@ -724,7 +724,7 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -733,7 +733,7 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ResourceState’:
+	// Set property "ResourceState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceState != nil {
@@ -742,7 +742,7 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -753,7 +753,7 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -764,7 +764,7 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		profile.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -772,7 +772,7 @@ func (profile *Profile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
@@ -976,7 +976,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -996,7 +996,7 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -1064,7 +1064,7 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -1137,37 +1137,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType

--- a/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen.go
+++ b/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen.go
@@ -352,16 +352,16 @@ func (endpoint *Profiles_Endpoint_Spec) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &Profiles_Endpoint_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if endpoint.Location != nil {
 		location := *endpoint.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if endpoint.ContentTypesToCompress != nil ||
 		endpoint.DefaultOriginGroup != nil ||
 		endpoint.DeliveryPolicy != nil ||
@@ -468,7 +468,7 @@ func (endpoint *Profiles_Endpoint_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.WebApplicationFirewallPolicyLink = &webApplicationFirewallPolicyLink
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if endpoint.Tags != nil {
 		result.Tags = make(map[string]string, len(endpoint.Tags))
 		for key, value := range endpoint.Tags {
@@ -490,10 +490,10 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Profiles_Endpoint_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	endpoint.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘ContentTypesToCompress’:
+	// Set property "ContentTypesToCompress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ContentTypesToCompress {
@@ -501,7 +501,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘DefaultOriginGroup’:
+	// Set property "DefaultOriginGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultOriginGroup != nil {
@@ -515,7 +515,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘DeliveryPolicy’:
+	// Set property "DeliveryPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeliveryPolicy != nil {
@@ -529,7 +529,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘GeoFilters’:
+	// Set property "GeoFilters":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.GeoFilters {
@@ -542,7 +542,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘IsCompressionEnabled’:
+	// Set property "IsCompressionEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsCompressionEnabled != nil {
@@ -551,7 +551,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘IsHttpAllowed’:
+	// Set property "IsHttpAllowed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHttpAllowed != nil {
@@ -560,7 +560,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘IsHttpsAllowed’:
+	// Set property "IsHttpsAllowed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHttpsAllowed != nil {
@@ -569,13 +569,13 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		endpoint.Location = &location
 	}
 
-	// Set property ‘OptimizationType’:
+	// Set property "OptimizationType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OptimizationType != nil {
@@ -584,7 +584,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘OriginGroups’:
+	// Set property "OriginGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.OriginGroups {
@@ -597,7 +597,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘OriginHostHeader’:
+	// Set property "OriginHostHeader":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginHostHeader != nil {
@@ -606,7 +606,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘OriginPath’:
+	// Set property "OriginPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginPath != nil {
@@ -615,7 +615,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Origins’:
+	// Set property "Origins":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Origins {
@@ -628,10 +628,10 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	endpoint.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ProbePath’:
+	// Set property "ProbePath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProbePath != nil {
@@ -640,7 +640,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘QueryStringCachingBehavior’:
+	// Set property "QueryStringCachingBehavior":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.QueryStringCachingBehavior != nil {
@@ -649,7 +649,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		endpoint.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -657,7 +657,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘UrlSigningKeys’:
+	// Set property "UrlSigningKeys":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.UrlSigningKeys {
@@ -670,7 +670,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘WebApplicationFirewallPolicyLink’:
+	// Set property "WebApplicationFirewallPolicyLink":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WebApplicationFirewallPolicyLink != nil {
@@ -1224,9 +1224,9 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Profiles_Endpoint_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ContentTypesToCompress’:
+	// Set property "ContentTypesToCompress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ContentTypesToCompress {
@@ -1234,7 +1234,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘CustomDomains’:
+	// Set property "CustomDomains":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CustomDomains {
@@ -1247,7 +1247,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘DefaultOriginGroup’:
+	// Set property "DefaultOriginGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultOriginGroup != nil {
@@ -1261,7 +1261,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘DeliveryPolicy’:
+	// Set property "DeliveryPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeliveryPolicy != nil {
@@ -1275,7 +1275,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘GeoFilters’:
+	// Set property "GeoFilters":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.GeoFilters {
@@ -1288,7 +1288,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -1297,13 +1297,13 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		endpoint.Id = &id
 	}
 
-	// Set property ‘IsCompressionEnabled’:
+	// Set property "IsCompressionEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsCompressionEnabled != nil {
@@ -1312,7 +1312,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘IsHttpAllowed’:
+	// Set property "IsHttpAllowed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHttpAllowed != nil {
@@ -1321,7 +1321,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘IsHttpsAllowed’:
+	// Set property "IsHttpsAllowed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHttpsAllowed != nil {
@@ -1330,19 +1330,19 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		endpoint.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		endpoint.Name = &name
 	}
 
-	// Set property ‘OptimizationType’:
+	// Set property "OptimizationType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OptimizationType != nil {
@@ -1351,7 +1351,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘OriginGroups’:
+	// Set property "OriginGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.OriginGroups {
@@ -1364,7 +1364,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘OriginHostHeader’:
+	// Set property "OriginHostHeader":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginHostHeader != nil {
@@ -1373,7 +1373,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘OriginPath’:
+	// Set property "OriginPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginPath != nil {
@@ -1382,7 +1382,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Origins’:
+	// Set property "Origins":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Origins {
@@ -1395,7 +1395,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘ProbePath’:
+	// Set property "ProbePath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProbePath != nil {
@@ -1404,7 +1404,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1413,7 +1413,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘QueryStringCachingBehavior’:
+	// Set property "QueryStringCachingBehavior":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.QueryStringCachingBehavior != nil {
@@ -1422,7 +1422,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘ResourceState’:
+	// Set property "ResourceState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceState != nil {
@@ -1431,7 +1431,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1442,7 +1442,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		endpoint.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		endpoint.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1450,13 +1450,13 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		endpoint.Type = &typeVar
 	}
 
-	// Set property ‘UrlSigningKeys’:
+	// Set property "UrlSigningKeys":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.UrlSigningKeys {
@@ -1469,7 +1469,7 @@ func (endpoint *Profiles_Endpoint_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘WebApplicationFirewallPolicyLink’:
+	// Set property "WebApplicationFirewallPolicyLink":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WebApplicationFirewallPolicyLink != nil {
@@ -1985,7 +1985,7 @@ func (domain *DeepCreatedCustomDomain_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeepCreatedCustomDomain_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -1994,13 +1994,13 @@ func (domain *DeepCreatedCustomDomain_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		domain.Name = &name
 	}
 
-	// Set property ‘ValidationData’:
+	// Set property "ValidationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ValidationData != nil {
@@ -2095,13 +2095,13 @@ func (origin *DeepCreatedOrigin) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &DeepCreatedOrigin_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if origin.Name != nil {
 		name := *origin.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if origin.Enabled != nil ||
 		origin.HostName != nil ||
 		origin.HttpPort != nil ||
@@ -2182,7 +2182,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeepCreatedOrigin_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Enabled != nil {
@@ -2191,7 +2191,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -2200,7 +2200,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘HttpPort’:
+	// Set property "HttpPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpPort != nil {
@@ -2209,7 +2209,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘HttpsPort’:
+	// Set property "HttpsPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpsPort != nil {
@@ -2218,13 +2218,13 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		origin.Name = &name
 	}
 
-	// Set property ‘OriginHostHeader’:
+	// Set property "OriginHostHeader":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginHostHeader != nil {
@@ -2233,7 +2233,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -2242,7 +2242,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PrivateLinkAlias’:
+	// Set property "PrivateLinkAlias":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkAlias != nil {
@@ -2251,7 +2251,7 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PrivateLinkApprovalMessage’:
+	// Set property "PrivateLinkApprovalMessage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkApprovalMessage != nil {
@@ -2260,11 +2260,11 @@ func (origin *DeepCreatedOrigin) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// no assignment for property ‘PrivateLinkLocationReference’
+	// no assignment for property "PrivateLinkLocationReference"
 
-	// no assignment for property ‘PrivateLinkResourceReference’
+	// no assignment for property "PrivateLinkResourceReference"
 
-	// Set property ‘Weight’:
+	// Set property "Weight":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Weight != nil {
@@ -2473,7 +2473,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeepCreatedOrigin_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Enabled != nil {
@@ -2482,7 +2482,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -2491,7 +2491,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘HttpPort’:
+	// Set property "HttpPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpPort != nil {
@@ -2500,7 +2500,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘HttpsPort’:
+	// Set property "HttpsPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpsPort != nil {
@@ -2509,13 +2509,13 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		origin.Name = &name
 	}
 
-	// Set property ‘OriginHostHeader’:
+	// Set property "OriginHostHeader":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OriginHostHeader != nil {
@@ -2524,7 +2524,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -2533,7 +2533,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘PrivateEndpointStatus’:
+	// Set property "PrivateEndpointStatus":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateEndpointStatus != nil {
@@ -2542,7 +2542,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘PrivateLinkAlias’:
+	// Set property "PrivateLinkAlias":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkAlias != nil {
@@ -2551,7 +2551,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘PrivateLinkApprovalMessage’:
+	// Set property "PrivateLinkApprovalMessage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkApprovalMessage != nil {
@@ -2560,7 +2560,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘PrivateLinkLocation’:
+	// Set property "PrivateLinkLocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkLocation != nil {
@@ -2569,7 +2569,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘PrivateLinkResourceId’:
+	// Set property "PrivateLinkResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkResourceId != nil {
@@ -2578,7 +2578,7 @@ func (origin *DeepCreatedOrigin_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Weight’:
+	// Set property "Weight":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Weight != nil {
@@ -2737,13 +2737,13 @@ func (group *DeepCreatedOriginGroup) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &DeepCreatedOriginGroup_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if group.Name != nil {
 		name := *group.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if group.HealthProbeSettings != nil ||
 		group.Origins != nil ||
 		group.ResponseBasedOriginErrorDetectionSettings != nil ||
@@ -2792,7 +2792,7 @@ func (group *DeepCreatedOriginGroup) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeepCreatedOriginGroup_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HealthProbeSettings’:
+	// Set property "HealthProbeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HealthProbeSettings != nil {
@@ -2806,13 +2806,13 @@ func (group *DeepCreatedOriginGroup) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		group.Name = &name
 	}
 
-	// Set property ‘Origins’:
+	// Set property "Origins":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Origins {
@@ -2825,7 +2825,7 @@ func (group *DeepCreatedOriginGroup) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ResponseBasedOriginErrorDetectionSettings’:
+	// Set property "ResponseBasedOriginErrorDetectionSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResponseBasedOriginErrorDetectionSettings != nil {
@@ -2839,7 +2839,7 @@ func (group *DeepCreatedOriginGroup) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TrafficRestorationTimeToHealedOrNewEndpointsInMinutes’:
+	// Set property "TrafficRestorationTimeToHealedOrNewEndpointsInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes != nil {
@@ -3004,7 +3004,7 @@ func (group *DeepCreatedOriginGroup_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeepCreatedOriginGroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HealthProbeSettings’:
+	// Set property "HealthProbeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HealthProbeSettings != nil {
@@ -3018,13 +3018,13 @@ func (group *DeepCreatedOriginGroup_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		group.Name = &name
 	}
 
-	// Set property ‘Origins’:
+	// Set property "Origins":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Origins {
@@ -3037,7 +3037,7 @@ func (group *DeepCreatedOriginGroup_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘ResponseBasedOriginErrorDetectionSettings’:
+	// Set property "ResponseBasedOriginErrorDetectionSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResponseBasedOriginErrorDetectionSettings != nil {
@@ -3051,7 +3051,7 @@ func (group *DeepCreatedOriginGroup_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘TrafficRestorationTimeToHealedOrNewEndpointsInMinutes’:
+	// Set property "TrafficRestorationTimeToHealedOrNewEndpointsInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes != nil {
@@ -3200,13 +3200,13 @@ func (policy *EndpointProperties_DeliveryPolicy) ConvertToARM(resolved genruntim
 	}
 	result := &EndpointProperties_DeliveryPolicy_ARM{}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if policy.Description != nil {
 		description := *policy.Description
 		result.Description = &description
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range policy.Rules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3229,13 +3229,13 @@ func (policy *EndpointProperties_DeliveryPolicy) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EndpointProperties_DeliveryPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		policy.Description = &description
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		var item1 DeliveryRule
 		err := item1.PopulateFromARM(owner, item)
@@ -3334,13 +3334,13 @@ func (policy *EndpointProperties_DeliveryPolicy_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EndpointProperties_DeliveryPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		policy.Description = &description
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		var item1 DeliveryRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3458,7 +3458,7 @@ func (link *EndpointProperties_WebApplicationFirewallPolicyLink) ConvertToARM(re
 	}
 	result := &EndpointProperties_WebApplicationFirewallPolicyLink_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if link.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*link.Reference)
 		if err != nil {
@@ -3482,7 +3482,7 @@ func (link *EndpointProperties_WebApplicationFirewallPolicyLink) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EndpointProperties_WebApplicationFirewallPolicyLink_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3546,7 +3546,7 @@ func (link *EndpointProperties_WebApplicationFirewallPolicyLink_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EndpointProperties_WebApplicationFirewallPolicyLink_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		link.Id = &id
@@ -3606,18 +3606,18 @@ func (filter *GeoFilter) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &GeoFilter_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if filter.Action != nil {
 		action := *filter.Action
 		result.Action = &action
 	}
 
-	// Set property ‘CountryCodes’:
+	// Set property "CountryCodes":
 	for _, item := range filter.CountryCodes {
 		result.CountryCodes = append(result.CountryCodes, item)
 	}
 
-	// Set property ‘RelativePath’:
+	// Set property "RelativePath":
 	if filter.RelativePath != nil {
 		relativePath := *filter.RelativePath
 		result.RelativePath = &relativePath
@@ -3637,18 +3637,18 @@ func (filter *GeoFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GeoFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		filter.Action = &action
 	}
 
-	// Set property ‘CountryCodes’:
+	// Set property "CountryCodes":
 	for _, item := range typedInput.CountryCodes {
 		filter.CountryCodes = append(filter.CountryCodes, item)
 	}
 
-	// Set property ‘RelativePath’:
+	// Set property "RelativePath":
 	if typedInput.RelativePath != nil {
 		relativePath := *typedInput.RelativePath
 		filter.RelativePath = &relativePath
@@ -3730,18 +3730,18 @@ func (filter *GeoFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GeoFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		filter.Action = &action
 	}
 
-	// Set property ‘CountryCodes’:
+	// Set property "CountryCodes":
 	for _, item := range typedInput.CountryCodes {
 		filter.CountryCodes = append(filter.CountryCodes, item)
 	}
 
-	// Set property ‘RelativePath’:
+	// Set property "RelativePath":
 	if typedInput.RelativePath != nil {
 		relativePath := *typedInput.RelativePath
 		filter.RelativePath = &relativePath
@@ -3860,7 +3860,7 @@ func (reference *ResourceReference) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ResourceReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -3884,7 +3884,7 @@ func (reference *ResourceReference) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceReference_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3948,7 +3948,7 @@ func (reference *ResourceReference_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
@@ -4005,13 +4005,13 @@ func (signingKey *UrlSigningKey) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &UrlSigningKey_ARM{}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	if signingKey.KeyId != nil {
 		keyId := *signingKey.KeyId
 		result.KeyId = &keyId
 	}
 
-	// Set property ‘KeySourceParameters’:
+	// Set property "KeySourceParameters":
 	if signingKey.KeySourceParameters != nil {
 		keySourceParameters_ARM, err := (*signingKey.KeySourceParameters).ConvertToARM(resolved)
 		if err != nil {
@@ -4035,13 +4035,13 @@ func (signingKey *UrlSigningKey) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningKey_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	if typedInput.KeyId != nil {
 		keyId := *typedInput.KeyId
 		signingKey.KeyId = &keyId
 	}
 
-	// Set property ‘KeySourceParameters’:
+	// Set property "KeySourceParameters":
 	if typedInput.KeySourceParameters != nil {
 		var keySourceParameters1 KeyVaultSigningKeyParameters
 		err := keySourceParameters1.PopulateFromARM(owner, *typedInput.KeySourceParameters)
@@ -4129,13 +4129,13 @@ func (signingKey *UrlSigningKey_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	if typedInput.KeyId != nil {
 		keyId := *typedInput.KeyId
 		signingKey.KeyId = &keyId
 	}
 
-	// Set property ‘KeySourceParameters’:
+	// Set property "KeySourceParameters":
 	if typedInput.KeySourceParameters != nil {
 		var keySourceParameters1 KeyVaultSigningKeyParameters_STATUS
 		err := keySourceParameters1.PopulateFromARM(owner, *typedInput.KeySourceParameters)
@@ -4223,7 +4223,7 @@ func (rule *DeliveryRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &DeliveryRule_ARM{}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	for _, item := range rule.Actions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4232,7 +4232,7 @@ func (rule *DeliveryRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Actions = append(result.Actions, *item_ARM.(*DeliveryRuleAction_ARM))
 	}
 
-	// Set property ‘Conditions’:
+	// Set property "Conditions":
 	for _, item := range rule.Conditions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4241,13 +4241,13 @@ func (rule *DeliveryRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Conditions = append(result.Conditions, *item_ARM.(*DeliveryRuleCondition_ARM))
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if rule.Name != nil {
 		name := *rule.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if rule.Order != nil {
 		order := *rule.Order
 		result.Order = &order
@@ -4267,7 +4267,7 @@ func (rule *DeliveryRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	for _, item := range typedInput.Actions {
 		var item1 DeliveryRuleAction
 		err := item1.PopulateFromARM(owner, item)
@@ -4277,7 +4277,7 @@ func (rule *DeliveryRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		rule.Actions = append(rule.Actions, item1)
 	}
 
-	// Set property ‘Conditions’:
+	// Set property "Conditions":
 	for _, item := range typedInput.Conditions {
 		var item1 DeliveryRuleCondition
 		err := item1.PopulateFromARM(owner, item)
@@ -4287,13 +4287,13 @@ func (rule *DeliveryRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		rule.Conditions = append(rule.Conditions, item1)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if typedInput.Order != nil {
 		order := *typedInput.Order
 		rule.Order = &order
@@ -4432,7 +4432,7 @@ func (rule *DeliveryRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	for _, item := range typedInput.Actions {
 		var item1 DeliveryRuleAction_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4442,15 +4442,15 @@ func (rule *DeliveryRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		rule.Actions = append(rule.Actions, item1)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if typedInput.Order != nil {
 		order := *typedInput.Order
 		rule.Order = &order
@@ -4603,25 +4603,25 @@ func (parameters *HealthProbeParameters) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &HealthProbeParameters_ARM{}
 
-	// Set property ‘ProbeIntervalInSeconds’:
+	// Set property "ProbeIntervalInSeconds":
 	if parameters.ProbeIntervalInSeconds != nil {
 		probeIntervalInSeconds := *parameters.ProbeIntervalInSeconds
 		result.ProbeIntervalInSeconds = &probeIntervalInSeconds
 	}
 
-	// Set property ‘ProbePath’:
+	// Set property "ProbePath":
 	if parameters.ProbePath != nil {
 		probePath := *parameters.ProbePath
 		result.ProbePath = &probePath
 	}
 
-	// Set property ‘ProbeProtocol’:
+	// Set property "ProbeProtocol":
 	if parameters.ProbeProtocol != nil {
 		probeProtocol := *parameters.ProbeProtocol
 		result.ProbeProtocol = &probeProtocol
 	}
 
-	// Set property ‘ProbeRequestType’:
+	// Set property "ProbeRequestType":
 	if parameters.ProbeRequestType != nil {
 		probeRequestType := *parameters.ProbeRequestType
 		result.ProbeRequestType = &probeRequestType
@@ -4641,25 +4641,25 @@ func (parameters *HealthProbeParameters) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HealthProbeParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ProbeIntervalInSeconds’:
+	// Set property "ProbeIntervalInSeconds":
 	if typedInput.ProbeIntervalInSeconds != nil {
 		probeIntervalInSeconds := *typedInput.ProbeIntervalInSeconds
 		parameters.ProbeIntervalInSeconds = &probeIntervalInSeconds
 	}
 
-	// Set property ‘ProbePath’:
+	// Set property "ProbePath":
 	if typedInput.ProbePath != nil {
 		probePath := *typedInput.ProbePath
 		parameters.ProbePath = &probePath
 	}
 
-	// Set property ‘ProbeProtocol’:
+	// Set property "ProbeProtocol":
 	if typedInput.ProbeProtocol != nil {
 		probeProtocol := *typedInput.ProbeProtocol
 		parameters.ProbeProtocol = &probeProtocol
 	}
 
-	// Set property ‘ProbeRequestType’:
+	// Set property "ProbeRequestType":
 	if typedInput.ProbeRequestType != nil {
 		probeRequestType := *typedInput.ProbeRequestType
 		parameters.ProbeRequestType = &probeRequestType
@@ -4768,25 +4768,25 @@ func (parameters *HealthProbeParameters_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HealthProbeParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ProbeIntervalInSeconds’:
+	// Set property "ProbeIntervalInSeconds":
 	if typedInput.ProbeIntervalInSeconds != nil {
 		probeIntervalInSeconds := *typedInput.ProbeIntervalInSeconds
 		parameters.ProbeIntervalInSeconds = &probeIntervalInSeconds
 	}
 
-	// Set property ‘ProbePath’:
+	// Set property "ProbePath":
 	if typedInput.ProbePath != nil {
 		probePath := *typedInput.ProbePath
 		parameters.ProbePath = &probePath
 	}
 
-	// Set property ‘ProbeProtocol’:
+	// Set property "ProbeProtocol":
 	if typedInput.ProbeProtocol != nil {
 		probeProtocol := *typedInput.ProbeProtocol
 		parameters.ProbeProtocol = &probeProtocol
 	}
 
-	// Set property ‘ProbeRequestType’:
+	// Set property "ProbeRequestType":
 	if typedInput.ProbeRequestType != nil {
 		probeRequestType := *typedInput.ProbeRequestType
 		parameters.ProbeRequestType = &probeRequestType
@@ -4893,37 +4893,37 @@ func (parameters *KeyVaultSigningKeyParameters) ConvertToARM(resolved genruntime
 	}
 	result := &KeyVaultSigningKeyParameters_ARM{}
 
-	// Set property ‘ResourceGroupName’:
+	// Set property "ResourceGroupName":
 	if parameters.ResourceGroupName != nil {
 		resourceGroupName := *parameters.ResourceGroupName
 		result.ResourceGroupName = &resourceGroupName
 	}
 
-	// Set property ‘SecretName’:
+	// Set property "SecretName":
 	if parameters.SecretName != nil {
 		secretName := *parameters.SecretName
 		result.SecretName = &secretName
 	}
 
-	// Set property ‘SecretVersion’:
+	// Set property "SecretVersion":
 	if parameters.SecretVersion != nil {
 		secretVersion := *parameters.SecretVersion
 		result.SecretVersion = &secretVersion
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if parameters.SubscriptionId != nil {
 		subscriptionId := *parameters.SubscriptionId
 		result.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
 	}
 
-	// Set property ‘VaultName’:
+	// Set property "VaultName":
 	if parameters.VaultName != nil {
 		vaultName := *parameters.VaultName
 		result.VaultName = &vaultName
@@ -4943,37 +4943,37 @@ func (parameters *KeyVaultSigningKeyParameters) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultSigningKeyParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ResourceGroupName’:
+	// Set property "ResourceGroupName":
 	if typedInput.ResourceGroupName != nil {
 		resourceGroupName := *typedInput.ResourceGroupName
 		parameters.ResourceGroupName = &resourceGroupName
 	}
 
-	// Set property ‘SecretName’:
+	// Set property "SecretName":
 	if typedInput.SecretName != nil {
 		secretName := *typedInput.SecretName
 		parameters.SecretName = &secretName
 	}
 
-	// Set property ‘SecretVersion’:
+	// Set property "SecretVersion":
 	if typedInput.SecretVersion != nil {
 		secretVersion := *typedInput.SecretVersion
 		parameters.SecretVersion = &secretVersion
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		parameters.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
 	}
 
-	// Set property ‘VaultName’:
+	// Set property "VaultName":
 	if typedInput.VaultName != nil {
 		vaultName := *typedInput.VaultName
 		parameters.VaultName = &vaultName
@@ -5076,37 +5076,37 @@ func (parameters *KeyVaultSigningKeyParameters_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultSigningKeyParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ResourceGroupName’:
+	// Set property "ResourceGroupName":
 	if typedInput.ResourceGroupName != nil {
 		resourceGroupName := *typedInput.ResourceGroupName
 		parameters.ResourceGroupName = &resourceGroupName
 	}
 
-	// Set property ‘SecretName’:
+	// Set property "SecretName":
 	if typedInput.SecretName != nil {
 		secretName := *typedInput.SecretName
 		parameters.SecretName = &secretName
 	}
 
-	// Set property ‘SecretVersion’:
+	// Set property "SecretVersion":
 	if typedInput.SecretVersion != nil {
 		secretVersion := *typedInput.SecretVersion
 		parameters.SecretVersion = &secretVersion
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		parameters.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
 	}
 
-	// Set property ‘VaultName’:
+	// Set property "VaultName":
 	if typedInput.VaultName != nil {
 		vaultName := *typedInput.VaultName
 		parameters.VaultName = &vaultName
@@ -5215,7 +5215,7 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters) ConvertToARM(reso
 	}
 	result := &ResponseBasedOriginErrorDetectionParameters_ARM{}
 
-	// Set property ‘HttpErrorRanges’:
+	// Set property "HttpErrorRanges":
 	for _, item := range parameters.HttpErrorRanges {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5224,13 +5224,13 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters) ConvertToARM(reso
 		result.HttpErrorRanges = append(result.HttpErrorRanges, *item_ARM.(*HttpErrorRangeParameters_ARM))
 	}
 
-	// Set property ‘ResponseBasedDetectedErrorTypes’:
+	// Set property "ResponseBasedDetectedErrorTypes":
 	if parameters.ResponseBasedDetectedErrorTypes != nil {
 		responseBasedDetectedErrorTypes := *parameters.ResponseBasedDetectedErrorTypes
 		result.ResponseBasedDetectedErrorTypes = &responseBasedDetectedErrorTypes
 	}
 
-	// Set property ‘ResponseBasedFailoverThresholdPercentage’:
+	// Set property "ResponseBasedFailoverThresholdPercentage":
 	if parameters.ResponseBasedFailoverThresholdPercentage != nil {
 		responseBasedFailoverThresholdPercentage := *parameters.ResponseBasedFailoverThresholdPercentage
 		result.ResponseBasedFailoverThresholdPercentage = &responseBasedFailoverThresholdPercentage
@@ -5250,7 +5250,7 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResponseBasedOriginErrorDetectionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpErrorRanges’:
+	// Set property "HttpErrorRanges":
 	for _, item := range typedInput.HttpErrorRanges {
 		var item1 HttpErrorRangeParameters
 		err := item1.PopulateFromARM(owner, item)
@@ -5260,13 +5260,13 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters) PopulateFromARM(o
 		parameters.HttpErrorRanges = append(parameters.HttpErrorRanges, item1)
 	}
 
-	// Set property ‘ResponseBasedDetectedErrorTypes’:
+	// Set property "ResponseBasedDetectedErrorTypes":
 	if typedInput.ResponseBasedDetectedErrorTypes != nil {
 		responseBasedDetectedErrorTypes := *typedInput.ResponseBasedDetectedErrorTypes
 		parameters.ResponseBasedDetectedErrorTypes = &responseBasedDetectedErrorTypes
 	}
 
-	// Set property ‘ResponseBasedFailoverThresholdPercentage’:
+	// Set property "ResponseBasedFailoverThresholdPercentage":
 	if typedInput.ResponseBasedFailoverThresholdPercentage != nil {
 		responseBasedFailoverThresholdPercentage := *typedInput.ResponseBasedFailoverThresholdPercentage
 		parameters.ResponseBasedFailoverThresholdPercentage = &responseBasedFailoverThresholdPercentage
@@ -5388,7 +5388,7 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters_STATUS) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResponseBasedOriginErrorDetectionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpErrorRanges’:
+	// Set property "HttpErrorRanges":
 	for _, item := range typedInput.HttpErrorRanges {
 		var item1 HttpErrorRangeParameters_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5398,13 +5398,13 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters_STATUS) PopulateFr
 		parameters.HttpErrorRanges = append(parameters.HttpErrorRanges, item1)
 	}
 
-	// Set property ‘ResponseBasedDetectedErrorTypes’:
+	// Set property "ResponseBasedDetectedErrorTypes":
 	if typedInput.ResponseBasedDetectedErrorTypes != nil {
 		responseBasedDetectedErrorTypes := *typedInput.ResponseBasedDetectedErrorTypes
 		parameters.ResponseBasedDetectedErrorTypes = &responseBasedDetectedErrorTypes
 	}
 
-	// Set property ‘ResponseBasedFailoverThresholdPercentage’:
+	// Set property "ResponseBasedFailoverThresholdPercentage":
 	if typedInput.ResponseBasedFailoverThresholdPercentage != nil {
 		responseBasedFailoverThresholdPercentage := *typedInput.ResponseBasedFailoverThresholdPercentage
 		parameters.ResponseBasedFailoverThresholdPercentage = &responseBasedFailoverThresholdPercentage
@@ -5517,7 +5517,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &DeliveryRuleAction_ARM{}
 
-	// Set property ‘CacheExpiration’:
+	// Set property "CacheExpiration":
 	if action.CacheExpiration != nil {
 		cacheExpiration_ARM, err := (*action.CacheExpiration).ConvertToARM(resolved)
 		if err != nil {
@@ -5527,7 +5527,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.CacheExpiration = &cacheExpiration
 	}
 
-	// Set property ‘CacheKeyQueryString’:
+	// Set property "CacheKeyQueryString":
 	if action.CacheKeyQueryString != nil {
 		cacheKeyQueryString_ARM, err := (*action.CacheKeyQueryString).ConvertToARM(resolved)
 		if err != nil {
@@ -5537,7 +5537,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.CacheKeyQueryString = &cacheKeyQueryString
 	}
 
-	// Set property ‘ModifyRequestHeader’:
+	// Set property "ModifyRequestHeader":
 	if action.ModifyRequestHeader != nil {
 		modifyRequestHeader_ARM, err := (*action.ModifyRequestHeader).ConvertToARM(resolved)
 		if err != nil {
@@ -5547,7 +5547,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.ModifyRequestHeader = &modifyRequestHeader
 	}
 
-	// Set property ‘ModifyResponseHeader’:
+	// Set property "ModifyResponseHeader":
 	if action.ModifyResponseHeader != nil {
 		modifyResponseHeader_ARM, err := (*action.ModifyResponseHeader).ConvertToARM(resolved)
 		if err != nil {
@@ -5557,7 +5557,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.ModifyResponseHeader = &modifyResponseHeader
 	}
 
-	// Set property ‘OriginGroupOverride’:
+	// Set property "OriginGroupOverride":
 	if action.OriginGroupOverride != nil {
 		originGroupOverride_ARM, err := (*action.OriginGroupOverride).ConvertToARM(resolved)
 		if err != nil {
@@ -5567,7 +5567,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.OriginGroupOverride = &originGroupOverride
 	}
 
-	// Set property ‘RouteConfigurationOverride’:
+	// Set property "RouteConfigurationOverride":
 	if action.RouteConfigurationOverride != nil {
 		routeConfigurationOverride_ARM, err := (*action.RouteConfigurationOverride).ConvertToARM(resolved)
 		if err != nil {
@@ -5577,7 +5577,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.RouteConfigurationOverride = &routeConfigurationOverride
 	}
 
-	// Set property ‘UrlRedirect’:
+	// Set property "UrlRedirect":
 	if action.UrlRedirect != nil {
 		urlRedirect_ARM, err := (*action.UrlRedirect).ConvertToARM(resolved)
 		if err != nil {
@@ -5587,7 +5587,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.UrlRedirect = &urlRedirect
 	}
 
-	// Set property ‘UrlRewrite’:
+	// Set property "UrlRewrite":
 	if action.UrlRewrite != nil {
 		urlRewrite_ARM, err := (*action.UrlRewrite).ConvertToARM(resolved)
 		if err != nil {
@@ -5597,7 +5597,7 @@ func (action *DeliveryRuleAction) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.UrlRewrite = &urlRewrite
 	}
 
-	// Set property ‘UrlSigning’:
+	// Set property "UrlSigning":
 	if action.UrlSigning != nil {
 		urlSigning_ARM, err := (*action.UrlSigning).ConvertToARM(resolved)
 		if err != nil {
@@ -5621,7 +5621,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheExpiration’:
+	// Set property "CacheExpiration":
 	if typedInput.CacheExpiration != nil {
 		var cacheExpiration1 DeliveryRuleCacheExpirationAction
 		err := cacheExpiration1.PopulateFromARM(owner, *typedInput.CacheExpiration)
@@ -5632,7 +5632,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.CacheExpiration = &cacheExpiration
 	}
 
-	// Set property ‘CacheKeyQueryString’:
+	// Set property "CacheKeyQueryString":
 	if typedInput.CacheKeyQueryString != nil {
 		var cacheKeyQueryString1 DeliveryRuleCacheKeyQueryStringAction
 		err := cacheKeyQueryString1.PopulateFromARM(owner, *typedInput.CacheKeyQueryString)
@@ -5643,7 +5643,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.CacheKeyQueryString = &cacheKeyQueryString
 	}
 
-	// Set property ‘ModifyRequestHeader’:
+	// Set property "ModifyRequestHeader":
 	if typedInput.ModifyRequestHeader != nil {
 		var modifyRequestHeader1 DeliveryRuleRequestHeaderAction
 		err := modifyRequestHeader1.PopulateFromARM(owner, *typedInput.ModifyRequestHeader)
@@ -5654,7 +5654,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.ModifyRequestHeader = &modifyRequestHeader
 	}
 
-	// Set property ‘ModifyResponseHeader’:
+	// Set property "ModifyResponseHeader":
 	if typedInput.ModifyResponseHeader != nil {
 		var modifyResponseHeader1 DeliveryRuleResponseHeaderAction
 		err := modifyResponseHeader1.PopulateFromARM(owner, *typedInput.ModifyResponseHeader)
@@ -5665,7 +5665,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.ModifyResponseHeader = &modifyResponseHeader
 	}
 
-	// Set property ‘OriginGroupOverride’:
+	// Set property "OriginGroupOverride":
 	if typedInput.OriginGroupOverride != nil {
 		var originGroupOverride1 OriginGroupOverrideAction
 		err := originGroupOverride1.PopulateFromARM(owner, *typedInput.OriginGroupOverride)
@@ -5676,7 +5676,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.OriginGroupOverride = &originGroupOverride
 	}
 
-	// Set property ‘RouteConfigurationOverride’:
+	// Set property "RouteConfigurationOverride":
 	if typedInput.RouteConfigurationOverride != nil {
 		var routeConfigurationOverride1 DeliveryRuleRouteConfigurationOverrideAction
 		err := routeConfigurationOverride1.PopulateFromARM(owner, *typedInput.RouteConfigurationOverride)
@@ -5687,7 +5687,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.RouteConfigurationOverride = &routeConfigurationOverride
 	}
 
-	// Set property ‘UrlRedirect’:
+	// Set property "UrlRedirect":
 	if typedInput.UrlRedirect != nil {
 		var urlRedirect1 UrlRedirectAction
 		err := urlRedirect1.PopulateFromARM(owner, *typedInput.UrlRedirect)
@@ -5698,7 +5698,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.UrlRedirect = &urlRedirect
 	}
 
-	// Set property ‘UrlRewrite’:
+	// Set property "UrlRewrite":
 	if typedInput.UrlRewrite != nil {
 		var urlRewrite1 UrlRewriteAction
 		err := urlRewrite1.PopulateFromARM(owner, *typedInput.UrlRewrite)
@@ -5709,7 +5709,7 @@ func (action *DeliveryRuleAction) PopulateFromARM(owner genruntime.ArbitraryOwne
 		action.UrlRewrite = &urlRewrite
 	}
 
-	// Set property ‘UrlSigning’:
+	// Set property "UrlSigning":
 	if typedInput.UrlSigning != nil {
 		var urlSigning1 UrlSigningAction
 		err := urlSigning1.PopulateFromARM(owner, *typedInput.UrlSigning)
@@ -5990,7 +5990,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheExpiration’:
+	// Set property "CacheExpiration":
 	if typedInput.CacheExpiration != nil {
 		var cacheExpiration1 DeliveryRuleCacheExpirationAction_STATUS
 		err := cacheExpiration1.PopulateFromARM(owner, *typedInput.CacheExpiration)
@@ -6001,7 +6001,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.CacheExpiration = &cacheExpiration
 	}
 
-	// Set property ‘CacheKeyQueryString’:
+	// Set property "CacheKeyQueryString":
 	if typedInput.CacheKeyQueryString != nil {
 		var cacheKeyQueryString1 DeliveryRuleCacheKeyQueryStringAction_STATUS
 		err := cacheKeyQueryString1.PopulateFromARM(owner, *typedInput.CacheKeyQueryString)
@@ -6012,7 +6012,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.CacheKeyQueryString = &cacheKeyQueryString
 	}
 
-	// Set property ‘ModifyRequestHeader’:
+	// Set property "ModifyRequestHeader":
 	if typedInput.ModifyRequestHeader != nil {
 		var modifyRequestHeader1 DeliveryRuleRequestHeaderAction_STATUS
 		err := modifyRequestHeader1.PopulateFromARM(owner, *typedInput.ModifyRequestHeader)
@@ -6023,7 +6023,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.ModifyRequestHeader = &modifyRequestHeader
 	}
 
-	// Set property ‘ModifyResponseHeader’:
+	// Set property "ModifyResponseHeader":
 	if typedInput.ModifyResponseHeader != nil {
 		var modifyResponseHeader1 DeliveryRuleResponseHeaderAction_STATUS
 		err := modifyResponseHeader1.PopulateFromARM(owner, *typedInput.ModifyResponseHeader)
@@ -6034,7 +6034,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.ModifyResponseHeader = &modifyResponseHeader
 	}
 
-	// Set property ‘OriginGroupOverride’:
+	// Set property "OriginGroupOverride":
 	if typedInput.OriginGroupOverride != nil {
 		var originGroupOverride1 OriginGroupOverrideAction_STATUS
 		err := originGroupOverride1.PopulateFromARM(owner, *typedInput.OriginGroupOverride)
@@ -6045,7 +6045,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.OriginGroupOverride = &originGroupOverride
 	}
 
-	// Set property ‘RouteConfigurationOverride’:
+	// Set property "RouteConfigurationOverride":
 	if typedInput.RouteConfigurationOverride != nil {
 		var routeConfigurationOverride1 DeliveryRuleRouteConfigurationOverrideAction_STATUS
 		err := routeConfigurationOverride1.PopulateFromARM(owner, *typedInput.RouteConfigurationOverride)
@@ -6056,7 +6056,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.RouteConfigurationOverride = &routeConfigurationOverride
 	}
 
-	// Set property ‘UrlRedirect’:
+	// Set property "UrlRedirect":
 	if typedInput.UrlRedirect != nil {
 		var urlRedirect1 UrlRedirectAction_STATUS
 		err := urlRedirect1.PopulateFromARM(owner, *typedInput.UrlRedirect)
@@ -6067,7 +6067,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.UrlRedirect = &urlRedirect
 	}
 
-	// Set property ‘UrlRewrite’:
+	// Set property "UrlRewrite":
 	if typedInput.UrlRewrite != nil {
 		var urlRewrite1 UrlRewriteAction_STATUS
 		err := urlRewrite1.PopulateFromARM(owner, *typedInput.UrlRewrite)
@@ -6078,7 +6078,7 @@ func (action *DeliveryRuleAction_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		action.UrlRewrite = &urlRewrite
 	}
 
-	// Set property ‘UrlSigning’:
+	// Set property "UrlSigning":
 	if typedInput.UrlSigning != nil {
 		var urlSigning1 UrlSigningAction_STATUS
 		err := urlSigning1.PopulateFromARM(owner, *typedInput.UrlSigning)
@@ -6364,7 +6364,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &DeliveryRuleCondition_ARM{}
 
-	// Set property ‘ClientPort’:
+	// Set property "ClientPort":
 	if condition.ClientPort != nil {
 		clientPort_ARM, err := (*condition.ClientPort).ConvertToARM(resolved)
 		if err != nil {
@@ -6374,7 +6374,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.ClientPort = &clientPort
 	}
 
-	// Set property ‘Cookies’:
+	// Set property "Cookies":
 	if condition.Cookies != nil {
 		cookies_ARM, err := (*condition.Cookies).ConvertToARM(resolved)
 		if err != nil {
@@ -6384,7 +6384,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.Cookies = &cookies
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	if condition.HostName != nil {
 		hostName_ARM, err := (*condition.HostName).ConvertToARM(resolved)
 		if err != nil {
@@ -6394,7 +6394,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.HostName = &hostName
 	}
 
-	// Set property ‘HttpVersion’:
+	// Set property "HttpVersion":
 	if condition.HttpVersion != nil {
 		httpVersion_ARM, err := (*condition.HttpVersion).ConvertToARM(resolved)
 		if err != nil {
@@ -6404,7 +6404,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.HttpVersion = &httpVersion
 	}
 
-	// Set property ‘IsDevice’:
+	// Set property "IsDevice":
 	if condition.IsDevice != nil {
 		isDevice_ARM, err := (*condition.IsDevice).ConvertToARM(resolved)
 		if err != nil {
@@ -6414,7 +6414,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.IsDevice = &isDevice
 	}
 
-	// Set property ‘PostArgs’:
+	// Set property "PostArgs":
 	if condition.PostArgs != nil {
 		postArgs_ARM, err := (*condition.PostArgs).ConvertToARM(resolved)
 		if err != nil {
@@ -6424,7 +6424,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.PostArgs = &postArgs
 	}
 
-	// Set property ‘QueryString’:
+	// Set property "QueryString":
 	if condition.QueryString != nil {
 		queryString_ARM, err := (*condition.QueryString).ConvertToARM(resolved)
 		if err != nil {
@@ -6434,7 +6434,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.QueryString = &queryString
 	}
 
-	// Set property ‘RemoteAddress’:
+	// Set property "RemoteAddress":
 	if condition.RemoteAddress != nil {
 		remoteAddress_ARM, err := (*condition.RemoteAddress).ConvertToARM(resolved)
 		if err != nil {
@@ -6444,7 +6444,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.RemoteAddress = &remoteAddress
 	}
 
-	// Set property ‘RequestBody’:
+	// Set property "RequestBody":
 	if condition.RequestBody != nil {
 		requestBody_ARM, err := (*condition.RequestBody).ConvertToARM(resolved)
 		if err != nil {
@@ -6454,7 +6454,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.RequestBody = &requestBody
 	}
 
-	// Set property ‘RequestHeader’:
+	// Set property "RequestHeader":
 	if condition.RequestHeader != nil {
 		requestHeader_ARM, err := (*condition.RequestHeader).ConvertToARM(resolved)
 		if err != nil {
@@ -6464,7 +6464,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.RequestHeader = &requestHeader
 	}
 
-	// Set property ‘RequestMethod’:
+	// Set property "RequestMethod":
 	if condition.RequestMethod != nil {
 		requestMethod_ARM, err := (*condition.RequestMethod).ConvertToARM(resolved)
 		if err != nil {
@@ -6474,7 +6474,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.RequestMethod = &requestMethod
 	}
 
-	// Set property ‘RequestScheme’:
+	// Set property "RequestScheme":
 	if condition.RequestScheme != nil {
 		requestScheme_ARM, err := (*condition.RequestScheme).ConvertToARM(resolved)
 		if err != nil {
@@ -6484,7 +6484,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.RequestScheme = &requestScheme
 	}
 
-	// Set property ‘RequestUri’:
+	// Set property "RequestUri":
 	if condition.RequestUri != nil {
 		requestUri_ARM, err := (*condition.RequestUri).ConvertToARM(resolved)
 		if err != nil {
@@ -6494,7 +6494,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.RequestUri = &requestUri
 	}
 
-	// Set property ‘ServerPort’:
+	// Set property "ServerPort":
 	if condition.ServerPort != nil {
 		serverPort_ARM, err := (*condition.ServerPort).ConvertToARM(resolved)
 		if err != nil {
@@ -6504,7 +6504,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.ServerPort = &serverPort
 	}
 
-	// Set property ‘SocketAddr’:
+	// Set property "SocketAddr":
 	if condition.SocketAddr != nil {
 		socketAddr_ARM, err := (*condition.SocketAddr).ConvertToARM(resolved)
 		if err != nil {
@@ -6514,7 +6514,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.SocketAddr = &socketAddr
 	}
 
-	// Set property ‘SslProtocol’:
+	// Set property "SslProtocol":
 	if condition.SslProtocol != nil {
 		sslProtocol_ARM, err := (*condition.SslProtocol).ConvertToARM(resolved)
 		if err != nil {
@@ -6524,7 +6524,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.SslProtocol = &sslProtocol
 	}
 
-	// Set property ‘UrlFileExtension’:
+	// Set property "UrlFileExtension":
 	if condition.UrlFileExtension != nil {
 		urlFileExtension_ARM, err := (*condition.UrlFileExtension).ConvertToARM(resolved)
 		if err != nil {
@@ -6534,7 +6534,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.UrlFileExtension = &urlFileExtension
 	}
 
-	// Set property ‘UrlFileName’:
+	// Set property "UrlFileName":
 	if condition.UrlFileName != nil {
 		urlFileName_ARM, err := (*condition.UrlFileName).ConvertToARM(resolved)
 		if err != nil {
@@ -6544,7 +6544,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		result.UrlFileName = &urlFileName
 	}
 
-	// Set property ‘UrlPath’:
+	// Set property "UrlPath":
 	if condition.UrlPath != nil {
 		urlPath_ARM, err := (*condition.UrlPath).ConvertToARM(resolved)
 		if err != nil {
@@ -6568,7 +6568,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientPort’:
+	// Set property "ClientPort":
 	if typedInput.ClientPort != nil {
 		var clientPort1 DeliveryRuleClientPortCondition
 		err := clientPort1.PopulateFromARM(owner, *typedInput.ClientPort)
@@ -6579,7 +6579,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.ClientPort = &clientPort
 	}
 
-	// Set property ‘Cookies’:
+	// Set property "Cookies":
 	if typedInput.Cookies != nil {
 		var cookies1 DeliveryRuleCookiesCondition
 		err := cookies1.PopulateFromARM(owner, *typedInput.Cookies)
@@ -6590,7 +6590,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.Cookies = &cookies
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	if typedInput.HostName != nil {
 		var hostName1 DeliveryRuleHostNameCondition
 		err := hostName1.PopulateFromARM(owner, *typedInput.HostName)
@@ -6601,7 +6601,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.HostName = &hostName
 	}
 
-	// Set property ‘HttpVersion’:
+	// Set property "HttpVersion":
 	if typedInput.HttpVersion != nil {
 		var httpVersion1 DeliveryRuleHttpVersionCondition
 		err := httpVersion1.PopulateFromARM(owner, *typedInput.HttpVersion)
@@ -6612,7 +6612,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.HttpVersion = &httpVersion
 	}
 
-	// Set property ‘IsDevice’:
+	// Set property "IsDevice":
 	if typedInput.IsDevice != nil {
 		var isDevice1 DeliveryRuleIsDeviceCondition
 		err := isDevice1.PopulateFromARM(owner, *typedInput.IsDevice)
@@ -6623,7 +6623,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.IsDevice = &isDevice
 	}
 
-	// Set property ‘PostArgs’:
+	// Set property "PostArgs":
 	if typedInput.PostArgs != nil {
 		var postArgs1 DeliveryRulePostArgsCondition
 		err := postArgs1.PopulateFromARM(owner, *typedInput.PostArgs)
@@ -6634,7 +6634,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.PostArgs = &postArgs
 	}
 
-	// Set property ‘QueryString’:
+	// Set property "QueryString":
 	if typedInput.QueryString != nil {
 		var queryString1 DeliveryRuleQueryStringCondition
 		err := queryString1.PopulateFromARM(owner, *typedInput.QueryString)
@@ -6645,7 +6645,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.QueryString = &queryString
 	}
 
-	// Set property ‘RemoteAddress’:
+	// Set property "RemoteAddress":
 	if typedInput.RemoteAddress != nil {
 		var remoteAddress1 DeliveryRuleRemoteAddressCondition
 		err := remoteAddress1.PopulateFromARM(owner, *typedInput.RemoteAddress)
@@ -6656,7 +6656,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.RemoteAddress = &remoteAddress
 	}
 
-	// Set property ‘RequestBody’:
+	// Set property "RequestBody":
 	if typedInput.RequestBody != nil {
 		var requestBody1 DeliveryRuleRequestBodyCondition
 		err := requestBody1.PopulateFromARM(owner, *typedInput.RequestBody)
@@ -6667,7 +6667,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.RequestBody = &requestBody
 	}
 
-	// Set property ‘RequestHeader’:
+	// Set property "RequestHeader":
 	if typedInput.RequestHeader != nil {
 		var requestHeader1 DeliveryRuleRequestHeaderCondition
 		err := requestHeader1.PopulateFromARM(owner, *typedInput.RequestHeader)
@@ -6678,7 +6678,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.RequestHeader = &requestHeader
 	}
 
-	// Set property ‘RequestMethod’:
+	// Set property "RequestMethod":
 	if typedInput.RequestMethod != nil {
 		var requestMethod1 DeliveryRuleRequestMethodCondition
 		err := requestMethod1.PopulateFromARM(owner, *typedInput.RequestMethod)
@@ -6689,7 +6689,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.RequestMethod = &requestMethod
 	}
 
-	// Set property ‘RequestScheme’:
+	// Set property "RequestScheme":
 	if typedInput.RequestScheme != nil {
 		var requestScheme1 DeliveryRuleRequestSchemeCondition
 		err := requestScheme1.PopulateFromARM(owner, *typedInput.RequestScheme)
@@ -6700,7 +6700,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.RequestScheme = &requestScheme
 	}
 
-	// Set property ‘RequestUri’:
+	// Set property "RequestUri":
 	if typedInput.RequestUri != nil {
 		var requestUri1 DeliveryRuleRequestUriCondition
 		err := requestUri1.PopulateFromARM(owner, *typedInput.RequestUri)
@@ -6711,7 +6711,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.RequestUri = &requestUri
 	}
 
-	// Set property ‘ServerPort’:
+	// Set property "ServerPort":
 	if typedInput.ServerPort != nil {
 		var serverPort1 DeliveryRuleServerPortCondition
 		err := serverPort1.PopulateFromARM(owner, *typedInput.ServerPort)
@@ -6722,7 +6722,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.ServerPort = &serverPort
 	}
 
-	// Set property ‘SocketAddr’:
+	// Set property "SocketAddr":
 	if typedInput.SocketAddr != nil {
 		var socketAddr1 DeliveryRuleSocketAddrCondition
 		err := socketAddr1.PopulateFromARM(owner, *typedInput.SocketAddr)
@@ -6733,7 +6733,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.SocketAddr = &socketAddr
 	}
 
-	// Set property ‘SslProtocol’:
+	// Set property "SslProtocol":
 	if typedInput.SslProtocol != nil {
 		var sslProtocol1 DeliveryRuleSslProtocolCondition
 		err := sslProtocol1.PopulateFromARM(owner, *typedInput.SslProtocol)
@@ -6744,7 +6744,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.SslProtocol = &sslProtocol
 	}
 
-	// Set property ‘UrlFileExtension’:
+	// Set property "UrlFileExtension":
 	if typedInput.UrlFileExtension != nil {
 		var urlFileExtension1 DeliveryRuleUrlFileExtensionCondition
 		err := urlFileExtension1.PopulateFromARM(owner, *typedInput.UrlFileExtension)
@@ -6755,7 +6755,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.UrlFileExtension = &urlFileExtension
 	}
 
-	// Set property ‘UrlFileName’:
+	// Set property "UrlFileName":
 	if typedInput.UrlFileName != nil {
 		var urlFileName1 DeliveryRuleUrlFileNameCondition
 		err := urlFileName1.PopulateFromARM(owner, *typedInput.UrlFileName)
@@ -6766,7 +6766,7 @@ func (condition *DeliveryRuleCondition) PopulateFromARM(owner genruntime.Arbitra
 		condition.UrlFileName = &urlFileName
 	}
 
-	// Set property ‘UrlPath’:
+	// Set property "UrlPath":
 	if typedInput.UrlPath != nil {
 		var urlPath1 DeliveryRuleUrlPathCondition
 		err := urlPath1.PopulateFromARM(owner, *typedInput.UrlPath)
@@ -7297,7 +7297,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientPort’:
+	// Set property "ClientPort":
 	if typedInput.ClientPort != nil {
 		var clientPort1 DeliveryRuleClientPortCondition_STATUS
 		err := clientPort1.PopulateFromARM(owner, *typedInput.ClientPort)
@@ -7308,7 +7308,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.ClientPort = &clientPort
 	}
 
-	// Set property ‘Cookies’:
+	// Set property "Cookies":
 	if typedInput.Cookies != nil {
 		var cookies1 DeliveryRuleCookiesCondition_STATUS
 		err := cookies1.PopulateFromARM(owner, *typedInput.Cookies)
@@ -7319,7 +7319,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.Cookies = &cookies
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	if typedInput.HostName != nil {
 		var hostName1 DeliveryRuleHostNameCondition_STATUS
 		err := hostName1.PopulateFromARM(owner, *typedInput.HostName)
@@ -7330,7 +7330,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.HostName = &hostName
 	}
 
-	// Set property ‘HttpVersion’:
+	// Set property "HttpVersion":
 	if typedInput.HttpVersion != nil {
 		var httpVersion1 DeliveryRuleHttpVersionCondition_STATUS
 		err := httpVersion1.PopulateFromARM(owner, *typedInput.HttpVersion)
@@ -7341,7 +7341,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.HttpVersion = &httpVersion
 	}
 
-	// Set property ‘IsDevice’:
+	// Set property "IsDevice":
 	if typedInput.IsDevice != nil {
 		var isDevice1 DeliveryRuleIsDeviceCondition_STATUS
 		err := isDevice1.PopulateFromARM(owner, *typedInput.IsDevice)
@@ -7352,7 +7352,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.IsDevice = &isDevice
 	}
 
-	// Set property ‘PostArgs’:
+	// Set property "PostArgs":
 	if typedInput.PostArgs != nil {
 		var postArgs1 DeliveryRulePostArgsCondition_STATUS
 		err := postArgs1.PopulateFromARM(owner, *typedInput.PostArgs)
@@ -7363,7 +7363,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.PostArgs = &postArgs
 	}
 
-	// Set property ‘QueryString’:
+	// Set property "QueryString":
 	if typedInput.QueryString != nil {
 		var queryString1 DeliveryRuleQueryStringCondition_STATUS
 		err := queryString1.PopulateFromARM(owner, *typedInput.QueryString)
@@ -7374,7 +7374,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.QueryString = &queryString
 	}
 
-	// Set property ‘RemoteAddress’:
+	// Set property "RemoteAddress":
 	if typedInput.RemoteAddress != nil {
 		var remoteAddress1 DeliveryRuleRemoteAddressCondition_STATUS
 		err := remoteAddress1.PopulateFromARM(owner, *typedInput.RemoteAddress)
@@ -7385,7 +7385,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.RemoteAddress = &remoteAddress
 	}
 
-	// Set property ‘RequestBody’:
+	// Set property "RequestBody":
 	if typedInput.RequestBody != nil {
 		var requestBody1 DeliveryRuleRequestBodyCondition_STATUS
 		err := requestBody1.PopulateFromARM(owner, *typedInput.RequestBody)
@@ -7396,7 +7396,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.RequestBody = &requestBody
 	}
 
-	// Set property ‘RequestHeader’:
+	// Set property "RequestHeader":
 	if typedInput.RequestHeader != nil {
 		var requestHeader1 DeliveryRuleRequestHeaderCondition_STATUS
 		err := requestHeader1.PopulateFromARM(owner, *typedInput.RequestHeader)
@@ -7407,7 +7407,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.RequestHeader = &requestHeader
 	}
 
-	// Set property ‘RequestMethod’:
+	// Set property "RequestMethod":
 	if typedInput.RequestMethod != nil {
 		var requestMethod1 DeliveryRuleRequestMethodCondition_STATUS
 		err := requestMethod1.PopulateFromARM(owner, *typedInput.RequestMethod)
@@ -7418,7 +7418,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.RequestMethod = &requestMethod
 	}
 
-	// Set property ‘RequestScheme’:
+	// Set property "RequestScheme":
 	if typedInput.RequestScheme != nil {
 		var requestScheme1 DeliveryRuleRequestSchemeCondition_STATUS
 		err := requestScheme1.PopulateFromARM(owner, *typedInput.RequestScheme)
@@ -7429,7 +7429,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.RequestScheme = &requestScheme
 	}
 
-	// Set property ‘RequestUri’:
+	// Set property "RequestUri":
 	if typedInput.RequestUri != nil {
 		var requestUri1 DeliveryRuleRequestUriCondition_STATUS
 		err := requestUri1.PopulateFromARM(owner, *typedInput.RequestUri)
@@ -7440,7 +7440,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.RequestUri = &requestUri
 	}
 
-	// Set property ‘ServerPort’:
+	// Set property "ServerPort":
 	if typedInput.ServerPort != nil {
 		var serverPort1 DeliveryRuleServerPortCondition_STATUS
 		err := serverPort1.PopulateFromARM(owner, *typedInput.ServerPort)
@@ -7451,7 +7451,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.ServerPort = &serverPort
 	}
 
-	// Set property ‘SocketAddr’:
+	// Set property "SocketAddr":
 	if typedInput.SocketAddr != nil {
 		var socketAddr1 DeliveryRuleSocketAddrCondition_STATUS
 		err := socketAddr1.PopulateFromARM(owner, *typedInput.SocketAddr)
@@ -7462,7 +7462,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.SocketAddr = &socketAddr
 	}
 
-	// Set property ‘SslProtocol’:
+	// Set property "SslProtocol":
 	if typedInput.SslProtocol != nil {
 		var sslProtocol1 DeliveryRuleSslProtocolCondition_STATUS
 		err := sslProtocol1.PopulateFromARM(owner, *typedInput.SslProtocol)
@@ -7473,7 +7473,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.SslProtocol = &sslProtocol
 	}
 
-	// Set property ‘UrlFileExtension’:
+	// Set property "UrlFileExtension":
 	if typedInput.UrlFileExtension != nil {
 		var urlFileExtension1 DeliveryRuleUrlFileExtensionCondition_STATUS
 		err := urlFileExtension1.PopulateFromARM(owner, *typedInput.UrlFileExtension)
@@ -7484,7 +7484,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.UrlFileExtension = &urlFileExtension
 	}
 
-	// Set property ‘UrlFileName’:
+	// Set property "UrlFileName":
 	if typedInput.UrlFileName != nil {
 		var urlFileName1 DeliveryRuleUrlFileNameCondition_STATUS
 		err := urlFileName1.PopulateFromARM(owner, *typedInput.UrlFileName)
@@ -7495,7 +7495,7 @@ func (condition *DeliveryRuleCondition_STATUS) PopulateFromARM(owner genruntime.
 		condition.UrlFileName = &urlFileName
 	}
 
-	// Set property ‘UrlPath’:
+	// Set property "UrlPath":
 	if typedInput.UrlPath != nil {
 		var urlPath1 DeliveryRuleUrlPathCondition_STATUS
 		err := urlPath1.PopulateFromARM(owner, *typedInput.UrlPath)
@@ -8050,13 +8050,13 @@ func (parameters *HttpErrorRangeParameters) ConvertToARM(resolved genruntime.Con
 	}
 	result := &HttpErrorRangeParameters_ARM{}
 
-	// Set property ‘Begin’:
+	// Set property "Begin":
 	if parameters.Begin != nil {
 		begin := *parameters.Begin
 		result.Begin = &begin
 	}
 
-	// Set property ‘End’:
+	// Set property "End":
 	if parameters.End != nil {
 		end := *parameters.End
 		result.End = &end
@@ -8076,13 +8076,13 @@ func (parameters *HttpErrorRangeParameters) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HttpErrorRangeParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Begin’:
+	// Set property "Begin":
 	if typedInput.Begin != nil {
 		begin := *typedInput.Begin
 		parameters.Begin = &begin
 	}
 
-	// Set property ‘End’:
+	// Set property "End":
 	if typedInput.End != nil {
 		end := *typedInput.End
 		parameters.End = &end
@@ -8167,13 +8167,13 @@ func (parameters *HttpErrorRangeParameters_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HttpErrorRangeParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Begin’:
+	// Set property "Begin":
 	if typedInput.Begin != nil {
 		begin := *typedInput.Begin
 		parameters.Begin = &begin
 	}
 
-	// Set property ‘End’:
+	// Set property "End":
 	if typedInput.End != nil {
 		end := *typedInput.End
 		parameters.End = &end
@@ -8270,12 +8270,12 @@ func (action *DeliveryRuleCacheExpirationAction) ConvertToARM(resolved genruntim
 	}
 	result := &DeliveryRuleCacheExpirationAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -8299,10 +8299,10 @@ func (action *DeliveryRuleCacheExpirationAction) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCacheExpirationAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 CacheExpirationActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -8400,10 +8400,10 @@ func (action *DeliveryRuleCacheExpirationAction_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCacheExpirationAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 CacheExpirationActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -8499,12 +8499,12 @@ func (action *DeliveryRuleCacheKeyQueryStringAction) ConvertToARM(resolved genru
 	}
 	result := &DeliveryRuleCacheKeyQueryStringAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -8528,10 +8528,10 @@ func (action *DeliveryRuleCacheKeyQueryStringAction) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCacheKeyQueryStringAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 CacheKeyQueryStringActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -8629,10 +8629,10 @@ func (action *DeliveryRuleCacheKeyQueryStringAction_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCacheKeyQueryStringAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 CacheKeyQueryStringActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -8728,12 +8728,12 @@ func (condition *DeliveryRuleClientPortCondition) ConvertToARM(resolved genrunti
 	}
 	result := &DeliveryRuleClientPortCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -8757,10 +8757,10 @@ func (condition *DeliveryRuleClientPortCondition) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleClientPortCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 ClientPortMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -8858,10 +8858,10 @@ func (condition *DeliveryRuleClientPortCondition_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleClientPortCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 ClientPortMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -8957,12 +8957,12 @@ func (condition *DeliveryRuleCookiesCondition) ConvertToARM(resolved genruntime.
 	}
 	result := &DeliveryRuleCookiesCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -8986,10 +8986,10 @@ func (condition *DeliveryRuleCookiesCondition) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCookiesCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 CookiesMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -9087,10 +9087,10 @@ func (condition *DeliveryRuleCookiesCondition_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleCookiesCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 CookiesMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -9186,12 +9186,12 @@ func (condition *DeliveryRuleHostNameCondition) ConvertToARM(resolved genruntime
 	}
 	result := &DeliveryRuleHostNameCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -9215,10 +9215,10 @@ func (condition *DeliveryRuleHostNameCondition) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleHostNameCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HostNameMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -9316,10 +9316,10 @@ func (condition *DeliveryRuleHostNameCondition_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleHostNameCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HostNameMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -9415,12 +9415,12 @@ func (condition *DeliveryRuleHttpVersionCondition) ConvertToARM(resolved genrunt
 	}
 	result := &DeliveryRuleHttpVersionCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -9444,10 +9444,10 @@ func (condition *DeliveryRuleHttpVersionCondition) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleHttpVersionCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HttpVersionMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -9545,10 +9545,10 @@ func (condition *DeliveryRuleHttpVersionCondition_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleHttpVersionCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HttpVersionMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -9644,12 +9644,12 @@ func (condition *DeliveryRuleIsDeviceCondition) ConvertToARM(resolved genruntime
 	}
 	result := &DeliveryRuleIsDeviceCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -9673,10 +9673,10 @@ func (condition *DeliveryRuleIsDeviceCondition) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleIsDeviceCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 IsDeviceMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -9774,10 +9774,10 @@ func (condition *DeliveryRuleIsDeviceCondition_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleIsDeviceCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 IsDeviceMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -9873,12 +9873,12 @@ func (condition *DeliveryRulePostArgsCondition) ConvertToARM(resolved genruntime
 	}
 	result := &DeliveryRulePostArgsCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -9902,10 +9902,10 @@ func (condition *DeliveryRulePostArgsCondition) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRulePostArgsCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 PostArgsMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10003,10 +10003,10 @@ func (condition *DeliveryRulePostArgsCondition_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRulePostArgsCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 PostArgsMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10102,12 +10102,12 @@ func (condition *DeliveryRuleQueryStringCondition) ConvertToARM(resolved genrunt
 	}
 	result := &DeliveryRuleQueryStringCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -10131,10 +10131,10 @@ func (condition *DeliveryRuleQueryStringCondition) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleQueryStringCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 QueryStringMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10232,10 +10232,10 @@ func (condition *DeliveryRuleQueryStringCondition_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleQueryStringCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 QueryStringMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10331,12 +10331,12 @@ func (condition *DeliveryRuleRemoteAddressCondition) ConvertToARM(resolved genru
 	}
 	result := &DeliveryRuleRemoteAddressCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -10360,10 +10360,10 @@ func (condition *DeliveryRuleRemoteAddressCondition) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRemoteAddressCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RemoteAddressMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10461,10 +10461,10 @@ func (condition *DeliveryRuleRemoteAddressCondition_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRemoteAddressCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RemoteAddressMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10560,12 +10560,12 @@ func (condition *DeliveryRuleRequestBodyCondition) ConvertToARM(resolved genrunt
 	}
 	result := &DeliveryRuleRequestBodyCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -10589,10 +10589,10 @@ func (condition *DeliveryRuleRequestBodyCondition) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestBodyCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestBodyMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10690,10 +10690,10 @@ func (condition *DeliveryRuleRequestBodyCondition_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestBodyCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestBodyMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10789,12 +10789,12 @@ func (action *DeliveryRuleRequestHeaderAction) ConvertToARM(resolved genruntime.
 	}
 	result := &DeliveryRuleRequestHeaderAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -10818,10 +10818,10 @@ func (action *DeliveryRuleRequestHeaderAction) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestHeaderAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HeaderActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -10919,10 +10919,10 @@ func (action *DeliveryRuleRequestHeaderAction_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestHeaderAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HeaderActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11018,12 +11018,12 @@ func (condition *DeliveryRuleRequestHeaderCondition) ConvertToARM(resolved genru
 	}
 	result := &DeliveryRuleRequestHeaderCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -11047,10 +11047,10 @@ func (condition *DeliveryRuleRequestHeaderCondition) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestHeaderCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestHeaderMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11148,10 +11148,10 @@ func (condition *DeliveryRuleRequestHeaderCondition_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestHeaderCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestHeaderMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11247,12 +11247,12 @@ func (condition *DeliveryRuleRequestMethodCondition) ConvertToARM(resolved genru
 	}
 	result := &DeliveryRuleRequestMethodCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -11276,10 +11276,10 @@ func (condition *DeliveryRuleRequestMethodCondition) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestMethodCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestMethodMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11377,10 +11377,10 @@ func (condition *DeliveryRuleRequestMethodCondition_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestMethodCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestMethodMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11476,12 +11476,12 @@ func (condition *DeliveryRuleRequestSchemeCondition) ConvertToARM(resolved genru
 	}
 	result := &DeliveryRuleRequestSchemeCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -11505,10 +11505,10 @@ func (condition *DeliveryRuleRequestSchemeCondition) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestSchemeCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestSchemeMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11606,10 +11606,10 @@ func (condition *DeliveryRuleRequestSchemeCondition_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestSchemeCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestSchemeMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11705,12 +11705,12 @@ func (condition *DeliveryRuleRequestUriCondition) ConvertToARM(resolved genrunti
 	}
 	result := &DeliveryRuleRequestUriCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -11734,10 +11734,10 @@ func (condition *DeliveryRuleRequestUriCondition) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestUriCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestUriMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11835,10 +11835,10 @@ func (condition *DeliveryRuleRequestUriCondition_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRequestUriCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RequestUriMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -11934,12 +11934,12 @@ func (action *DeliveryRuleResponseHeaderAction) ConvertToARM(resolved genruntime
 	}
 	result := &DeliveryRuleResponseHeaderAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -11963,10 +11963,10 @@ func (action *DeliveryRuleResponseHeaderAction) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleResponseHeaderAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HeaderActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12064,10 +12064,10 @@ func (action *DeliveryRuleResponseHeaderAction_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleResponseHeaderAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 HeaderActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12163,12 +12163,12 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction) ConvertToARM(resolve
 	}
 	result := &DeliveryRuleRouteConfigurationOverrideAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -12192,10 +12192,10 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRouteConfigurationOverrideAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RouteConfigurationOverrideActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12293,10 +12293,10 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleRouteConfigurationOverrideAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 RouteConfigurationOverrideActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12392,12 +12392,12 @@ func (condition *DeliveryRuleServerPortCondition) ConvertToARM(resolved genrunti
 	}
 	result := &DeliveryRuleServerPortCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -12421,10 +12421,10 @@ func (condition *DeliveryRuleServerPortCondition) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleServerPortCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 ServerPortMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12522,10 +12522,10 @@ func (condition *DeliveryRuleServerPortCondition_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleServerPortCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 ServerPortMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12621,12 +12621,12 @@ func (condition *DeliveryRuleSocketAddrCondition) ConvertToARM(resolved genrunti
 	}
 	result := &DeliveryRuleSocketAddrCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -12650,10 +12650,10 @@ func (condition *DeliveryRuleSocketAddrCondition) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleSocketAddrCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 SocketAddrMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12751,10 +12751,10 @@ func (condition *DeliveryRuleSocketAddrCondition_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleSocketAddrCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 SocketAddrMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12850,12 +12850,12 @@ func (condition *DeliveryRuleSslProtocolCondition) ConvertToARM(resolved genrunt
 	}
 	result := &DeliveryRuleSslProtocolCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -12879,10 +12879,10 @@ func (condition *DeliveryRuleSslProtocolCondition) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleSslProtocolCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 SslProtocolMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -12980,10 +12980,10 @@ func (condition *DeliveryRuleSslProtocolCondition_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleSslProtocolCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 SslProtocolMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13079,12 +13079,12 @@ func (condition *DeliveryRuleUrlFileExtensionCondition) ConvertToARM(resolved ge
 	}
 	result := &DeliveryRuleUrlFileExtensionCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -13108,10 +13108,10 @@ func (condition *DeliveryRuleUrlFileExtensionCondition) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleUrlFileExtensionCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlFileExtensionMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13209,10 +13209,10 @@ func (condition *DeliveryRuleUrlFileExtensionCondition_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleUrlFileExtensionCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlFileExtensionMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13308,12 +13308,12 @@ func (condition *DeliveryRuleUrlFileNameCondition) ConvertToARM(resolved genrunt
 	}
 	result := &DeliveryRuleUrlFileNameCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -13337,10 +13337,10 @@ func (condition *DeliveryRuleUrlFileNameCondition) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleUrlFileNameCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlFileNameMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13438,10 +13438,10 @@ func (condition *DeliveryRuleUrlFileNameCondition_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleUrlFileNameCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlFileNameMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13537,12 +13537,12 @@ func (condition *DeliveryRuleUrlPathCondition) ConvertToARM(resolved genruntime.
 	}
 	result := &DeliveryRuleUrlPathCondition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if condition.Name != nil {
 		result.Name = *condition.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if condition.Parameters != nil {
 		parameters_ARM, err := (*condition.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -13566,10 +13566,10 @@ func (condition *DeliveryRuleUrlPathCondition) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleUrlPathCondition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlPathMatchConditionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13667,10 +13667,10 @@ func (condition *DeliveryRuleUrlPathCondition_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeliveryRuleUrlPathCondition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	condition.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlPathMatchConditionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13766,12 +13766,12 @@ func (action *OriginGroupOverrideAction) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &OriginGroupOverrideAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -13795,10 +13795,10 @@ func (action *OriginGroupOverrideAction) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OriginGroupOverrideAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 OriginGroupOverrideActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13896,10 +13896,10 @@ func (action *OriginGroupOverrideAction_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OriginGroupOverrideAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 OriginGroupOverrideActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -13995,12 +13995,12 @@ func (action *UrlRedirectAction) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &UrlRedirectAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -14024,10 +14024,10 @@ func (action *UrlRedirectAction) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRedirectAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlRedirectActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -14125,10 +14125,10 @@ func (action *UrlRedirectAction_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRedirectAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlRedirectActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -14224,12 +14224,12 @@ func (action *UrlRewriteAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &UrlRewriteAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -14253,10 +14253,10 @@ func (action *UrlRewriteAction) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRewriteAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlRewriteActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -14354,10 +14354,10 @@ func (action *UrlRewriteAction_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRewriteAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlRewriteActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -14453,12 +14453,12 @@ func (action *UrlSigningAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &UrlSigningAction_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if action.Name != nil {
 		result.Name = *action.Name
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters_ARM, err := (*action.Parameters).ConvertToARM(resolved)
 		if err != nil {
@@ -14482,10 +14482,10 @@ func (action *UrlSigningAction) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlSigningActionParameters
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -14583,10 +14583,10 @@ func (action *UrlSigningAction_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	action.Name = &typedInput.Name
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 UrlSigningActionParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -14686,25 +14686,25 @@ func (parameters *CacheExpirationActionParameters) ConvertToARM(resolved genrunt
 	}
 	result := &CacheExpirationActionParameters_ARM{}
 
-	// Set property ‘CacheBehavior’:
+	// Set property "CacheBehavior":
 	if parameters.CacheBehavior != nil {
 		cacheBehavior := *parameters.CacheBehavior
 		result.CacheBehavior = &cacheBehavior
 	}
 
-	// Set property ‘CacheDuration’:
+	// Set property "CacheDuration":
 	if parameters.CacheDuration != nil {
 		cacheDuration := *parameters.CacheDuration
 		result.CacheDuration = &cacheDuration
 	}
 
-	// Set property ‘CacheType’:
+	// Set property "CacheType":
 	if parameters.CacheType != nil {
 		cacheType := *parameters.CacheType
 		result.CacheType = &cacheType
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -14724,25 +14724,25 @@ func (parameters *CacheExpirationActionParameters) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CacheExpirationActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheBehavior’:
+	// Set property "CacheBehavior":
 	if typedInput.CacheBehavior != nil {
 		cacheBehavior := *typedInput.CacheBehavior
 		parameters.CacheBehavior = &cacheBehavior
 	}
 
-	// Set property ‘CacheDuration’:
+	// Set property "CacheDuration":
 	if typedInput.CacheDuration != nil {
 		cacheDuration := *typedInput.CacheDuration
 		parameters.CacheDuration = &cacheDuration
 	}
 
-	// Set property ‘CacheType’:
+	// Set property "CacheType":
 	if typedInput.CacheType != nil {
 		cacheType := *typedInput.CacheType
 		parameters.CacheType = &cacheType
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -14851,25 +14851,25 @@ func (parameters *CacheExpirationActionParameters_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CacheExpirationActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheBehavior’:
+	// Set property "CacheBehavior":
 	if typedInput.CacheBehavior != nil {
 		cacheBehavior := *typedInput.CacheBehavior
 		parameters.CacheBehavior = &cacheBehavior
 	}
 
-	// Set property ‘CacheDuration’:
+	// Set property "CacheDuration":
 	if typedInput.CacheDuration != nil {
 		cacheDuration := *typedInput.CacheDuration
 		parameters.CacheDuration = &cacheDuration
 	}
 
-	// Set property ‘CacheType’:
+	// Set property "CacheType":
 	if typedInput.CacheType != nil {
 		cacheType := *typedInput.CacheType
 		parameters.CacheType = &cacheType
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -14976,19 +14976,19 @@ func (parameters *CacheKeyQueryStringActionParameters) ConvertToARM(resolved gen
 	}
 	result := &CacheKeyQueryStringActionParameters_ARM{}
 
-	// Set property ‘QueryParameters’:
+	// Set property "QueryParameters":
 	if parameters.QueryParameters != nil {
 		queryParameters := *parameters.QueryParameters
 		result.QueryParameters = &queryParameters
 	}
 
-	// Set property ‘QueryStringBehavior’:
+	// Set property "QueryStringBehavior":
 	if parameters.QueryStringBehavior != nil {
 		queryStringBehavior := *parameters.QueryStringBehavior
 		result.QueryStringBehavior = &queryStringBehavior
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -15008,19 +15008,19 @@ func (parameters *CacheKeyQueryStringActionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CacheKeyQueryStringActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘QueryParameters’:
+	// Set property "QueryParameters":
 	if typedInput.QueryParameters != nil {
 		queryParameters := *typedInput.QueryParameters
 		parameters.QueryParameters = &queryParameters
 	}
 
-	// Set property ‘QueryStringBehavior’:
+	// Set property "QueryStringBehavior":
 	if typedInput.QueryStringBehavior != nil {
 		queryStringBehavior := *typedInput.QueryStringBehavior
 		parameters.QueryStringBehavior = &queryStringBehavior
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -15112,19 +15112,19 @@ func (parameters *CacheKeyQueryStringActionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CacheKeyQueryStringActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘QueryParameters’:
+	// Set property "QueryParameters":
 	if typedInput.QueryParameters != nil {
 		queryParameters := *typedInput.QueryParameters
 		parameters.QueryParameters = &queryParameters
 	}
 
-	// Set property ‘QueryStringBehavior’:
+	// Set property "QueryStringBehavior":
 	if typedInput.QueryStringBehavior != nil {
 		queryStringBehavior := *typedInput.QueryStringBehavior
 		parameters.QueryStringBehavior = &queryStringBehavior
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -15217,29 +15217,29 @@ func (parameters *ClientPortMatchConditionParameters) ConvertToARM(resolved genr
 	}
 	result := &ClientPortMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -15259,29 +15259,29 @@ func (parameters *ClientPortMatchConditionParameters) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ClientPortMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -15417,29 +15417,29 @@ func (parameters *ClientPortMatchConditionParameters_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ClientPortMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -15575,35 +15575,35 @@ func (parameters *CookiesMatchConditionParameters) ConvertToARM(resolved genrunt
 	}
 	result := &CookiesMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if parameters.Selector != nil {
 		selector := *parameters.Selector
 		result.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -15623,35 +15623,35 @@ func (parameters *CookiesMatchConditionParameters) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CookiesMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if typedInput.Selector != nil {
 		selector := *typedInput.Selector
 		parameters.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -15794,35 +15794,35 @@ func (parameters *CookiesMatchConditionParameters_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CookiesMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if typedInput.Selector != nil {
 		selector := *typedInput.Selector
 		parameters.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -16270,25 +16270,25 @@ func (parameters *HeaderActionParameters) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &HeaderActionParameters_ARM{}
 
-	// Set property ‘HeaderAction’:
+	// Set property "HeaderAction":
 	if parameters.HeaderAction != nil {
 		headerAction := *parameters.HeaderAction
 		result.HeaderAction = &headerAction
 	}
 
-	// Set property ‘HeaderName’:
+	// Set property "HeaderName":
 	if parameters.HeaderName != nil {
 		headerName := *parameters.HeaderName
 		result.HeaderName = &headerName
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if parameters.Value != nil {
 		value := *parameters.Value
 		result.Value = &value
@@ -16308,25 +16308,25 @@ func (parameters *HeaderActionParameters) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HeaderActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HeaderAction’:
+	// Set property "HeaderAction":
 	if typedInput.HeaderAction != nil {
 		headerAction := *typedInput.HeaderAction
 		parameters.HeaderAction = &headerAction
 	}
 
-	// Set property ‘HeaderName’:
+	// Set property "HeaderName":
 	if typedInput.HeaderName != nil {
 		headerName := *typedInput.HeaderName
 		parameters.HeaderName = &headerName
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		parameters.Value = &value
@@ -16425,25 +16425,25 @@ func (parameters *HeaderActionParameters_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HeaderActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HeaderAction’:
+	// Set property "HeaderAction":
 	if typedInput.HeaderAction != nil {
 		headerAction := *typedInput.HeaderAction
 		parameters.HeaderAction = &headerAction
 	}
 
-	// Set property ‘HeaderName’:
+	// Set property "HeaderName":
 	if typedInput.HeaderName != nil {
 		headerName := *typedInput.HeaderName
 		parameters.HeaderName = &headerName
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		parameters.Value = &value
@@ -16542,29 +16542,29 @@ func (parameters *HostNameMatchConditionParameters) ConvertToARM(resolved genrun
 	}
 	result := &HostNameMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -16584,29 +16584,29 @@ func (parameters *HostNameMatchConditionParameters) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HostNameMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -16742,29 +16742,29 @@ func (parameters *HostNameMatchConditionParameters_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HostNameMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -16899,29 +16899,29 @@ func (parameters *HttpVersionMatchConditionParameters) ConvertToARM(resolved gen
 	}
 	result := &HttpVersionMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -16941,29 +16941,29 @@ func (parameters *HttpVersionMatchConditionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HttpVersionMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -17099,29 +17099,29 @@ func (parameters *HttpVersionMatchConditionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HttpVersionMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -17256,29 +17256,29 @@ func (parameters *IsDeviceMatchConditionParameters) ConvertToARM(resolved genrun
 	}
 	result := &IsDeviceMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -17298,29 +17298,29 @@ func (parameters *IsDeviceMatchConditionParameters) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IsDeviceMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -17476,29 +17476,29 @@ func (parameters *IsDeviceMatchConditionParameters_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IsDeviceMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -17661,7 +17661,7 @@ func (parameters *OriginGroupOverrideActionParameters) ConvertToARM(resolved gen
 	}
 	result := &OriginGroupOverrideActionParameters_ARM{}
 
-	// Set property ‘OriginGroup’:
+	// Set property "OriginGroup":
 	if parameters.OriginGroup != nil {
 		originGroup_ARM, err := (*parameters.OriginGroup).ConvertToARM(resolved)
 		if err != nil {
@@ -17671,7 +17671,7 @@ func (parameters *OriginGroupOverrideActionParameters) ConvertToARM(resolved gen
 		result.OriginGroup = &originGroup
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -17691,7 +17691,7 @@ func (parameters *OriginGroupOverrideActionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OriginGroupOverrideActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘OriginGroup’:
+	// Set property "OriginGroup":
 	if typedInput.OriginGroup != nil {
 		var originGroup1 ResourceReference
 		err := originGroup1.PopulateFromARM(owner, *typedInput.OriginGroup)
@@ -17702,7 +17702,7 @@ func (parameters *OriginGroupOverrideActionParameters) PopulateFromARM(owner gen
 		parameters.OriginGroup = &originGroup
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -17795,7 +17795,7 @@ func (parameters *OriginGroupOverrideActionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OriginGroupOverrideActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘OriginGroup’:
+	// Set property "OriginGroup":
 	if typedInput.OriginGroup != nil {
 		var originGroup1 ResourceReference_STATUS
 		err := originGroup1.PopulateFromARM(owner, *typedInput.OriginGroup)
@@ -17806,7 +17806,7 @@ func (parameters *OriginGroupOverrideActionParameters_STATUS) PopulateFromARM(ow
 		parameters.OriginGroup = &originGroup
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -17902,35 +17902,35 @@ func (parameters *PostArgsMatchConditionParameters) ConvertToARM(resolved genrun
 	}
 	result := &PostArgsMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if parameters.Selector != nil {
 		selector := *parameters.Selector
 		result.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -17950,35 +17950,35 @@ func (parameters *PostArgsMatchConditionParameters) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PostArgsMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if typedInput.Selector != nil {
 		selector := *typedInput.Selector
 		parameters.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -18121,35 +18121,35 @@ func (parameters *PostArgsMatchConditionParameters_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PostArgsMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if typedInput.Selector != nil {
 		selector := *typedInput.Selector
 		parameters.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -18290,29 +18290,29 @@ func (parameters *QueryStringMatchConditionParameters) ConvertToARM(resolved gen
 	}
 	result := &QueryStringMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -18332,29 +18332,29 @@ func (parameters *QueryStringMatchConditionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected QueryStringMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -18490,29 +18490,29 @@ func (parameters *QueryStringMatchConditionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected QueryStringMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -18647,29 +18647,29 @@ func (parameters *RemoteAddressMatchConditionParameters) ConvertToARM(resolved g
 	}
 	result := &RemoteAddressMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -18689,29 +18689,29 @@ func (parameters *RemoteAddressMatchConditionParameters) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RemoteAddressMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -18847,29 +18847,29 @@ func (parameters *RemoteAddressMatchConditionParameters_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RemoteAddressMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -19004,29 +19004,29 @@ func (parameters *RequestBodyMatchConditionParameters) ConvertToARM(resolved gen
 	}
 	result := &RequestBodyMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -19046,29 +19046,29 @@ func (parameters *RequestBodyMatchConditionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestBodyMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -19204,29 +19204,29 @@ func (parameters *RequestBodyMatchConditionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestBodyMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -19362,35 +19362,35 @@ func (parameters *RequestHeaderMatchConditionParameters) ConvertToARM(resolved g
 	}
 	result := &RequestHeaderMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if parameters.Selector != nil {
 		selector := *parameters.Selector
 		result.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -19410,35 +19410,35 @@ func (parameters *RequestHeaderMatchConditionParameters) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestHeaderMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if typedInput.Selector != nil {
 		selector := *typedInput.Selector
 		parameters.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -19581,35 +19581,35 @@ func (parameters *RequestHeaderMatchConditionParameters_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestHeaderMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Selector’:
+	// Set property "Selector":
 	if typedInput.Selector != nil {
 		selector := *typedInput.Selector
 		parameters.Selector = &selector
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -19750,29 +19750,29 @@ func (parameters *RequestMethodMatchConditionParameters) ConvertToARM(resolved g
 	}
 	result := &RequestMethodMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -19792,29 +19792,29 @@ func (parameters *RequestMethodMatchConditionParameters) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestMethodMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -19970,29 +19970,29 @@ func (parameters *RequestMethodMatchConditionParameters_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestMethodMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -20147,29 +20147,29 @@ func (parameters *RequestSchemeMatchConditionParameters) ConvertToARM(resolved g
 	}
 	result := &RequestSchemeMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -20189,29 +20189,29 @@ func (parameters *RequestSchemeMatchConditionParameters) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestSchemeMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -20367,29 +20367,29 @@ func (parameters *RequestSchemeMatchConditionParameters_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestSchemeMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -20544,29 +20544,29 @@ func (parameters *RequestUriMatchConditionParameters) ConvertToARM(resolved genr
 	}
 	result := &RequestUriMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -20586,29 +20586,29 @@ func (parameters *RequestUriMatchConditionParameters) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestUriMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -20744,29 +20744,29 @@ func (parameters *RequestUriMatchConditionParameters_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestUriMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -20897,7 +20897,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) ConvertToARM(resol
 	}
 	result := &RouteConfigurationOverrideActionParameters_ARM{}
 
-	// Set property ‘CacheConfiguration’:
+	// Set property "CacheConfiguration":
 	if parameters.CacheConfiguration != nil {
 		cacheConfiguration_ARM, err := (*parameters.CacheConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -20907,7 +20907,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) ConvertToARM(resol
 		result.CacheConfiguration = &cacheConfiguration
 	}
 
-	// Set property ‘OriginGroupOverride’:
+	// Set property "OriginGroupOverride":
 	if parameters.OriginGroupOverride != nil {
 		originGroupOverride_ARM, err := (*parameters.OriginGroupOverride).ConvertToARM(resolved)
 		if err != nil {
@@ -20917,7 +20917,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) ConvertToARM(resol
 		result.OriginGroupOverride = &originGroupOverride
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -20937,7 +20937,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteConfigurationOverrideActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheConfiguration’:
+	// Set property "CacheConfiguration":
 	if typedInput.CacheConfiguration != nil {
 		var cacheConfiguration1 CacheConfiguration
 		err := cacheConfiguration1.PopulateFromARM(owner, *typedInput.CacheConfiguration)
@@ -20948,7 +20948,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) PopulateFromARM(ow
 		parameters.CacheConfiguration = &cacheConfiguration
 	}
 
-	// Set property ‘OriginGroupOverride’:
+	// Set property "OriginGroupOverride":
 	if typedInput.OriginGroupOverride != nil {
 		var originGroupOverride1 OriginGroupOverride
 		err := originGroupOverride1.PopulateFromARM(owner, *typedInput.OriginGroupOverride)
@@ -20959,7 +20959,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) PopulateFromARM(ow
 		parameters.OriginGroupOverride = &originGroupOverride
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -21077,7 +21077,7 @@ func (parameters *RouteConfigurationOverrideActionParameters_STATUS) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteConfigurationOverrideActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheConfiguration’:
+	// Set property "CacheConfiguration":
 	if typedInput.CacheConfiguration != nil {
 		var cacheConfiguration1 CacheConfiguration_STATUS
 		err := cacheConfiguration1.PopulateFromARM(owner, *typedInput.CacheConfiguration)
@@ -21088,7 +21088,7 @@ func (parameters *RouteConfigurationOverrideActionParameters_STATUS) PopulateFro
 		parameters.CacheConfiguration = &cacheConfiguration
 	}
 
-	// Set property ‘OriginGroupOverride’:
+	// Set property "OriginGroupOverride":
 	if typedInput.OriginGroupOverride != nil {
 		var originGroupOverride1 OriginGroupOverride_STATUS
 		err := originGroupOverride1.PopulateFromARM(owner, *typedInput.OriginGroupOverride)
@@ -21099,7 +21099,7 @@ func (parameters *RouteConfigurationOverrideActionParameters_STATUS) PopulateFro
 		parameters.OriginGroupOverride = &originGroupOverride
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -21218,29 +21218,29 @@ func (parameters *ServerPortMatchConditionParameters) ConvertToARM(resolved genr
 	}
 	result := &ServerPortMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -21260,29 +21260,29 @@ func (parameters *ServerPortMatchConditionParameters) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPortMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -21418,29 +21418,29 @@ func (parameters *ServerPortMatchConditionParameters_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPortMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -21575,29 +21575,29 @@ func (parameters *SocketAddrMatchConditionParameters) ConvertToARM(resolved genr
 	}
 	result := &SocketAddrMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -21617,29 +21617,29 @@ func (parameters *SocketAddrMatchConditionParameters) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SocketAddrMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -21775,29 +21775,29 @@ func (parameters *SocketAddrMatchConditionParameters_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SocketAddrMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -21932,29 +21932,29 @@ func (parameters *SslProtocolMatchConditionParameters) ConvertToARM(resolved gen
 	}
 	result := &SslProtocolMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -21974,29 +21974,29 @@ func (parameters *SslProtocolMatchConditionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SslProtocolMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -22152,29 +22152,29 @@ func (parameters *SslProtocolMatchConditionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SslProtocolMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -22329,29 +22329,29 @@ func (parameters *UrlFileExtensionMatchConditionParameters) ConvertToARM(resolve
 	}
 	result := &UrlFileExtensionMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -22371,29 +22371,29 @@ func (parameters *UrlFileExtensionMatchConditionParameters) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlFileExtensionMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -22529,29 +22529,29 @@ func (parameters *UrlFileExtensionMatchConditionParameters_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlFileExtensionMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -22686,29 +22686,29 @@ func (parameters *UrlFileNameMatchConditionParameters) ConvertToARM(resolved gen
 	}
 	result := &UrlFileNameMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -22728,29 +22728,29 @@ func (parameters *UrlFileNameMatchConditionParameters) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlFileNameMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -22886,29 +22886,29 @@ func (parameters *UrlFileNameMatchConditionParameters_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlFileNameMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -23043,29 +23043,29 @@ func (parameters *UrlPathMatchConditionParameters) ConvertToARM(resolved genrunt
 	}
 	result := &UrlPathMatchConditionParameters_ARM{}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range parameters.MatchValues {
 		result.MatchValues = append(result.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if parameters.NegateCondition != nil {
 		negateCondition := *parameters.NegateCondition
 		result.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if parameters.Operator != nil {
 		operator := *parameters.Operator
 		result.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range parameters.Transforms {
 		result.Transforms = append(result.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -23085,29 +23085,29 @@ func (parameters *UrlPathMatchConditionParameters) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlPathMatchConditionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -23243,29 +23243,29 @@ func (parameters *UrlPathMatchConditionParameters_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlPathMatchConditionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MatchValues’:
+	// Set property "MatchValues":
 	for _, item := range typedInput.MatchValues {
 		parameters.MatchValues = append(parameters.MatchValues, item)
 	}
 
-	// Set property ‘NegateCondition’:
+	// Set property "NegateCondition":
 	if typedInput.NegateCondition != nil {
 		negateCondition := *typedInput.NegateCondition
 		parameters.NegateCondition = &negateCondition
 	}
 
-	// Set property ‘Operator’:
+	// Set property "Operator":
 	if typedInput.Operator != nil {
 		operator := *typedInput.Operator
 		parameters.Operator = &operator
 	}
 
-	// Set property ‘Transforms’:
+	// Set property "Transforms":
 	for _, item := range typedInput.Transforms {
 		parameters.Transforms = append(parameters.Transforms, item)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -23413,43 +23413,43 @@ func (parameters *UrlRedirectActionParameters) ConvertToARM(resolved genruntime.
 	}
 	result := &UrlRedirectActionParameters_ARM{}
 
-	// Set property ‘CustomFragment’:
+	// Set property "CustomFragment":
 	if parameters.CustomFragment != nil {
 		customFragment := *parameters.CustomFragment
 		result.CustomFragment = &customFragment
 	}
 
-	// Set property ‘CustomHostname’:
+	// Set property "CustomHostname":
 	if parameters.CustomHostname != nil {
 		customHostname := *parameters.CustomHostname
 		result.CustomHostname = &customHostname
 	}
 
-	// Set property ‘CustomPath’:
+	// Set property "CustomPath":
 	if parameters.CustomPath != nil {
 		customPath := *parameters.CustomPath
 		result.CustomPath = &customPath
 	}
 
-	// Set property ‘CustomQueryString’:
+	// Set property "CustomQueryString":
 	if parameters.CustomQueryString != nil {
 		customQueryString := *parameters.CustomQueryString
 		result.CustomQueryString = &customQueryString
 	}
 
-	// Set property ‘DestinationProtocol’:
+	// Set property "DestinationProtocol":
 	if parameters.DestinationProtocol != nil {
 		destinationProtocol := *parameters.DestinationProtocol
 		result.DestinationProtocol = &destinationProtocol
 	}
 
-	// Set property ‘RedirectType’:
+	// Set property "RedirectType":
 	if parameters.RedirectType != nil {
 		redirectType := *parameters.RedirectType
 		result.RedirectType = &redirectType
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -23469,43 +23469,43 @@ func (parameters *UrlRedirectActionParameters) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRedirectActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomFragment’:
+	// Set property "CustomFragment":
 	if typedInput.CustomFragment != nil {
 		customFragment := *typedInput.CustomFragment
 		parameters.CustomFragment = &customFragment
 	}
 
-	// Set property ‘CustomHostname’:
+	// Set property "CustomHostname":
 	if typedInput.CustomHostname != nil {
 		customHostname := *typedInput.CustomHostname
 		parameters.CustomHostname = &customHostname
 	}
 
-	// Set property ‘CustomPath’:
+	// Set property "CustomPath":
 	if typedInput.CustomPath != nil {
 		customPath := *typedInput.CustomPath
 		parameters.CustomPath = &customPath
 	}
 
-	// Set property ‘CustomQueryString’:
+	// Set property "CustomQueryString":
 	if typedInput.CustomQueryString != nil {
 		customQueryString := *typedInput.CustomQueryString
 		parameters.CustomQueryString = &customQueryString
 	}
 
-	// Set property ‘DestinationProtocol’:
+	// Set property "DestinationProtocol":
 	if typedInput.DestinationProtocol != nil {
 		destinationProtocol := *typedInput.DestinationProtocol
 		parameters.DestinationProtocol = &destinationProtocol
 	}
 
-	// Set property ‘RedirectType’:
+	// Set property "RedirectType":
 	if typedInput.RedirectType != nil {
 		redirectType := *typedInput.RedirectType
 		parameters.RedirectType = &redirectType
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -23635,43 +23635,43 @@ func (parameters *UrlRedirectActionParameters_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRedirectActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomFragment’:
+	// Set property "CustomFragment":
 	if typedInput.CustomFragment != nil {
 		customFragment := *typedInput.CustomFragment
 		parameters.CustomFragment = &customFragment
 	}
 
-	// Set property ‘CustomHostname’:
+	// Set property "CustomHostname":
 	if typedInput.CustomHostname != nil {
 		customHostname := *typedInput.CustomHostname
 		parameters.CustomHostname = &customHostname
 	}
 
-	// Set property ‘CustomPath’:
+	// Set property "CustomPath":
 	if typedInput.CustomPath != nil {
 		customPath := *typedInput.CustomPath
 		parameters.CustomPath = &customPath
 	}
 
-	// Set property ‘CustomQueryString’:
+	// Set property "CustomQueryString":
 	if typedInput.CustomQueryString != nil {
 		customQueryString := *typedInput.CustomQueryString
 		parameters.CustomQueryString = &customQueryString
 	}
 
-	// Set property ‘DestinationProtocol’:
+	// Set property "DestinationProtocol":
 	if typedInput.DestinationProtocol != nil {
 		destinationProtocol := *typedInput.DestinationProtocol
 		parameters.DestinationProtocol = &destinationProtocol
 	}
 
-	// Set property ‘RedirectType’:
+	// Set property "RedirectType":
 	if typedInput.RedirectType != nil {
 		redirectType := *typedInput.RedirectType
 		parameters.RedirectType = &redirectType
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -23809,25 +23809,25 @@ func (parameters *UrlRewriteActionParameters) ConvertToARM(resolved genruntime.C
 	}
 	result := &UrlRewriteActionParameters_ARM{}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	if parameters.Destination != nil {
 		destination := *parameters.Destination
 		result.Destination = &destination
 	}
 
-	// Set property ‘PreserveUnmatchedPath’:
+	// Set property "PreserveUnmatchedPath":
 	if parameters.PreserveUnmatchedPath != nil {
 		preserveUnmatchedPath := *parameters.PreserveUnmatchedPath
 		result.PreserveUnmatchedPath = &preserveUnmatchedPath
 	}
 
-	// Set property ‘SourcePattern’:
+	// Set property "SourcePattern":
 	if parameters.SourcePattern != nil {
 		sourcePattern := *parameters.SourcePattern
 		result.SourcePattern = &sourcePattern
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -23847,25 +23847,25 @@ func (parameters *UrlRewriteActionParameters) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRewriteActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	if typedInput.Destination != nil {
 		destination := *typedInput.Destination
 		parameters.Destination = &destination
 	}
 
-	// Set property ‘PreserveUnmatchedPath’:
+	// Set property "PreserveUnmatchedPath":
 	if typedInput.PreserveUnmatchedPath != nil {
 		preserveUnmatchedPath := *typedInput.PreserveUnmatchedPath
 		parameters.PreserveUnmatchedPath = &preserveUnmatchedPath
 	}
 
-	// Set property ‘SourcePattern’:
+	// Set property "SourcePattern":
 	if typedInput.SourcePattern != nil {
 		sourcePattern := *typedInput.SourcePattern
 		parameters.SourcePattern = &sourcePattern
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -23964,25 +23964,25 @@ func (parameters *UrlRewriteActionParameters_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlRewriteActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	if typedInput.Destination != nil {
 		destination := *typedInput.Destination
 		parameters.Destination = &destination
 	}
 
-	// Set property ‘PreserveUnmatchedPath’:
+	// Set property "PreserveUnmatchedPath":
 	if typedInput.PreserveUnmatchedPath != nil {
 		preserveUnmatchedPath := *typedInput.PreserveUnmatchedPath
 		parameters.PreserveUnmatchedPath = &preserveUnmatchedPath
 	}
 
-	// Set property ‘SourcePattern’:
+	// Set property "SourcePattern":
 	if typedInput.SourcePattern != nil {
 		sourcePattern := *typedInput.SourcePattern
 		parameters.SourcePattern = &sourcePattern
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -24088,13 +24088,13 @@ func (parameters *UrlSigningActionParameters) ConvertToARM(resolved genruntime.C
 	}
 	result := &UrlSigningActionParameters_ARM{}
 
-	// Set property ‘Algorithm’:
+	// Set property "Algorithm":
 	if parameters.Algorithm != nil {
 		algorithm := *parameters.Algorithm
 		result.Algorithm = &algorithm
 	}
 
-	// Set property ‘ParameterNameOverride’:
+	// Set property "ParameterNameOverride":
 	for _, item := range parameters.ParameterNameOverride {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -24103,7 +24103,7 @@ func (parameters *UrlSigningActionParameters) ConvertToARM(resolved genruntime.C
 		result.ParameterNameOverride = append(result.ParameterNameOverride, *item_ARM.(*UrlSigningParamIdentifier_ARM))
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if parameters.TypeName != nil {
 		typeName := *parameters.TypeName
 		result.TypeName = &typeName
@@ -24123,13 +24123,13 @@ func (parameters *UrlSigningActionParameters) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningActionParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Algorithm’:
+	// Set property "Algorithm":
 	if typedInput.Algorithm != nil {
 		algorithm := *typedInput.Algorithm
 		parameters.Algorithm = &algorithm
 	}
 
-	// Set property ‘ParameterNameOverride’:
+	// Set property "ParameterNameOverride":
 	for _, item := range typedInput.ParameterNameOverride {
 		var item1 UrlSigningParamIdentifier
 		err := item1.PopulateFromARM(owner, item)
@@ -24139,7 +24139,7 @@ func (parameters *UrlSigningActionParameters) PopulateFromARM(owner genruntime.A
 		parameters.ParameterNameOverride = append(parameters.ParameterNameOverride, item1)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -24261,13 +24261,13 @@ func (parameters *UrlSigningActionParameters_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningActionParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Algorithm’:
+	// Set property "Algorithm":
 	if typedInput.Algorithm != nil {
 		algorithm := *typedInput.Algorithm
 		parameters.Algorithm = &algorithm
 	}
 
-	// Set property ‘ParameterNameOverride’:
+	// Set property "ParameterNameOverride":
 	for _, item := range typedInput.ParameterNameOverride {
 		var item1 UrlSigningParamIdentifier_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -24277,7 +24277,7 @@ func (parameters *UrlSigningActionParameters_STATUS) PopulateFromARM(owner genru
 		parameters.ParameterNameOverride = append(parameters.ParameterNameOverride, item1)
 	}
 
-	// Set property ‘TypeName’:
+	// Set property "TypeName":
 	if typedInput.TypeName != nil {
 		typeName := *typedInput.TypeName
 		parameters.TypeName = &typeName
@@ -24396,31 +24396,31 @@ func (configuration *CacheConfiguration) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &CacheConfiguration_ARM{}
 
-	// Set property ‘CacheBehavior’:
+	// Set property "CacheBehavior":
 	if configuration.CacheBehavior != nil {
 		cacheBehavior := *configuration.CacheBehavior
 		result.CacheBehavior = &cacheBehavior
 	}
 
-	// Set property ‘CacheDuration’:
+	// Set property "CacheDuration":
 	if configuration.CacheDuration != nil {
 		cacheDuration := *configuration.CacheDuration
 		result.CacheDuration = &cacheDuration
 	}
 
-	// Set property ‘IsCompressionEnabled’:
+	// Set property "IsCompressionEnabled":
 	if configuration.IsCompressionEnabled != nil {
 		isCompressionEnabled := *configuration.IsCompressionEnabled
 		result.IsCompressionEnabled = &isCompressionEnabled
 	}
 
-	// Set property ‘QueryParameters’:
+	// Set property "QueryParameters":
 	if configuration.QueryParameters != nil {
 		queryParameters := *configuration.QueryParameters
 		result.QueryParameters = &queryParameters
 	}
 
-	// Set property ‘QueryStringCachingBehavior’:
+	// Set property "QueryStringCachingBehavior":
 	if configuration.QueryStringCachingBehavior != nil {
 		queryStringCachingBehavior := *configuration.QueryStringCachingBehavior
 		result.QueryStringCachingBehavior = &queryStringCachingBehavior
@@ -24440,31 +24440,31 @@ func (configuration *CacheConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CacheConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheBehavior’:
+	// Set property "CacheBehavior":
 	if typedInput.CacheBehavior != nil {
 		cacheBehavior := *typedInput.CacheBehavior
 		configuration.CacheBehavior = &cacheBehavior
 	}
 
-	// Set property ‘CacheDuration’:
+	// Set property "CacheDuration":
 	if typedInput.CacheDuration != nil {
 		cacheDuration := *typedInput.CacheDuration
 		configuration.CacheDuration = &cacheDuration
 	}
 
-	// Set property ‘IsCompressionEnabled’:
+	// Set property "IsCompressionEnabled":
 	if typedInput.IsCompressionEnabled != nil {
 		isCompressionEnabled := *typedInput.IsCompressionEnabled
 		configuration.IsCompressionEnabled = &isCompressionEnabled
 	}
 
-	// Set property ‘QueryParameters’:
+	// Set property "QueryParameters":
 	if typedInput.QueryParameters != nil {
 		queryParameters := *typedInput.QueryParameters
 		configuration.QueryParameters = &queryParameters
 	}
 
-	// Set property ‘QueryStringCachingBehavior’:
+	// Set property "QueryStringCachingBehavior":
 	if typedInput.QueryStringCachingBehavior != nil {
 		queryStringCachingBehavior := *typedInput.QueryStringCachingBehavior
 		configuration.QueryStringCachingBehavior = &queryStringCachingBehavior
@@ -24580,31 +24580,31 @@ func (configuration *CacheConfiguration_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CacheConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CacheBehavior’:
+	// Set property "CacheBehavior":
 	if typedInput.CacheBehavior != nil {
 		cacheBehavior := *typedInput.CacheBehavior
 		configuration.CacheBehavior = &cacheBehavior
 	}
 
-	// Set property ‘CacheDuration’:
+	// Set property "CacheDuration":
 	if typedInput.CacheDuration != nil {
 		cacheDuration := *typedInput.CacheDuration
 		configuration.CacheDuration = &cacheDuration
 	}
 
-	// Set property ‘IsCompressionEnabled’:
+	// Set property "IsCompressionEnabled":
 	if typedInput.IsCompressionEnabled != nil {
 		isCompressionEnabled := *typedInput.IsCompressionEnabled
 		configuration.IsCompressionEnabled = &isCompressionEnabled
 	}
 
-	// Set property ‘QueryParameters’:
+	// Set property "QueryParameters":
 	if typedInput.QueryParameters != nil {
 		queryParameters := *typedInput.QueryParameters
 		configuration.QueryParameters = &queryParameters
 	}
 
-	// Set property ‘QueryStringCachingBehavior’:
+	// Set property "QueryStringCachingBehavior":
 	if typedInput.QueryStringCachingBehavior != nil {
 		queryStringCachingBehavior := *typedInput.QueryStringCachingBehavior
 		configuration.QueryStringCachingBehavior = &queryStringCachingBehavior
@@ -25042,13 +25042,13 @@ func (override *OriginGroupOverride) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &OriginGroupOverride_ARM{}
 
-	// Set property ‘ForwardingProtocol’:
+	// Set property "ForwardingProtocol":
 	if override.ForwardingProtocol != nil {
 		forwardingProtocol := *override.ForwardingProtocol
 		result.ForwardingProtocol = &forwardingProtocol
 	}
 
-	// Set property ‘OriginGroup’:
+	// Set property "OriginGroup":
 	if override.OriginGroup != nil {
 		originGroup_ARM, err := (*override.OriginGroup).ConvertToARM(resolved)
 		if err != nil {
@@ -25072,13 +25072,13 @@ func (override *OriginGroupOverride) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OriginGroupOverride_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ForwardingProtocol’:
+	// Set property "ForwardingProtocol":
 	if typedInput.ForwardingProtocol != nil {
 		forwardingProtocol := *typedInput.ForwardingProtocol
 		override.ForwardingProtocol = &forwardingProtocol
 	}
 
-	// Set property ‘OriginGroup’:
+	// Set property "OriginGroup":
 	if typedInput.OriginGroup != nil {
 		var originGroup1 ResourceReference
 		err := originGroup1.PopulateFromARM(owner, *typedInput.OriginGroup)
@@ -25176,13 +25176,13 @@ func (override *OriginGroupOverride_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OriginGroupOverride_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ForwardingProtocol’:
+	// Set property "ForwardingProtocol":
 	if typedInput.ForwardingProtocol != nil {
 		forwardingProtocol := *typedInput.ForwardingProtocol
 		override.ForwardingProtocol = &forwardingProtocol
 	}
 
-	// Set property ‘OriginGroup’:
+	// Set property "OriginGroup":
 	if typedInput.OriginGroup != nil {
 		var originGroup1 ResourceReference_STATUS
 		err := originGroup1.PopulateFromARM(owner, *typedInput.OriginGroup)
@@ -26068,13 +26068,13 @@ func (identifier *UrlSigningParamIdentifier) ConvertToARM(resolved genruntime.Co
 	}
 	result := &UrlSigningParamIdentifier_ARM{}
 
-	// Set property ‘ParamIndicator’:
+	// Set property "ParamIndicator":
 	if identifier.ParamIndicator != nil {
 		paramIndicator := *identifier.ParamIndicator
 		result.ParamIndicator = &paramIndicator
 	}
 
-	// Set property ‘ParamName’:
+	// Set property "ParamName":
 	if identifier.ParamName != nil {
 		paramName := *identifier.ParamName
 		result.ParamName = &paramName
@@ -26094,13 +26094,13 @@ func (identifier *UrlSigningParamIdentifier) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningParamIdentifier_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ParamIndicator’:
+	// Set property "ParamIndicator":
 	if typedInput.ParamIndicator != nil {
 		paramIndicator := *typedInput.ParamIndicator
 		identifier.ParamIndicator = &paramIndicator
 	}
 
-	// Set property ‘ParamName’:
+	// Set property "ParamName":
 	if typedInput.ParamName != nil {
 		paramName := *typedInput.ParamName
 		identifier.ParamName = &paramName
@@ -26175,13 +26175,13 @@ func (identifier *UrlSigningParamIdentifier_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UrlSigningParamIdentifier_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ParamIndicator’:
+	// Set property "ParamIndicator":
 	if typedInput.ParamIndicator != nil {
 		paramIndicator := *typedInput.ParamIndicator
 		identifier.ParamIndicator = &paramIndicator
 	}
 
-	// Set property ‘ParamName’:
+	// Set property "ParamName":
 	if typedInput.ParamName != nil {
 		paramName := *typedInput.ParamName
 		identifier.ParamName = &paramName

--- a/v2/api/compute/v1api20200930/disk_types_gen.go
+++ b/v2/api/compute/v1api20200930/disk_types_gen.go
@@ -412,7 +412,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 	}
 	result := &Disk_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if disk.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*disk.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -422,16 +422,16 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if disk.Location != nil {
 		location := *disk.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if disk.BurstingEnabled != nil ||
 		disk.CreationData != nil ||
 		disk.DiskAccessReference != nil ||
@@ -535,7 +535,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.Tier = &tier
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if disk.Sku != nil {
 		sku_ARM, err := (*disk.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -545,7 +545,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if disk.Tags != nil {
 		result.Tags = make(map[string]string, len(disk.Tags))
 		for key, value := range disk.Tags {
@@ -553,7 +553,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range disk.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -572,10 +572,10 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Disk_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	disk.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BurstingEnabled’:
+	// Set property "BurstingEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BurstingEnabled != nil {
@@ -584,7 +584,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -598,9 +598,9 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// no assignment for property ‘DiskAccessReference’
+	// no assignment for property "DiskAccessReference"
 
-	// Set property ‘DiskIOPSReadOnly’:
+	// Set property "DiskIOPSReadOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskIOPSReadOnly != nil {
@@ -609,7 +609,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskIOPSReadWrite != nil {
@@ -618,7 +618,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘DiskMBpsReadOnly’:
+	// Set property "DiskMBpsReadOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskMBpsReadOnly != nil {
@@ -627,7 +627,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskMBpsReadWrite != nil {
@@ -636,7 +636,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskSizeGB != nil {
@@ -645,7 +645,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -659,7 +659,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘EncryptionSettingsCollection’:
+	// Set property "EncryptionSettingsCollection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionSettingsCollection != nil {
@@ -673,7 +673,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -684,7 +684,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		disk.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -693,13 +693,13 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		disk.Location = &location
 	}
 
-	// Set property ‘MaxShares’:
+	// Set property "MaxShares":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxShares != nil {
@@ -708,7 +708,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘NetworkAccessPolicy’:
+	// Set property "NetworkAccessPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAccessPolicy != nil {
@@ -717,7 +717,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -726,10 +726,10 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	disk.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PurchasePlan’:
+	// Set property "PurchasePlan":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PurchasePlan != nil {
@@ -743,7 +743,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 DiskSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -754,7 +754,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		disk.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		disk.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -762,7 +762,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tier != nil {
@@ -771,7 +771,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		disk.Zones = append(disk.Zones, item)
 	}
@@ -1498,7 +1498,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Disk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BurstingEnabled’:
+	// Set property "BurstingEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BurstingEnabled != nil {
@@ -1507,9 +1507,9 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -1523,7 +1523,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskAccessId’:
+	// Set property "DiskAccessId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskAccessId != nil {
@@ -1532,7 +1532,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskIOPSReadOnly’:
+	// Set property "DiskIOPSReadOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskIOPSReadOnly != nil {
@@ -1541,7 +1541,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskIOPSReadWrite != nil {
@@ -1550,7 +1550,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskMBpsReadOnly’:
+	// Set property "DiskMBpsReadOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskMBpsReadOnly != nil {
@@ -1559,7 +1559,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskMBpsReadWrite != nil {
@@ -1568,7 +1568,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskSizeBytes’:
+	// Set property "DiskSizeBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskSizeBytes != nil {
@@ -1577,7 +1577,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskSizeGB != nil {
@@ -1586,7 +1586,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskState’:
+	// Set property "DiskState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskState != nil {
@@ -1595,7 +1595,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1609,7 +1609,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘EncryptionSettingsCollection’:
+	// Set property "EncryptionSettingsCollection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionSettingsCollection != nil {
@@ -1623,7 +1623,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1634,7 +1634,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -1643,30 +1643,30 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		disk.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		disk.Location = &location
 	}
 
-	// Set property ‘ManagedBy’:
+	// Set property "ManagedBy":
 	if typedInput.ManagedBy != nil {
 		managedBy := *typedInput.ManagedBy
 		disk.ManagedBy = &managedBy
 	}
 
-	// Set property ‘ManagedByExtended’:
+	// Set property "ManagedByExtended":
 	for _, item := range typedInput.ManagedByExtended {
 		disk.ManagedByExtended = append(disk.ManagedByExtended, item)
 	}
 
-	// Set property ‘MaxShares’:
+	// Set property "MaxShares":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxShares != nil {
@@ -1675,13 +1675,13 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘NetworkAccessPolicy’:
+	// Set property "NetworkAccessPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAccessPolicy != nil {
@@ -1690,7 +1690,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -1699,7 +1699,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1708,7 +1708,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘PurchasePlan’:
+	// Set property "PurchasePlan":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PurchasePlan != nil {
@@ -1722,7 +1722,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ShareInfo’:
+	// Set property "ShareInfo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ShareInfo {
@@ -1735,7 +1735,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 DiskSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1746,7 +1746,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		disk.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1754,7 +1754,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tier != nil {
@@ -1763,7 +1763,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘TimeCreated’:
+	// Set property "TimeCreated":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TimeCreated != nil {
@@ -1772,13 +1772,13 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		disk.Type = &typeVar
 	}
 
-	// Set property ‘UniqueId’:
+	// Set property "UniqueId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UniqueId != nil {
@@ -1787,7 +1787,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		disk.Zones = append(disk.Zones, item)
 	}
@@ -2246,13 +2246,13 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &CreationData_ARM{}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if data.CreateOption != nil {
 		createOption := *data.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘GalleryImageReference’:
+	// Set property "GalleryImageReference":
 	if data.GalleryImageReference != nil {
 		galleryImageReference_ARM, err := (*data.GalleryImageReference).ConvertToARM(resolved)
 		if err != nil {
@@ -2262,7 +2262,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.GalleryImageReference = &galleryImageReference
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if data.ImageReference != nil {
 		imageReference_ARM, err := (*data.ImageReference).ConvertToARM(resolved)
 		if err != nil {
@@ -2272,13 +2272,13 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.ImageReference = &imageReference
 	}
 
-	// Set property ‘LogicalSectorSize’:
+	// Set property "LogicalSectorSize":
 	if data.LogicalSectorSize != nil {
 		logicalSectorSize := *data.LogicalSectorSize
 		result.LogicalSectorSize = &logicalSectorSize
 	}
 
-	// Set property ‘SourceResourceId’:
+	// Set property "SourceResourceId":
 	if data.SourceResourceReference != nil {
 		sourceResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*data.SourceResourceReference)
 		if err != nil {
@@ -2288,19 +2288,19 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.SourceResourceId = &sourceResourceReference
 	}
 
-	// Set property ‘SourceUri’:
+	// Set property "SourceUri":
 	if data.SourceUri != nil {
 		sourceUri := *data.SourceUri
 		result.SourceUri = &sourceUri
 	}
 
-	// Set property ‘StorageAccountId’:
+	// Set property "StorageAccountId":
 	if data.StorageAccountId != nil {
 		storageAccountId := *data.StorageAccountId
 		result.StorageAccountId = &storageAccountId
 	}
 
-	// Set property ‘UploadSizeBytes’:
+	// Set property "UploadSizeBytes":
 	if data.UploadSizeBytes != nil {
 		uploadSizeBytes := *data.UploadSizeBytes
 		result.UploadSizeBytes = &uploadSizeBytes
@@ -2320,13 +2320,13 @@ func (data *CreationData) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CreationData_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		data.CreateOption = &createOption
 	}
 
-	// Set property ‘GalleryImageReference’:
+	// Set property "GalleryImageReference":
 	if typedInput.GalleryImageReference != nil {
 		var galleryImageReference1 ImageDiskReference
 		err := galleryImageReference1.PopulateFromARM(owner, *typedInput.GalleryImageReference)
@@ -2337,7 +2337,7 @@ func (data *CreationData) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		data.GalleryImageReference = &galleryImageReference
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageDiskReference
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -2348,27 +2348,27 @@ func (data *CreationData) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		data.ImageReference = &imageReference
 	}
 
-	// Set property ‘LogicalSectorSize’:
+	// Set property "LogicalSectorSize":
 	if typedInput.LogicalSectorSize != nil {
 		logicalSectorSize := *typedInput.LogicalSectorSize
 		data.LogicalSectorSize = &logicalSectorSize
 	}
 
-	// no assignment for property ‘SourceResourceReference’
+	// no assignment for property "SourceResourceReference"
 
-	// Set property ‘SourceUri’:
+	// Set property "SourceUri":
 	if typedInput.SourceUri != nil {
 		sourceUri := *typedInput.SourceUri
 		data.SourceUri = &sourceUri
 	}
 
-	// Set property ‘StorageAccountId’:
+	// Set property "StorageAccountId":
 	if typedInput.StorageAccountId != nil {
 		storageAccountId := *typedInput.StorageAccountId
 		data.StorageAccountId = &storageAccountId
 	}
 
-	// Set property ‘UploadSizeBytes’:
+	// Set property "UploadSizeBytes":
 	if typedInput.UploadSizeBytes != nil {
 		uploadSizeBytes := *typedInput.UploadSizeBytes
 		data.UploadSizeBytes = &uploadSizeBytes
@@ -2612,13 +2612,13 @@ func (data *CreationData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CreationData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		data.CreateOption = &createOption
 	}
 
-	// Set property ‘GalleryImageReference’:
+	// Set property "GalleryImageReference":
 	if typedInput.GalleryImageReference != nil {
 		var galleryImageReference1 ImageDiskReference_STATUS
 		err := galleryImageReference1.PopulateFromARM(owner, *typedInput.GalleryImageReference)
@@ -2629,7 +2629,7 @@ func (data *CreationData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		data.GalleryImageReference = &galleryImageReference
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageDiskReference_STATUS
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -2640,37 +2640,37 @@ func (data *CreationData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		data.ImageReference = &imageReference
 	}
 
-	// Set property ‘LogicalSectorSize’:
+	// Set property "LogicalSectorSize":
 	if typedInput.LogicalSectorSize != nil {
 		logicalSectorSize := *typedInput.LogicalSectorSize
 		data.LogicalSectorSize = &logicalSectorSize
 	}
 
-	// Set property ‘SourceResourceId’:
+	// Set property "SourceResourceId":
 	if typedInput.SourceResourceId != nil {
 		sourceResourceId := *typedInput.SourceResourceId
 		data.SourceResourceId = &sourceResourceId
 	}
 
-	// Set property ‘SourceUniqueId’:
+	// Set property "SourceUniqueId":
 	if typedInput.SourceUniqueId != nil {
 		sourceUniqueId := *typedInput.SourceUniqueId
 		data.SourceUniqueId = &sourceUniqueId
 	}
 
-	// Set property ‘SourceUri’:
+	// Set property "SourceUri":
 	if typedInput.SourceUri != nil {
 		sourceUri := *typedInput.SourceUri
 		data.SourceUri = &sourceUri
 	}
 
-	// Set property ‘StorageAccountId’:
+	// Set property "StorageAccountId":
 	if typedInput.StorageAccountId != nil {
 		storageAccountId := *typedInput.StorageAccountId
 		data.StorageAccountId = &storageAccountId
 	}
 
-	// Set property ‘UploadSizeBytes’:
+	// Set property "UploadSizeBytes":
 	if typedInput.UploadSizeBytes != nil {
 		uploadSizeBytes := *typedInput.UploadSizeBytes
 		data.UploadSizeBytes = &uploadSizeBytes
@@ -2848,7 +2848,7 @@ func (diskSku *DiskSku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &DiskSku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if diskSku.Name != nil {
 		name := *diskSku.Name
 		result.Name = &name
@@ -2868,7 +2868,7 @@ func (diskSku *DiskSku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		diskSku.Name = &name
@@ -2955,13 +2955,13 @@ func (diskSku *DiskSku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		diskSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		diskSku.Tier = &tier
@@ -3046,7 +3046,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Encryption_ARM{}
 
-	// Set property ‘DiskEncryptionSetId’:
+	// Set property "DiskEncryptionSetId":
 	if encryption.DiskEncryptionSetReference != nil {
 		diskEncryptionSetReferenceARMID, err := resolved.ResolvedReferences.Lookup(*encryption.DiskEncryptionSetReference)
 		if err != nil {
@@ -3056,7 +3056,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.DiskEncryptionSetId = &diskEncryptionSetReference
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if encryption.Type != nil {
 		typeVar := *encryption.Type
 		result.Type = &typeVar
@@ -3076,9 +3076,9 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘DiskEncryptionSetReference’
+	// no assignment for property "DiskEncryptionSetReference"
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		encryption.Type = &typeVar
@@ -3189,13 +3189,13 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSetId’:
+	// Set property "DiskEncryptionSetId":
 	if typedInput.DiskEncryptionSetId != nil {
 		diskEncryptionSetId := *typedInput.DiskEncryptionSetId
 		encryption.DiskEncryptionSetId = &diskEncryptionSetId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		encryption.Type = &typeVar
@@ -3275,13 +3275,13 @@ func (collection *EncryptionSettingsCollection) ConvertToARM(resolved genruntime
 	}
 	result := &EncryptionSettingsCollection_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if collection.Enabled != nil {
 		enabled := *collection.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	for _, item := range collection.EncryptionSettings {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3290,7 +3290,7 @@ func (collection *EncryptionSettingsCollection) ConvertToARM(resolved genruntime
 		result.EncryptionSettings = append(result.EncryptionSettings, *item_ARM.(*EncryptionSettingsElement_ARM))
 	}
 
-	// Set property ‘EncryptionSettingsVersion’:
+	// Set property "EncryptionSettingsVersion":
 	if collection.EncryptionSettingsVersion != nil {
 		encryptionSettingsVersion := *collection.EncryptionSettingsVersion
 		result.EncryptionSettingsVersion = &encryptionSettingsVersion
@@ -3310,13 +3310,13 @@ func (collection *EncryptionSettingsCollection) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionSettingsCollection_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		collection.Enabled = &enabled
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	for _, item := range typedInput.EncryptionSettings {
 		var item1 EncryptionSettingsElement
 		err := item1.PopulateFromARM(owner, item)
@@ -3326,7 +3326,7 @@ func (collection *EncryptionSettingsCollection) PopulateFromARM(owner genruntime
 		collection.EncryptionSettings = append(collection.EncryptionSettings, item1)
 	}
 
-	// Set property ‘EncryptionSettingsVersion’:
+	// Set property "EncryptionSettingsVersion":
 	if typedInput.EncryptionSettingsVersion != nil {
 		encryptionSettingsVersion := *typedInput.EncryptionSettingsVersion
 		collection.EncryptionSettingsVersion = &encryptionSettingsVersion
@@ -3482,13 +3482,13 @@ func (collection *EncryptionSettingsCollection_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionSettingsCollection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		collection.Enabled = &enabled
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	for _, item := range typedInput.EncryptionSettings {
 		var item1 EncryptionSettingsElement_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3498,7 +3498,7 @@ func (collection *EncryptionSettingsCollection_STATUS) PopulateFromARM(owner gen
 		collection.EncryptionSettings = append(collection.EncryptionSettings, item1)
 	}
 
-	// Set property ‘EncryptionSettingsVersion’:
+	// Set property "EncryptionSettingsVersion":
 	if typedInput.EncryptionSettingsVersion != nil {
 		encryptionSettingsVersion := *typedInput.EncryptionSettingsVersion
 		collection.EncryptionSettingsVersion = &encryptionSettingsVersion
@@ -3607,13 +3607,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -3633,13 +3633,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -3735,13 +3735,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -3843,25 +3843,25 @@ func (plan *PurchasePlan) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &PurchasePlan_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if plan.Name != nil {
 		name := *plan.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if plan.Product != nil {
 		product := *plan.Product
 		result.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if plan.PromotionCode != nil {
 		promotionCode := *plan.PromotionCode
 		result.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if plan.Publisher != nil {
 		publisher := *plan.Publisher
 		result.Publisher = &publisher
@@ -3881,25 +3881,25 @@ func (plan *PurchasePlan) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PurchasePlan_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		plan.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if typedInput.Product != nil {
 		product := *typedInput.Product
 		plan.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if typedInput.PromotionCode != nil {
 		promotionCode := *typedInput.PromotionCode
 		plan.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		plan.Publisher = &publisher
@@ -4005,25 +4005,25 @@ func (plan *PurchasePlan_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PurchasePlan_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		plan.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if typedInput.Product != nil {
 		product := *typedInput.Product
 		plan.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if typedInput.PromotionCode != nil {
 		promotionCode := *typedInput.PromotionCode
 		plan.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		plan.Publisher = &publisher
@@ -4099,7 +4099,7 @@ func (element *ShareInfoElement_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ShareInfoElement_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmUri’:
+	// Set property "VmUri":
 	if typedInput.VmUri != nil {
 		vmUri := *typedInput.VmUri
 		element.VmUri = &vmUri
@@ -4182,7 +4182,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &EncryptionSettingsElement_ARM{}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if element.DiskEncryptionKey != nil {
 		diskEncryptionKey_ARM, err := (*element.DiskEncryptionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -4192,7 +4192,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 		result.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if element.KeyEncryptionKey != nil {
 		keyEncryptionKey_ARM, err := (*element.KeyEncryptionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -4216,7 +4216,7 @@ func (element *EncryptionSettingsElement) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionSettingsElement_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if typedInput.DiskEncryptionKey != nil {
 		var diskEncryptionKey1 KeyVaultAndSecretReference
 		err := diskEncryptionKey1.PopulateFromARM(owner, *typedInput.DiskEncryptionKey)
@@ -4227,7 +4227,7 @@ func (element *EncryptionSettingsElement) PopulateFromARM(owner genruntime.Arbit
 		element.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if typedInput.KeyEncryptionKey != nil {
 		var keyEncryptionKey1 KeyVaultAndKeyReference
 		err := keyEncryptionKey1.PopulateFromARM(owner, *typedInput.KeyEncryptionKey)
@@ -4368,7 +4368,7 @@ func (element *EncryptionSettingsElement_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionSettingsElement_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if typedInput.DiskEncryptionKey != nil {
 		var diskEncryptionKey1 KeyVaultAndSecretReference_STATUS
 		err := diskEncryptionKey1.PopulateFromARM(owner, *typedInput.DiskEncryptionKey)
@@ -4379,7 +4379,7 @@ func (element *EncryptionSettingsElement_STATUS) PopulateFromARM(owner genruntim
 		element.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if typedInput.KeyEncryptionKey != nil {
 		var keyEncryptionKey1 KeyVaultAndKeyReference_STATUS
 		err := keyEncryptionKey1.PopulateFromARM(owner, *typedInput.KeyEncryptionKey)
@@ -4504,7 +4504,7 @@ func (reference *ImageDiskReference) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &ImageDiskReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -4514,7 +4514,7 @@ func (reference *ImageDiskReference) ConvertToARM(resolved genruntime.ConvertToA
 		result.Id = &reference1
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if reference.Lun != nil {
 		lun := *reference.Lun
 		result.Lun = &lun
@@ -4534,13 +4534,13 @@ func (reference *ImageDiskReference) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageDiskReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		reference.Lun = &lun
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -4633,13 +4633,13 @@ func (reference *ImageDiskReference_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageDiskReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		reference.Lun = &lun
@@ -4704,13 +4704,13 @@ func (reference *KeyVaultAndKeyReference) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &KeyVaultAndKeyReference_ARM{}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if reference.KeyUrl != nil {
 		keyUrl := *reference.KeyUrl
 		result.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if reference.SourceVault != nil {
 		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -4734,13 +4734,13 @@ func (reference *KeyVaultAndKeyReference) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultAndKeyReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if typedInput.KeyUrl != nil {
 		keyUrl := *typedInput.KeyUrl
 		reference.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SourceVault
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -4853,13 +4853,13 @@ func (reference *KeyVaultAndKeyReference_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultAndKeyReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if typedInput.KeyUrl != nil {
 		keyUrl := *typedInput.KeyUrl
 		reference.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SourceVault_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -4947,13 +4947,13 @@ func (reference *KeyVaultAndSecretReference) ConvertToARM(resolved genruntime.Co
 	}
 	result := &KeyVaultAndSecretReference_ARM{}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if reference.SecretUrl != nil {
 		secretUrl := *reference.SecretUrl
 		result.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if reference.SourceVault != nil {
 		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -4977,13 +4977,13 @@ func (reference *KeyVaultAndSecretReference) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultAndSecretReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if typedInput.SecretUrl != nil {
 		secretUrl := *typedInput.SecretUrl
 		reference.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SourceVault
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -5096,13 +5096,13 @@ func (reference *KeyVaultAndSecretReference_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultAndSecretReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if typedInput.SecretUrl != nil {
 		secretUrl := *typedInput.SecretUrl
 		reference.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SourceVault_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -5186,7 +5186,7 @@ func (vault *SourceVault) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &SourceVault_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if vault.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*vault.Reference)
 		if err != nil {
@@ -5210,7 +5210,7 @@ func (vault *SourceVault) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SourceVault_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -5291,7 +5291,7 @@ func (vault *SourceVault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SourceVault_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		vault.Id = &id

--- a/v2/api/compute/v1api20200930/snapshot_types_gen.go
+++ b/v2/api/compute/v1api20200930/snapshot_types_gen.go
@@ -383,7 +383,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &Snapshot_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if snapshot.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*snapshot.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -393,16 +393,16 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if snapshot.Location != nil {
 		location := *snapshot.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if snapshot.CreationData != nil ||
 		snapshot.DiskAccessReference != nil ||
 		snapshot.DiskSizeGB != nil ||
@@ -481,7 +481,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.PurchasePlan = &purchasePlan
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if snapshot.Sku != nil {
 		sku_ARM, err := (*snapshot.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -491,7 +491,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if snapshot.Tags != nil {
 		result.Tags = make(map[string]string, len(snapshot.Tags))
 		for key, value := range snapshot.Tags {
@@ -513,10 +513,10 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Snapshot_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	snapshot.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -530,9 +530,9 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// no assignment for property ‘DiskAccessReference’
+	// no assignment for property "DiskAccessReference"
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskSizeGB != nil {
@@ -541,7 +541,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘DiskState’:
+	// Set property "DiskState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskState != nil {
@@ -550,7 +550,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -564,7 +564,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘EncryptionSettingsCollection’:
+	// Set property "EncryptionSettingsCollection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionSettingsCollection != nil {
@@ -578,7 +578,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -589,7 +589,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		snapshot.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -598,7 +598,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Incremental’:
+	// Set property "Incremental":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Incremental != nil {
@@ -607,13 +607,13 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		snapshot.Location = &location
 	}
 
-	// Set property ‘NetworkAccessPolicy’:
+	// Set property "NetworkAccessPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAccessPolicy != nil {
@@ -622,7 +622,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -631,10 +631,10 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	snapshot.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PurchasePlan’:
+	// Set property "PurchasePlan":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PurchasePlan != nil {
@@ -648,7 +648,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 SnapshotSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -659,7 +659,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		snapshot.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		snapshot.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1315,9 +1315,9 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Snapshot_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -1331,7 +1331,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DiskAccessId’:
+	// Set property "DiskAccessId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskAccessId != nil {
@@ -1340,7 +1340,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DiskSizeBytes’:
+	// Set property "DiskSizeBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskSizeBytes != nil {
@@ -1349,7 +1349,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskSizeGB != nil {
@@ -1358,7 +1358,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DiskState’:
+	// Set property "DiskState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskState != nil {
@@ -1367,7 +1367,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1381,7 +1381,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘EncryptionSettingsCollection’:
+	// Set property "EncryptionSettingsCollection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionSettingsCollection != nil {
@@ -1395,7 +1395,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1406,7 +1406,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		snapshot.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -1415,13 +1415,13 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		snapshot.Id = &id
 	}
 
-	// Set property ‘Incremental’:
+	// Set property "Incremental":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Incremental != nil {
@@ -1430,25 +1430,25 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		snapshot.Location = &location
 	}
 
-	// Set property ‘ManagedBy’:
+	// Set property "ManagedBy":
 	if typedInput.ManagedBy != nil {
 		managedBy := *typedInput.ManagedBy
 		snapshot.ManagedBy = &managedBy
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		snapshot.Name = &name
 	}
 
-	// Set property ‘NetworkAccessPolicy’:
+	// Set property "NetworkAccessPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAccessPolicy != nil {
@@ -1457,7 +1457,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -1466,7 +1466,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1475,7 +1475,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PurchasePlan’:
+	// Set property "PurchasePlan":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PurchasePlan != nil {
@@ -1489,7 +1489,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 SnapshotSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1500,7 +1500,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		snapshot.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		snapshot.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1508,7 +1508,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘TimeCreated’:
+	// Set property "TimeCreated":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TimeCreated != nil {
@@ -1517,13 +1517,13 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		snapshot.Type = &typeVar
 	}
 
-	// Set property ‘UniqueId’:
+	// Set property "UniqueId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UniqueId != nil {
@@ -1920,7 +1920,7 @@ func (snapshotSku *SnapshotSku) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &SnapshotSku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if snapshotSku.Name != nil {
 		name := *snapshotSku.Name
 		result.Name = &name
@@ -1940,7 +1940,7 @@ func (snapshotSku *SnapshotSku) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SnapshotSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		snapshotSku.Name = &name
@@ -2028,13 +2028,13 @@ func (snapshotSku *SnapshotSku_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SnapshotSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		snapshotSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		snapshotSku.Tier = &tier

--- a/v2/api/compute/v1api20201201/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/compute/v1api20201201/virtual_machine_scale_set_types_gen.go
@@ -409,7 +409,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 	}
 	result := &VirtualMachineScaleSet_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if scaleSet.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*scaleSet.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -419,7 +419,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if scaleSet.Identity != nil {
 		identity_ARM, err := (*scaleSet.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -429,16 +429,16 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if scaleSet.Location != nil {
 		location := *scaleSet.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if scaleSet.Plan != nil {
 		plan_ARM, err := (*scaleSet.Plan).ConvertToARM(resolved)
 		if err != nil {
@@ -448,7 +448,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Plan = &plan
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if scaleSet.AdditionalCapabilities != nil ||
 		scaleSet.AutomaticRepairsPolicy != nil ||
 		scaleSet.DoNotRunExtensionsOnOverprovisionedVMs != nil ||
@@ -545,7 +545,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.ZoneBalance = &zoneBalance
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if scaleSet.Sku != nil {
 		sku_ARM, err := (*scaleSet.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -555,7 +555,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if scaleSet.Tags != nil {
 		result.Tags = make(map[string]string, len(scaleSet.Tags))
 		for key, value := range scaleSet.Tags {
@@ -563,7 +563,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range scaleSet.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -582,7 +582,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSet_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -596,7 +596,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘AutomaticRepairsPolicy’:
+	// Set property "AutomaticRepairsPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticRepairsPolicy != nil {
@@ -610,10 +610,10 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	scaleSet.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DoNotRunExtensionsOnOverprovisionedVMs’:
+	// Set property "DoNotRunExtensionsOnOverprovisionedVMs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DoNotRunExtensionsOnOverprovisionedVMs != nil {
@@ -622,7 +622,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -633,7 +633,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -647,7 +647,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineScaleSetIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -658,13 +658,13 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		scaleSet.Location = &location
 	}
 
-	// Set property ‘OrchestrationMode’:
+	// Set property "OrchestrationMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestrationMode != nil {
@@ -673,7 +673,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Overprovision’:
+	// Set property "Overprovision":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Overprovision != nil {
@@ -682,10 +682,10 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	scaleSet.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -696,7 +696,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomainCount’:
+	// Set property "PlatformFaultDomainCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomainCount != nil {
@@ -705,7 +705,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -719,7 +719,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ScaleInPolicy’:
+	// Set property "ScaleInPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleInPolicy != nil {
@@ -733,7 +733,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘SinglePlacementGroup’:
+	// Set property "SinglePlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SinglePlacementGroup != nil {
@@ -742,7 +742,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -753,7 +753,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		scaleSet.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -761,7 +761,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘UpgradePolicy’:
+	// Set property "UpgradePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradePolicy != nil {
@@ -775,7 +775,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘VirtualMachineProfile’:
+	// Set property "VirtualMachineProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineProfile != nil {
@@ -789,7 +789,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ZoneBalance’:
+	// Set property "ZoneBalance":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneBalance != nil {
@@ -798,7 +798,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		scaleSet.Zones = append(scaleSet.Zones, item)
 	}
@@ -1441,7 +1441,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -1455,7 +1455,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘AutomaticRepairsPolicy’:
+	// Set property "AutomaticRepairsPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticRepairsPolicy != nil {
@@ -1469,9 +1469,9 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DoNotRunExtensionsOnOverprovisionedVMs’:
+	// Set property "DoNotRunExtensionsOnOverprovisionedVMs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DoNotRunExtensionsOnOverprovisionedVMs != nil {
@@ -1480,7 +1480,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1491,7 +1491,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -1505,13 +1505,13 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		scaleSet.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineScaleSetIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1522,19 +1522,19 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		scaleSet.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		scaleSet.Name = &name
 	}
 
-	// Set property ‘OrchestrationMode’:
+	// Set property "OrchestrationMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestrationMode != nil {
@@ -1543,7 +1543,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Overprovision’:
+	// Set property "Overprovision":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Overprovision != nil {
@@ -1552,7 +1552,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan_STATUS
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -1563,7 +1563,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomainCount’:
+	// Set property "PlatformFaultDomainCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomainCount != nil {
@@ -1572,7 +1572,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1581,7 +1581,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -1595,7 +1595,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ScaleInPolicy’:
+	// Set property "ScaleInPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleInPolicy != nil {
@@ -1609,7 +1609,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘SinglePlacementGroup’:
+	// Set property "SinglePlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SinglePlacementGroup != nil {
@@ -1618,7 +1618,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1629,7 +1629,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		scaleSet.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1637,13 +1637,13 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		scaleSet.Type = &typeVar
 	}
 
-	// Set property ‘UniqueId’:
+	// Set property "UniqueId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UniqueId != nil {
@@ -1652,7 +1652,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘UpgradePolicy’:
+	// Set property "UpgradePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradePolicy != nil {
@@ -1666,7 +1666,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘VirtualMachineProfile’:
+	// Set property "VirtualMachineProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineProfile != nil {
@@ -1680,7 +1680,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ZoneBalance’:
+	// Set property "ZoneBalance":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneBalance != nil {
@@ -1689,7 +1689,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		scaleSet.Zones = append(scaleSet.Zones, item)
 	}
@@ -2147,13 +2147,13 @@ func (policy *AutomaticRepairsPolicy) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &AutomaticRepairsPolicy_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if policy.Enabled != nil {
 		enabled := *policy.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘GracePeriod’:
+	// Set property "GracePeriod":
 	if policy.GracePeriod != nil {
 		gracePeriod := *policy.GracePeriod
 		result.GracePeriod = &gracePeriod
@@ -2173,13 +2173,13 @@ func (policy *AutomaticRepairsPolicy) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticRepairsPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
 	}
 
-	// Set property ‘GracePeriod’:
+	// Set property "GracePeriod":
 	if typedInput.GracePeriod != nil {
 		gracePeriod := *typedInput.GracePeriod
 		policy.GracePeriod = &gracePeriod
@@ -2261,13 +2261,13 @@ func (policy *AutomaticRepairsPolicy_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticRepairsPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
 	}
 
-	// Set property ‘GracePeriod’:
+	// Set property "GracePeriod":
 	if typedInput.GracePeriod != nil {
 		gracePeriod := *typedInput.GracePeriod
 		policy.GracePeriod = &gracePeriod
@@ -2364,7 +2364,7 @@ func (policy *ScaleInPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &ScaleInPolicy_ARM{}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range policy.Rules {
 		result.Rules = append(result.Rules, item)
 	}
@@ -2383,7 +2383,7 @@ func (policy *ScaleInPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScaleInPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		policy.Rules = append(policy.Rules, item)
 	}
@@ -2471,7 +2471,7 @@ func (policy *ScaleInPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScaleInPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		policy.Rules = append(policy.Rules, item)
 	}
@@ -2554,19 +2554,19 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sku.Capacity != nil {
 		capacity := *sku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -2586,19 +2586,19 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2679,19 +2679,19 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2767,7 +2767,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &UpgradePolicy_ARM{}
 
-	// Set property ‘AutomaticOSUpgradePolicy’:
+	// Set property "AutomaticOSUpgradePolicy":
 	if policy.AutomaticOSUpgradePolicy != nil {
 		automaticOSUpgradePolicy_ARM, err := (*policy.AutomaticOSUpgradePolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -2777,13 +2777,13 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if policy.Mode != nil {
 		mode := *policy.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘RollingUpgradePolicy’:
+	// Set property "RollingUpgradePolicy":
 	if policy.RollingUpgradePolicy != nil {
 		rollingUpgradePolicy_ARM, err := (*policy.RollingUpgradePolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -2807,7 +2807,7 @@ func (policy *UpgradePolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpgradePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticOSUpgradePolicy’:
+	// Set property "AutomaticOSUpgradePolicy":
 	if typedInput.AutomaticOSUpgradePolicy != nil {
 		var automaticOSUpgradePolicy1 AutomaticOSUpgradePolicy
 		err := automaticOSUpgradePolicy1.PopulateFromARM(owner, *typedInput.AutomaticOSUpgradePolicy)
@@ -2818,13 +2818,13 @@ func (policy *UpgradePolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		policy.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		policy.Mode = &mode
 	}
 
-	// Set property ‘RollingUpgradePolicy’:
+	// Set property "RollingUpgradePolicy":
 	if typedInput.RollingUpgradePolicy != nil {
 		var rollingUpgradePolicy1 RollingUpgradePolicy
 		err := rollingUpgradePolicy1.PopulateFromARM(owner, *typedInput.RollingUpgradePolicy)
@@ -2956,7 +2956,7 @@ func (policy *UpgradePolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpgradePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticOSUpgradePolicy’:
+	// Set property "AutomaticOSUpgradePolicy":
 	if typedInput.AutomaticOSUpgradePolicy != nil {
 		var automaticOSUpgradePolicy1 AutomaticOSUpgradePolicy_STATUS
 		err := automaticOSUpgradePolicy1.PopulateFromARM(owner, *typedInput.AutomaticOSUpgradePolicy)
@@ -2967,13 +2967,13 @@ func (policy *UpgradePolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		policy.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		policy.Mode = &mode
 	}
 
-	// Set property ‘RollingUpgradePolicy’:
+	// Set property "RollingUpgradePolicy":
 	if typedInput.RollingUpgradePolicy != nil {
 		var rollingUpgradePolicy1 RollingUpgradePolicy_STATUS
 		err := rollingUpgradePolicy1.PopulateFromARM(owner, *typedInput.RollingUpgradePolicy)
@@ -3097,13 +3097,13 @@ func (identity *VirtualMachineScaleSetIdentity) ConvertToARM(resolved genruntime
 	}
 	result := &VirtualMachineScaleSetIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -3128,13 +3128,13 @@ func (identity *VirtualMachineScaleSetIdentity) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -3250,25 +3250,25 @@ func (identity *VirtualMachineScaleSetIdentity_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -3434,7 +3434,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 	}
 	result := &VirtualMachineScaleSetVMProfile_ARM{}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	if profile.BillingProfile != nil {
 		billingProfile_ARM, err := (*profile.BillingProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3444,7 +3444,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.BillingProfile = &billingProfile
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	if profile.DiagnosticsProfile != nil {
 		diagnosticsProfile_ARM, err := (*profile.DiagnosticsProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3454,13 +3454,13 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.DiagnosticsProfile = &diagnosticsProfile
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	if profile.EvictionPolicy != nil {
 		evictionPolicy := *profile.EvictionPolicy
 		result.EvictionPolicy = &evictionPolicy
 	}
 
-	// Set property ‘ExtensionProfile’:
+	// Set property "ExtensionProfile":
 	if profile.ExtensionProfile != nil {
 		extensionProfile_ARM, err := (*profile.ExtensionProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3470,13 +3470,13 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.ExtensionProfile = &extensionProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if profile.LicenseType != nil {
 		licenseType := *profile.LicenseType
 		result.LicenseType = &licenseType
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if profile.NetworkProfile != nil {
 		networkProfile_ARM, err := (*profile.NetworkProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3486,7 +3486,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	if profile.OsProfile != nil {
 		osProfile_ARM, err := (*profile.OsProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3496,13 +3496,13 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.OsProfile = &osProfile
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if profile.Priority != nil {
 		priority := *profile.Priority
 		result.Priority = &priority
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	if profile.ScheduledEventsProfile != nil {
 		scheduledEventsProfile_ARM, err := (*profile.ScheduledEventsProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3512,7 +3512,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if profile.SecurityProfile != nil {
 		securityProfile_ARM, err := (*profile.SecurityProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3522,7 +3522,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if profile.StorageProfile != nil {
 		storageProfile_ARM, err := (*profile.StorageProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3546,7 +3546,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetVMProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	if typedInput.BillingProfile != nil {
 		var billingProfile1 BillingProfile
 		err := billingProfile1.PopulateFromARM(owner, *typedInput.BillingProfile)
@@ -3557,7 +3557,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.BillingProfile = &billingProfile
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	if typedInput.DiagnosticsProfile != nil {
 		var diagnosticsProfile1 DiagnosticsProfile
 		err := diagnosticsProfile1.PopulateFromARM(owner, *typedInput.DiagnosticsProfile)
@@ -3568,13 +3568,13 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.DiagnosticsProfile = &diagnosticsProfile
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	if typedInput.EvictionPolicy != nil {
 		evictionPolicy := *typedInput.EvictionPolicy
 		profile.EvictionPolicy = &evictionPolicy
 	}
 
-	// Set property ‘ExtensionProfile’:
+	// Set property "ExtensionProfile":
 	if typedInput.ExtensionProfile != nil {
 		var extensionProfile1 VirtualMachineScaleSetExtensionProfile
 		err := extensionProfile1.PopulateFromARM(owner, *typedInput.ExtensionProfile)
@@ -3585,13 +3585,13 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.ExtensionProfile = &extensionProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if typedInput.NetworkProfile != nil {
 		var networkProfile1 VirtualMachineScaleSetNetworkProfile
 		err := networkProfile1.PopulateFromARM(owner, *typedInput.NetworkProfile)
@@ -3602,7 +3602,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	if typedInput.OsProfile != nil {
 		var osProfile1 VirtualMachineScaleSetOSProfile
 		err := osProfile1.PopulateFromARM(owner, *typedInput.OsProfile)
@@ -3613,13 +3613,13 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.OsProfile = &osProfile
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		profile.Priority = &priority
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	if typedInput.ScheduledEventsProfile != nil {
 		var scheduledEventsProfile1 ScheduledEventsProfile
 		err := scheduledEventsProfile1.PopulateFromARM(owner, *typedInput.ScheduledEventsProfile)
@@ -3630,7 +3630,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 SecurityProfile
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -3641,7 +3641,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 VirtualMachineScaleSetStorageProfile
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -3976,7 +3976,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetVMProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	if typedInput.BillingProfile != nil {
 		var billingProfile1 BillingProfile_STATUS
 		err := billingProfile1.PopulateFromARM(owner, *typedInput.BillingProfile)
@@ -3987,7 +3987,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.BillingProfile = &billingProfile
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	if typedInput.DiagnosticsProfile != nil {
 		var diagnosticsProfile1 DiagnosticsProfile_STATUS
 		err := diagnosticsProfile1.PopulateFromARM(owner, *typedInput.DiagnosticsProfile)
@@ -3998,13 +3998,13 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.DiagnosticsProfile = &diagnosticsProfile
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	if typedInput.EvictionPolicy != nil {
 		evictionPolicy := *typedInput.EvictionPolicy
 		profile.EvictionPolicy = &evictionPolicy
 	}
 
-	// Set property ‘ExtensionProfile’:
+	// Set property "ExtensionProfile":
 	if typedInput.ExtensionProfile != nil {
 		var extensionProfile1 VirtualMachineScaleSetExtensionProfile_STATUS
 		err := extensionProfile1.PopulateFromARM(owner, *typedInput.ExtensionProfile)
@@ -4015,13 +4015,13 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.ExtensionProfile = &extensionProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if typedInput.NetworkProfile != nil {
 		var networkProfile1 VirtualMachineScaleSetNetworkProfile_STATUS
 		err := networkProfile1.PopulateFromARM(owner, *typedInput.NetworkProfile)
@@ -4032,7 +4032,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	if typedInput.OsProfile != nil {
 		var osProfile1 VirtualMachineScaleSetOSProfile_STATUS
 		err := osProfile1.PopulateFromARM(owner, *typedInput.OsProfile)
@@ -4043,13 +4043,13 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.OsProfile = &osProfile
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		profile.Priority = &priority
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	if typedInput.ScheduledEventsProfile != nil {
 		var scheduledEventsProfile1 ScheduledEventsProfile_STATUS
 		err := scheduledEventsProfile1.PopulateFromARM(owner, *typedInput.ScheduledEventsProfile)
@@ -4060,7 +4060,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 SecurityProfile_STATUS
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -4071,7 +4071,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 VirtualMachineScaleSetStorageProfile_STATUS
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -4361,13 +4361,13 @@ func (policy *AutomaticOSUpgradePolicy) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &AutomaticOSUpgradePolicy_ARM{}
 
-	// Set property ‘DisableAutomaticRollback’:
+	// Set property "DisableAutomaticRollback":
 	if policy.DisableAutomaticRollback != nil {
 		disableAutomaticRollback := *policy.DisableAutomaticRollback
 		result.DisableAutomaticRollback = &disableAutomaticRollback
 	}
 
-	// Set property ‘EnableAutomaticOSUpgrade’:
+	// Set property "EnableAutomaticOSUpgrade":
 	if policy.EnableAutomaticOSUpgrade != nil {
 		enableAutomaticOSUpgrade := *policy.EnableAutomaticOSUpgrade
 		result.EnableAutomaticOSUpgrade = &enableAutomaticOSUpgrade
@@ -4387,13 +4387,13 @@ func (policy *AutomaticOSUpgradePolicy) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticOSUpgradePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisableAutomaticRollback’:
+	// Set property "DisableAutomaticRollback":
 	if typedInput.DisableAutomaticRollback != nil {
 		disableAutomaticRollback := *typedInput.DisableAutomaticRollback
 		policy.DisableAutomaticRollback = &disableAutomaticRollback
 	}
 
-	// Set property ‘EnableAutomaticOSUpgrade’:
+	// Set property "EnableAutomaticOSUpgrade":
 	if typedInput.EnableAutomaticOSUpgrade != nil {
 		enableAutomaticOSUpgrade := *typedInput.EnableAutomaticOSUpgrade
 		policy.EnableAutomaticOSUpgrade = &enableAutomaticOSUpgrade
@@ -4485,13 +4485,13 @@ func (policy *AutomaticOSUpgradePolicy_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticOSUpgradePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisableAutomaticRollback’:
+	// Set property "DisableAutomaticRollback":
 	if typedInput.DisableAutomaticRollback != nil {
 		disableAutomaticRollback := *typedInput.DisableAutomaticRollback
 		policy.DisableAutomaticRollback = &disableAutomaticRollback
 	}
 
-	// Set property ‘EnableAutomaticOSUpgrade’:
+	// Set property "EnableAutomaticOSUpgrade":
 	if typedInput.EnableAutomaticOSUpgrade != nil {
 		enableAutomaticOSUpgrade := *typedInput.EnableAutomaticOSUpgrade
 		policy.EnableAutomaticOSUpgrade = &enableAutomaticOSUpgrade
@@ -4601,37 +4601,37 @@ func (policy *RollingUpgradePolicy) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &RollingUpgradePolicy_ARM{}
 
-	// Set property ‘EnableCrossZoneUpgrade’:
+	// Set property "EnableCrossZoneUpgrade":
 	if policy.EnableCrossZoneUpgrade != nil {
 		enableCrossZoneUpgrade := *policy.EnableCrossZoneUpgrade
 		result.EnableCrossZoneUpgrade = &enableCrossZoneUpgrade
 	}
 
-	// Set property ‘MaxBatchInstancePercent’:
+	// Set property "MaxBatchInstancePercent":
 	if policy.MaxBatchInstancePercent != nil {
 		maxBatchInstancePercent := *policy.MaxBatchInstancePercent
 		result.MaxBatchInstancePercent = &maxBatchInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyInstancePercent’:
+	// Set property "MaxUnhealthyInstancePercent":
 	if policy.MaxUnhealthyInstancePercent != nil {
 		maxUnhealthyInstancePercent := *policy.MaxUnhealthyInstancePercent
 		result.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyUpgradedInstancePercent’:
+	// Set property "MaxUnhealthyUpgradedInstancePercent":
 	if policy.MaxUnhealthyUpgradedInstancePercent != nil {
 		maxUnhealthyUpgradedInstancePercent := *policy.MaxUnhealthyUpgradedInstancePercent
 		result.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
 	}
 
-	// Set property ‘PauseTimeBetweenBatches’:
+	// Set property "PauseTimeBetweenBatches":
 	if policy.PauseTimeBetweenBatches != nil {
 		pauseTimeBetweenBatches := *policy.PauseTimeBetweenBatches
 		result.PauseTimeBetweenBatches = &pauseTimeBetweenBatches
 	}
 
-	// Set property ‘PrioritizeUnhealthyInstances’:
+	// Set property "PrioritizeUnhealthyInstances":
 	if policy.PrioritizeUnhealthyInstances != nil {
 		prioritizeUnhealthyInstances := *policy.PrioritizeUnhealthyInstances
 		result.PrioritizeUnhealthyInstances = &prioritizeUnhealthyInstances
@@ -4651,37 +4651,37 @@ func (policy *RollingUpgradePolicy) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RollingUpgradePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableCrossZoneUpgrade’:
+	// Set property "EnableCrossZoneUpgrade":
 	if typedInput.EnableCrossZoneUpgrade != nil {
 		enableCrossZoneUpgrade := *typedInput.EnableCrossZoneUpgrade
 		policy.EnableCrossZoneUpgrade = &enableCrossZoneUpgrade
 	}
 
-	// Set property ‘MaxBatchInstancePercent’:
+	// Set property "MaxBatchInstancePercent":
 	if typedInput.MaxBatchInstancePercent != nil {
 		maxBatchInstancePercent := *typedInput.MaxBatchInstancePercent
 		policy.MaxBatchInstancePercent = &maxBatchInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyInstancePercent’:
+	// Set property "MaxUnhealthyInstancePercent":
 	if typedInput.MaxUnhealthyInstancePercent != nil {
 		maxUnhealthyInstancePercent := *typedInput.MaxUnhealthyInstancePercent
 		policy.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyUpgradedInstancePercent’:
+	// Set property "MaxUnhealthyUpgradedInstancePercent":
 	if typedInput.MaxUnhealthyUpgradedInstancePercent != nil {
 		maxUnhealthyUpgradedInstancePercent := *typedInput.MaxUnhealthyUpgradedInstancePercent
 		policy.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
 	}
 
-	// Set property ‘PauseTimeBetweenBatches’:
+	// Set property "PauseTimeBetweenBatches":
 	if typedInput.PauseTimeBetweenBatches != nil {
 		pauseTimeBetweenBatches := *typedInput.PauseTimeBetweenBatches
 		policy.PauseTimeBetweenBatches = &pauseTimeBetweenBatches
 	}
 
-	// Set property ‘PrioritizeUnhealthyInstances’:
+	// Set property "PrioritizeUnhealthyInstances":
 	if typedInput.PrioritizeUnhealthyInstances != nil {
 		prioritizeUnhealthyInstances := *typedInput.PrioritizeUnhealthyInstances
 		policy.PrioritizeUnhealthyInstances = &prioritizeUnhealthyInstances
@@ -4844,37 +4844,37 @@ func (policy *RollingUpgradePolicy_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RollingUpgradePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableCrossZoneUpgrade’:
+	// Set property "EnableCrossZoneUpgrade":
 	if typedInput.EnableCrossZoneUpgrade != nil {
 		enableCrossZoneUpgrade := *typedInput.EnableCrossZoneUpgrade
 		policy.EnableCrossZoneUpgrade = &enableCrossZoneUpgrade
 	}
 
-	// Set property ‘MaxBatchInstancePercent’:
+	// Set property "MaxBatchInstancePercent":
 	if typedInput.MaxBatchInstancePercent != nil {
 		maxBatchInstancePercent := *typedInput.MaxBatchInstancePercent
 		policy.MaxBatchInstancePercent = &maxBatchInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyInstancePercent’:
+	// Set property "MaxUnhealthyInstancePercent":
 	if typedInput.MaxUnhealthyInstancePercent != nil {
 		maxUnhealthyInstancePercent := *typedInput.MaxUnhealthyInstancePercent
 		policy.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyUpgradedInstancePercent’:
+	// Set property "MaxUnhealthyUpgradedInstancePercent":
 	if typedInput.MaxUnhealthyUpgradedInstancePercent != nil {
 		maxUnhealthyUpgradedInstancePercent := *typedInput.MaxUnhealthyUpgradedInstancePercent
 		policy.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
 	}
 
-	// Set property ‘PauseTimeBetweenBatches’:
+	// Set property "PauseTimeBetweenBatches":
 	if typedInput.PauseTimeBetweenBatches != nil {
 		pauseTimeBetweenBatches := *typedInput.PauseTimeBetweenBatches
 		policy.PauseTimeBetweenBatches = &pauseTimeBetweenBatches
 	}
 
-	// Set property ‘PrioritizeUnhealthyInstances’:
+	// Set property "PrioritizeUnhealthyInstances":
 	if typedInput.PrioritizeUnhealthyInstances != nil {
 		prioritizeUnhealthyInstances := *typedInput.PrioritizeUnhealthyInstances
 		policy.PrioritizeUnhealthyInstances = &prioritizeUnhealthyInstances
@@ -4994,7 +4994,7 @@ func (profile *ScheduledEventsProfile) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &ScheduledEventsProfile_ARM{}
 
-	// Set property ‘TerminateNotificationProfile’:
+	// Set property "TerminateNotificationProfile":
 	if profile.TerminateNotificationProfile != nil {
 		terminateNotificationProfile_ARM, err := (*profile.TerminateNotificationProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -5018,7 +5018,7 @@ func (profile *ScheduledEventsProfile) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduledEventsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘TerminateNotificationProfile’:
+	// Set property "TerminateNotificationProfile":
 	if typedInput.TerminateNotificationProfile != nil {
 		var terminateNotificationProfile1 TerminateNotificationProfile
 		err := terminateNotificationProfile1.PopulateFromARM(owner, *typedInput.TerminateNotificationProfile)
@@ -5099,7 +5099,7 @@ func (profile *ScheduledEventsProfile_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduledEventsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘TerminateNotificationProfile’:
+	// Set property "TerminateNotificationProfile":
 	if typedInput.TerminateNotificationProfile != nil {
 		var terminateNotificationProfile1 TerminateNotificationProfile_STATUS
 		err := terminateNotificationProfile1.PopulateFromARM(owner, *typedInput.TerminateNotificationProfile)
@@ -5199,7 +5199,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) ConvertToARM(resolved gen
 	}
 	result := &VirtualMachineScaleSetExtensionProfile_ARM{}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range profile.Extensions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5208,7 +5208,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) ConvertToARM(resolved gen
 		result.Extensions = append(result.Extensions, *item_ARM.(*VirtualMachineScaleSetExtension_ARM))
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	if profile.ExtensionsTimeBudget != nil {
 		extensionsTimeBudget := *profile.ExtensionsTimeBudget
 		result.ExtensionsTimeBudget = &extensionsTimeBudget
@@ -5228,7 +5228,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtensionProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range typedInput.Extensions {
 		var item1 VirtualMachineScaleSetExtension
 		err := item1.PopulateFromARM(owner, item)
@@ -5238,7 +5238,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) PopulateFromARM(owner gen
 		profile.Extensions = append(profile.Extensions, item1)
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	if typedInput.ExtensionsTimeBudget != nil {
 		extensionsTimeBudget := *typedInput.ExtensionsTimeBudget
 		profile.ExtensionsTimeBudget = &extensionsTimeBudget
@@ -5339,7 +5339,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtensionProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range typedInput.Extensions {
 		var item1 VirtualMachineScaleSetExtension_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5349,7 +5349,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile_STATUS) PopulateFromARM(ow
 		profile.Extensions = append(profile.Extensions, item1)
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	if typedInput.ExtensionsTimeBudget != nil {
 		extensionsTimeBudget := *typedInput.ExtensionsTimeBudget
 		profile.ExtensionsTimeBudget = &extensionsTimeBudget
@@ -5446,13 +5446,13 @@ func (identities *VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -5517,7 +5517,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) ConvertToARM(resolved genru
 	}
 	result := &VirtualMachineScaleSetNetworkProfile_ARM{}
 
-	// Set property ‘HealthProbe’:
+	// Set property "HealthProbe":
 	if profile.HealthProbe != nil {
 		healthProbe_ARM, err := (*profile.HealthProbe).ConvertToARM(resolved)
 		if err != nil {
@@ -5527,7 +5527,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) ConvertToARM(resolved genru
 		result.HealthProbe = &healthProbe
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range profile.NetworkInterfaceConfigurations {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5550,7 +5550,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HealthProbe’:
+	// Set property "HealthProbe":
 	if typedInput.HealthProbe != nil {
 		var healthProbe1 ApiEntityReference
 		err := healthProbe1.PopulateFromARM(owner, *typedInput.HealthProbe)
@@ -5561,7 +5561,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) PopulateFromARM(owner genru
 		profile.HealthProbe = &healthProbe
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range typedInput.NetworkInterfaceConfigurations {
 		var item1 VirtualMachineScaleSetNetworkConfiguration
 		err := item1.PopulateFromARM(owner, item)
@@ -5683,7 +5683,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HealthProbe’:
+	// Set property "HealthProbe":
 	if typedInput.HealthProbe != nil {
 		var healthProbe1 ApiEntityReference_STATUS
 		err := healthProbe1.PopulateFromARM(owner, *typedInput.HealthProbe)
@@ -5694,7 +5694,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile_STATUS) PopulateFromARM(owne
 		profile.HealthProbe = &healthProbe
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range typedInput.NetworkInterfaceConfigurations {
 		var item1 VirtualMachineScaleSetNetworkConfiguration_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5859,7 +5859,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 	}
 	result := &VirtualMachineScaleSetOSProfile_ARM{}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if profile.AdminPassword != nil {
 		adminPasswordSecret, err := resolved.ResolvedSecrets.Lookup(*profile.AdminPassword)
 		if err != nil {
@@ -5869,25 +5869,25 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 		result.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘ComputerNamePrefix’:
+	// Set property "ComputerNamePrefix":
 	if profile.ComputerNamePrefix != nil {
 		computerNamePrefix := *profile.ComputerNamePrefix
 		result.ComputerNamePrefix = &computerNamePrefix
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if profile.CustomData != nil {
 		customData := *profile.CustomData
 		result.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if profile.LinuxConfiguration != nil {
 		linuxConfiguration_ARM, err := (*profile.LinuxConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -5897,7 +5897,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 		result.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range profile.Secrets {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5906,7 +5906,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 		result.Secrets = append(result.Secrets, *item_ARM.(*VaultSecretGroup_ARM))
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if profile.WindowsConfiguration != nil {
 		windowsConfiguration_ARM, err := (*profile.WindowsConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -5930,27 +5930,27 @@ func (profile *VirtualMachineScaleSetOSProfile) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSProfile_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘AdminPassword’
+	// no assignment for property "AdminPassword"
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘ComputerNamePrefix’:
+	// Set property "ComputerNamePrefix":
 	if typedInput.ComputerNamePrefix != nil {
 		computerNamePrefix := *typedInput.ComputerNamePrefix
 		profile.ComputerNamePrefix = &computerNamePrefix
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -5961,7 +5961,7 @@ func (profile *VirtualMachineScaleSetOSProfile) PopulateFromARM(owner genruntime
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup
 		err := item1.PopulateFromARM(owner, item)
@@ -5971,7 +5971,7 @@ func (profile *VirtualMachineScaleSetOSProfile) PopulateFromARM(owner genruntime
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -6182,25 +6182,25 @@ func (profile *VirtualMachineScaleSetOSProfile_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘ComputerNamePrefix’:
+	// Set property "ComputerNamePrefix":
 	if typedInput.ComputerNamePrefix != nil {
 		computerNamePrefix := *typedInput.ComputerNamePrefix
 		profile.ComputerNamePrefix = &computerNamePrefix
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration_STATUS
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -6211,7 +6211,7 @@ func (profile *VirtualMachineScaleSetOSProfile_STATUS) PopulateFromARM(owner gen
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6221,7 +6221,7 @@ func (profile *VirtualMachineScaleSetOSProfile_STATUS) PopulateFromARM(owner gen
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration_STATUS
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -6388,7 +6388,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 	}
 	result := &VirtualMachineScaleSetStorageProfile_ARM{}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range profile.DataDisks {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -6397,7 +6397,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		result.DataDisks = append(result.DataDisks, *item_ARM.(*VirtualMachineScaleSetDataDisk_ARM))
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if profile.ImageReference != nil {
 		imageReference_ARM, err := (*profile.ImageReference).ConvertToARM(resolved)
 		if err != nil {
@@ -6407,7 +6407,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		result.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if profile.OsDisk != nil {
 		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -6431,7 +6431,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetStorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 VirtualMachineScaleSetDataDisk
 		err := item1.PopulateFromARM(owner, item)
@@ -6441,7 +6441,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) PopulateFromARM(owner genru
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -6452,7 +6452,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) PopulateFromARM(owner genru
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 VirtualMachineScaleSetOSDisk
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -6606,7 +6606,7 @@ func (profile *VirtualMachineScaleSetStorageProfile_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetStorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 VirtualMachineScaleSetDataDisk_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6616,7 +6616,7 @@ func (profile *VirtualMachineScaleSetStorageProfile_STATUS) PopulateFromARM(owne
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference_STATUS
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -6627,7 +6627,7 @@ func (profile *VirtualMachineScaleSetStorageProfile_STATUS) PopulateFromARM(owne
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 VirtualMachineScaleSetOSDisk_STATUS
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -6764,7 +6764,7 @@ func (reference *ApiEntityReference) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &ApiEntityReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -6788,7 +6788,7 @@ func (reference *ApiEntityReference) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiEntityReference_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -6853,7 +6853,7 @@ func (reference *ApiEntityReference_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiEntityReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
@@ -6911,13 +6911,13 @@ func (profile *TerminateNotificationProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &TerminateNotificationProfile_ARM{}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if profile.Enable != nil {
 		enable := *profile.Enable
 		result.Enable = &enable
 	}
 
-	// Set property ‘NotBeforeTimeout’:
+	// Set property "NotBeforeTimeout":
 	if profile.NotBeforeTimeout != nil {
 		notBeforeTimeout := *profile.NotBeforeTimeout
 		result.NotBeforeTimeout = &notBeforeTimeout
@@ -6937,13 +6937,13 @@ func (profile *TerminateNotificationProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TerminateNotificationProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		profile.Enable = &enable
 	}
 
-	// Set property ‘NotBeforeTimeout’:
+	// Set property "NotBeforeTimeout":
 	if typedInput.NotBeforeTimeout != nil {
 		notBeforeTimeout := *typedInput.NotBeforeTimeout
 		profile.NotBeforeTimeout = &notBeforeTimeout
@@ -7022,13 +7022,13 @@ func (profile *TerminateNotificationProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TerminateNotificationProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		profile.Enable = &enable
 	}
 
-	// Set property ‘NotBeforeTimeout’:
+	// Set property "NotBeforeTimeout":
 	if typedInput.NotBeforeTimeout != nil {
 		notBeforeTimeout := *typedInput.NotBeforeTimeout
 		profile.NotBeforeTimeout = &notBeforeTimeout
@@ -7134,43 +7134,43 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 	}
 	result := &VirtualMachineScaleSetDataDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if disk.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *disk.DiskIOPSReadWrite
 		result.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if disk.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *disk.DiskMBpsReadWrite
 		result.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if disk.Lun != nil {
 		lun := *disk.Lun
 		result.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -7180,13 +7180,13 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -7206,43 +7206,43 @@ func (disk *VirtualMachineScaleSetDataDisk) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetDataDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if typedInput.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *typedInput.DiskIOPSReadWrite
 		disk.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if typedInput.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *typedInput.DiskMBpsReadWrite
 		disk.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -7253,13 +7253,13 @@ func (disk *VirtualMachineScaleSetDataDisk) PopulateFromARM(owner genruntime.Arb
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -7448,43 +7448,43 @@ func (disk *VirtualMachineScaleSetDataDisk_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetDataDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if typedInput.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *typedInput.DiskIOPSReadWrite
 		disk.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if typedInput.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *typedInput.DiskMBpsReadWrite
 		disk.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -7495,13 +7495,13 @@ func (disk *VirtualMachineScaleSetDataDisk_STATUS) PopulateFromARM(owner genrunt
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -7683,13 +7683,13 @@ func (extension *VirtualMachineScaleSetExtension) ConvertToARM(resolved genrunti
 	}
 	result := &VirtualMachineScaleSetExtension_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if extension.Name != nil {
 		name := *extension.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if extension.AutoUpgradeMinorVersion != nil ||
 		extension.EnableAutomaticUpgrade != nil ||
 		extension.ForceUpdateTag != nil ||
@@ -7755,7 +7755,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtension_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradeMinorVersion’:
+	// Set property "AutoUpgradeMinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeMinorVersion != nil {
@@ -7764,7 +7764,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticUpgrade != nil {
@@ -7773,7 +7773,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘ForceUpdateTag’:
+	// Set property "ForceUpdateTag":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceUpdateTag != nil {
@@ -7782,13 +7782,13 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		extension.Name = &name
 	}
 
-	// Set property ‘ProtectedSettings’:
+	// Set property "ProtectedSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettings != nil {
@@ -7799,7 +7799,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘ProvisionAfterExtensions’:
+	// Set property "ProvisionAfterExtensions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ProvisionAfterExtensions {
@@ -7807,7 +7807,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Publisher != nil {
@@ -7816,7 +7816,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Settings’:
+	// Set property "Settings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Settings != nil {
@@ -7827,7 +7827,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -7836,7 +7836,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TypeHandlerVersion != nil {
@@ -8053,7 +8053,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtension_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradeMinorVersion’:
+	// Set property "AutoUpgradeMinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeMinorVersion != nil {
@@ -8062,7 +8062,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticUpgrade != nil {
@@ -8071,7 +8071,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ForceUpdateTag’:
+	// Set property "ForceUpdateTag":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceUpdateTag != nil {
@@ -8080,19 +8080,19 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		extension.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		extension.Name = &name
 	}
 
-	// Set property ‘PropertiesType’:
+	// Set property "PropertiesType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -8101,7 +8101,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProtectedSettings’:
+	// Set property "ProtectedSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettings != nil {
@@ -8112,7 +8112,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProvisionAfterExtensions’:
+	// Set property "ProvisionAfterExtensions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ProvisionAfterExtensions {
@@ -8120,7 +8120,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -8129,7 +8129,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Publisher != nil {
@@ -8138,7 +8138,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Settings’:
+	// Set property "Settings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Settings != nil {
@@ -8149,13 +8149,13 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		extension.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TypeHandlerVersion != nil {
@@ -8370,7 +8370,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) ConvertToARM(re
 	}
 	result := &VirtualMachineScaleSetNetworkConfiguration_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if configuration.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*configuration.Reference)
 		if err != nil {
@@ -8380,13 +8380,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) ConvertToARM(re
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.DnsSettings != nil ||
 		configuration.EnableAcceleratedNetworking != nil ||
 		configuration.EnableFpga != nil ||
@@ -8450,7 +8450,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -8464,7 +8464,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -8473,7 +8473,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableFpga’:
+	// Set property "EnableFpga":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFpga != nil {
@@ -8482,7 +8482,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -8491,7 +8491,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -8504,13 +8504,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -8524,7 +8524,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -8533,7 +8533,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -8776,7 +8776,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -8790,7 +8790,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -8799,7 +8799,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘EnableFpga’:
+	// Set property "EnableFpga":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFpga != nil {
@@ -8808,7 +8808,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -8817,13 +8817,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -8836,13 +8836,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -8856,7 +8856,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -9110,19 +9110,19 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &VirtualMachineScaleSetOSDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if disk.DiffDiskSettings != nil {
 		diffDiskSettings_ARM, err := (*disk.DiffDiskSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -9132,13 +9132,13 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		result.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if disk.Image != nil {
 		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
 		if err != nil {
@@ -9148,7 +9148,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		result.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -9158,24 +9158,24 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if disk.OsType != nil {
 		osType := *disk.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘VhdContainers’:
+	// Set property "VhdContainers":
 	for _, item := range disk.VhdContainers {
 		result.VhdContainers = append(result.VhdContainers, item)
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -9195,19 +9195,19 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -9218,13 +9218,13 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -9235,7 +9235,7 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -9246,24 +9246,24 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘VhdContainers’:
+	// Set property "VhdContainers":
 	for _, item := range typedInput.VhdContainers {
 		disk.VhdContainers = append(disk.VhdContainers, item)
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -9512,19 +9512,19 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings_STATUS
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -9535,13 +9535,13 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk_STATUS
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -9552,7 +9552,7 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -9563,24 +9563,24 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘VhdContainers’:
+	// Set property "VhdContainers":
 	for _, item := range typedInput.VhdContainers {
 		disk.VhdContainers = append(disk.VhdContainers, item)
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -9817,7 +9817,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) ConvertToARM(resolve
 	}
 	result := &VirtualMachineScaleSetIPConfiguration_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if configuration.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*configuration.Reference)
 		if err != nil {
@@ -9827,13 +9827,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) ConvertToARM(resolve
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.ApplicationGatewayBackendAddressPools != nil ||
 		configuration.ApplicationSecurityGroups != nil ||
 		configuration.LoadBalancerBackendAddressPools != nil ||
@@ -9911,7 +9911,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIPConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -9924,7 +9924,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -9937,7 +9937,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -9950,7 +9950,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘LoadBalancerInboundNatPools’:
+	// Set property "LoadBalancerInboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerInboundNatPools {
@@ -9963,13 +9963,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -9978,7 +9978,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -9987,7 +9987,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘PublicIPAddressConfiguration’:
+	// Set property "PublicIPAddressConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressConfiguration != nil {
@@ -10001,9 +10001,9 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -10344,7 +10344,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIPConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -10357,7 +10357,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -10370,13 +10370,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -10389,7 +10389,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘LoadBalancerInboundNatPools’:
+	// Set property "LoadBalancerInboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerInboundNatPools {
@@ -10402,13 +10402,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -10417,7 +10417,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -10426,7 +10426,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘PublicIPAddressConfiguration’:
+	// Set property "PublicIPAddressConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressConfiguration != nil {
@@ -10440,7 +10440,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -10736,7 +10736,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 	}
 	result := &VirtualMachineScaleSetManagedDiskParameters_ARM{}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if parameters.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*parameters.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -10746,7 +10746,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if parameters.StorageAccountType != nil {
 		storageAccountType := *parameters.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -10766,7 +10766,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetManagedDiskParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -10777,7 +10777,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) PopulateFromARM(o
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -10874,7 +10874,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters_STATUS) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetManagedDiskParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -10885,7 +10885,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters_STATUS) PopulateFr
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -10973,7 +10973,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings) ConvertTo
 	}
 	result := &VirtualMachineScaleSetNetworkConfigurationDnsSettings_ARM{}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range settings.DnsServers {
 		result.DnsServers = append(result.DnsServers, item)
 	}
@@ -10992,7 +10992,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfigurationDnsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		settings.DnsServers = append(settings.DnsServers, item)
 	}
@@ -11050,7 +11050,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS) Po
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		settings.DnsServers = append(settings.DnsServers, item)
 	}
@@ -11150,13 +11150,13 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Convert
 	}
 	result := &VirtualMachineScaleSetPublicIPAddressConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.DnsSettings != nil ||
 		configuration.IdleTimeoutInMinutes != nil ||
 		configuration.IpTags != nil ||
@@ -11210,7 +11210,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -11224,7 +11224,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -11233,7 +11233,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -11246,13 +11246,13 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -11261,7 +11261,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -11450,7 +11450,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -11464,7 +11464,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -11473,7 +11473,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -11486,13 +11486,13 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -11501,7 +11501,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -11672,13 +11672,13 @@ func (ipTag *VirtualMachineScaleSetIpTag) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &VirtualMachineScaleSetIpTag_ARM{}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if ipTag.IpTagType != nil {
 		ipTagType := *ipTag.IpTagType
 		result.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if ipTag.Tag != nil {
 		tag := *ipTag.Tag
 		result.Tag = &tag
@@ -11698,13 +11698,13 @@ func (ipTag *VirtualMachineScaleSetIpTag) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIpTag_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -11772,13 +11772,13 @@ func (ipTag *VirtualMachineScaleSetIpTag_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIpTag_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -11840,7 +11840,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings) C
 	}
 	result := &VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_ARM{}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if settings.DomainNameLabel != nil {
 		domainNameLabel := *settings.DomainNameLabel
 		result.DomainNameLabel = &domainNameLabel
@@ -11860,7 +11860,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings) P
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		settings.DomainNameLabel = &domainNameLabel
@@ -11920,7 +11920,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_ST
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		settings.DomainNameLabel = &domainNameLabel

--- a/v2/api/compute/v1api20201201/virtual_machine_types_gen.go
+++ b/v2/api/compute/v1api20201201/virtual_machine_types_gen.go
@@ -462,7 +462,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &VirtualMachine_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if machine.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*machine.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -472,7 +472,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if machine.Identity != nil {
 		identity_ARM, err := (*machine.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -482,16 +482,16 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if machine.Location != nil {
 		location := *machine.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if machine.Plan != nil {
 		plan_ARM, err := (*machine.Plan).ConvertToARM(resolved)
 		if err != nil {
@@ -501,7 +501,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Plan = &plan
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if machine.AdditionalCapabilities != nil ||
 		machine.AvailabilitySet != nil ||
 		machine.BillingProfile != nil ||
@@ -647,7 +647,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.VirtualMachineScaleSet = &virtualMachineScaleSet
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if machine.Tags != nil {
 		result.Tags = make(map[string]string, len(machine.Tags))
 		for key, value := range machine.Tags {
@@ -655,7 +655,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range machine.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -674,7 +674,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -688,7 +688,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AvailabilitySet’:
+	// Set property "AvailabilitySet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilitySet != nil {
@@ -702,10 +702,10 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	machine.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BillingProfile != nil {
@@ -719,7 +719,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiagnosticsProfile != nil {
@@ -733,7 +733,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EvictionPolicy != nil {
@@ -742,7 +742,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -753,7 +753,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		machine.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExtensionsTimeBudget != nil {
@@ -762,7 +762,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HardwareProfile != nil {
@@ -776,7 +776,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Host != nil {
@@ -790,7 +790,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -804,7 +804,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -815,7 +815,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		machine.Identity = &identity
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LicenseType != nil {
@@ -824,13 +824,13 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		machine.Location = &location
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -844,7 +844,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsProfile != nil {
@@ -858,10 +858,10 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	machine.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -872,7 +872,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		machine.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomain’:
+	// Set property "PlatformFaultDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomain != nil {
@@ -881,7 +881,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -890,7 +890,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -904,7 +904,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecurityProfile != nil {
@@ -918,7 +918,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -932,7 +932,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		machine.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -940,7 +940,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘VirtualMachineScaleSet’:
+	// Set property "VirtualMachineScaleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineScaleSet != nil {
@@ -954,7 +954,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		machine.Zones = append(machine.Zones, item)
 	}
@@ -1734,7 +1734,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -1748,7 +1748,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AvailabilitySet’:
+	// Set property "AvailabilitySet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilitySet != nil {
@@ -1762,7 +1762,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BillingProfile != nil {
@@ -1776,9 +1776,9 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiagnosticsProfile != nil {
@@ -1792,7 +1792,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EvictionPolicy != nil {
@@ -1801,7 +1801,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1812,7 +1812,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExtensionsTimeBudget != nil {
@@ -1821,7 +1821,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HardwareProfile != nil {
@@ -1835,7 +1835,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Host != nil {
@@ -1849,7 +1849,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -1863,13 +1863,13 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		machine.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1880,7 +1880,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Identity = &identity
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -1894,7 +1894,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LicenseType != nil {
@@ -1903,19 +1903,19 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		machine.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		machine.Name = &name
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -1929,7 +1929,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsProfile != nil {
@@ -1943,7 +1943,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan_STATUS
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -1954,7 +1954,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomain’:
+	// Set property "PlatformFaultDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomain != nil {
@@ -1963,7 +1963,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -1972,7 +1972,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1981,7 +1981,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -1995,7 +1995,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	for _, item := range typedInput.Resources {
 		var item1 VirtualMachineExtension_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2005,7 +2005,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Resources = append(machine.Resources, item1)
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecurityProfile != nil {
@@ -2019,7 +2019,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -2033,7 +2033,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		machine.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -2041,13 +2041,13 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		machine.Type = &typeVar
 	}
 
-	// Set property ‘VirtualMachineScaleSet’:
+	// Set property "VirtualMachineScaleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineScaleSet != nil {
@@ -2061,7 +2061,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘VmId’:
+	// Set property "VmId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VmId != nil {
@@ -2070,7 +2070,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		machine.Zones = append(machine.Zones, item)
 	}
@@ -2667,7 +2667,7 @@ func (capabilities *AdditionalCapabilities) ConvertToARM(resolved genruntime.Con
 	}
 	result := &AdditionalCapabilities_ARM{}
 
-	// Set property ‘UltraSSDEnabled’:
+	// Set property "UltraSSDEnabled":
 	if capabilities.UltraSSDEnabled != nil {
 		ultraSSDEnabled := *capabilities.UltraSSDEnabled
 		result.UltraSSDEnabled = &ultraSSDEnabled
@@ -2687,7 +2687,7 @@ func (capabilities *AdditionalCapabilities) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalCapabilities_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UltraSSDEnabled’:
+	// Set property "UltraSSDEnabled":
 	if typedInput.UltraSSDEnabled != nil {
 		ultraSSDEnabled := *typedInput.UltraSSDEnabled
 		capabilities.UltraSSDEnabled = &ultraSSDEnabled
@@ -2758,7 +2758,7 @@ func (capabilities *AdditionalCapabilities_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalCapabilities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UltraSSDEnabled’:
+	// Set property "UltraSSDEnabled":
 	if typedInput.UltraSSDEnabled != nil {
 		ultraSSDEnabled := *typedInput.UltraSSDEnabled
 		capabilities.UltraSSDEnabled = &ultraSSDEnabled
@@ -2834,7 +2834,7 @@ func (profile *BillingProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &BillingProfile_ARM{}
 
-	// Set property ‘MaxPrice’:
+	// Set property "MaxPrice":
 	if profile.MaxPrice != nil {
 		maxPrice := *profile.MaxPrice
 		result.MaxPrice = &maxPrice
@@ -2854,7 +2854,7 @@ func (profile *BillingProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BillingProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxPrice’:
+	// Set property "MaxPrice":
 	if typedInput.MaxPrice != nil {
 		maxPrice := *typedInput.MaxPrice
 		profile.MaxPrice = &maxPrice
@@ -2935,7 +2935,7 @@ func (profile *BillingProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BillingProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxPrice’:
+	// Set property "MaxPrice":
 	if typedInput.MaxPrice != nil {
 		maxPrice := *typedInput.MaxPrice
 		profile.MaxPrice = &maxPrice
@@ -3003,7 +3003,7 @@ func (profile *DiagnosticsProfile) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &DiagnosticsProfile_ARM{}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if profile.BootDiagnostics != nil {
 		bootDiagnostics_ARM, err := (*profile.BootDiagnostics).ConvertToARM(resolved)
 		if err != nil {
@@ -3027,7 +3027,7 @@ func (profile *DiagnosticsProfile) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiagnosticsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if typedInput.BootDiagnostics != nil {
 		var bootDiagnostics1 BootDiagnostics
 		err := bootDiagnostics1.PopulateFromARM(owner, *typedInput.BootDiagnostics)
@@ -3113,7 +3113,7 @@ func (profile *DiagnosticsProfile_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiagnosticsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if typedInput.BootDiagnostics != nil {
 		var bootDiagnostics1 BootDiagnostics_STATUS
 		err := bootDiagnostics1.PopulateFromARM(owner, *typedInput.BootDiagnostics)
@@ -3210,13 +3210,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -3236,13 +3236,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -3320,13 +3320,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -3406,7 +3406,7 @@ func (profile *HardwareProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &HardwareProfile_ARM{}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if profile.VmSize != nil {
 		vmSize := *profile.VmSize
 		result.VmSize = &vmSize
@@ -3426,7 +3426,7 @@ func (profile *HardwareProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HardwareProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
@@ -3505,7 +3505,7 @@ func (profile *HardwareProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HardwareProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
@@ -3569,7 +3569,7 @@ func (profile *NetworkProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &NetworkProfile_ARM{}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	for _, item := range profile.NetworkInterfaces {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3592,7 +3592,7 @@ func (profile *NetworkProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	for _, item := range typedInput.NetworkInterfaces {
 		var item1 NetworkInterfaceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -3685,7 +3685,7 @@ func (profile *NetworkProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	for _, item := range typedInput.NetworkInterfaces {
 		var item1 NetworkInterfaceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3844,7 +3844,7 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &OSProfile_ARM{}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if profile.AdminPassword != nil {
 		adminPasswordSecret, err := resolved.ResolvedSecrets.Lookup(*profile.AdminPassword)
 		if err != nil {
@@ -3854,31 +3854,31 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if profile.AllowExtensionOperations != nil {
 		allowExtensionOperations := *profile.AllowExtensionOperations
 		result.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if profile.ComputerName != nil {
 		computerName := *profile.ComputerName
 		result.ComputerName = &computerName
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if profile.CustomData != nil {
 		customData := *profile.CustomData
 		result.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if profile.LinuxConfiguration != nil {
 		linuxConfiguration_ARM, err := (*profile.LinuxConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -3888,13 +3888,13 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘RequireGuestProvisionSignal’:
+	// Set property "RequireGuestProvisionSignal":
 	if profile.RequireGuestProvisionSignal != nil {
 		requireGuestProvisionSignal := *profile.RequireGuestProvisionSignal
 		result.RequireGuestProvisionSignal = &requireGuestProvisionSignal
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range profile.Secrets {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3903,7 +3903,7 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Secrets = append(result.Secrets, *item_ARM.(*VaultSecretGroup_ARM))
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if profile.WindowsConfiguration != nil {
 		windowsConfiguration_ARM, err := (*profile.WindowsConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -3927,33 +3927,33 @@ func (profile *OSProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSProfile_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘AdminPassword’
+	// no assignment for property "AdminPassword"
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if typedInput.AllowExtensionOperations != nil {
 		allowExtensionOperations := *typedInput.AllowExtensionOperations
 		profile.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if typedInput.ComputerName != nil {
 		computerName := *typedInput.ComputerName
 		profile.ComputerName = &computerName
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -3964,13 +3964,13 @@ func (profile *OSProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘RequireGuestProvisionSignal’:
+	// Set property "RequireGuestProvisionSignal":
 	if typedInput.RequireGuestProvisionSignal != nil {
 		requireGuestProvisionSignal := *typedInput.RequireGuestProvisionSignal
 		profile.RequireGuestProvisionSignal = &requireGuestProvisionSignal
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup
 		err := item1.PopulateFromARM(owner, item)
@@ -3980,7 +3980,7 @@ func (profile *OSProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -4241,31 +4241,31 @@ func (profile *OSProfile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if typedInput.AllowExtensionOperations != nil {
 		allowExtensionOperations := *typedInput.AllowExtensionOperations
 		profile.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if typedInput.ComputerName != nil {
 		computerName := *typedInput.ComputerName
 		profile.ComputerName = &computerName
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration_STATUS
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -4276,13 +4276,13 @@ func (profile *OSProfile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘RequireGuestProvisionSignal’:
+	// Set property "RequireGuestProvisionSignal":
 	if typedInput.RequireGuestProvisionSignal != nil {
 		requireGuestProvisionSignal := *typedInput.RequireGuestProvisionSignal
 		profile.RequireGuestProvisionSignal = &requireGuestProvisionSignal
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4292,7 +4292,7 @@ func (profile *OSProfile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration_STATUS
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -4492,25 +4492,25 @@ func (plan *Plan) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) 
 	}
 	result := &Plan_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if plan.Name != nil {
 		name := *plan.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if plan.Product != nil {
 		product := *plan.Product
 		result.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if plan.PromotionCode != nil {
 		promotionCode := *plan.PromotionCode
 		result.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if plan.Publisher != nil {
 		publisher := *plan.Publisher
 		result.Publisher = &publisher
@@ -4530,25 +4530,25 @@ func (plan *Plan) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armI
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Plan_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		plan.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if typedInput.Product != nil {
 		product := *typedInput.Product
 		plan.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if typedInput.PromotionCode != nil {
 		promotionCode := *typedInput.PromotionCode
 		plan.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		plan.Publisher = &publisher
@@ -4638,25 +4638,25 @@ func (plan *Plan_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Plan_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		plan.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if typedInput.Product != nil {
 		product := *typedInput.Product
 		plan.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if typedInput.PromotionCode != nil {
 		promotionCode := *typedInput.PromotionCode
 		plan.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		plan.Publisher = &publisher
@@ -4762,19 +4762,19 @@ func (profile *SecurityProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &SecurityProfile_ARM{}
 
-	// Set property ‘EncryptionAtHost’:
+	// Set property "EncryptionAtHost":
 	if profile.EncryptionAtHost != nil {
 		encryptionAtHost := *profile.EncryptionAtHost
 		result.EncryptionAtHost = &encryptionAtHost
 	}
 
-	// Set property ‘SecurityType’:
+	// Set property "SecurityType":
 	if profile.SecurityType != nil {
 		securityType := *profile.SecurityType
 		result.SecurityType = &securityType
 	}
 
-	// Set property ‘UefiSettings’:
+	// Set property "UefiSettings":
 	if profile.UefiSettings != nil {
 		uefiSettings_ARM, err := (*profile.UefiSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -4798,19 +4798,19 @@ func (profile *SecurityProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SecurityProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EncryptionAtHost’:
+	// Set property "EncryptionAtHost":
 	if typedInput.EncryptionAtHost != nil {
 		encryptionAtHost := *typedInput.EncryptionAtHost
 		profile.EncryptionAtHost = &encryptionAtHost
 	}
 
-	// Set property ‘SecurityType’:
+	// Set property "SecurityType":
 	if typedInput.SecurityType != nil {
 		securityType := *typedInput.SecurityType
 		profile.SecurityType = &securityType
 	}
 
-	// Set property ‘UefiSettings’:
+	// Set property "UefiSettings":
 	if typedInput.UefiSettings != nil {
 		var uefiSettings1 UefiSettings
 		err := uefiSettings1.PopulateFromARM(owner, *typedInput.UefiSettings)
@@ -4935,19 +4935,19 @@ func (profile *SecurityProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SecurityProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EncryptionAtHost’:
+	// Set property "EncryptionAtHost":
 	if typedInput.EncryptionAtHost != nil {
 		encryptionAtHost := *typedInput.EncryptionAtHost
 		profile.EncryptionAtHost = &encryptionAtHost
 	}
 
-	// Set property ‘SecurityType’:
+	// Set property "SecurityType":
 	if typedInput.SecurityType != nil {
 		securityType := *typedInput.SecurityType
 		profile.SecurityType = &securityType
 	}
 
-	// Set property ‘UefiSettings’:
+	// Set property "UefiSettings":
 	if typedInput.UefiSettings != nil {
 		var uefiSettings1 UefiSettings_STATUS
 		err := uefiSettings1.PopulateFromARM(owner, *typedInput.UefiSettings)
@@ -5068,7 +5068,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &StorageProfile_ARM{}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range profile.DataDisks {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5077,7 +5077,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.DataDisks = append(result.DataDisks, *item_ARM.(*DataDisk_ARM))
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if profile.ImageReference != nil {
 		imageReference_ARM, err := (*profile.ImageReference).ConvertToARM(resolved)
 		if err != nil {
@@ -5087,7 +5087,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if profile.OsDisk != nil {
 		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -5111,7 +5111,7 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 DataDisk
 		err := item1.PopulateFromARM(owner, item)
@@ -5121,7 +5121,7 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -5132,7 +5132,7 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 OSDisk
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -5286,7 +5286,7 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 DataDisk_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5296,7 +5296,7 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference_STATUS
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -5307,7 +5307,7 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 OSDisk_STATUS
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -5443,7 +5443,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -5467,7 +5467,7 @@ func (resource *SubResource) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -5531,7 +5531,7 @@ func (resource *SubResource_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
@@ -5636,7 +5636,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineExtension_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradeMinorVersion’:
+	// Set property "AutoUpgradeMinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeMinorVersion != nil {
@@ -5645,7 +5645,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticUpgrade != nil {
@@ -5654,7 +5654,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ForceUpdateTag’:
+	// Set property "ForceUpdateTag":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceUpdateTag != nil {
@@ -5663,13 +5663,13 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		extension.Id = &id
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -5683,19 +5683,19 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		extension.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		extension.Name = &name
 	}
 
-	// Set property ‘PropertiesType’:
+	// Set property "PropertiesType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -5704,7 +5704,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ProtectedSettings’:
+	// Set property "ProtectedSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettings != nil {
@@ -5715,7 +5715,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -5724,7 +5724,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Publisher != nil {
@@ -5733,7 +5733,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Settings’:
+	// Set property "Settings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Settings != nil {
@@ -5744,7 +5744,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		extension.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -5752,13 +5752,13 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		extension.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TypeHandlerVersion != nil {
@@ -5984,13 +5984,13 @@ func (identity *VirtualMachineIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &VirtualMachineIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -6015,13 +6015,13 @@ func (identity *VirtualMachineIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -6137,25 +6137,25 @@ func (identity *VirtualMachineIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]VirtualMachineIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -6329,13 +6329,13 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssignedHost’:
+	// Set property "AssignedHost":
 	if typedInput.AssignedHost != nil {
 		assignedHost := *typedInput.AssignedHost
 		view.AssignedHost = &assignedHost
 	}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if typedInput.BootDiagnostics != nil {
 		var bootDiagnostics1 BootDiagnosticsInstanceView_STATUS
 		err := bootDiagnostics1.PopulateFromARM(owner, *typedInput.BootDiagnostics)
@@ -6346,13 +6346,13 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.BootDiagnostics = &bootDiagnostics
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if typedInput.ComputerName != nil {
 		computerName := *typedInput.ComputerName
 		view.ComputerName = &computerName
 	}
 
-	// Set property ‘Disks’:
+	// Set property "Disks":
 	for _, item := range typedInput.Disks {
 		var item1 DiskInstanceView_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6362,7 +6362,7 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.Disks = append(view.Disks, item1)
 	}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range typedInput.Extensions {
 		var item1 VirtualMachineExtensionInstanceView_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6372,13 +6372,13 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.Extensions = append(view.Extensions, item1)
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	if typedInput.HyperVGeneration != nil {
 		hyperVGeneration := *typedInput.HyperVGeneration
 		view.HyperVGeneration = &hyperVGeneration
 	}
 
-	// Set property ‘MaintenanceRedeployStatus’:
+	// Set property "MaintenanceRedeployStatus":
 	if typedInput.MaintenanceRedeployStatus != nil {
 		var maintenanceRedeployStatus1 MaintenanceRedeployStatus_STATUS
 		err := maintenanceRedeployStatus1.PopulateFromARM(owner, *typedInput.MaintenanceRedeployStatus)
@@ -6389,19 +6389,19 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.MaintenanceRedeployStatus = &maintenanceRedeployStatus
 	}
 
-	// Set property ‘OsName’:
+	// Set property "OsName":
 	if typedInput.OsName != nil {
 		osName := *typedInput.OsName
 		view.OsName = &osName
 	}
 
-	// Set property ‘OsVersion’:
+	// Set property "OsVersion":
 	if typedInput.OsVersion != nil {
 		osVersion := *typedInput.OsVersion
 		view.OsVersion = &osVersion
 	}
 
-	// Set property ‘PatchStatus’:
+	// Set property "PatchStatus":
 	if typedInput.PatchStatus != nil {
 		var patchStatus1 VirtualMachinePatchStatus_STATUS
 		err := patchStatus1.PopulateFromARM(owner, *typedInput.PatchStatus)
@@ -6412,25 +6412,25 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.PatchStatus = &patchStatus
 	}
 
-	// Set property ‘PlatformFaultDomain’:
+	// Set property "PlatformFaultDomain":
 	if typedInput.PlatformFaultDomain != nil {
 		platformFaultDomain := *typedInput.PlatformFaultDomain
 		view.PlatformFaultDomain = &platformFaultDomain
 	}
 
-	// Set property ‘PlatformUpdateDomain’:
+	// Set property "PlatformUpdateDomain":
 	if typedInput.PlatformUpdateDomain != nil {
 		platformUpdateDomain := *typedInput.PlatformUpdateDomain
 		view.PlatformUpdateDomain = &platformUpdateDomain
 	}
 
-	// Set property ‘RdpThumbPrint’:
+	// Set property "RdpThumbPrint":
 	if typedInput.RdpThumbPrint != nil {
 		rdpThumbPrint := *typedInput.RdpThumbPrint
 		view.RdpThumbPrint = &rdpThumbPrint
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6440,7 +6440,7 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.Statuses = append(view.Statuses, item1)
 	}
 
-	// Set property ‘VmAgent’:
+	// Set property "VmAgent":
 	if typedInput.VmAgent != nil {
 		var vmAgent1 VirtualMachineAgentInstanceView_STATUS
 		err := vmAgent1.PopulateFromARM(owner, *typedInput.VmAgent)
@@ -6451,7 +6451,7 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.VmAgent = &vmAgent
 	}
 
-	// Set property ‘VmHealth’:
+	// Set property "VmHealth":
 	if typedInput.VmHealth != nil {
 		var vmHealth1 VirtualMachineHealthStatus_STATUS
 		err := vmHealth1.PopulateFromARM(owner, *typedInput.VmHealth)
@@ -6797,13 +6797,13 @@ func (diagnostics *BootDiagnostics) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &BootDiagnostics_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if diagnostics.Enabled != nil {
 		enabled := *diagnostics.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘StorageUri’:
+	// Set property "StorageUri":
 	if diagnostics.StorageUri != nil {
 		storageUri := *diagnostics.StorageUri
 		result.StorageUri = &storageUri
@@ -6823,13 +6823,13 @@ func (diagnostics *BootDiagnostics) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BootDiagnostics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		diagnostics.Enabled = &enabled
 	}
 
-	// Set property ‘StorageUri’:
+	// Set property "StorageUri":
 	if typedInput.StorageUri != nil {
 		storageUri := *typedInput.StorageUri
 		diagnostics.StorageUri = &storageUri
@@ -6911,13 +6911,13 @@ func (diagnostics *BootDiagnostics_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BootDiagnostics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		diagnostics.Enabled = &enabled
 	}
 
-	// Set property ‘StorageUri’:
+	// Set property "StorageUri":
 	if typedInput.StorageUri != nil {
 		storageUri := *typedInput.StorageUri
 		diagnostics.StorageUri = &storageUri
@@ -7001,19 +7001,19 @@ func (view *BootDiagnosticsInstanceView_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BootDiagnosticsInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConsoleScreenshotBlobUri’:
+	// Set property "ConsoleScreenshotBlobUri":
 	if typedInput.ConsoleScreenshotBlobUri != nil {
 		consoleScreenshotBlobUri := *typedInput.ConsoleScreenshotBlobUri
 		view.ConsoleScreenshotBlobUri = &consoleScreenshotBlobUri
 	}
 
-	// Set property ‘SerialConsoleLogBlobUri’:
+	// Set property "SerialConsoleLogBlobUri":
 	if typedInput.SerialConsoleLogBlobUri != nil {
 		serialConsoleLogBlobUri := *typedInput.SerialConsoleLogBlobUri
 		view.SerialConsoleLogBlobUri = &serialConsoleLogBlobUri
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		var status1 InstanceViewStatus_STATUS
 		err := status1.PopulateFromARM(owner, *typedInput.Status)
@@ -7155,31 +7155,31 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &DataDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DetachOption’:
+	// Set property "DetachOption":
 	if disk.DetachOption != nil {
 		detachOption := *disk.DetachOption
 		result.DetachOption = &detachOption
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if disk.Image != nil {
 		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
 		if err != nil {
@@ -7189,13 +7189,13 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.Image = &image
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if disk.Lun != nil {
 		lun := *disk.Lun
 		result.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -7205,19 +7205,19 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ToBeDetached’:
+	// Set property "ToBeDetached":
 	if disk.ToBeDetached != nil {
 		toBeDetached := *disk.ToBeDetached
 		result.ToBeDetached = &toBeDetached
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if disk.Vhd != nil {
 		vhd_ARM, err := (*disk.Vhd).ConvertToARM(resolved)
 		if err != nil {
@@ -7227,7 +7227,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -7247,31 +7247,31 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DetachOption’:
+	// Set property "DetachOption":
 	if typedInput.DetachOption != nil {
 		detachOption := *typedInput.DetachOption
 		disk.DetachOption = &detachOption
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -7282,13 +7282,13 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		disk.Image = &image
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -7299,19 +7299,19 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘ToBeDetached’:
+	// Set property "ToBeDetached":
 	if typedInput.ToBeDetached != nil {
 		toBeDetached := *typedInput.ToBeDetached
 		disk.ToBeDetached = &toBeDetached
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -7322,7 +7322,7 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -7605,43 +7605,43 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DetachOption’:
+	// Set property "DetachOption":
 	if typedInput.DetachOption != nil {
 		detachOption := *typedInput.DetachOption
 		disk.DetachOption = &detachOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if typedInput.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *typedInput.DiskIOPSReadWrite
 		disk.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if typedInput.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *typedInput.DiskMBpsReadWrite
 		disk.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk_STATUS
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -7652,13 +7652,13 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		disk.Image = &image
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -7669,19 +7669,19 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘ToBeDetached’:
+	// Set property "ToBeDetached":
 	if typedInput.ToBeDetached != nil {
 		toBeDetached := *typedInput.ToBeDetached
 		disk.ToBeDetached = &toBeDetached
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk_STATUS
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -7692,7 +7692,7 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -7934,7 +7934,7 @@ func (view *DiskInstanceView_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	for _, item := range typedInput.EncryptionSettings {
 		var item1 DiskEncryptionSettings_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7944,13 +7944,13 @@ func (view *DiskInstanceView_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		view.EncryptionSettings = append(view.EncryptionSettings, item1)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		view.Name = &name
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8441,7 +8441,7 @@ func (reference *ImageReference) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ImageReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -8451,25 +8451,25 @@ func (reference *ImageReference) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Id = &reference1
 	}
 
-	// Set property ‘Offer’:
+	// Set property "Offer":
 	if reference.Offer != nil {
 		offer := *reference.Offer
 		result.Offer = &offer
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if reference.Publisher != nil {
 		publisher := *reference.Publisher
 		result.Publisher = &publisher
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if reference.Sku != nil {
 		sku := *reference.Sku
 		result.Sku = &sku
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if reference.Version != nil {
 		version := *reference.Version
 		result.Version = &version
@@ -8489,27 +8489,27 @@ func (reference *ImageReference) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Offer’:
+	// Set property "Offer":
 	if typedInput.Offer != nil {
 		offer := *typedInput.Offer
 		reference.Offer = &offer
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		reference.Publisher = &publisher
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		sku := *typedInput.Sku
 		reference.Sku = &sku
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		reference.Version = &version
@@ -8624,37 +8624,37 @@ func (reference *ImageReference_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExactVersion’:
+	// Set property "ExactVersion":
 	if typedInput.ExactVersion != nil {
 		exactVersion := *typedInput.ExactVersion
 		reference.ExactVersion = &exactVersion
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
 	}
 
-	// Set property ‘Offer’:
+	// Set property "Offer":
 	if typedInput.Offer != nil {
 		offer := *typedInput.Offer
 		reference.Offer = &offer
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		reference.Publisher = &publisher
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		sku := *typedInput.Sku
 		reference.Sku = &sku
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		reference.Version = &version
@@ -8755,31 +8755,31 @@ func (status *InstanceViewStatus_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InstanceViewStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		status.Code = &code
 	}
 
-	// Set property ‘DisplayStatus’:
+	// Set property "DisplayStatus":
 	if typedInput.DisplayStatus != nil {
 		displayStatus := *typedInput.DisplayStatus
 		status.DisplayStatus = &displayStatus
 	}
 
-	// Set property ‘Level’:
+	// Set property "Level":
 	if typedInput.Level != nil {
 		level := *typedInput.Level
 		status.Level = &level
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		status.Message = &message
 	}
 
-	// Set property ‘Time’:
+	// Set property "Time":
 	if typedInput.Time != nil {
 		time := *typedInput.Time
 		status.Time = &time
@@ -8883,13 +8883,13 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &LinuxConfiguration_ARM{}
 
-	// Set property ‘DisablePasswordAuthentication’:
+	// Set property "DisablePasswordAuthentication":
 	if configuration.DisablePasswordAuthentication != nil {
 		disablePasswordAuthentication := *configuration.DisablePasswordAuthentication
 		result.DisablePasswordAuthentication = &disablePasswordAuthentication
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if configuration.PatchSettings != nil {
 		patchSettings_ARM, err := (*configuration.PatchSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -8899,13 +8899,13 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 		result.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if configuration.ProvisionVMAgent != nil {
 		provisionVMAgent := *configuration.ProvisionVMAgent
 		result.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if configuration.Ssh != nil {
 		ssh_ARM, err := (*configuration.Ssh).ConvertToARM(resolved)
 		if err != nil {
@@ -8929,13 +8929,13 @@ func (configuration *LinuxConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisablePasswordAuthentication’:
+	// Set property "DisablePasswordAuthentication":
 	if typedInput.DisablePasswordAuthentication != nil {
 		disablePasswordAuthentication := *typedInput.DisablePasswordAuthentication
 		configuration.DisablePasswordAuthentication = &disablePasswordAuthentication
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 LinuxPatchSettings
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -8946,13 +8946,13 @@ func (configuration *LinuxConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 SshConfiguration
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -9106,13 +9106,13 @@ func (configuration *LinuxConfiguration_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisablePasswordAuthentication’:
+	// Set property "DisablePasswordAuthentication":
 	if typedInput.DisablePasswordAuthentication != nil {
 		disablePasswordAuthentication := *typedInput.DisablePasswordAuthentication
 		configuration.DisablePasswordAuthentication = &disablePasswordAuthentication
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 LinuxPatchSettings_STATUS
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -9123,13 +9123,13 @@ func (configuration *LinuxConfiguration_STATUS) PopulateFromARM(owner genruntime
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 SshConfiguration_STATUS
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -9285,43 +9285,43 @@ func (status *MaintenanceRedeployStatus_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceRedeployStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IsCustomerInitiatedMaintenanceAllowed’:
+	// Set property "IsCustomerInitiatedMaintenanceAllowed":
 	if typedInput.IsCustomerInitiatedMaintenanceAllowed != nil {
 		isCustomerInitiatedMaintenanceAllowed := *typedInput.IsCustomerInitiatedMaintenanceAllowed
 		status.IsCustomerInitiatedMaintenanceAllowed = &isCustomerInitiatedMaintenanceAllowed
 	}
 
-	// Set property ‘LastOperationMessage’:
+	// Set property "LastOperationMessage":
 	if typedInput.LastOperationMessage != nil {
 		lastOperationMessage := *typedInput.LastOperationMessage
 		status.LastOperationMessage = &lastOperationMessage
 	}
 
-	// Set property ‘LastOperationResultCode’:
+	// Set property "LastOperationResultCode":
 	if typedInput.LastOperationResultCode != nil {
 		lastOperationResultCode := *typedInput.LastOperationResultCode
 		status.LastOperationResultCode = &lastOperationResultCode
 	}
 
-	// Set property ‘MaintenanceWindowEndTime’:
+	// Set property "MaintenanceWindowEndTime":
 	if typedInput.MaintenanceWindowEndTime != nil {
 		maintenanceWindowEndTime := *typedInput.MaintenanceWindowEndTime
 		status.MaintenanceWindowEndTime = &maintenanceWindowEndTime
 	}
 
-	// Set property ‘MaintenanceWindowStartTime’:
+	// Set property "MaintenanceWindowStartTime":
 	if typedInput.MaintenanceWindowStartTime != nil {
 		maintenanceWindowStartTime := *typedInput.MaintenanceWindowStartTime
 		status.MaintenanceWindowStartTime = &maintenanceWindowStartTime
 	}
 
-	// Set property ‘PreMaintenanceWindowEndTime’:
+	// Set property "PreMaintenanceWindowEndTime":
 	if typedInput.PreMaintenanceWindowEndTime != nil {
 		preMaintenanceWindowEndTime := *typedInput.PreMaintenanceWindowEndTime
 		status.PreMaintenanceWindowEndTime = &preMaintenanceWindowEndTime
 	}
 
-	// Set property ‘PreMaintenanceWindowStartTime’:
+	// Set property "PreMaintenanceWindowStartTime":
 	if typedInput.PreMaintenanceWindowStartTime != nil {
 		preMaintenanceWindowStartTime := *typedInput.PreMaintenanceWindowStartTime
 		status.PreMaintenanceWindowStartTime = &preMaintenanceWindowStartTime
@@ -9434,7 +9434,7 @@ func (reference *NetworkInterfaceReference) ConvertToARM(resolved genruntime.Con
 	}
 	result := &NetworkInterfaceReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -9444,7 +9444,7 @@ func (reference *NetworkInterfaceReference) ConvertToARM(resolved genruntime.Con
 		result.Id = &reference1
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if reference.Primary != nil {
 		result.Properties = &NetworkInterfaceReferenceProperties_ARM{}
 	}
@@ -9467,7 +9467,7 @@ func (reference *NetworkInterfaceReference) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -9476,7 +9476,7 @@ func (reference *NetworkInterfaceReference) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -9560,13 +9560,13 @@ func (reference *NetworkInterfaceReference_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -9691,19 +9691,19 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &OSDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if disk.DiffDiskSettings != nil {
 		diffDiskSettings_ARM, err := (*disk.DiffDiskSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -9713,13 +9713,13 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	if disk.EncryptionSettings != nil {
 		encryptionSettings_ARM, err := (*disk.EncryptionSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -9729,7 +9729,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.EncryptionSettings = &encryptionSettings
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if disk.Image != nil {
 		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
 		if err != nil {
@@ -9739,7 +9739,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -9749,19 +9749,19 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if disk.OsType != nil {
 		osType := *disk.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if disk.Vhd != nil {
 		vhd_ARM, err := (*disk.Vhd).ConvertToARM(resolved)
 		if err != nil {
@@ -9771,7 +9771,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -9791,19 +9791,19 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -9814,13 +9814,13 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	if typedInput.EncryptionSettings != nil {
 		var encryptionSettings1 DiskEncryptionSettings
 		err := encryptionSettings1.PopulateFromARM(owner, *typedInput.EncryptionSettings)
@@ -9831,7 +9831,7 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.EncryptionSettings = &encryptionSettings
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -9842,7 +9842,7 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -9853,19 +9853,19 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -9876,7 +9876,7 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -10176,19 +10176,19 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings_STATUS
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -10199,13 +10199,13 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	if typedInput.EncryptionSettings != nil {
 		var encryptionSettings1 DiskEncryptionSettings_STATUS
 		err := encryptionSettings1.PopulateFromARM(owner, *typedInput.EncryptionSettings)
@@ -10216,7 +10216,7 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.EncryptionSettings = &encryptionSettings
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk_STATUS
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -10227,7 +10227,7 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -10238,19 +10238,19 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk_STATUS
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -10261,7 +10261,7 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -10521,13 +10521,13 @@ func (settings *UefiSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &UefiSettings_ARM{}
 
-	// Set property ‘SecureBootEnabled’:
+	// Set property "SecureBootEnabled":
 	if settings.SecureBootEnabled != nil {
 		secureBootEnabled := *settings.SecureBootEnabled
 		result.SecureBootEnabled = &secureBootEnabled
 	}
 
-	// Set property ‘VTpmEnabled’:
+	// Set property "VTpmEnabled":
 	if settings.VTpmEnabled != nil {
 		vTpmEnabled := *settings.VTpmEnabled
 		result.VTpmEnabled = &vTpmEnabled
@@ -10547,13 +10547,13 @@ func (settings *UefiSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UefiSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecureBootEnabled’:
+	// Set property "SecureBootEnabled":
 	if typedInput.SecureBootEnabled != nil {
 		secureBootEnabled := *typedInput.SecureBootEnabled
 		settings.SecureBootEnabled = &secureBootEnabled
 	}
 
-	// Set property ‘VTpmEnabled’:
+	// Set property "VTpmEnabled":
 	if typedInput.VTpmEnabled != nil {
 		vTpmEnabled := *typedInput.VTpmEnabled
 		settings.VTpmEnabled = &vTpmEnabled
@@ -10645,13 +10645,13 @@ func (settings *UefiSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UefiSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecureBootEnabled’:
+	// Set property "SecureBootEnabled":
 	if typedInput.SecureBootEnabled != nil {
 		secureBootEnabled := *typedInput.SecureBootEnabled
 		settings.SecureBootEnabled = &secureBootEnabled
 	}
 
-	// Set property ‘VTpmEnabled’:
+	// Set property "VTpmEnabled":
 	if typedInput.VTpmEnabled != nil {
 		vTpmEnabled := *typedInput.VTpmEnabled
 		settings.VTpmEnabled = &vTpmEnabled
@@ -10768,7 +10768,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &VaultSecretGroup_ARM{}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if group.SourceVault != nil {
 		sourceVault_ARM, err := (*group.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -10778,7 +10778,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.SourceVault = &sourceVault
 	}
 
-	// Set property ‘VaultCertificates’:
+	// Set property "VaultCertificates":
 	for _, item := range group.VaultCertificates {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -10801,7 +10801,7 @@ func (group *VaultSecretGroup) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultSecretGroup_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -10812,7 +10812,7 @@ func (group *VaultSecretGroup) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		group.SourceVault = &sourceVault
 	}
 
-	// Set property ‘VaultCertificates’:
+	// Set property "VaultCertificates":
 	for _, item := range typedInput.VaultCertificates {
 		var item1 VaultCertificate
 		err := item1.PopulateFromARM(owner, item)
@@ -10932,7 +10932,7 @@ func (group *VaultSecretGroup_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultSecretGroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -10943,7 +10943,7 @@ func (group *VaultSecretGroup_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		group.SourceVault = &sourceVault
 	}
 
-	// Set property ‘VaultCertificates’:
+	// Set property "VaultCertificates":
 	for _, item := range typedInput.VaultCertificates {
 		var item1 VaultCertificate_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11066,7 +11066,7 @@ func (view *VirtualMachineAgentInstanceView_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineAgentInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExtensionHandlers’:
+	// Set property "ExtensionHandlers":
 	for _, item := range typedInput.ExtensionHandlers {
 		var item1 VirtualMachineExtensionHandlerInstanceView_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11076,7 +11076,7 @@ func (view *VirtualMachineAgentInstanceView_STATUS) PopulateFromARM(owner genrun
 		view.ExtensionHandlers = append(view.ExtensionHandlers, item1)
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11086,7 +11086,7 @@ func (view *VirtualMachineAgentInstanceView_STATUS) PopulateFromARM(owner genrun
 		view.Statuses = append(view.Statuses, item1)
 	}
 
-	// Set property ‘VmAgentVersion’:
+	// Set property "VmAgentVersion":
 	if typedInput.VmAgentVersion != nil {
 		vmAgentVersion := *typedInput.VmAgentVersion
 		view.VmAgentVersion = &vmAgentVersion
@@ -11229,13 +11229,13 @@ func (view *VirtualMachineExtensionInstanceView_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineExtensionInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		view.Name = &name
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11245,7 +11245,7 @@ func (view *VirtualMachineExtensionInstanceView_STATUS) PopulateFromARM(owner ge
 		view.Statuses = append(view.Statuses, item1)
 	}
 
-	// Set property ‘Substatuses’:
+	// Set property "Substatuses":
 	for _, item := range typedInput.Substatuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11255,13 +11255,13 @@ func (view *VirtualMachineExtensionInstanceView_STATUS) PopulateFromARM(owner ge
 		view.Substatuses = append(view.Substatuses, item1)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		view.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	if typedInput.TypeHandlerVersion != nil {
 		typeHandlerVersion := *typedInput.TypeHandlerVersion
 		view.TypeHandlerVersion = &typeHandlerVersion
@@ -11404,7 +11404,7 @@ func (status *VirtualMachineHealthStatus_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineHealthStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		var status2 InstanceViewStatus_STATUS
 		err := status2.PopulateFromARM(owner, *typedInput.Status)
@@ -11488,13 +11488,13 @@ func (identities *VirtualMachineIdentity_UserAssignedIdentities_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -11572,7 +11572,7 @@ func (status *VirtualMachinePatchStatus_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachinePatchStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailablePatchSummary’:
+	// Set property "AvailablePatchSummary":
 	if typedInput.AvailablePatchSummary != nil {
 		var availablePatchSummary1 AvailablePatchSummary_STATUS
 		err := availablePatchSummary1.PopulateFromARM(owner, *typedInput.AvailablePatchSummary)
@@ -11583,7 +11583,7 @@ func (status *VirtualMachinePatchStatus_STATUS) PopulateFromARM(owner genruntime
 		status.AvailablePatchSummary = &availablePatchSummary
 	}
 
-	// Set property ‘ConfigurationStatuses’:
+	// Set property "ConfigurationStatuses":
 	for _, item := range typedInput.ConfigurationStatuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11593,7 +11593,7 @@ func (status *VirtualMachinePatchStatus_STATUS) PopulateFromARM(owner genruntime
 		status.ConfigurationStatuses = append(status.ConfigurationStatuses, item1)
 	}
 
-	// Set property ‘LastPatchInstallationSummary’:
+	// Set property "LastPatchInstallationSummary":
 	if typedInput.LastPatchInstallationSummary != nil {
 		var lastPatchInstallationSummary1 LastPatchInstallationSummary_STATUS
 		err := lastPatchInstallationSummary1.PopulateFromARM(owner, *typedInput.LastPatchInstallationSummary)
@@ -11754,7 +11754,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &WindowsConfiguration_ARM{}
 
-	// Set property ‘AdditionalUnattendContent’:
+	// Set property "AdditionalUnattendContent":
 	for _, item := range configuration.AdditionalUnattendContent {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -11763,13 +11763,13 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		result.AdditionalUnattendContent = append(result.AdditionalUnattendContent, *item_ARM.(*AdditionalUnattendContent_ARM))
 	}
 
-	// Set property ‘EnableAutomaticUpdates’:
+	// Set property "EnableAutomaticUpdates":
 	if configuration.EnableAutomaticUpdates != nil {
 		enableAutomaticUpdates := *configuration.EnableAutomaticUpdates
 		result.EnableAutomaticUpdates = &enableAutomaticUpdates
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if configuration.PatchSettings != nil {
 		patchSettings_ARM, err := (*configuration.PatchSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -11779,19 +11779,19 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		result.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if configuration.ProvisionVMAgent != nil {
 		provisionVMAgent := *configuration.ProvisionVMAgent
 		result.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if configuration.TimeZone != nil {
 		timeZone := *configuration.TimeZone
 		result.TimeZone = &timeZone
 	}
 
-	// Set property ‘WinRM’:
+	// Set property "WinRM":
 	if configuration.WinRM != nil {
 		winRM_ARM, err := (*configuration.WinRM).ConvertToARM(resolved)
 		if err != nil {
@@ -11815,7 +11815,7 @@ func (configuration *WindowsConfiguration) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalUnattendContent’:
+	// Set property "AdditionalUnattendContent":
 	for _, item := range typedInput.AdditionalUnattendContent {
 		var item1 AdditionalUnattendContent
 		err := item1.PopulateFromARM(owner, item)
@@ -11825,13 +11825,13 @@ func (configuration *WindowsConfiguration) PopulateFromARM(owner genruntime.Arbi
 		configuration.AdditionalUnattendContent = append(configuration.AdditionalUnattendContent, item1)
 	}
 
-	// Set property ‘EnableAutomaticUpdates’:
+	// Set property "EnableAutomaticUpdates":
 	if typedInput.EnableAutomaticUpdates != nil {
 		enableAutomaticUpdates := *typedInput.EnableAutomaticUpdates
 		configuration.EnableAutomaticUpdates = &enableAutomaticUpdates
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 PatchSettings
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -11842,19 +11842,19 @@ func (configuration *WindowsConfiguration) PopulateFromARM(owner genruntime.Arbi
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if typedInput.TimeZone != nil {
 		timeZone := *typedInput.TimeZone
 		configuration.TimeZone = &timeZone
 	}
 
-	// Set property ‘WinRM’:
+	// Set property "WinRM":
 	if typedInput.WinRM != nil {
 		var winRM1 WinRMConfiguration
 		err := winRM1.PopulateFromARM(owner, *typedInput.WinRM)
@@ -12058,7 +12058,7 @@ func (configuration *WindowsConfiguration_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalUnattendContent’:
+	// Set property "AdditionalUnattendContent":
 	for _, item := range typedInput.AdditionalUnattendContent {
 		var item1 AdditionalUnattendContent_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -12068,13 +12068,13 @@ func (configuration *WindowsConfiguration_STATUS) PopulateFromARM(owner genrunti
 		configuration.AdditionalUnattendContent = append(configuration.AdditionalUnattendContent, item1)
 	}
 
-	// Set property ‘EnableAutomaticUpdates’:
+	// Set property "EnableAutomaticUpdates":
 	if typedInput.EnableAutomaticUpdates != nil {
 		enableAutomaticUpdates := *typedInput.EnableAutomaticUpdates
 		configuration.EnableAutomaticUpdates = &enableAutomaticUpdates
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 PatchSettings_STATUS
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -12085,19 +12085,19 @@ func (configuration *WindowsConfiguration_STATUS) PopulateFromARM(owner genrunti
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if typedInput.TimeZone != nil {
 		timeZone := *typedInput.TimeZone
 		configuration.TimeZone = &timeZone
 	}
 
-	// Set property ‘WinRM’:
+	// Set property "WinRM":
 	if typedInput.WinRM != nil {
 		var winRM1 WinRMConfiguration_STATUS
 		err := winRM1.PopulateFromARM(owner, *typedInput.WinRM)
@@ -12285,25 +12285,25 @@ func (content *AdditionalUnattendContent) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &AdditionalUnattendContent_ARM{}
 
-	// Set property ‘ComponentName’:
+	// Set property "ComponentName":
 	if content.ComponentName != nil {
 		componentName := *content.ComponentName
 		result.ComponentName = &componentName
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if content.Content != nil {
 		content1 := *content.Content
 		result.Content = &content1
 	}
 
-	// Set property ‘PassName’:
+	// Set property "PassName":
 	if content.PassName != nil {
 		passName := *content.PassName
 		result.PassName = &passName
 	}
 
-	// Set property ‘SettingName’:
+	// Set property "SettingName":
 	if content.SettingName != nil {
 		settingName := *content.SettingName
 		result.SettingName = &settingName
@@ -12323,25 +12323,25 @@ func (content *AdditionalUnattendContent) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalUnattendContent_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComponentName’:
+	// Set property "ComponentName":
 	if typedInput.ComponentName != nil {
 		componentName := *typedInput.ComponentName
 		content.ComponentName = &componentName
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if typedInput.Content != nil {
 		content1 := *typedInput.Content
 		content.Content = &content1
 	}
 
-	// Set property ‘PassName’:
+	// Set property "PassName":
 	if typedInput.PassName != nil {
 		passName := *typedInput.PassName
 		content.PassName = &passName
 	}
 
-	// Set property ‘SettingName’:
+	// Set property "SettingName":
 	if typedInput.SettingName != nil {
 		settingName := *typedInput.SettingName
 		content.SettingName = &settingName
@@ -12461,25 +12461,25 @@ func (content *AdditionalUnattendContent_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalUnattendContent_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComponentName’:
+	// Set property "ComponentName":
 	if typedInput.ComponentName != nil {
 		componentName := *typedInput.ComponentName
 		content.ComponentName = &componentName
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if typedInput.Content != nil {
 		content1 := *typedInput.Content
 		content.Content = &content1
 	}
 
-	// Set property ‘PassName’:
+	// Set property "PassName":
 	if typedInput.PassName != nil {
 		passName := *typedInput.PassName
 		content.PassName = &passName
 	}
 
-	// Set property ‘SettingName’:
+	// Set property "SettingName":
 	if typedInput.SettingName != nil {
 		settingName := *typedInput.SettingName
 		content.SettingName = &settingName
@@ -12611,19 +12611,19 @@ func (summary *AvailablePatchSummary_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AvailablePatchSummary_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssessmentActivityId’:
+	// Set property "AssessmentActivityId":
 	if typedInput.AssessmentActivityId != nil {
 		assessmentActivityId := *typedInput.AssessmentActivityId
 		summary.AssessmentActivityId = &assessmentActivityId
 	}
 
-	// Set property ‘CriticalAndSecurityPatchCount’:
+	// Set property "CriticalAndSecurityPatchCount":
 	if typedInput.CriticalAndSecurityPatchCount != nil {
 		criticalAndSecurityPatchCount := *typedInput.CriticalAndSecurityPatchCount
 		summary.CriticalAndSecurityPatchCount = &criticalAndSecurityPatchCount
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ApiError_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -12634,31 +12634,31 @@ func (summary *AvailablePatchSummary_STATUS) PopulateFromARM(owner genruntime.Ar
 		summary.Error = &error
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	if typedInput.LastModifiedTime != nil {
 		lastModifiedTime := *typedInput.LastModifiedTime
 		summary.LastModifiedTime = &lastModifiedTime
 	}
 
-	// Set property ‘OtherPatchCount’:
+	// Set property "OtherPatchCount":
 	if typedInput.OtherPatchCount != nil {
 		otherPatchCount := *typedInput.OtherPatchCount
 		summary.OtherPatchCount = &otherPatchCount
 	}
 
-	// Set property ‘RebootPending’:
+	// Set property "RebootPending":
 	if typedInput.RebootPending != nil {
 		rebootPending := *typedInput.RebootPending
 		summary.RebootPending = &rebootPending
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		summary.StartTime = &startTime
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		summary.Status = &status
@@ -12893,13 +12893,13 @@ func (settings *DiffDiskSettings) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &DiffDiskSettings_ARM{}
 
-	// Set property ‘Option’:
+	// Set property "Option":
 	if settings.Option != nil {
 		option := *settings.Option
 		result.Option = &option
 	}
 
-	// Set property ‘Placement’:
+	// Set property "Placement":
 	if settings.Placement != nil {
 		placement := *settings.Placement
 		result.Placement = &placement
@@ -12919,13 +12919,13 @@ func (settings *DiffDiskSettings) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiffDiskSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Option’:
+	// Set property "Option":
 	if typedInput.Option != nil {
 		option := *typedInput.Option
 		settings.Option = &option
 	}
 
-	// Set property ‘Placement’:
+	// Set property "Placement":
 	if typedInput.Placement != nil {
 		placement := *typedInput.Placement
 		settings.Placement = &placement
@@ -13022,13 +13022,13 @@ func (settings *DiffDiskSettings_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiffDiskSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Option’:
+	// Set property "Option":
 	if typedInput.Option != nil {
 		option := *typedInput.Option
 		settings.Option = &option
 	}
 
-	// Set property ‘Placement’:
+	// Set property "Placement":
 	if typedInput.Placement != nil {
 		placement := *typedInput.Placement
 		settings.Placement = &placement
@@ -13114,7 +13114,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &DiskEncryptionSettings_ARM{}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if settings.DiskEncryptionKey != nil {
 		diskEncryptionKey_ARM, err := (*settings.DiskEncryptionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -13124,13 +13124,13 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 		result.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if settings.Enabled != nil {
 		enabled := *settings.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if settings.KeyEncryptionKey != nil {
 		keyEncryptionKey_ARM, err := (*settings.KeyEncryptionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -13154,7 +13154,7 @@ func (settings *DiskEncryptionSettings) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskEncryptionSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if typedInput.DiskEncryptionKey != nil {
 		var diskEncryptionKey1 KeyVaultSecretReference
 		err := diskEncryptionKey1.PopulateFromARM(owner, *typedInput.DiskEncryptionKey)
@@ -13165,13 +13165,13 @@ func (settings *DiskEncryptionSettings) PopulateFromARM(owner genruntime.Arbitra
 		settings.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		settings.Enabled = &enabled
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if typedInput.KeyEncryptionKey != nil {
 		var keyEncryptionKey1 KeyVaultKeyReference
 		err := keyEncryptionKey1.PopulateFromARM(owner, *typedInput.KeyEncryptionKey)
@@ -13299,7 +13299,7 @@ func (settings *DiskEncryptionSettings_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskEncryptionSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if typedInput.DiskEncryptionKey != nil {
 		var diskEncryptionKey1 KeyVaultSecretReference_STATUS
 		err := diskEncryptionKey1.PopulateFromARM(owner, *typedInput.DiskEncryptionKey)
@@ -13310,13 +13310,13 @@ func (settings *DiskEncryptionSettings_STATUS) PopulateFromARM(owner genruntime.
 		settings.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		settings.Enabled = &enabled
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if typedInput.KeyEncryptionKey != nil {
 		var keyEncryptionKey1 KeyVaultKeyReference_STATUS
 		err := keyEncryptionKey1.PopulateFromARM(owner, *typedInput.KeyEncryptionKey)
@@ -13481,7 +13481,7 @@ func (summary *LastPatchInstallationSummary_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LastPatchInstallationSummary_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ApiError_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -13492,61 +13492,61 @@ func (summary *LastPatchInstallationSummary_STATUS) PopulateFromARM(owner genrun
 		summary.Error = &error
 	}
 
-	// Set property ‘ExcludedPatchCount’:
+	// Set property "ExcludedPatchCount":
 	if typedInput.ExcludedPatchCount != nil {
 		excludedPatchCount := *typedInput.ExcludedPatchCount
 		summary.ExcludedPatchCount = &excludedPatchCount
 	}
 
-	// Set property ‘FailedPatchCount’:
+	// Set property "FailedPatchCount":
 	if typedInput.FailedPatchCount != nil {
 		failedPatchCount := *typedInput.FailedPatchCount
 		summary.FailedPatchCount = &failedPatchCount
 	}
 
-	// Set property ‘InstallationActivityId’:
+	// Set property "InstallationActivityId":
 	if typedInput.InstallationActivityId != nil {
 		installationActivityId := *typedInput.InstallationActivityId
 		summary.InstallationActivityId = &installationActivityId
 	}
 
-	// Set property ‘InstalledPatchCount’:
+	// Set property "InstalledPatchCount":
 	if typedInput.InstalledPatchCount != nil {
 		installedPatchCount := *typedInput.InstalledPatchCount
 		summary.InstalledPatchCount = &installedPatchCount
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	if typedInput.LastModifiedTime != nil {
 		lastModifiedTime := *typedInput.LastModifiedTime
 		summary.LastModifiedTime = &lastModifiedTime
 	}
 
-	// Set property ‘MaintenanceWindowExceeded’:
+	// Set property "MaintenanceWindowExceeded":
 	if typedInput.MaintenanceWindowExceeded != nil {
 		maintenanceWindowExceeded := *typedInput.MaintenanceWindowExceeded
 		summary.MaintenanceWindowExceeded = &maintenanceWindowExceeded
 	}
 
-	// Set property ‘NotSelectedPatchCount’:
+	// Set property "NotSelectedPatchCount":
 	if typedInput.NotSelectedPatchCount != nil {
 		notSelectedPatchCount := *typedInput.NotSelectedPatchCount
 		summary.NotSelectedPatchCount = &notSelectedPatchCount
 	}
 
-	// Set property ‘PendingPatchCount’:
+	// Set property "PendingPatchCount":
 	if typedInput.PendingPatchCount != nil {
 		pendingPatchCount := *typedInput.PendingPatchCount
 		summary.PendingPatchCount = &pendingPatchCount
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		summary.StartTime = &startTime
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		summary.Status = &status
@@ -13702,7 +13702,7 @@ func (settings *LinuxPatchSettings) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &LinuxPatchSettings_ARM{}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if settings.PatchMode != nil {
 		patchMode := *settings.PatchMode
 		result.PatchMode = &patchMode
@@ -13722,7 +13722,7 @@ func (settings *LinuxPatchSettings) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxPatchSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -13795,7 +13795,7 @@ func (settings *LinuxPatchSettings_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxPatchSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -13876,7 +13876,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &ManagedDiskParameters_ARM{}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if parameters.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*parameters.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -13886,7 +13886,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if parameters.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*parameters.Reference)
 		if err != nil {
@@ -13896,7 +13896,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 		result.Id = &reference
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if parameters.StorageAccountType != nil {
 		storageAccountType := *parameters.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -13916,7 +13916,7 @@ func (parameters *ManagedDiskParameters) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedDiskParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -13927,9 +13927,9 @@ func (parameters *ManagedDiskParameters) PopulateFromARM(owner genruntime.Arbitr
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -14046,7 +14046,7 @@ func (parameters *ManagedDiskParameters_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedDiskParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -14057,13 +14057,13 @@ func (parameters *ManagedDiskParameters_STATUS) PopulateFromARM(owner genruntime
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		parameters.Id = &id
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -14184,13 +14184,13 @@ func (settings *PatchSettings) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &PatchSettings_ARM{}
 
-	// Set property ‘EnableHotpatching’:
+	// Set property "EnableHotpatching":
 	if settings.EnableHotpatching != nil {
 		enableHotpatching := *settings.EnableHotpatching
 		result.EnableHotpatching = &enableHotpatching
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if settings.PatchMode != nil {
 		patchMode := *settings.PatchMode
 		result.PatchMode = &patchMode
@@ -14210,13 +14210,13 @@ func (settings *PatchSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PatchSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableHotpatching’:
+	// Set property "EnableHotpatching":
 	if typedInput.EnableHotpatching != nil {
 		enableHotpatching := *typedInput.EnableHotpatching
 		settings.EnableHotpatching = &enableHotpatching
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -14313,13 +14313,13 @@ func (settings *PatchSettings_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PatchSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableHotpatching’:
+	// Set property "EnableHotpatching":
 	if typedInput.EnableHotpatching != nil {
 		enableHotpatching := *typedInput.EnableHotpatching
 		settings.EnableHotpatching = &enableHotpatching
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -14399,7 +14399,7 @@ func (configuration *SshConfiguration) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &SshConfiguration_ARM{}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range configuration.PublicKeys {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -14422,7 +14422,7 @@ func (configuration *SshConfiguration) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 SshPublicKeySpec
 		err := item1.PopulateFromARM(owner, item)
@@ -14515,7 +14515,7 @@ func (configuration *SshConfiguration_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 SshPublicKey_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -14618,13 +14618,13 @@ func (certificate *VaultCertificate) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &VaultCertificate_ARM{}
 
-	// Set property ‘CertificateStore’:
+	// Set property "CertificateStore":
 	if certificate.CertificateStore != nil {
 		certificateStore := *certificate.CertificateStore
 		result.CertificateStore = &certificateStore
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if certificate.CertificateUrl != nil {
 		certificateUrl := *certificate.CertificateUrl
 		result.CertificateUrl = &certificateUrl
@@ -14644,13 +14644,13 @@ func (certificate *VaultCertificate) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultCertificate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateStore’:
+	// Set property "CertificateStore":
 	if typedInput.CertificateStore != nil {
 		certificateStore := *typedInput.CertificateStore
 		certificate.CertificateStore = &certificateStore
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		certificate.CertificateUrl = &certificateUrl
@@ -14730,13 +14730,13 @@ func (certificate *VaultCertificate_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultCertificate_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateStore’:
+	// Set property "CertificateStore":
 	if typedInput.CertificateStore != nil {
 		certificateStore := *typedInput.CertificateStore
 		certificate.CertificateStore = &certificateStore
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		certificate.CertificateUrl = &certificateUrl
@@ -14796,7 +14796,7 @@ func (disk *VirtualHardDisk) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &VirtualHardDisk_ARM{}
 
-	// Set property ‘Uri’:
+	// Set property "Uri":
 	if disk.Uri != nil {
 		uri := *disk.Uri
 		result.Uri = &uri
@@ -14816,7 +14816,7 @@ func (disk *VirtualHardDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualHardDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Uri’:
+	// Set property "Uri":
 	if typedInput.Uri != nil {
 		uri := *typedInput.Uri
 		disk.Uri = &uri
@@ -14875,7 +14875,7 @@ func (disk *VirtualHardDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualHardDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Uri’:
+	// Set property "Uri":
 	if typedInput.Uri != nil {
 		uri := *typedInput.Uri
 		disk.Uri = &uri
@@ -14940,7 +14940,7 @@ func (view *VirtualMachineExtensionHandlerInstanceView_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineExtensionHandlerInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		var status1 InstanceViewStatus_STATUS
 		err := status1.PopulateFromARM(owner, *typedInput.Status)
@@ -14951,13 +14951,13 @@ func (view *VirtualMachineExtensionHandlerInstanceView_STATUS) PopulateFromARM(o
 		view.Status = &status
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		view.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	if typedInput.TypeHandlerVersion != nil {
 		typeHandlerVersion := *typedInput.TypeHandlerVersion
 		view.TypeHandlerVersion = &typeHandlerVersion
@@ -15041,7 +15041,7 @@ func (configuration *WinRMConfiguration) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &WinRMConfiguration_ARM{}
 
-	// Set property ‘Listeners’:
+	// Set property "Listeners":
 	for _, item := range configuration.Listeners {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -15064,7 +15064,7 @@ func (configuration *WinRMConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Listeners’:
+	// Set property "Listeners":
 	for _, item := range typedInput.Listeners {
 		var item1 WinRMListener
 		err := item1.PopulateFromARM(owner, item)
@@ -15157,7 +15157,7 @@ func (configuration *WinRMConfiguration_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Listeners’:
+	// Set property "Listeners":
 	for _, item := range typedInput.Listeners {
 		var item1 WinRMListener_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -15295,13 +15295,13 @@ func (error *ApiError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		error.Code = &code
 	}
 
-	// Set property ‘Details’:
+	// Set property "Details":
 	for _, item := range typedInput.Details {
 		var item1 ApiErrorBase_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -15311,7 +15311,7 @@ func (error *ApiError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		error.Details = append(error.Details, item1)
 	}
 
-	// Set property ‘Innererror’:
+	// Set property "Innererror":
 	if typedInput.Innererror != nil {
 		var innererror1 InnerError_STATUS
 		err := innererror1.PopulateFromARM(owner, *typedInput.Innererror)
@@ -15322,13 +15322,13 @@ func (error *ApiError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		error.Innererror = &innererror
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		error.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		error.Target = &target
@@ -15505,13 +15505,13 @@ func (reference *KeyVaultKeyReference) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &KeyVaultKeyReference_ARM{}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if reference.KeyUrl != nil {
 		keyUrl := *reference.KeyUrl
 		result.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if reference.SourceVault != nil {
 		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -15535,13 +15535,13 @@ func (reference *KeyVaultKeyReference) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultKeyReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if typedInput.KeyUrl != nil {
 		keyUrl := *typedInput.KeyUrl
 		reference.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -15632,13 +15632,13 @@ func (reference *KeyVaultKeyReference_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultKeyReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if typedInput.KeyUrl != nil {
 		keyUrl := *typedInput.KeyUrl
 		reference.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -15726,13 +15726,13 @@ func (reference *KeyVaultSecretReference) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &KeyVaultSecretReference_ARM{}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if reference.SecretUrl != nil {
 		secretUrl := *reference.SecretUrl
 		result.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if reference.SourceVault != nil {
 		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -15756,13 +15756,13 @@ func (reference *KeyVaultSecretReference) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultSecretReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if typedInput.SecretUrl != nil {
 		secretUrl := *typedInput.SecretUrl
 		reference.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -15853,13 +15853,13 @@ func (reference *KeyVaultSecretReference_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultSecretReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if typedInput.SecretUrl != nil {
 		secretUrl := *typedInput.SecretUrl
 		reference.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -15996,13 +15996,13 @@ func (publicKey *SshPublicKey_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshPublicKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		publicKey.Path = &path
@@ -16069,13 +16069,13 @@ func (publicKey *SshPublicKeySpec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &SshPublicKeySpec_ARM{}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if publicKey.KeyData != nil {
 		keyData := *publicKey.KeyData
 		result.KeyData = &keyData
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if publicKey.Path != nil {
 		path := *publicKey.Path
 		result.Path = &path
@@ -16095,13 +16095,13 @@ func (publicKey *SshPublicKeySpec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshPublicKeySpec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		publicKey.Path = &path
@@ -16210,13 +16210,13 @@ func (listener *WinRMListener) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &WinRMListener_ARM{}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if listener.CertificateUrl != nil {
 		certificateUrl := *listener.CertificateUrl
 		result.CertificateUrl = &certificateUrl
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if listener.Protocol != nil {
 		protocol := *listener.Protocol
 		result.Protocol = &protocol
@@ -16236,13 +16236,13 @@ func (listener *WinRMListener) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMListener_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		listener.CertificateUrl = &certificateUrl
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		listener.Protocol = &protocol
@@ -16331,13 +16331,13 @@ func (listener *WinRMListener_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMListener_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		listener.CertificateUrl = &certificateUrl
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		listener.Protocol = &protocol
@@ -16418,19 +16418,19 @@ func (base *ApiErrorBase_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiErrorBase_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		base.Code = &code
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		base.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		base.Target = &target
@@ -16504,13 +16504,13 @@ func (error *InnerError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InnerError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Errordetail’:
+	// Set property "Errordetail":
 	if typedInput.Errordetail != nil {
 		errordetail := *typedInput.Errordetail
 		error.Errordetail = &errordetail
 	}
 
-	// Set property ‘Exceptiontype’:
+	// Set property "Exceptiontype":
 	if typedInput.Exceptiontype != nil {
 		exceptiontype := *typedInput.Exceptiontype
 		error.Exceptiontype = &exceptiontype

--- a/v2/api/compute/v1api20210701/image_types_gen.go
+++ b/v2/api/compute/v1api20210701/image_types_gen.go
@@ -361,7 +361,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &Image_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if image.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*image.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -371,16 +371,16 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if image.Location != nil {
 		location := *image.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if image.HyperVGeneration != nil ||
 		image.SourceVirtualMachine != nil ||
 		image.StorageProfile != nil {
@@ -407,7 +407,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if image.Tags != nil {
 		result.Tags = make(map[string]string, len(image.Tags))
 		for key, value := range image.Tags {
@@ -429,10 +429,10 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Image_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	image.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -443,7 +443,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		image.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -452,16 +452,16 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		image.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	image.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘SourceVirtualMachine’:
+	// Set property "SourceVirtualMachine":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceVirtualMachine != nil {
@@ -475,7 +475,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -489,7 +489,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		image.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -811,9 +811,9 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Image_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -824,7 +824,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		image.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -833,25 +833,25 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		image.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		image.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		image.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -860,7 +860,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘SourceVirtualMachine’:
+	// Set property "SourceVirtualMachine":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceVirtualMachine != nil {
@@ -874,7 +874,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -888,7 +888,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		image.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -896,7 +896,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		image.Type = &typeVar
@@ -1077,13 +1077,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -1103,13 +1103,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -1187,13 +1187,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -1291,7 +1291,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ImageStorageProfile_ARM{}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range profile.DataDisks {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1300,7 +1300,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 		result.DataDisks = append(result.DataDisks, *item_ARM.(*ImageDataDisk_ARM))
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if profile.OsDisk != nil {
 		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -1310,7 +1310,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 		result.OsDisk = &osDisk
 	}
 
-	// Set property ‘ZoneResilient’:
+	// Set property "ZoneResilient":
 	if profile.ZoneResilient != nil {
 		zoneResilient := *profile.ZoneResilient
 		result.ZoneResilient = &zoneResilient
@@ -1330,7 +1330,7 @@ func (profile *ImageStorageProfile) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageStorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 ImageDataDisk
 		err := item1.PopulateFromARM(owner, item)
@@ -1340,7 +1340,7 @@ func (profile *ImageStorageProfile) PopulateFromARM(owner genruntime.ArbitraryOw
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 ImageOSDisk
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -1351,7 +1351,7 @@ func (profile *ImageStorageProfile) PopulateFromARM(owner genruntime.ArbitraryOw
 		profile.OsDisk = &osDisk
 	}
 
-	// Set property ‘ZoneResilient’:
+	// Set property "ZoneResilient":
 	if typedInput.ZoneResilient != nil {
 		zoneResilient := *typedInput.ZoneResilient
 		profile.ZoneResilient = &zoneResilient
@@ -1491,7 +1491,7 @@ func (profile *ImageStorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageStorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 ImageDataDisk_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1501,7 +1501,7 @@ func (profile *ImageStorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbi
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 ImageOSDisk_STATUS
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -1512,7 +1512,7 @@ func (profile *ImageStorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbi
 		profile.OsDisk = &osDisk
 	}
 
-	// Set property ‘ZoneResilient’:
+	// Set property "ZoneResilient":
 	if typedInput.ZoneResilient != nil {
 		zoneResilient := *typedInput.ZoneResilient
 		profile.ZoneResilient = &zoneResilient
@@ -1635,7 +1635,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -1659,7 +1659,7 @@ func (resource *SubResource) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1723,7 +1723,7 @@ func (resource *SubResource_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
@@ -1808,19 +1808,19 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &ImageDataDisk_ARM{}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if disk.BlobUri != nil {
 		blobUri := *disk.BlobUri
 		result.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if disk.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*disk.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -1830,19 +1830,19 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if disk.Lun != nil {
 		lun := *disk.Lun
 		result.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -1852,7 +1852,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if disk.Snapshot != nil {
 		snapshot_ARM, err := (*disk.Snapshot).ConvertToARM(resolved)
 		if err != nil {
@@ -1862,7 +1862,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if disk.StorageAccountType != nil {
 		storageAccountType := *disk.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -1882,19 +1882,19 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageDataDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -1905,19 +1905,19 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -1928,7 +1928,7 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -1939,7 +1939,7 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType
@@ -2144,19 +2144,19 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageDataDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -2167,19 +2167,19 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -2190,7 +2190,7 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource_STATUS
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -2201,7 +2201,7 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType
@@ -2409,19 +2409,19 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &ImageOSDisk_ARM{}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if disk.BlobUri != nil {
 		blobUri := *disk.BlobUri
 		result.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if disk.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*disk.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -2431,13 +2431,13 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -2447,19 +2447,19 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘OsState’:
+	// Set property "OsState":
 	if disk.OsState != nil {
 		osState := *disk.OsState
 		result.OsState = &osState
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if disk.OsType != nil {
 		osType := *disk.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if disk.Snapshot != nil {
 		snapshot_ARM, err := (*disk.Snapshot).ConvertToARM(resolved)
 		if err != nil {
@@ -2469,7 +2469,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if disk.StorageAccountType != nil {
 		storageAccountType := *disk.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -2489,19 +2489,19 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageOSDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -2512,13 +2512,13 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -2529,19 +2529,19 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘OsState’:
+	// Set property "OsState":
 	if typedInput.OsState != nil {
 		osState := *typedInput.OsState
 		disk.OsState = &osState
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -2552,7 +2552,7 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType
@@ -2789,19 +2789,19 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageOSDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -2812,13 +2812,13 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -2829,19 +2829,19 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘OsState’:
+	// Set property "OsState":
 	if typedInput.OsState != nil {
 		osState := *typedInput.OsState
 		disk.OsState = &osState
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource_STATUS
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -2852,7 +2852,7 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType

--- a/v2/api/compute/v1api20220301/image_types_gen.go
+++ b/v2/api/compute/v1api20220301/image_types_gen.go
@@ -358,7 +358,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &Image_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if image.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*image.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -368,16 +368,16 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if image.Location != nil {
 		location := *image.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if image.HyperVGeneration != nil ||
 		image.SourceVirtualMachine != nil ||
 		image.StorageProfile != nil {
@@ -404,7 +404,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if image.Tags != nil {
 		result.Tags = make(map[string]string, len(image.Tags))
 		for key, value := range image.Tags {
@@ -426,10 +426,10 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Image_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	image.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -440,7 +440,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		image.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -449,16 +449,16 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		image.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	image.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘SourceVirtualMachine’:
+	// Set property "SourceVirtualMachine":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceVirtualMachine != nil {
@@ -472,7 +472,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -486,7 +486,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		image.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -865,9 +865,9 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Image_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -878,7 +878,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		image.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -887,25 +887,25 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		image.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		image.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		image.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -914,7 +914,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘SourceVirtualMachine’:
+	// Set property "SourceVirtualMachine":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceVirtualMachine != nil {
@@ -928,7 +928,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -942,7 +942,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		image.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -950,7 +950,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		image.Type = &typeVar
@@ -1131,13 +1131,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -1157,13 +1157,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -1259,13 +1259,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -1363,7 +1363,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ImageStorageProfile_ARM{}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range profile.DataDisks {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1372,7 +1372,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 		result.DataDisks = append(result.DataDisks, *item_ARM.(*ImageDataDisk_ARM))
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if profile.OsDisk != nil {
 		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -1382,7 +1382,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 		result.OsDisk = &osDisk
 	}
 
-	// Set property ‘ZoneResilient’:
+	// Set property "ZoneResilient":
 	if profile.ZoneResilient != nil {
 		zoneResilient := *profile.ZoneResilient
 		result.ZoneResilient = &zoneResilient
@@ -1402,7 +1402,7 @@ func (profile *ImageStorageProfile) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageStorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 ImageDataDisk
 		err := item1.PopulateFromARM(owner, item)
@@ -1412,7 +1412,7 @@ func (profile *ImageStorageProfile) PopulateFromARM(owner genruntime.ArbitraryOw
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 ImageOSDisk
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -1423,7 +1423,7 @@ func (profile *ImageStorageProfile) PopulateFromARM(owner genruntime.ArbitraryOw
 		profile.OsDisk = &osDisk
 	}
 
-	// Set property ‘ZoneResilient’:
+	// Set property "ZoneResilient":
 	if typedInput.ZoneResilient != nil {
 		zoneResilient := *typedInput.ZoneResilient
 		profile.ZoneResilient = &zoneResilient
@@ -1608,7 +1608,7 @@ func (profile *ImageStorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageStorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 ImageDataDisk_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1618,7 +1618,7 @@ func (profile *ImageStorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbi
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 ImageOSDisk_STATUS
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -1629,7 +1629,7 @@ func (profile *ImageStorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbi
 		profile.OsDisk = &osDisk
 	}
 
-	// Set property ‘ZoneResilient’:
+	// Set property "ZoneResilient":
 	if typedInput.ZoneResilient != nil {
 		zoneResilient := *typedInput.ZoneResilient
 		profile.ZoneResilient = &zoneResilient
@@ -1752,7 +1752,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -1776,7 +1776,7 @@ func (resource *SubResource) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1855,7 +1855,7 @@ func (resource *SubResource_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
@@ -1940,19 +1940,19 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &ImageDataDisk_ARM{}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if disk.BlobUri != nil {
 		blobUri := *disk.BlobUri
 		result.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if disk.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*disk.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -1962,19 +1962,19 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if disk.Lun != nil {
 		lun := *disk.Lun
 		result.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -1984,7 +1984,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if disk.Snapshot != nil {
 		snapshot_ARM, err := (*disk.Snapshot).ConvertToARM(resolved)
 		if err != nil {
@@ -1994,7 +1994,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if disk.StorageAccountType != nil {
 		storageAccountType := *disk.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -2014,19 +2014,19 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageDataDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -2037,19 +2037,19 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -2060,7 +2060,7 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -2071,7 +2071,7 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType
@@ -2344,19 +2344,19 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageDataDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -2367,19 +2367,19 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -2390,7 +2390,7 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource_STATUS
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -2401,7 +2401,7 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType
@@ -2609,19 +2609,19 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &ImageOSDisk_ARM{}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if disk.BlobUri != nil {
 		blobUri := *disk.BlobUri
 		result.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if disk.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*disk.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -2631,13 +2631,13 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -2647,19 +2647,19 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘OsState’:
+	// Set property "OsState":
 	if disk.OsState != nil {
 		osState := *disk.OsState
 		result.OsState = &osState
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if disk.OsType != nil {
 		osType := *disk.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if disk.Snapshot != nil {
 		snapshot_ARM, err := (*disk.Snapshot).ConvertToARM(resolved)
 		if err != nil {
@@ -2669,7 +2669,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if disk.StorageAccountType != nil {
 		storageAccountType := *disk.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -2689,19 +2689,19 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageOSDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -2712,13 +2712,13 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -2729,19 +2729,19 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘OsState’:
+	// Set property "OsState":
 	if typedInput.OsState != nil {
 		osState := *typedInput.OsState
 		disk.OsState = &osState
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -2752,7 +2752,7 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType
@@ -3070,19 +3070,19 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageOSDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -3093,13 +3093,13 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -3110,19 +3110,19 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘OsState’:
+	// Set property "OsState":
 	if typedInput.OsState != nil {
 		osState := *typedInput.OsState
 		disk.OsState = &osState
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource_STATUS
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -3133,7 +3133,7 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType

--- a/v2/api/compute/v1api20220301/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/compute/v1api20220301/virtual_machine_scale_set_types_gen.go
@@ -410,7 +410,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 	}
 	result := &VirtualMachineScaleSet_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if scaleSet.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*scaleSet.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -420,7 +420,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if scaleSet.Identity != nil {
 		identity_ARM, err := (*scaleSet.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -430,16 +430,16 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if scaleSet.Location != nil {
 		location := *scaleSet.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if scaleSet.Plan != nil {
 		plan_ARM, err := (*scaleSet.Plan).ConvertToARM(resolved)
 		if err != nil {
@@ -449,7 +449,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Plan = &plan
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if scaleSet.AdditionalCapabilities != nil ||
 		scaleSet.AutomaticRepairsPolicy != nil ||
 		scaleSet.DoNotRunExtensionsOnOverprovisionedVMs != nil ||
@@ -555,7 +555,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.ZoneBalance = &zoneBalance
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if scaleSet.Sku != nil {
 		sku_ARM, err := (*scaleSet.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -565,7 +565,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if scaleSet.Tags != nil {
 		result.Tags = make(map[string]string, len(scaleSet.Tags))
 		for key, value := range scaleSet.Tags {
@@ -573,7 +573,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range scaleSet.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -592,7 +592,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSet_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -606,7 +606,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘AutomaticRepairsPolicy’:
+	// Set property "AutomaticRepairsPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticRepairsPolicy != nil {
@@ -620,10 +620,10 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	scaleSet.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DoNotRunExtensionsOnOverprovisionedVMs’:
+	// Set property "DoNotRunExtensionsOnOverprovisionedVMs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DoNotRunExtensionsOnOverprovisionedVMs != nil {
@@ -632,7 +632,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -643,7 +643,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -657,7 +657,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineScaleSetIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -668,13 +668,13 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		scaleSet.Location = &location
 	}
 
-	// Set property ‘OrchestrationMode’:
+	// Set property "OrchestrationMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestrationMode != nil {
@@ -683,7 +683,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Overprovision’:
+	// Set property "Overprovision":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Overprovision != nil {
@@ -692,10 +692,10 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	scaleSet.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -706,7 +706,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomainCount’:
+	// Set property "PlatformFaultDomainCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomainCount != nil {
@@ -715,7 +715,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -729,7 +729,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ScaleInPolicy’:
+	// Set property "ScaleInPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleInPolicy != nil {
@@ -743,7 +743,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘SinglePlacementGroup’:
+	// Set property "SinglePlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SinglePlacementGroup != nil {
@@ -752,7 +752,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -763,7 +763,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.Sku = &sku
 	}
 
-	// Set property ‘SpotRestorePolicy’:
+	// Set property "SpotRestorePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotRestorePolicy != nil {
@@ -777,7 +777,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		scaleSet.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -785,7 +785,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘UpgradePolicy’:
+	// Set property "UpgradePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradePolicy != nil {
@@ -799,7 +799,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘VirtualMachineProfile’:
+	// Set property "VirtualMachineProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineProfile != nil {
@@ -813,7 +813,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ZoneBalance’:
+	// Set property "ZoneBalance":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneBalance != nil {
@@ -822,7 +822,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		scaleSet.Zones = append(scaleSet.Zones, item)
 	}
@@ -1700,7 +1700,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -1714,7 +1714,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘AutomaticRepairsPolicy’:
+	// Set property "AutomaticRepairsPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticRepairsPolicy != nil {
@@ -1728,9 +1728,9 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DoNotRunExtensionsOnOverprovisionedVMs’:
+	// Set property "DoNotRunExtensionsOnOverprovisionedVMs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DoNotRunExtensionsOnOverprovisionedVMs != nil {
@@ -1739,7 +1739,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1750,7 +1750,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -1764,13 +1764,13 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		scaleSet.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineScaleSetIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1781,19 +1781,19 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		scaleSet.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		scaleSet.Name = &name
 	}
 
-	// Set property ‘OrchestrationMode’:
+	// Set property "OrchestrationMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestrationMode != nil {
@@ -1802,7 +1802,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Overprovision’:
+	// Set property "Overprovision":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Overprovision != nil {
@@ -1811,7 +1811,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan_STATUS
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -1822,7 +1822,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomainCount’:
+	// Set property "PlatformFaultDomainCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomainCount != nil {
@@ -1831,7 +1831,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1840,7 +1840,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -1854,7 +1854,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ScaleInPolicy’:
+	// Set property "ScaleInPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleInPolicy != nil {
@@ -1868,7 +1868,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘SinglePlacementGroup’:
+	// Set property "SinglePlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SinglePlacementGroup != nil {
@@ -1877,7 +1877,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1888,7 +1888,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.Sku = &sku
 	}
 
-	// Set property ‘SpotRestorePolicy’:
+	// Set property "SpotRestorePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotRestorePolicy != nil {
@@ -1902,7 +1902,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		scaleSet.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1910,7 +1910,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘TimeCreated’:
+	// Set property "TimeCreated":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TimeCreated != nil {
@@ -1919,13 +1919,13 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		scaleSet.Type = &typeVar
 	}
 
-	// Set property ‘UniqueId’:
+	// Set property "UniqueId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UniqueId != nil {
@@ -1934,7 +1934,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘UpgradePolicy’:
+	// Set property "UpgradePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradePolicy != nil {
@@ -1948,7 +1948,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘VirtualMachineProfile’:
+	// Set property "VirtualMachineProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineProfile != nil {
@@ -1962,7 +1962,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ZoneBalance’:
+	// Set property "ZoneBalance":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneBalance != nil {
@@ -1971,7 +1971,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		scaleSet.Zones = append(scaleSet.Zones, item)
 	}
@@ -2463,19 +2463,19 @@ func (policy *AutomaticRepairsPolicy) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &AutomaticRepairsPolicy_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if policy.Enabled != nil {
 		enabled := *policy.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘GracePeriod’:
+	// Set property "GracePeriod":
 	if policy.GracePeriod != nil {
 		gracePeriod := *policy.GracePeriod
 		result.GracePeriod = &gracePeriod
 	}
 
-	// Set property ‘RepairAction’:
+	// Set property "RepairAction":
 	if policy.RepairAction != nil {
 		repairAction := *policy.RepairAction
 		result.RepairAction = &repairAction
@@ -2495,19 +2495,19 @@ func (policy *AutomaticRepairsPolicy) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticRepairsPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
 	}
 
-	// Set property ‘GracePeriod’:
+	// Set property "GracePeriod":
 	if typedInput.GracePeriod != nil {
 		gracePeriod := *typedInput.GracePeriod
 		policy.GracePeriod = &gracePeriod
 	}
 
-	// Set property ‘RepairAction’:
+	// Set property "RepairAction":
 	if typedInput.RepairAction != nil {
 		repairAction := *typedInput.RepairAction
 		policy.RepairAction = &repairAction
@@ -2635,19 +2635,19 @@ func (policy *AutomaticRepairsPolicy_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticRepairsPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
 	}
 
-	// Set property ‘GracePeriod’:
+	// Set property "GracePeriod":
 	if typedInput.GracePeriod != nil {
 		gracePeriod := *typedInput.GracePeriod
 		policy.GracePeriod = &gracePeriod
 	}
 
-	// Set property ‘RepairAction’:
+	// Set property "RepairAction":
 	if typedInput.RepairAction != nil {
 		repairAction := *typedInput.RepairAction
 		policy.RepairAction = &repairAction
@@ -2764,13 +2764,13 @@ func (policy *ScaleInPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &ScaleInPolicy_ARM{}
 
-	// Set property ‘ForceDeletion’:
+	// Set property "ForceDeletion":
 	if policy.ForceDeletion != nil {
 		forceDeletion := *policy.ForceDeletion
 		result.ForceDeletion = &forceDeletion
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range policy.Rules {
 		result.Rules = append(result.Rules, item)
 	}
@@ -2789,13 +2789,13 @@ func (policy *ScaleInPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScaleInPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ForceDeletion’:
+	// Set property "ForceDeletion":
 	if typedInput.ForceDeletion != nil {
 		forceDeletion := *typedInput.ForceDeletion
 		policy.ForceDeletion = &forceDeletion
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		policy.Rules = append(policy.Rules, item)
 	}
@@ -2932,13 +2932,13 @@ func (policy *ScaleInPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScaleInPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ForceDeletion’:
+	// Set property "ForceDeletion":
 	if typedInput.ForceDeletion != nil {
 		forceDeletion := *typedInput.ForceDeletion
 		policy.ForceDeletion = &forceDeletion
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		policy.Rules = append(policy.Rules, item)
 	}
@@ -3037,19 +3037,19 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sku.Capacity != nil {
 		capacity := *sku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -3069,19 +3069,19 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3178,19 +3178,19 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3264,13 +3264,13 @@ func (policy *SpotRestorePolicy) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &SpotRestorePolicy_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if policy.Enabled != nil {
 		enabled := *policy.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘RestoreTimeout’:
+	// Set property "RestoreTimeout":
 	if policy.RestoreTimeout != nil {
 		restoreTimeout := *policy.RestoreTimeout
 		result.RestoreTimeout = &restoreTimeout
@@ -3290,13 +3290,13 @@ func (policy *SpotRestorePolicy) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SpotRestorePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
 	}
 
-	// Set property ‘RestoreTimeout’:
+	// Set property "RestoreTimeout":
 	if typedInput.RestoreTimeout != nil {
 		restoreTimeout := *typedInput.RestoreTimeout
 		policy.RestoreTimeout = &restoreTimeout
@@ -3397,13 +3397,13 @@ func (policy *SpotRestorePolicy_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SpotRestorePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
 	}
 
-	// Set property ‘RestoreTimeout’:
+	// Set property "RestoreTimeout":
 	if typedInput.RestoreTimeout != nil {
 		restoreTimeout := *typedInput.RestoreTimeout
 		policy.RestoreTimeout = &restoreTimeout
@@ -3483,7 +3483,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &UpgradePolicy_ARM{}
 
-	// Set property ‘AutomaticOSUpgradePolicy’:
+	// Set property "AutomaticOSUpgradePolicy":
 	if policy.AutomaticOSUpgradePolicy != nil {
 		automaticOSUpgradePolicy_ARM, err := (*policy.AutomaticOSUpgradePolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -3493,13 +3493,13 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if policy.Mode != nil {
 		mode := *policy.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘RollingUpgradePolicy’:
+	// Set property "RollingUpgradePolicy":
 	if policy.RollingUpgradePolicy != nil {
 		rollingUpgradePolicy_ARM, err := (*policy.RollingUpgradePolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -3523,7 +3523,7 @@ func (policy *UpgradePolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpgradePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticOSUpgradePolicy’:
+	// Set property "AutomaticOSUpgradePolicy":
 	if typedInput.AutomaticOSUpgradePolicy != nil {
 		var automaticOSUpgradePolicy1 AutomaticOSUpgradePolicy
 		err := automaticOSUpgradePolicy1.PopulateFromARM(owner, *typedInput.AutomaticOSUpgradePolicy)
@@ -3534,13 +3534,13 @@ func (policy *UpgradePolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		policy.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		policy.Mode = &mode
 	}
 
-	// Set property ‘RollingUpgradePolicy’:
+	// Set property "RollingUpgradePolicy":
 	if typedInput.RollingUpgradePolicy != nil {
 		var rollingUpgradePolicy1 RollingUpgradePolicy
 		err := rollingUpgradePolicy1.PopulateFromARM(owner, *typedInput.RollingUpgradePolicy)
@@ -3711,7 +3711,7 @@ func (policy *UpgradePolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpgradePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticOSUpgradePolicy’:
+	// Set property "AutomaticOSUpgradePolicy":
 	if typedInput.AutomaticOSUpgradePolicy != nil {
 		var automaticOSUpgradePolicy1 AutomaticOSUpgradePolicy_STATUS
 		err := automaticOSUpgradePolicy1.PopulateFromARM(owner, *typedInput.AutomaticOSUpgradePolicy)
@@ -3722,13 +3722,13 @@ func (policy *UpgradePolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		policy.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		policy.Mode = &mode
 	}
 
-	// Set property ‘RollingUpgradePolicy’:
+	// Set property "RollingUpgradePolicy":
 	if typedInput.RollingUpgradePolicy != nil {
 		var rollingUpgradePolicy1 RollingUpgradePolicy_STATUS
 		err := rollingUpgradePolicy1.PopulateFromARM(owner, *typedInput.RollingUpgradePolicy)
@@ -3852,13 +3852,13 @@ func (identity *VirtualMachineScaleSetIdentity) ConvertToARM(resolved genruntime
 	}
 	result := &VirtualMachineScaleSetIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -3883,13 +3883,13 @@ func (identity *VirtualMachineScaleSetIdentity) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -4032,25 +4032,25 @@ func (identity *VirtualMachineScaleSetIdentity_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -4232,7 +4232,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 	}
 	result := &VirtualMachineScaleSetVMProfile_ARM{}
 
-	// Set property ‘ApplicationProfile’:
+	// Set property "ApplicationProfile":
 	if profile.ApplicationProfile != nil {
 		applicationProfile_ARM, err := (*profile.ApplicationProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4242,7 +4242,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.ApplicationProfile = &applicationProfile
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	if profile.BillingProfile != nil {
 		billingProfile_ARM, err := (*profile.BillingProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4252,7 +4252,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.BillingProfile = &billingProfile
 	}
 
-	// Set property ‘CapacityReservation’:
+	// Set property "CapacityReservation":
 	if profile.CapacityReservation != nil {
 		capacityReservation_ARM, err := (*profile.CapacityReservation).ConvertToARM(resolved)
 		if err != nil {
@@ -4262,7 +4262,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.CapacityReservation = &capacityReservation
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	if profile.DiagnosticsProfile != nil {
 		diagnosticsProfile_ARM, err := (*profile.DiagnosticsProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4272,13 +4272,13 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.DiagnosticsProfile = &diagnosticsProfile
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	if profile.EvictionPolicy != nil {
 		evictionPolicy := *profile.EvictionPolicy
 		result.EvictionPolicy = &evictionPolicy
 	}
 
-	// Set property ‘ExtensionProfile’:
+	// Set property "ExtensionProfile":
 	if profile.ExtensionProfile != nil {
 		extensionProfile_ARM, err := (*profile.ExtensionProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4288,7 +4288,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.ExtensionProfile = &extensionProfile
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	if profile.HardwareProfile != nil {
 		hardwareProfile_ARM, err := (*profile.HardwareProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4298,13 +4298,13 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.HardwareProfile = &hardwareProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if profile.LicenseType != nil {
 		licenseType := *profile.LicenseType
 		result.LicenseType = &licenseType
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if profile.NetworkProfile != nil {
 		networkProfile_ARM, err := (*profile.NetworkProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4314,7 +4314,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	if profile.OsProfile != nil {
 		osProfile_ARM, err := (*profile.OsProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4324,13 +4324,13 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.OsProfile = &osProfile
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if profile.Priority != nil {
 		priority := *profile.Priority
 		result.Priority = &priority
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	if profile.ScheduledEventsProfile != nil {
 		scheduledEventsProfile_ARM, err := (*profile.ScheduledEventsProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4340,7 +4340,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if profile.SecurityProfile != nil {
 		securityProfile_ARM, err := (*profile.SecurityProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4350,7 +4350,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if profile.StorageProfile != nil {
 		storageProfile_ARM, err := (*profile.StorageProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4360,7 +4360,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘UserData’:
+	// Set property "UserData":
 	if profile.UserData != nil {
 		userData := *profile.UserData
 		result.UserData = &userData
@@ -4380,7 +4380,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetVMProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationProfile’:
+	// Set property "ApplicationProfile":
 	if typedInput.ApplicationProfile != nil {
 		var applicationProfile1 ApplicationProfile
 		err := applicationProfile1.PopulateFromARM(owner, *typedInput.ApplicationProfile)
@@ -4391,7 +4391,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.ApplicationProfile = &applicationProfile
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	if typedInput.BillingProfile != nil {
 		var billingProfile1 BillingProfile
 		err := billingProfile1.PopulateFromARM(owner, *typedInput.BillingProfile)
@@ -4402,7 +4402,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.BillingProfile = &billingProfile
 	}
 
-	// Set property ‘CapacityReservation’:
+	// Set property "CapacityReservation":
 	if typedInput.CapacityReservation != nil {
 		var capacityReservation1 CapacityReservationProfile
 		err := capacityReservation1.PopulateFromARM(owner, *typedInput.CapacityReservation)
@@ -4413,7 +4413,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.CapacityReservation = &capacityReservation
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	if typedInput.DiagnosticsProfile != nil {
 		var diagnosticsProfile1 DiagnosticsProfile
 		err := diagnosticsProfile1.PopulateFromARM(owner, *typedInput.DiagnosticsProfile)
@@ -4424,13 +4424,13 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.DiagnosticsProfile = &diagnosticsProfile
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	if typedInput.EvictionPolicy != nil {
 		evictionPolicy := *typedInput.EvictionPolicy
 		profile.EvictionPolicy = &evictionPolicy
 	}
 
-	// Set property ‘ExtensionProfile’:
+	// Set property "ExtensionProfile":
 	if typedInput.ExtensionProfile != nil {
 		var extensionProfile1 VirtualMachineScaleSetExtensionProfile
 		err := extensionProfile1.PopulateFromARM(owner, *typedInput.ExtensionProfile)
@@ -4441,7 +4441,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.ExtensionProfile = &extensionProfile
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	if typedInput.HardwareProfile != nil {
 		var hardwareProfile1 VirtualMachineScaleSetHardwareProfile
 		err := hardwareProfile1.PopulateFromARM(owner, *typedInput.HardwareProfile)
@@ -4452,13 +4452,13 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.HardwareProfile = &hardwareProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if typedInput.NetworkProfile != nil {
 		var networkProfile1 VirtualMachineScaleSetNetworkProfile
 		err := networkProfile1.PopulateFromARM(owner, *typedInput.NetworkProfile)
@@ -4469,7 +4469,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	if typedInput.OsProfile != nil {
 		var osProfile1 VirtualMachineScaleSetOSProfile
 		err := osProfile1.PopulateFromARM(owner, *typedInput.OsProfile)
@@ -4480,13 +4480,13 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.OsProfile = &osProfile
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		profile.Priority = &priority
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	if typedInput.ScheduledEventsProfile != nil {
 		var scheduledEventsProfile1 ScheduledEventsProfile
 		err := scheduledEventsProfile1.PopulateFromARM(owner, *typedInput.ScheduledEventsProfile)
@@ -4497,7 +4497,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 SecurityProfile
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -4508,7 +4508,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 VirtualMachineScaleSetStorageProfile
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -4519,7 +4519,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘UserData’:
+	// Set property "UserData":
 	if typedInput.UserData != nil {
 		userData := *typedInput.UserData
 		profile.UserData = &userData
@@ -5104,7 +5104,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetVMProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationProfile’:
+	// Set property "ApplicationProfile":
 	if typedInput.ApplicationProfile != nil {
 		var applicationProfile1 ApplicationProfile_STATUS
 		err := applicationProfile1.PopulateFromARM(owner, *typedInput.ApplicationProfile)
@@ -5115,7 +5115,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.ApplicationProfile = &applicationProfile
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	if typedInput.BillingProfile != nil {
 		var billingProfile1 BillingProfile_STATUS
 		err := billingProfile1.PopulateFromARM(owner, *typedInput.BillingProfile)
@@ -5126,7 +5126,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.BillingProfile = &billingProfile
 	}
 
-	// Set property ‘CapacityReservation’:
+	// Set property "CapacityReservation":
 	if typedInput.CapacityReservation != nil {
 		var capacityReservation1 CapacityReservationProfile_STATUS
 		err := capacityReservation1.PopulateFromARM(owner, *typedInput.CapacityReservation)
@@ -5137,7 +5137,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.CapacityReservation = &capacityReservation
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	if typedInput.DiagnosticsProfile != nil {
 		var diagnosticsProfile1 DiagnosticsProfile_STATUS
 		err := diagnosticsProfile1.PopulateFromARM(owner, *typedInput.DiagnosticsProfile)
@@ -5148,13 +5148,13 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.DiagnosticsProfile = &diagnosticsProfile
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	if typedInput.EvictionPolicy != nil {
 		evictionPolicy := *typedInput.EvictionPolicy
 		profile.EvictionPolicy = &evictionPolicy
 	}
 
-	// Set property ‘ExtensionProfile’:
+	// Set property "ExtensionProfile":
 	if typedInput.ExtensionProfile != nil {
 		var extensionProfile1 VirtualMachineScaleSetExtensionProfile_STATUS
 		err := extensionProfile1.PopulateFromARM(owner, *typedInput.ExtensionProfile)
@@ -5165,7 +5165,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.ExtensionProfile = &extensionProfile
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	if typedInput.HardwareProfile != nil {
 		var hardwareProfile1 VirtualMachineScaleSetHardwareProfile_STATUS
 		err := hardwareProfile1.PopulateFromARM(owner, *typedInput.HardwareProfile)
@@ -5176,13 +5176,13 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.HardwareProfile = &hardwareProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if typedInput.NetworkProfile != nil {
 		var networkProfile1 VirtualMachineScaleSetNetworkProfile_STATUS
 		err := networkProfile1.PopulateFromARM(owner, *typedInput.NetworkProfile)
@@ -5193,7 +5193,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	if typedInput.OsProfile != nil {
 		var osProfile1 VirtualMachineScaleSetOSProfile_STATUS
 		err := osProfile1.PopulateFromARM(owner, *typedInput.OsProfile)
@@ -5204,13 +5204,13 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.OsProfile = &osProfile
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		profile.Priority = &priority
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	if typedInput.ScheduledEventsProfile != nil {
 		var scheduledEventsProfile1 ScheduledEventsProfile_STATUS
 		err := scheduledEventsProfile1.PopulateFromARM(owner, *typedInput.ScheduledEventsProfile)
@@ -5221,7 +5221,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 SecurityProfile_STATUS
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -5232,7 +5232,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 VirtualMachineScaleSetStorageProfile_STATUS
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -5243,7 +5243,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘UserData’:
+	// Set property "UserData":
 	if typedInput.UserData != nil {
 		userData := *typedInput.UserData
 		profile.UserData = &userData
@@ -5610,19 +5610,19 @@ func (policy *AutomaticOSUpgradePolicy) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &AutomaticOSUpgradePolicy_ARM{}
 
-	// Set property ‘DisableAutomaticRollback’:
+	// Set property "DisableAutomaticRollback":
 	if policy.DisableAutomaticRollback != nil {
 		disableAutomaticRollback := *policy.DisableAutomaticRollback
 		result.DisableAutomaticRollback = &disableAutomaticRollback
 	}
 
-	// Set property ‘EnableAutomaticOSUpgrade’:
+	// Set property "EnableAutomaticOSUpgrade":
 	if policy.EnableAutomaticOSUpgrade != nil {
 		enableAutomaticOSUpgrade := *policy.EnableAutomaticOSUpgrade
 		result.EnableAutomaticOSUpgrade = &enableAutomaticOSUpgrade
 	}
 
-	// Set property ‘UseRollingUpgradePolicy’:
+	// Set property "UseRollingUpgradePolicy":
 	if policy.UseRollingUpgradePolicy != nil {
 		useRollingUpgradePolicy := *policy.UseRollingUpgradePolicy
 		result.UseRollingUpgradePolicy = &useRollingUpgradePolicy
@@ -5642,19 +5642,19 @@ func (policy *AutomaticOSUpgradePolicy) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticOSUpgradePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisableAutomaticRollback’:
+	// Set property "DisableAutomaticRollback":
 	if typedInput.DisableAutomaticRollback != nil {
 		disableAutomaticRollback := *typedInput.DisableAutomaticRollback
 		policy.DisableAutomaticRollback = &disableAutomaticRollback
 	}
 
-	// Set property ‘EnableAutomaticOSUpgrade’:
+	// Set property "EnableAutomaticOSUpgrade":
 	if typedInput.EnableAutomaticOSUpgrade != nil {
 		enableAutomaticOSUpgrade := *typedInput.EnableAutomaticOSUpgrade
 		policy.EnableAutomaticOSUpgrade = &enableAutomaticOSUpgrade
 	}
 
-	// Set property ‘UseRollingUpgradePolicy’:
+	// Set property "UseRollingUpgradePolicy":
 	if typedInput.UseRollingUpgradePolicy != nil {
 		useRollingUpgradePolicy := *typedInput.UseRollingUpgradePolicy
 		policy.UseRollingUpgradePolicy = &useRollingUpgradePolicy
@@ -5797,19 +5797,19 @@ func (policy *AutomaticOSUpgradePolicy_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticOSUpgradePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisableAutomaticRollback’:
+	// Set property "DisableAutomaticRollback":
 	if typedInput.DisableAutomaticRollback != nil {
 		disableAutomaticRollback := *typedInput.DisableAutomaticRollback
 		policy.DisableAutomaticRollback = &disableAutomaticRollback
 	}
 
-	// Set property ‘EnableAutomaticOSUpgrade’:
+	// Set property "EnableAutomaticOSUpgrade":
 	if typedInput.EnableAutomaticOSUpgrade != nil {
 		enableAutomaticOSUpgrade := *typedInput.EnableAutomaticOSUpgrade
 		policy.EnableAutomaticOSUpgrade = &enableAutomaticOSUpgrade
 	}
 
-	// Set property ‘UseRollingUpgradePolicy’:
+	// Set property "UseRollingUpgradePolicy":
 	if typedInput.UseRollingUpgradePolicy != nil {
 		useRollingUpgradePolicy := *typedInput.UseRollingUpgradePolicy
 		policy.UseRollingUpgradePolicy = &useRollingUpgradePolicy
@@ -5952,37 +5952,37 @@ func (policy *RollingUpgradePolicy) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &RollingUpgradePolicy_ARM{}
 
-	// Set property ‘EnableCrossZoneUpgrade’:
+	// Set property "EnableCrossZoneUpgrade":
 	if policy.EnableCrossZoneUpgrade != nil {
 		enableCrossZoneUpgrade := *policy.EnableCrossZoneUpgrade
 		result.EnableCrossZoneUpgrade = &enableCrossZoneUpgrade
 	}
 
-	// Set property ‘MaxBatchInstancePercent’:
+	// Set property "MaxBatchInstancePercent":
 	if policy.MaxBatchInstancePercent != nil {
 		maxBatchInstancePercent := *policy.MaxBatchInstancePercent
 		result.MaxBatchInstancePercent = &maxBatchInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyInstancePercent’:
+	// Set property "MaxUnhealthyInstancePercent":
 	if policy.MaxUnhealthyInstancePercent != nil {
 		maxUnhealthyInstancePercent := *policy.MaxUnhealthyInstancePercent
 		result.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyUpgradedInstancePercent’:
+	// Set property "MaxUnhealthyUpgradedInstancePercent":
 	if policy.MaxUnhealthyUpgradedInstancePercent != nil {
 		maxUnhealthyUpgradedInstancePercent := *policy.MaxUnhealthyUpgradedInstancePercent
 		result.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
 	}
 
-	// Set property ‘PauseTimeBetweenBatches’:
+	// Set property "PauseTimeBetweenBatches":
 	if policy.PauseTimeBetweenBatches != nil {
 		pauseTimeBetweenBatches := *policy.PauseTimeBetweenBatches
 		result.PauseTimeBetweenBatches = &pauseTimeBetweenBatches
 	}
 
-	// Set property ‘PrioritizeUnhealthyInstances’:
+	// Set property "PrioritizeUnhealthyInstances":
 	if policy.PrioritizeUnhealthyInstances != nil {
 		prioritizeUnhealthyInstances := *policy.PrioritizeUnhealthyInstances
 		result.PrioritizeUnhealthyInstances = &prioritizeUnhealthyInstances
@@ -6002,37 +6002,37 @@ func (policy *RollingUpgradePolicy) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RollingUpgradePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableCrossZoneUpgrade’:
+	// Set property "EnableCrossZoneUpgrade":
 	if typedInput.EnableCrossZoneUpgrade != nil {
 		enableCrossZoneUpgrade := *typedInput.EnableCrossZoneUpgrade
 		policy.EnableCrossZoneUpgrade = &enableCrossZoneUpgrade
 	}
 
-	// Set property ‘MaxBatchInstancePercent’:
+	// Set property "MaxBatchInstancePercent":
 	if typedInput.MaxBatchInstancePercent != nil {
 		maxBatchInstancePercent := *typedInput.MaxBatchInstancePercent
 		policy.MaxBatchInstancePercent = &maxBatchInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyInstancePercent’:
+	// Set property "MaxUnhealthyInstancePercent":
 	if typedInput.MaxUnhealthyInstancePercent != nil {
 		maxUnhealthyInstancePercent := *typedInput.MaxUnhealthyInstancePercent
 		policy.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyUpgradedInstancePercent’:
+	// Set property "MaxUnhealthyUpgradedInstancePercent":
 	if typedInput.MaxUnhealthyUpgradedInstancePercent != nil {
 		maxUnhealthyUpgradedInstancePercent := *typedInput.MaxUnhealthyUpgradedInstancePercent
 		policy.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
 	}
 
-	// Set property ‘PauseTimeBetweenBatches’:
+	// Set property "PauseTimeBetweenBatches":
 	if typedInput.PauseTimeBetweenBatches != nil {
 		pauseTimeBetweenBatches := *typedInput.PauseTimeBetweenBatches
 		policy.PauseTimeBetweenBatches = &pauseTimeBetweenBatches
 	}
 
-	// Set property ‘PrioritizeUnhealthyInstances’:
+	// Set property "PrioritizeUnhealthyInstances":
 	if typedInput.PrioritizeUnhealthyInstances != nil {
 		prioritizeUnhealthyInstances := *typedInput.PrioritizeUnhealthyInstances
 		policy.PrioritizeUnhealthyInstances = &prioritizeUnhealthyInstances
@@ -6245,37 +6245,37 @@ func (policy *RollingUpgradePolicy_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RollingUpgradePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableCrossZoneUpgrade’:
+	// Set property "EnableCrossZoneUpgrade":
 	if typedInput.EnableCrossZoneUpgrade != nil {
 		enableCrossZoneUpgrade := *typedInput.EnableCrossZoneUpgrade
 		policy.EnableCrossZoneUpgrade = &enableCrossZoneUpgrade
 	}
 
-	// Set property ‘MaxBatchInstancePercent’:
+	// Set property "MaxBatchInstancePercent":
 	if typedInput.MaxBatchInstancePercent != nil {
 		maxBatchInstancePercent := *typedInput.MaxBatchInstancePercent
 		policy.MaxBatchInstancePercent = &maxBatchInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyInstancePercent’:
+	// Set property "MaxUnhealthyInstancePercent":
 	if typedInput.MaxUnhealthyInstancePercent != nil {
 		maxUnhealthyInstancePercent := *typedInput.MaxUnhealthyInstancePercent
 		policy.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyUpgradedInstancePercent’:
+	// Set property "MaxUnhealthyUpgradedInstancePercent":
 	if typedInput.MaxUnhealthyUpgradedInstancePercent != nil {
 		maxUnhealthyUpgradedInstancePercent := *typedInput.MaxUnhealthyUpgradedInstancePercent
 		policy.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
 	}
 
-	// Set property ‘PauseTimeBetweenBatches’:
+	// Set property "PauseTimeBetweenBatches":
 	if typedInput.PauseTimeBetweenBatches != nil {
 		pauseTimeBetweenBatches := *typedInput.PauseTimeBetweenBatches
 		policy.PauseTimeBetweenBatches = &pauseTimeBetweenBatches
 	}
 
-	// Set property ‘PrioritizeUnhealthyInstances’:
+	// Set property "PrioritizeUnhealthyInstances":
 	if typedInput.PrioritizeUnhealthyInstances != nil {
 		prioritizeUnhealthyInstances := *typedInput.PrioritizeUnhealthyInstances
 		policy.PrioritizeUnhealthyInstances = &prioritizeUnhealthyInstances
@@ -6419,7 +6419,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) ConvertToARM(resolved gen
 	}
 	result := &VirtualMachineScaleSetExtensionProfile_ARM{}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range profile.Extensions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -6428,7 +6428,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) ConvertToARM(resolved gen
 		result.Extensions = append(result.Extensions, *item_ARM.(*VirtualMachineScaleSetExtension_ARM))
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	if profile.ExtensionsTimeBudget != nil {
 		extensionsTimeBudget := *profile.ExtensionsTimeBudget
 		result.ExtensionsTimeBudget = &extensionsTimeBudget
@@ -6448,7 +6448,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtensionProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range typedInput.Extensions {
 		var item1 VirtualMachineScaleSetExtension
 		err := item1.PopulateFromARM(owner, item)
@@ -6458,7 +6458,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) PopulateFromARM(owner gen
 		profile.Extensions = append(profile.Extensions, item1)
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	if typedInput.ExtensionsTimeBudget != nil {
 		extensionsTimeBudget := *typedInput.ExtensionsTimeBudget
 		profile.ExtensionsTimeBudget = &extensionsTimeBudget
@@ -6587,7 +6587,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtensionProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range typedInput.Extensions {
 		var item1 VirtualMachineScaleSetExtension_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6597,7 +6597,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile_STATUS) PopulateFromARM(ow
 		profile.Extensions = append(profile.Extensions, item1)
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	if typedInput.ExtensionsTimeBudget != nil {
 		extensionsTimeBudget := *typedInput.ExtensionsTimeBudget
 		profile.ExtensionsTimeBudget = &extensionsTimeBudget
@@ -6689,7 +6689,7 @@ func (profile *VirtualMachineScaleSetHardwareProfile) ConvertToARM(resolved genr
 	}
 	result := &VirtualMachineScaleSetHardwareProfile_ARM{}
 
-	// Set property ‘VmSizeProperties’:
+	// Set property "VmSizeProperties":
 	if profile.VmSizeProperties != nil {
 		vmSizeProperties_ARM, err := (*profile.VmSizeProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -6713,7 +6713,7 @@ func (profile *VirtualMachineScaleSetHardwareProfile) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetHardwareProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmSizeProperties’:
+	// Set property "VmSizeProperties":
 	if typedInput.VmSizeProperties != nil {
 		var vmSizeProperties1 VMSizeProperties
 		err := vmSizeProperties1.PopulateFromARM(owner, *typedInput.VmSizeProperties)
@@ -6816,7 +6816,7 @@ func (profile *VirtualMachineScaleSetHardwareProfile_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetHardwareProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmSizeProperties’:
+	// Set property "VmSizeProperties":
 	if typedInput.VmSizeProperties != nil {
 		var vmSizeProperties1 VMSizeProperties_STATUS
 		err := vmSizeProperties1.PopulateFromARM(owner, *typedInput.VmSizeProperties)
@@ -6900,13 +6900,13 @@ func (identities *VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -6975,7 +6975,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) ConvertToARM(resolved genru
 	}
 	result := &VirtualMachineScaleSetNetworkProfile_ARM{}
 
-	// Set property ‘HealthProbe’:
+	// Set property "HealthProbe":
 	if profile.HealthProbe != nil {
 		healthProbe_ARM, err := (*profile.HealthProbe).ConvertToARM(resolved)
 		if err != nil {
@@ -6985,13 +6985,13 @@ func (profile *VirtualMachineScaleSetNetworkProfile) ConvertToARM(resolved genru
 		result.HealthProbe = &healthProbe
 	}
 
-	// Set property ‘NetworkApiVersion’:
+	// Set property "NetworkApiVersion":
 	if profile.NetworkApiVersion != nil {
 		networkApiVersion := *profile.NetworkApiVersion
 		result.NetworkApiVersion = &networkApiVersion
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range profile.NetworkInterfaceConfigurations {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -7014,7 +7014,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HealthProbe’:
+	// Set property "HealthProbe":
 	if typedInput.HealthProbe != nil {
 		var healthProbe1 ApiEntityReference
 		err := healthProbe1.PopulateFromARM(owner, *typedInput.HealthProbe)
@@ -7025,13 +7025,13 @@ func (profile *VirtualMachineScaleSetNetworkProfile) PopulateFromARM(owner genru
 		profile.HealthProbe = &healthProbe
 	}
 
-	// Set property ‘NetworkApiVersion’:
+	// Set property "NetworkApiVersion":
 	if typedInput.NetworkApiVersion != nil {
 		networkApiVersion := *typedInput.NetworkApiVersion
 		profile.NetworkApiVersion = &networkApiVersion
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range typedInput.NetworkInterfaceConfigurations {
 		var item1 VirtualMachineScaleSetNetworkConfiguration
 		err := item1.PopulateFromARM(owner, item)
@@ -7218,7 +7218,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HealthProbe’:
+	// Set property "HealthProbe":
 	if typedInput.HealthProbe != nil {
 		var healthProbe1 ApiEntityReference_STATUS
 		err := healthProbe1.PopulateFromARM(owner, *typedInput.HealthProbe)
@@ -7229,13 +7229,13 @@ func (profile *VirtualMachineScaleSetNetworkProfile_STATUS) PopulateFromARM(owne
 		profile.HealthProbe = &healthProbe
 	}
 
-	// Set property ‘NetworkApiVersion’:
+	// Set property "NetworkApiVersion":
 	if typedInput.NetworkApiVersion != nil {
 		networkApiVersion := *typedInput.NetworkApiVersion
 		profile.NetworkApiVersion = &networkApiVersion
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range typedInput.NetworkInterfaceConfigurations {
 		var item1 VirtualMachineScaleSetNetworkConfiguration_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7416,7 +7416,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 	}
 	result := &VirtualMachineScaleSetOSProfile_ARM{}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if profile.AdminPassword != nil {
 		adminPasswordSecret, err := resolved.ResolvedSecrets.Lookup(*profile.AdminPassword)
 		if err != nil {
@@ -7426,31 +7426,31 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 		result.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if profile.AllowExtensionOperations != nil {
 		allowExtensionOperations := *profile.AllowExtensionOperations
 		result.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerNamePrefix’:
+	// Set property "ComputerNamePrefix":
 	if profile.ComputerNamePrefix != nil {
 		computerNamePrefix := *profile.ComputerNamePrefix
 		result.ComputerNamePrefix = &computerNamePrefix
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if profile.CustomData != nil {
 		customData := *profile.CustomData
 		result.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if profile.LinuxConfiguration != nil {
 		linuxConfiguration_ARM, err := (*profile.LinuxConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -7460,7 +7460,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 		result.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range profile.Secrets {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -7469,7 +7469,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 		result.Secrets = append(result.Secrets, *item_ARM.(*VaultSecretGroup_ARM))
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if profile.WindowsConfiguration != nil {
 		windowsConfiguration_ARM, err := (*profile.WindowsConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -7493,33 +7493,33 @@ func (profile *VirtualMachineScaleSetOSProfile) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSProfile_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘AdminPassword’
+	// no assignment for property "AdminPassword"
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if typedInput.AllowExtensionOperations != nil {
 		allowExtensionOperations := *typedInput.AllowExtensionOperations
 		profile.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerNamePrefix’:
+	// Set property "ComputerNamePrefix":
 	if typedInput.ComputerNamePrefix != nil {
 		computerNamePrefix := *typedInput.ComputerNamePrefix
 		profile.ComputerNamePrefix = &computerNamePrefix
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -7530,7 +7530,7 @@ func (profile *VirtualMachineScaleSetOSProfile) PopulateFromARM(owner genruntime
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup
 		err := item1.PopulateFromARM(owner, item)
@@ -7540,7 +7540,7 @@ func (profile *VirtualMachineScaleSetOSProfile) PopulateFromARM(owner genruntime
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -7833,31 +7833,31 @@ func (profile *VirtualMachineScaleSetOSProfile_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if typedInput.AllowExtensionOperations != nil {
 		allowExtensionOperations := *typedInput.AllowExtensionOperations
 		profile.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerNamePrefix’:
+	// Set property "ComputerNamePrefix":
 	if typedInput.ComputerNamePrefix != nil {
 		computerNamePrefix := *typedInput.ComputerNamePrefix
 		profile.ComputerNamePrefix = &computerNamePrefix
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration_STATUS
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -7868,7 +7868,7 @@ func (profile *VirtualMachineScaleSetOSProfile_STATUS) PopulateFromARM(owner gen
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7878,7 +7878,7 @@ func (profile *VirtualMachineScaleSetOSProfile_STATUS) PopulateFromARM(owner gen
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration_STATUS
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -8061,7 +8061,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 	}
 	result := &VirtualMachineScaleSetStorageProfile_ARM{}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range profile.DataDisks {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -8070,7 +8070,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		result.DataDisks = append(result.DataDisks, *item_ARM.(*VirtualMachineScaleSetDataDisk_ARM))
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if profile.ImageReference != nil {
 		imageReference_ARM, err := (*profile.ImageReference).ConvertToARM(resolved)
 		if err != nil {
@@ -8080,7 +8080,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		result.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if profile.OsDisk != nil {
 		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -8104,7 +8104,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetStorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 VirtualMachineScaleSetDataDisk
 		err := item1.PopulateFromARM(owner, item)
@@ -8114,7 +8114,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) PopulateFromARM(owner genru
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -8125,7 +8125,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) PopulateFromARM(owner genru
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 VirtualMachineScaleSetOSDisk
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -8328,7 +8328,7 @@ func (profile *VirtualMachineScaleSetStorageProfile_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetStorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 VirtualMachineScaleSetDataDisk_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8338,7 +8338,7 @@ func (profile *VirtualMachineScaleSetStorageProfile_STATUS) PopulateFromARM(owne
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference_STATUS
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -8349,7 +8349,7 @@ func (profile *VirtualMachineScaleSetStorageProfile_STATUS) PopulateFromARM(owne
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 VirtualMachineScaleSetOSDisk_STATUS
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -8486,7 +8486,7 @@ func (reference *ApiEntityReference) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &ApiEntityReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -8510,7 +8510,7 @@ func (reference *ApiEntityReference) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiEntityReference_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -8590,7 +8590,7 @@ func (reference *ApiEntityReference_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiEntityReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
@@ -8688,49 +8688,49 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 	}
 	result := &VirtualMachineScaleSetDataDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if disk.DeleteOption != nil {
 		deleteOption := *disk.DeleteOption
 		result.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if disk.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *disk.DiskIOPSReadWrite
 		result.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if disk.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *disk.DiskMBpsReadWrite
 		result.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if disk.Lun != nil {
 		lun := *disk.Lun
 		result.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -8740,13 +8740,13 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -8766,49 +8766,49 @@ func (disk *VirtualMachineScaleSetDataDisk) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetDataDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if typedInput.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *typedInput.DiskIOPSReadWrite
 		disk.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if typedInput.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *typedInput.DiskMBpsReadWrite
 		disk.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -8819,13 +8819,13 @@ func (disk *VirtualMachineScaleSetDataDisk) PopulateFromARM(owner genruntime.Arb
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -9104,49 +9104,49 @@ func (disk *VirtualMachineScaleSetDataDisk_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetDataDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if typedInput.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *typedInput.DiskIOPSReadWrite
 		disk.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if typedInput.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *typedInput.DiskMBpsReadWrite
 		disk.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -9157,13 +9157,13 @@ func (disk *VirtualMachineScaleSetDataDisk_STATUS) PopulateFromARM(owner genrunt
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -9369,13 +9369,13 @@ func (extension *VirtualMachineScaleSetExtension) ConvertToARM(resolved genrunti
 	}
 	result := &VirtualMachineScaleSetExtension_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if extension.Name != nil {
 		name := *extension.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if extension.AutoUpgradeMinorVersion != nil ||
 		extension.EnableAutomaticUpgrade != nil ||
 		extension.ForceUpdateTag != nil ||
@@ -9455,7 +9455,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtension_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradeMinorVersion’:
+	// Set property "AutoUpgradeMinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeMinorVersion != nil {
@@ -9464,7 +9464,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticUpgrade != nil {
@@ -9473,7 +9473,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘ForceUpdateTag’:
+	// Set property "ForceUpdateTag":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceUpdateTag != nil {
@@ -9482,13 +9482,13 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		extension.Name = &name
 	}
 
-	// Set property ‘ProtectedSettings’:
+	// Set property "ProtectedSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettings != nil {
@@ -9499,7 +9499,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘ProtectedSettingsFromKeyVault’:
+	// Set property "ProtectedSettingsFromKeyVault":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettingsFromKeyVault != nil {
@@ -9513,7 +9513,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘ProvisionAfterExtensions’:
+	// Set property "ProvisionAfterExtensions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ProvisionAfterExtensions {
@@ -9521,7 +9521,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Publisher != nil {
@@ -9530,7 +9530,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Settings’:
+	// Set property "Settings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Settings != nil {
@@ -9541,7 +9541,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘SuppressFailures’:
+	// Set property "SuppressFailures":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SuppressFailures != nil {
@@ -9550,7 +9550,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -9559,7 +9559,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TypeHandlerVersion != nil {
@@ -9911,7 +9911,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtension_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradeMinorVersion’:
+	// Set property "AutoUpgradeMinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeMinorVersion != nil {
@@ -9920,7 +9920,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticUpgrade != nil {
@@ -9929,7 +9929,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ForceUpdateTag’:
+	// Set property "ForceUpdateTag":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceUpdateTag != nil {
@@ -9938,19 +9938,19 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		extension.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		extension.Name = &name
 	}
 
-	// Set property ‘PropertiesType’:
+	// Set property "PropertiesType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -9959,7 +9959,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProtectedSettings’:
+	// Set property "ProtectedSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettings != nil {
@@ -9970,7 +9970,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProtectedSettingsFromKeyVault’:
+	// Set property "ProtectedSettingsFromKeyVault":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettingsFromKeyVault != nil {
@@ -9984,7 +9984,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProvisionAfterExtensions’:
+	// Set property "ProvisionAfterExtensions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ProvisionAfterExtensions {
@@ -9992,7 +9992,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -10001,7 +10001,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Publisher != nil {
@@ -10010,7 +10010,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Settings’:
+	// Set property "Settings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Settings != nil {
@@ -10021,7 +10021,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘SuppressFailures’:
+	// Set property "SuppressFailures":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SuppressFailures != nil {
@@ -10030,13 +10030,13 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		extension.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TypeHandlerVersion != nil {
@@ -10294,7 +10294,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) ConvertToARM(re
 	}
 	result := &VirtualMachineScaleSetNetworkConfiguration_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if configuration.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*configuration.Reference)
 		if err != nil {
@@ -10304,13 +10304,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) ConvertToARM(re
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.DeleteOption != nil ||
 		configuration.DnsSettings != nil ||
 		configuration.EnableAcceleratedNetworking != nil ||
@@ -10379,7 +10379,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -10388,7 +10388,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -10402,7 +10402,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -10411,7 +10411,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableFpga’:
+	// Set property "EnableFpga":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFpga != nil {
@@ -10420,7 +10420,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -10429,7 +10429,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -10442,13 +10442,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -10462,7 +10462,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -10471,7 +10471,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -10833,7 +10833,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -10842,7 +10842,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -10856,7 +10856,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -10865,7 +10865,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘EnableFpga’:
+	// Set property "EnableFpga":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFpga != nil {
@@ -10874,7 +10874,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -10883,13 +10883,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -10902,13 +10902,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -10922,7 +10922,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -11210,25 +11210,25 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &VirtualMachineScaleSetOSDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if disk.DeleteOption != nil {
 		deleteOption := *disk.DeleteOption
 		result.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if disk.DiffDiskSettings != nil {
 		diffDiskSettings_ARM, err := (*disk.DiffDiskSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -11238,13 +11238,13 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		result.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if disk.Image != nil {
 		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
 		if err != nil {
@@ -11254,7 +11254,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		result.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -11264,24 +11264,24 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if disk.OsType != nil {
 		osType := *disk.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘VhdContainers’:
+	// Set property "VhdContainers":
 	for _, item := range disk.VhdContainers {
 		result.VhdContainers = append(result.VhdContainers, item)
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -11301,25 +11301,25 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -11330,13 +11330,13 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -11347,7 +11347,7 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -11358,24 +11358,24 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘VhdContainers’:
+	// Set property "VhdContainers":
 	for _, item := range typedInput.VhdContainers {
 		disk.VhdContainers = append(disk.VhdContainers, item)
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -11741,25 +11741,25 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings_STATUS
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -11770,13 +11770,13 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk_STATUS
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -11787,7 +11787,7 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -11798,24 +11798,24 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘VhdContainers’:
+	// Set property "VhdContainers":
 	for _, item := range typedInput.VhdContainers {
 		disk.VhdContainers = append(disk.VhdContainers, item)
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -12068,7 +12068,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) ConvertToARM(resolve
 	}
 	result := &VirtualMachineScaleSetIPConfiguration_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if configuration.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*configuration.Reference)
 		if err != nil {
@@ -12078,13 +12078,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) ConvertToARM(resolve
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.ApplicationGatewayBackendAddressPools != nil ||
 		configuration.ApplicationSecurityGroups != nil ||
 		configuration.LoadBalancerBackendAddressPools != nil ||
@@ -12162,7 +12162,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIPConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -12175,7 +12175,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -12188,7 +12188,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -12201,7 +12201,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘LoadBalancerInboundNatPools’:
+	// Set property "LoadBalancerInboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerInboundNatPools {
@@ -12214,13 +12214,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -12229,7 +12229,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -12238,7 +12238,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘PublicIPAddressConfiguration’:
+	// Set property "PublicIPAddressConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressConfiguration != nil {
@@ -12252,9 +12252,9 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -12725,7 +12725,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIPConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -12738,7 +12738,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -12751,13 +12751,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -12770,7 +12770,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘LoadBalancerInboundNatPools’:
+	// Set property "LoadBalancerInboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerInboundNatPools {
@@ -12783,13 +12783,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -12798,7 +12798,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -12807,7 +12807,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘PublicIPAddressConfiguration’:
+	// Set property "PublicIPAddressConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressConfiguration != nil {
@@ -12821,7 +12821,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -13120,7 +13120,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 	}
 	result := &VirtualMachineScaleSetManagedDiskParameters_ARM{}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if parameters.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*parameters.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -13130,7 +13130,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if parameters.SecurityProfile != nil {
 		securityProfile_ARM, err := (*parameters.SecurityProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -13140,7 +13140,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 		result.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if parameters.StorageAccountType != nil {
 		storageAccountType := *parameters.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -13160,7 +13160,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetManagedDiskParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -13171,7 +13171,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) PopulateFromARM(o
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 VMDiskSecurityProfile
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -13182,7 +13182,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) PopulateFromARM(o
 		parameters.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -13345,7 +13345,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters_STATUS) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetManagedDiskParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -13356,7 +13356,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters_STATUS) PopulateFr
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 VMDiskSecurityProfile_STATUS
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -13367,7 +13367,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters_STATUS) PopulateFr
 		parameters.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -13479,7 +13479,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings) ConvertTo
 	}
 	result := &VirtualMachineScaleSetNetworkConfigurationDnsSettings_ARM{}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range settings.DnsServers {
 		result.DnsServers = append(result.DnsServers, item)
 	}
@@ -13498,7 +13498,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfigurationDnsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		settings.DnsServers = append(settings.DnsServers, item)
 	}
@@ -13566,7 +13566,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS) Po
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		settings.DnsServers = append(settings.DnsServers, item)
 	}
@@ -13687,13 +13687,13 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Convert
 	}
 	result := &VirtualMachineScaleSetPublicIPAddressConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.DeleteOption != nil ||
 		configuration.DnsSettings != nil ||
 		configuration.IdleTimeoutInMinutes != nil ||
@@ -13738,7 +13738,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Convert
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if configuration.Sku != nil {
 		sku_ARM, err := (*configuration.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -13762,7 +13762,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -13771,7 +13771,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -13785,7 +13785,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -13794,7 +13794,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -13807,13 +13807,13 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -13822,7 +13822,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -13836,7 +13836,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPAddressSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -14151,7 +14151,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -14160,7 +14160,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -14174,7 +14174,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -14183,7 +14183,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -14196,13 +14196,13 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -14211,7 +14211,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -14225,7 +14225,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPAddressSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -14433,13 +14433,13 @@ func (ipTag *VirtualMachineScaleSetIpTag) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &VirtualMachineScaleSetIpTag_ARM{}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if ipTag.IpTagType != nil {
 		ipTagType := *ipTag.IpTagType
 		result.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if ipTag.Tag != nil {
 		tag := *ipTag.Tag
 		result.Tag = &tag
@@ -14459,13 +14459,13 @@ func (ipTag *VirtualMachineScaleSetIpTag) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIpTag_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -14546,13 +14546,13 @@ func (ipTag *VirtualMachineScaleSetIpTag_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIpTag_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -14614,7 +14614,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings) C
 	}
 	result := &VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_ARM{}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if settings.DomainNameLabel != nil {
 		domainNameLabel := *settings.DomainNameLabel
 		result.DomainNameLabel = &domainNameLabel
@@ -14634,7 +14634,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings) P
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		settings.DomainNameLabel = &domainNameLabel
@@ -14704,7 +14704,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_ST
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		settings.DomainNameLabel = &domainNameLabel

--- a/v2/api/compute/v1api20220301/virtual_machine_types_gen.go
+++ b/v2/api/compute/v1api20220301/virtual_machine_types_gen.go
@@ -468,7 +468,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &VirtualMachine_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if machine.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*machine.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -478,7 +478,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if machine.Identity != nil {
 		identity_ARM, err := (*machine.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -488,16 +488,16 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if machine.Location != nil {
 		location := *machine.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if machine.Plan != nil {
 		plan_ARM, err := (*machine.Plan).ConvertToARM(resolved)
 		if err != nil {
@@ -507,7 +507,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Plan = &plan
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if machine.AdditionalCapabilities != nil ||
 		machine.ApplicationProfile != nil ||
 		machine.AvailabilitySet != nil ||
@@ -685,7 +685,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.VirtualMachineScaleSet = &virtualMachineScaleSet
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if machine.Tags != nil {
 		result.Tags = make(map[string]string, len(machine.Tags))
 		for key, value := range machine.Tags {
@@ -693,7 +693,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range machine.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -712,7 +712,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -726,7 +726,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ApplicationProfile’:
+	// Set property "ApplicationProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApplicationProfile != nil {
@@ -740,7 +740,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AvailabilitySet’:
+	// Set property "AvailabilitySet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilitySet != nil {
@@ -754,10 +754,10 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	machine.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BillingProfile != nil {
@@ -771,7 +771,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘CapacityReservation’:
+	// Set property "CapacityReservation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CapacityReservation != nil {
@@ -785,7 +785,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiagnosticsProfile != nil {
@@ -799,7 +799,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EvictionPolicy != nil {
@@ -808,7 +808,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -819,7 +819,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		machine.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExtensionsTimeBudget != nil {
@@ -828,7 +828,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HardwareProfile != nil {
@@ -842,7 +842,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Host != nil {
@@ -856,7 +856,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -870,7 +870,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -881,7 +881,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		machine.Identity = &identity
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LicenseType != nil {
@@ -890,13 +890,13 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		machine.Location = &location
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -910,7 +910,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsProfile != nil {
@@ -924,10 +924,10 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	machine.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -938,7 +938,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		machine.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomain’:
+	// Set property "PlatformFaultDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomain != nil {
@@ -947,7 +947,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -956,7 +956,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -970,7 +970,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScheduledEventsProfile != nil {
@@ -984,7 +984,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecurityProfile != nil {
@@ -998,7 +998,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -1012,7 +1012,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		machine.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1020,7 +1020,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘UserData’:
+	// Set property "UserData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UserData != nil {
@@ -1029,7 +1029,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘VirtualMachineScaleSet’:
+	// Set property "VirtualMachineScaleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineScaleSet != nil {
@@ -1043,7 +1043,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		machine.Zones = append(machine.Zones, item)
 	}
@@ -2191,7 +2191,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -2205,7 +2205,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ApplicationProfile’:
+	// Set property "ApplicationProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApplicationProfile != nil {
@@ -2219,7 +2219,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AvailabilitySet’:
+	// Set property "AvailabilitySet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilitySet != nil {
@@ -2233,7 +2233,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BillingProfile != nil {
@@ -2247,7 +2247,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘CapacityReservation’:
+	// Set property "CapacityReservation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CapacityReservation != nil {
@@ -2261,9 +2261,9 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiagnosticsProfile != nil {
@@ -2277,7 +2277,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EvictionPolicy != nil {
@@ -2286,7 +2286,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -2297,7 +2297,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExtensionsTimeBudget != nil {
@@ -2306,7 +2306,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HardwareProfile != nil {
@@ -2320,7 +2320,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Host != nil {
@@ -2334,7 +2334,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -2348,13 +2348,13 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		machine.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2365,7 +2365,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Identity = &identity
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -2379,7 +2379,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LicenseType != nil {
@@ -2388,19 +2388,19 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		machine.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		machine.Name = &name
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -2414,7 +2414,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsProfile != nil {
@@ -2428,7 +2428,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan_STATUS
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -2439,7 +2439,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomain’:
+	// Set property "PlatformFaultDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomain != nil {
@@ -2448,7 +2448,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -2457,7 +2457,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2466,7 +2466,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -2480,7 +2480,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	for _, item := range typedInput.Resources {
 		var item1 VirtualMachineExtension_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2490,7 +2490,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Resources = append(machine.Resources, item1)
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScheduledEventsProfile != nil {
@@ -2504,7 +2504,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecurityProfile != nil {
@@ -2518,7 +2518,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -2532,7 +2532,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		machine.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -2540,7 +2540,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘TimeCreated’:
+	// Set property "TimeCreated":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TimeCreated != nil {
@@ -2549,13 +2549,13 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		machine.Type = &typeVar
 	}
 
-	// Set property ‘UserData’:
+	// Set property "UserData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UserData != nil {
@@ -2564,7 +2564,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘VirtualMachineScaleSet’:
+	// Set property "VirtualMachineScaleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineScaleSet != nil {
@@ -2578,7 +2578,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘VmId’:
+	// Set property "VmId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VmId != nil {
@@ -2587,7 +2587,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		machine.Zones = append(machine.Zones, item)
 	}
@@ -3271,13 +3271,13 @@ func (capabilities *AdditionalCapabilities) ConvertToARM(resolved genruntime.Con
 	}
 	result := &AdditionalCapabilities_ARM{}
 
-	// Set property ‘HibernationEnabled’:
+	// Set property "HibernationEnabled":
 	if capabilities.HibernationEnabled != nil {
 		hibernationEnabled := *capabilities.HibernationEnabled
 		result.HibernationEnabled = &hibernationEnabled
 	}
 
-	// Set property ‘UltraSSDEnabled’:
+	// Set property "UltraSSDEnabled":
 	if capabilities.UltraSSDEnabled != nil {
 		ultraSSDEnabled := *capabilities.UltraSSDEnabled
 		result.UltraSSDEnabled = &ultraSSDEnabled
@@ -3297,13 +3297,13 @@ func (capabilities *AdditionalCapabilities) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalCapabilities_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HibernationEnabled’:
+	// Set property "HibernationEnabled":
 	if typedInput.HibernationEnabled != nil {
 		hibernationEnabled := *typedInput.HibernationEnabled
 		capabilities.HibernationEnabled = &hibernationEnabled
 	}
 
-	// Set property ‘UltraSSDEnabled’:
+	// Set property "UltraSSDEnabled":
 	if typedInput.UltraSSDEnabled != nil {
 		ultraSSDEnabled := *typedInput.UltraSSDEnabled
 		capabilities.UltraSSDEnabled = &ultraSSDEnabled
@@ -3416,13 +3416,13 @@ func (capabilities *AdditionalCapabilities_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalCapabilities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HibernationEnabled’:
+	// Set property "HibernationEnabled":
 	if typedInput.HibernationEnabled != nil {
 		hibernationEnabled := *typedInput.HibernationEnabled
 		capabilities.HibernationEnabled = &hibernationEnabled
 	}
 
-	// Set property ‘UltraSSDEnabled’:
+	// Set property "UltraSSDEnabled":
 	if typedInput.UltraSSDEnabled != nil {
 		ultraSSDEnabled := *typedInput.UltraSSDEnabled
 		capabilities.UltraSSDEnabled = &ultraSSDEnabled
@@ -3502,7 +3502,7 @@ func (profile *ApplicationProfile) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &ApplicationProfile_ARM{}
 
-	// Set property ‘GalleryApplications’:
+	// Set property "GalleryApplications":
 	for _, item := range profile.GalleryApplications {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3525,7 +3525,7 @@ func (profile *ApplicationProfile) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GalleryApplications’:
+	// Set property "GalleryApplications":
 	for _, item := range typedInput.GalleryApplications {
 		var item1 VMGalleryApplication
 		err := item1.PopulateFromARM(owner, item)
@@ -3643,7 +3643,7 @@ func (profile *ApplicationProfile_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GalleryApplications’:
+	// Set property "GalleryApplications":
 	for _, item := range typedInput.GalleryApplications {
 		var item1 VMGalleryApplication_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3743,7 +3743,7 @@ func (profile *BillingProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &BillingProfile_ARM{}
 
-	// Set property ‘MaxPrice’:
+	// Set property "MaxPrice":
 	if profile.MaxPrice != nil {
 		maxPrice := *profile.MaxPrice
 		result.MaxPrice = &maxPrice
@@ -3763,7 +3763,7 @@ func (profile *BillingProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BillingProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxPrice’:
+	// Set property "MaxPrice":
 	if typedInput.MaxPrice != nil {
 		maxPrice := *typedInput.MaxPrice
 		profile.MaxPrice = &maxPrice
@@ -3859,7 +3859,7 @@ func (profile *BillingProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BillingProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxPrice’:
+	// Set property "MaxPrice":
 	if typedInput.MaxPrice != nil {
 		maxPrice := *typedInput.MaxPrice
 		profile.MaxPrice = &maxPrice
@@ -3925,7 +3925,7 @@ func (profile *CapacityReservationProfile) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &CapacityReservationProfile_ARM{}
 
-	// Set property ‘CapacityReservationGroup’:
+	// Set property "CapacityReservationGroup":
 	if profile.CapacityReservationGroup != nil {
 		capacityReservationGroup_ARM, err := (*profile.CapacityReservationGroup).ConvertToARM(resolved)
 		if err != nil {
@@ -3949,7 +3949,7 @@ func (profile *CapacityReservationProfile) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CapacityReservationProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CapacityReservationGroup’:
+	// Set property "CapacityReservationGroup":
 	if typedInput.CapacityReservationGroup != nil {
 		var capacityReservationGroup1 SubResource
 		err := capacityReservationGroup1.PopulateFromARM(owner, *typedInput.CapacityReservationGroup)
@@ -4052,7 +4052,7 @@ func (profile *CapacityReservationProfile_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CapacityReservationProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CapacityReservationGroup’:
+	// Set property "CapacityReservationGroup":
 	if typedInput.CapacityReservationGroup != nil {
 		var capacityReservationGroup1 SubResource_STATUS
 		err := capacityReservationGroup1.PopulateFromARM(owner, *typedInput.CapacityReservationGroup)
@@ -4135,7 +4135,7 @@ func (profile *DiagnosticsProfile) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &DiagnosticsProfile_ARM{}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if profile.BootDiagnostics != nil {
 		bootDiagnostics_ARM, err := (*profile.BootDiagnostics).ConvertToARM(resolved)
 		if err != nil {
@@ -4159,7 +4159,7 @@ func (profile *DiagnosticsProfile) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiagnosticsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if typedInput.BootDiagnostics != nil {
 		var bootDiagnostics1 BootDiagnostics
 		err := bootDiagnostics1.PopulateFromARM(owner, *typedInput.BootDiagnostics)
@@ -4266,7 +4266,7 @@ func (profile *DiagnosticsProfile_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiagnosticsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if typedInput.BootDiagnostics != nil {
 		var bootDiagnostics1 BootDiagnostics_STATUS
 		err := bootDiagnostics1.PopulateFromARM(owner, *typedInput.BootDiagnostics)
@@ -4375,13 +4375,13 @@ func (profile *HardwareProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &HardwareProfile_ARM{}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if profile.VmSize != nil {
 		vmSize := *profile.VmSize
 		result.VmSize = &vmSize
 	}
 
-	// Set property ‘VmSizeProperties’:
+	// Set property "VmSizeProperties":
 	if profile.VmSizeProperties != nil {
 		vmSizeProperties_ARM, err := (*profile.VmSizeProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -4405,13 +4405,13 @@ func (profile *HardwareProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HardwareProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
 	}
 
-	// Set property ‘VmSizeProperties’:
+	// Set property "VmSizeProperties":
 	if typedInput.VmSizeProperties != nil {
 		var vmSizeProperties1 VMSizeProperties
 		err := vmSizeProperties1.PopulateFromARM(owner, *typedInput.VmSizeProperties)
@@ -4551,13 +4551,13 @@ func (profile *HardwareProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HardwareProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
 	}
 
-	// Set property ‘VmSizeProperties’:
+	// Set property "VmSizeProperties":
 	if typedInput.VmSizeProperties != nil {
 		var vmSizeProperties1 VMSizeProperties_STATUS
 		err := vmSizeProperties1.PopulateFromARM(owner, *typedInput.VmSizeProperties)
@@ -4658,13 +4658,13 @@ func (profile *NetworkProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &NetworkProfile_ARM{}
 
-	// Set property ‘NetworkApiVersion’:
+	// Set property "NetworkApiVersion":
 	if profile.NetworkApiVersion != nil {
 		networkApiVersion := *profile.NetworkApiVersion
 		result.NetworkApiVersion = &networkApiVersion
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range profile.NetworkInterfaceConfigurations {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4673,7 +4673,7 @@ func (profile *NetworkProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.NetworkInterfaceConfigurations = append(result.NetworkInterfaceConfigurations, *item_ARM.(*VirtualMachineNetworkInterfaceConfiguration_ARM))
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	for _, item := range profile.NetworkInterfaces {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4696,13 +4696,13 @@ func (profile *NetworkProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NetworkApiVersion’:
+	// Set property "NetworkApiVersion":
 	if typedInput.NetworkApiVersion != nil {
 		networkApiVersion := *typedInput.NetworkApiVersion
 		profile.NetworkApiVersion = &networkApiVersion
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range typedInput.NetworkInterfaceConfigurations {
 		var item1 VirtualMachineNetworkInterfaceConfiguration
 		err := item1.PopulateFromARM(owner, item)
@@ -4712,7 +4712,7 @@ func (profile *NetworkProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.NetworkInterfaceConfigurations = append(profile.NetworkInterfaceConfigurations, item1)
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	for _, item := range typedInput.NetworkInterfaces {
 		var item1 NetworkInterfaceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -4916,13 +4916,13 @@ func (profile *NetworkProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NetworkApiVersion’:
+	// Set property "NetworkApiVersion":
 	if typedInput.NetworkApiVersion != nil {
 		networkApiVersion := *typedInput.NetworkApiVersion
 		profile.NetworkApiVersion = &networkApiVersion
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range typedInput.NetworkInterfaceConfigurations {
 		var item1 VirtualMachineNetworkInterfaceConfiguration_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4932,7 +4932,7 @@ func (profile *NetworkProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		profile.NetworkInterfaceConfigurations = append(profile.NetworkInterfaceConfigurations, item1)
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	for _, item := range typedInput.NetworkInterfaces {
 		var item1 NetworkInterfaceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5138,7 +5138,7 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &OSProfile_ARM{}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if profile.AdminPassword != nil {
 		adminPasswordSecret, err := resolved.ResolvedSecrets.Lookup(*profile.AdminPassword)
 		if err != nil {
@@ -5148,31 +5148,31 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if profile.AllowExtensionOperations != nil {
 		allowExtensionOperations := *profile.AllowExtensionOperations
 		result.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if profile.ComputerName != nil {
 		computerName := *profile.ComputerName
 		result.ComputerName = &computerName
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if profile.CustomData != nil {
 		customData := *profile.CustomData
 		result.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if profile.LinuxConfiguration != nil {
 		linuxConfiguration_ARM, err := (*profile.LinuxConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -5182,13 +5182,13 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘RequireGuestProvisionSignal’:
+	// Set property "RequireGuestProvisionSignal":
 	if profile.RequireGuestProvisionSignal != nil {
 		requireGuestProvisionSignal := *profile.RequireGuestProvisionSignal
 		result.RequireGuestProvisionSignal = &requireGuestProvisionSignal
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range profile.Secrets {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5197,7 +5197,7 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Secrets = append(result.Secrets, *item_ARM.(*VaultSecretGroup_ARM))
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if profile.WindowsConfiguration != nil {
 		windowsConfiguration_ARM, err := (*profile.WindowsConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -5221,33 +5221,33 @@ func (profile *OSProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSProfile_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘AdminPassword’
+	// no assignment for property "AdminPassword"
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if typedInput.AllowExtensionOperations != nil {
 		allowExtensionOperations := *typedInput.AllowExtensionOperations
 		profile.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if typedInput.ComputerName != nil {
 		computerName := *typedInput.ComputerName
 		profile.ComputerName = &computerName
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -5258,13 +5258,13 @@ func (profile *OSProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘RequireGuestProvisionSignal’:
+	// Set property "RequireGuestProvisionSignal":
 	if typedInput.RequireGuestProvisionSignal != nil {
 		requireGuestProvisionSignal := *typedInput.RequireGuestProvisionSignal
 		profile.RequireGuestProvisionSignal = &requireGuestProvisionSignal
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup
 		err := item1.PopulateFromARM(owner, item)
@@ -5274,7 +5274,7 @@ func (profile *OSProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -5604,31 +5604,31 @@ func (profile *OSProfile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if typedInput.AllowExtensionOperations != nil {
 		allowExtensionOperations := *typedInput.AllowExtensionOperations
 		profile.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if typedInput.ComputerName != nil {
 		computerName := *typedInput.ComputerName
 		profile.ComputerName = &computerName
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration_STATUS
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -5639,13 +5639,13 @@ func (profile *OSProfile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘RequireGuestProvisionSignal’:
+	// Set property "RequireGuestProvisionSignal":
 	if typedInput.RequireGuestProvisionSignal != nil {
 		requireGuestProvisionSignal := *typedInput.RequireGuestProvisionSignal
 		profile.RequireGuestProvisionSignal = &requireGuestProvisionSignal
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5655,7 +5655,7 @@ func (profile *OSProfile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration_STATUS
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -5855,25 +5855,25 @@ func (plan *Plan) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) 
 	}
 	result := &Plan_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if plan.Name != nil {
 		name := *plan.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if plan.Product != nil {
 		product := *plan.Product
 		result.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if plan.PromotionCode != nil {
 		promotionCode := *plan.PromotionCode
 		result.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if plan.Publisher != nil {
 		publisher := *plan.Publisher
 		result.Publisher = &publisher
@@ -5893,25 +5893,25 @@ func (plan *Plan) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armI
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Plan_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		plan.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if typedInput.Product != nil {
 		product := *typedInput.Product
 		plan.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if typedInput.PromotionCode != nil {
 		promotionCode := *typedInput.PromotionCode
 		plan.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		plan.Publisher = &publisher
@@ -6020,25 +6020,25 @@ func (plan *Plan_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Plan_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		plan.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if typedInput.Product != nil {
 		product := *typedInput.Product
 		plan.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if typedInput.PromotionCode != nil {
 		promotionCode := *typedInput.PromotionCode
 		plan.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		plan.Publisher = &publisher
@@ -6132,7 +6132,7 @@ func (profile *ScheduledEventsProfile) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &ScheduledEventsProfile_ARM{}
 
-	// Set property ‘TerminateNotificationProfile’:
+	// Set property "TerminateNotificationProfile":
 	if profile.TerminateNotificationProfile != nil {
 		terminateNotificationProfile_ARM, err := (*profile.TerminateNotificationProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -6156,7 +6156,7 @@ func (profile *ScheduledEventsProfile) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduledEventsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘TerminateNotificationProfile’:
+	// Set property "TerminateNotificationProfile":
 	if typedInput.TerminateNotificationProfile != nil {
 		var terminateNotificationProfile1 TerminateNotificationProfile
 		err := terminateNotificationProfile1.PopulateFromARM(owner, *typedInput.TerminateNotificationProfile)
@@ -6256,7 +6256,7 @@ func (profile *ScheduledEventsProfile_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduledEventsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘TerminateNotificationProfile’:
+	// Set property "TerminateNotificationProfile":
 	if typedInput.TerminateNotificationProfile != nil {
 		var terminateNotificationProfile1 TerminateNotificationProfile_STATUS
 		err := terminateNotificationProfile1.PopulateFromARM(owner, *typedInput.TerminateNotificationProfile)
@@ -6345,19 +6345,19 @@ func (profile *SecurityProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &SecurityProfile_ARM{}
 
-	// Set property ‘EncryptionAtHost’:
+	// Set property "EncryptionAtHost":
 	if profile.EncryptionAtHost != nil {
 		encryptionAtHost := *profile.EncryptionAtHost
 		result.EncryptionAtHost = &encryptionAtHost
 	}
 
-	// Set property ‘SecurityType’:
+	// Set property "SecurityType":
 	if profile.SecurityType != nil {
 		securityType := *profile.SecurityType
 		result.SecurityType = &securityType
 	}
 
-	// Set property ‘UefiSettings’:
+	// Set property "UefiSettings":
 	if profile.UefiSettings != nil {
 		uefiSettings_ARM, err := (*profile.UefiSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -6381,19 +6381,19 @@ func (profile *SecurityProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SecurityProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EncryptionAtHost’:
+	// Set property "EncryptionAtHost":
 	if typedInput.EncryptionAtHost != nil {
 		encryptionAtHost := *typedInput.EncryptionAtHost
 		profile.EncryptionAtHost = &encryptionAtHost
 	}
 
-	// Set property ‘SecurityType’:
+	// Set property "SecurityType":
 	if typedInput.SecurityType != nil {
 		securityType := *typedInput.SecurityType
 		profile.SecurityType = &securityType
 	}
 
-	// Set property ‘UefiSettings’:
+	// Set property "UefiSettings":
 	if typedInput.UefiSettings != nil {
 		var uefiSettings1 UefiSettings
 		err := uefiSettings1.PopulateFromARM(owner, *typedInput.UefiSettings)
@@ -6554,19 +6554,19 @@ func (profile *SecurityProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SecurityProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EncryptionAtHost’:
+	// Set property "EncryptionAtHost":
 	if typedInput.EncryptionAtHost != nil {
 		encryptionAtHost := *typedInput.EncryptionAtHost
 		profile.EncryptionAtHost = &encryptionAtHost
 	}
 
-	// Set property ‘SecurityType’:
+	// Set property "SecurityType":
 	if typedInput.SecurityType != nil {
 		securityType := *typedInput.SecurityType
 		profile.SecurityType = &securityType
 	}
 
-	// Set property ‘UefiSettings’:
+	// Set property "UefiSettings":
 	if typedInput.UefiSettings != nil {
 		var uefiSettings1 UefiSettings_STATUS
 		err := uefiSettings1.PopulateFromARM(owner, *typedInput.UefiSettings)
@@ -6687,7 +6687,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &StorageProfile_ARM{}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range profile.DataDisks {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -6696,7 +6696,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.DataDisks = append(result.DataDisks, *item_ARM.(*DataDisk_ARM))
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if profile.ImageReference != nil {
 		imageReference_ARM, err := (*profile.ImageReference).ConvertToARM(resolved)
 		if err != nil {
@@ -6706,7 +6706,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if profile.OsDisk != nil {
 		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -6730,7 +6730,7 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 DataDisk
 		err := item1.PopulateFromARM(owner, item)
@@ -6740,7 +6740,7 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -6751,7 +6751,7 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 OSDisk
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -6954,7 +6954,7 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 DataDisk_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6964,7 +6964,7 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference_STATUS
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -6975,7 +6975,7 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 OSDisk_STATUS
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -7171,7 +7171,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineExtension_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradeMinorVersion’:
+	// Set property "AutoUpgradeMinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeMinorVersion != nil {
@@ -7180,7 +7180,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticUpgrade != nil {
@@ -7189,7 +7189,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ForceUpdateTag’:
+	// Set property "ForceUpdateTag":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceUpdateTag != nil {
@@ -7198,13 +7198,13 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		extension.Id = &id
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -7218,19 +7218,19 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		extension.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		extension.Name = &name
 	}
 
-	// Set property ‘PropertiesType’:
+	// Set property "PropertiesType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -7239,7 +7239,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ProtectedSettings’:
+	// Set property "ProtectedSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettings != nil {
@@ -7250,7 +7250,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ProtectedSettingsFromKeyVault’:
+	// Set property "ProtectedSettingsFromKeyVault":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettingsFromKeyVault != nil {
@@ -7264,7 +7264,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -7273,7 +7273,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Publisher != nil {
@@ -7282,7 +7282,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Settings’:
+	// Set property "Settings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Settings != nil {
@@ -7293,7 +7293,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘SuppressFailures’:
+	// Set property "SuppressFailures":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SuppressFailures != nil {
@@ -7302,7 +7302,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		extension.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -7310,13 +7310,13 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		extension.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TypeHandlerVersion != nil {
@@ -7582,13 +7582,13 @@ func (identity *VirtualMachineIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &VirtualMachineIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -7613,13 +7613,13 @@ func (identity *VirtualMachineIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -7762,25 +7762,25 @@ func (identity *VirtualMachineIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]VirtualMachineIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -7954,13 +7954,13 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssignedHost’:
+	// Set property "AssignedHost":
 	if typedInput.AssignedHost != nil {
 		assignedHost := *typedInput.AssignedHost
 		view.AssignedHost = &assignedHost
 	}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if typedInput.BootDiagnostics != nil {
 		var bootDiagnostics1 BootDiagnosticsInstanceView_STATUS
 		err := bootDiagnostics1.PopulateFromARM(owner, *typedInput.BootDiagnostics)
@@ -7971,13 +7971,13 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.BootDiagnostics = &bootDiagnostics
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if typedInput.ComputerName != nil {
 		computerName := *typedInput.ComputerName
 		view.ComputerName = &computerName
 	}
 
-	// Set property ‘Disks’:
+	// Set property "Disks":
 	for _, item := range typedInput.Disks {
 		var item1 DiskInstanceView_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7987,7 +7987,7 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.Disks = append(view.Disks, item1)
 	}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range typedInput.Extensions {
 		var item1 VirtualMachineExtensionInstanceView_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7997,13 +7997,13 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.Extensions = append(view.Extensions, item1)
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	if typedInput.HyperVGeneration != nil {
 		hyperVGeneration := *typedInput.HyperVGeneration
 		view.HyperVGeneration = &hyperVGeneration
 	}
 
-	// Set property ‘MaintenanceRedeployStatus’:
+	// Set property "MaintenanceRedeployStatus":
 	if typedInput.MaintenanceRedeployStatus != nil {
 		var maintenanceRedeployStatus1 MaintenanceRedeployStatus_STATUS
 		err := maintenanceRedeployStatus1.PopulateFromARM(owner, *typedInput.MaintenanceRedeployStatus)
@@ -8014,19 +8014,19 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.MaintenanceRedeployStatus = &maintenanceRedeployStatus
 	}
 
-	// Set property ‘OsName’:
+	// Set property "OsName":
 	if typedInput.OsName != nil {
 		osName := *typedInput.OsName
 		view.OsName = &osName
 	}
 
-	// Set property ‘OsVersion’:
+	// Set property "OsVersion":
 	if typedInput.OsVersion != nil {
 		osVersion := *typedInput.OsVersion
 		view.OsVersion = &osVersion
 	}
 
-	// Set property ‘PatchStatus’:
+	// Set property "PatchStatus":
 	if typedInput.PatchStatus != nil {
 		var patchStatus1 VirtualMachinePatchStatus_STATUS
 		err := patchStatus1.PopulateFromARM(owner, *typedInput.PatchStatus)
@@ -8037,25 +8037,25 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.PatchStatus = &patchStatus
 	}
 
-	// Set property ‘PlatformFaultDomain’:
+	// Set property "PlatformFaultDomain":
 	if typedInput.PlatformFaultDomain != nil {
 		platformFaultDomain := *typedInput.PlatformFaultDomain
 		view.PlatformFaultDomain = &platformFaultDomain
 	}
 
-	// Set property ‘PlatformUpdateDomain’:
+	// Set property "PlatformUpdateDomain":
 	if typedInput.PlatformUpdateDomain != nil {
 		platformUpdateDomain := *typedInput.PlatformUpdateDomain
 		view.PlatformUpdateDomain = &platformUpdateDomain
 	}
 
-	// Set property ‘RdpThumbPrint’:
+	// Set property "RdpThumbPrint":
 	if typedInput.RdpThumbPrint != nil {
 		rdpThumbPrint := *typedInput.RdpThumbPrint
 		view.RdpThumbPrint = &rdpThumbPrint
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8065,7 +8065,7 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.Statuses = append(view.Statuses, item1)
 	}
 
-	// Set property ‘VmAgent’:
+	// Set property "VmAgent":
 	if typedInput.VmAgent != nil {
 		var vmAgent1 VirtualMachineAgentInstanceView_STATUS
 		err := vmAgent1.PopulateFromARM(owner, *typedInput.VmAgent)
@@ -8076,7 +8076,7 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.VmAgent = &vmAgent
 	}
 
-	// Set property ‘VmHealth’:
+	// Set property "VmHealth":
 	if typedInput.VmHealth != nil {
 		var vmHealth1 VirtualMachineHealthStatus_STATUS
 		err := vmHealth1.PopulateFromARM(owner, *typedInput.VmHealth)
@@ -8422,13 +8422,13 @@ func (diagnostics *BootDiagnostics) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &BootDiagnostics_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if diagnostics.Enabled != nil {
 		enabled := *diagnostics.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘StorageUri’:
+	// Set property "StorageUri":
 	if diagnostics.StorageUri != nil {
 		storageUri := *diagnostics.StorageUri
 		result.StorageUri = &storageUri
@@ -8448,13 +8448,13 @@ func (diagnostics *BootDiagnostics) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BootDiagnostics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		diagnostics.Enabled = &enabled
 	}
 
-	// Set property ‘StorageUri’:
+	// Set property "StorageUri":
 	if typedInput.StorageUri != nil {
 		storageUri := *typedInput.StorageUri
 		diagnostics.StorageUri = &storageUri
@@ -8554,13 +8554,13 @@ func (diagnostics *BootDiagnostics_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BootDiagnostics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		diagnostics.Enabled = &enabled
 	}
 
-	// Set property ‘StorageUri’:
+	// Set property "StorageUri":
 	if typedInput.StorageUri != nil {
 		storageUri := *typedInput.StorageUri
 		diagnostics.StorageUri = &storageUri
@@ -8644,19 +8644,19 @@ func (view *BootDiagnosticsInstanceView_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BootDiagnosticsInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConsoleScreenshotBlobUri’:
+	// Set property "ConsoleScreenshotBlobUri":
 	if typedInput.ConsoleScreenshotBlobUri != nil {
 		consoleScreenshotBlobUri := *typedInput.ConsoleScreenshotBlobUri
 		view.ConsoleScreenshotBlobUri = &consoleScreenshotBlobUri
 	}
 
-	// Set property ‘SerialConsoleLogBlobUri’:
+	// Set property "SerialConsoleLogBlobUri":
 	if typedInput.SerialConsoleLogBlobUri != nil {
 		serialConsoleLogBlobUri := *typedInput.SerialConsoleLogBlobUri
 		view.SerialConsoleLogBlobUri = &serialConsoleLogBlobUri
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		var status1 InstanceViewStatus_STATUS
 		err := status1.PopulateFromARM(owner, *typedInput.Status)
@@ -8805,37 +8805,37 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &DataDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if disk.DeleteOption != nil {
 		deleteOption := *disk.DeleteOption
 		result.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DetachOption’:
+	// Set property "DetachOption":
 	if disk.DetachOption != nil {
 		detachOption := *disk.DetachOption
 		result.DetachOption = &detachOption
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if disk.Image != nil {
 		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
 		if err != nil {
@@ -8845,13 +8845,13 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.Image = &image
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if disk.Lun != nil {
 		lun := *disk.Lun
 		result.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -8861,19 +8861,19 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ToBeDetached’:
+	// Set property "ToBeDetached":
 	if disk.ToBeDetached != nil {
 		toBeDetached := *disk.ToBeDetached
 		result.ToBeDetached = &toBeDetached
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if disk.Vhd != nil {
 		vhd_ARM, err := (*disk.Vhd).ConvertToARM(resolved)
 		if err != nil {
@@ -8883,7 +8883,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -8903,37 +8903,37 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DetachOption’:
+	// Set property "DetachOption":
 	if typedInput.DetachOption != nil {
 		detachOption := *typedInput.DetachOption
 		disk.DetachOption = &detachOption
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -8944,13 +8944,13 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		disk.Image = &image
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -8961,19 +8961,19 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘ToBeDetached’:
+	// Set property "ToBeDetached":
 	if typedInput.ToBeDetached != nil {
 		toBeDetached := *typedInput.ToBeDetached
 		disk.ToBeDetached = &toBeDetached
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -8984,7 +8984,7 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -9390,49 +9390,49 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DetachOption’:
+	// Set property "DetachOption":
 	if typedInput.DetachOption != nil {
 		detachOption := *typedInput.DetachOption
 		disk.DetachOption = &detachOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if typedInput.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *typedInput.DiskIOPSReadWrite
 		disk.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if typedInput.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *typedInput.DiskMBpsReadWrite
 		disk.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk_STATUS
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -9443,13 +9443,13 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		disk.Image = &image
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -9460,19 +9460,19 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘ToBeDetached’:
+	// Set property "ToBeDetached":
 	if typedInput.ToBeDetached != nil {
 		toBeDetached := *typedInput.ToBeDetached
 		disk.ToBeDetached = &toBeDetached
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk_STATUS
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -9483,7 +9483,7 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -9741,7 +9741,7 @@ func (view *DiskInstanceView_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	for _, item := range typedInput.EncryptionSettings {
 		var item1 DiskEncryptionSettings_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -9751,13 +9751,13 @@ func (view *DiskInstanceView_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		view.EncryptionSettings = append(view.EncryptionSettings, item1)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		view.Name = &name
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10260,13 +10260,13 @@ func (reference *ImageReference) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ImageReference_ARM{}
 
-	// Set property ‘CommunityGalleryImageId’:
+	// Set property "CommunityGalleryImageId":
 	if reference.CommunityGalleryImageId != nil {
 		communityGalleryImageId := *reference.CommunityGalleryImageId
 		result.CommunityGalleryImageId = &communityGalleryImageId
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -10276,31 +10276,31 @@ func (reference *ImageReference) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Id = &reference1
 	}
 
-	// Set property ‘Offer’:
+	// Set property "Offer":
 	if reference.Offer != nil {
 		offer := *reference.Offer
 		result.Offer = &offer
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if reference.Publisher != nil {
 		publisher := *reference.Publisher
 		result.Publisher = &publisher
 	}
 
-	// Set property ‘SharedGalleryImageId’:
+	// Set property "SharedGalleryImageId":
 	if reference.SharedGalleryImageId != nil {
 		sharedGalleryImageId := *reference.SharedGalleryImageId
 		result.SharedGalleryImageId = &sharedGalleryImageId
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if reference.Sku != nil {
 		sku := *reference.Sku
 		result.Sku = &sku
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if reference.Version != nil {
 		version := *reference.Version
 		result.Version = &version
@@ -10320,39 +10320,39 @@ func (reference *ImageReference) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CommunityGalleryImageId’:
+	// Set property "CommunityGalleryImageId":
 	if typedInput.CommunityGalleryImageId != nil {
 		communityGalleryImageId := *typedInput.CommunityGalleryImageId
 		reference.CommunityGalleryImageId = &communityGalleryImageId
 	}
 
-	// Set property ‘Offer’:
+	// Set property "Offer":
 	if typedInput.Offer != nil {
 		offer := *typedInput.Offer
 		reference.Offer = &offer
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		reference.Publisher = &publisher
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘SharedGalleryImageId’:
+	// Set property "SharedGalleryImageId":
 	if typedInput.SharedGalleryImageId != nil {
 		sharedGalleryImageId := *typedInput.SharedGalleryImageId
 		reference.SharedGalleryImageId = &sharedGalleryImageId
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		sku := *typedInput.Sku
 		reference.Sku = &sku
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		reference.Version = &version
@@ -10524,49 +10524,49 @@ func (reference *ImageReference_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CommunityGalleryImageId’:
+	// Set property "CommunityGalleryImageId":
 	if typedInput.CommunityGalleryImageId != nil {
 		communityGalleryImageId := *typedInput.CommunityGalleryImageId
 		reference.CommunityGalleryImageId = &communityGalleryImageId
 	}
 
-	// Set property ‘ExactVersion’:
+	// Set property "ExactVersion":
 	if typedInput.ExactVersion != nil {
 		exactVersion := *typedInput.ExactVersion
 		reference.ExactVersion = &exactVersion
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
 	}
 
-	// Set property ‘Offer’:
+	// Set property "Offer":
 	if typedInput.Offer != nil {
 		offer := *typedInput.Offer
 		reference.Offer = &offer
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		reference.Publisher = &publisher
 	}
 
-	// Set property ‘SharedGalleryImageId’:
+	// Set property "SharedGalleryImageId":
 	if typedInput.SharedGalleryImageId != nil {
 		sharedGalleryImageId := *typedInput.SharedGalleryImageId
 		reference.SharedGalleryImageId = &sharedGalleryImageId
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		sku := *typedInput.Sku
 		reference.Sku = &sku
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		reference.Version = &version
@@ -10679,31 +10679,31 @@ func (status *InstanceViewStatus_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InstanceViewStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		status.Code = &code
 	}
 
-	// Set property ‘DisplayStatus’:
+	// Set property "DisplayStatus":
 	if typedInput.DisplayStatus != nil {
 		displayStatus := *typedInput.DisplayStatus
 		status.DisplayStatus = &displayStatus
 	}
 
-	// Set property ‘Level’:
+	// Set property "Level":
 	if typedInput.Level != nil {
 		level := *typedInput.Level
 		status.Level = &level
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		status.Message = &message
 	}
 
-	// Set property ‘Time’:
+	// Set property "Time":
 	if typedInput.Time != nil {
 		time := *typedInput.Time
 		status.Time = &time
@@ -10799,13 +10799,13 @@ func (reference *KeyVaultSecretReference_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultSecretReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if typedInput.SecretUrl != nil {
 		secretUrl := *typedInput.SecretUrl
 		reference.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -10902,13 +10902,13 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &LinuxConfiguration_ARM{}
 
-	// Set property ‘DisablePasswordAuthentication’:
+	// Set property "DisablePasswordAuthentication":
 	if configuration.DisablePasswordAuthentication != nil {
 		disablePasswordAuthentication := *configuration.DisablePasswordAuthentication
 		result.DisablePasswordAuthentication = &disablePasswordAuthentication
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if configuration.PatchSettings != nil {
 		patchSettings_ARM, err := (*configuration.PatchSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -10918,13 +10918,13 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 		result.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if configuration.ProvisionVMAgent != nil {
 		provisionVMAgent := *configuration.ProvisionVMAgent
 		result.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if configuration.Ssh != nil {
 		ssh_ARM, err := (*configuration.Ssh).ConvertToARM(resolved)
 		if err != nil {
@@ -10948,13 +10948,13 @@ func (configuration *LinuxConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisablePasswordAuthentication’:
+	// Set property "DisablePasswordAuthentication":
 	if typedInput.DisablePasswordAuthentication != nil {
 		disablePasswordAuthentication := *typedInput.DisablePasswordAuthentication
 		configuration.DisablePasswordAuthentication = &disablePasswordAuthentication
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 LinuxPatchSettings
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -10965,13 +10965,13 @@ func (configuration *LinuxConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 SshConfiguration
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -11170,13 +11170,13 @@ func (configuration *LinuxConfiguration_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisablePasswordAuthentication’:
+	// Set property "DisablePasswordAuthentication":
 	if typedInput.DisablePasswordAuthentication != nil {
 		disablePasswordAuthentication := *typedInput.DisablePasswordAuthentication
 		configuration.DisablePasswordAuthentication = &disablePasswordAuthentication
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 LinuxPatchSettings_STATUS
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -11187,13 +11187,13 @@ func (configuration *LinuxConfiguration_STATUS) PopulateFromARM(owner genruntime
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 SshConfiguration_STATUS
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -11349,43 +11349,43 @@ func (status *MaintenanceRedeployStatus_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceRedeployStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IsCustomerInitiatedMaintenanceAllowed’:
+	// Set property "IsCustomerInitiatedMaintenanceAllowed":
 	if typedInput.IsCustomerInitiatedMaintenanceAllowed != nil {
 		isCustomerInitiatedMaintenanceAllowed := *typedInput.IsCustomerInitiatedMaintenanceAllowed
 		status.IsCustomerInitiatedMaintenanceAllowed = &isCustomerInitiatedMaintenanceAllowed
 	}
 
-	// Set property ‘LastOperationMessage’:
+	// Set property "LastOperationMessage":
 	if typedInput.LastOperationMessage != nil {
 		lastOperationMessage := *typedInput.LastOperationMessage
 		status.LastOperationMessage = &lastOperationMessage
 	}
 
-	// Set property ‘LastOperationResultCode’:
+	// Set property "LastOperationResultCode":
 	if typedInput.LastOperationResultCode != nil {
 		lastOperationResultCode := *typedInput.LastOperationResultCode
 		status.LastOperationResultCode = &lastOperationResultCode
 	}
 
-	// Set property ‘MaintenanceWindowEndTime’:
+	// Set property "MaintenanceWindowEndTime":
 	if typedInput.MaintenanceWindowEndTime != nil {
 		maintenanceWindowEndTime := *typedInput.MaintenanceWindowEndTime
 		status.MaintenanceWindowEndTime = &maintenanceWindowEndTime
 	}
 
-	// Set property ‘MaintenanceWindowStartTime’:
+	// Set property "MaintenanceWindowStartTime":
 	if typedInput.MaintenanceWindowStartTime != nil {
 		maintenanceWindowStartTime := *typedInput.MaintenanceWindowStartTime
 		status.MaintenanceWindowStartTime = &maintenanceWindowStartTime
 	}
 
-	// Set property ‘PreMaintenanceWindowEndTime’:
+	// Set property "PreMaintenanceWindowEndTime":
 	if typedInput.PreMaintenanceWindowEndTime != nil {
 		preMaintenanceWindowEndTime := *typedInput.PreMaintenanceWindowEndTime
 		status.PreMaintenanceWindowEndTime = &preMaintenanceWindowEndTime
 	}
 
-	// Set property ‘PreMaintenanceWindowStartTime’:
+	// Set property "PreMaintenanceWindowStartTime":
 	if typedInput.PreMaintenanceWindowStartTime != nil {
 		preMaintenanceWindowStartTime := *typedInput.PreMaintenanceWindowStartTime
 		status.PreMaintenanceWindowStartTime = &preMaintenanceWindowStartTime
@@ -11501,7 +11501,7 @@ func (reference *NetworkInterfaceReference) ConvertToARM(resolved genruntime.Con
 	}
 	result := &NetworkInterfaceReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -11511,7 +11511,7 @@ func (reference *NetworkInterfaceReference) ConvertToARM(resolved genruntime.Con
 		result.Id = &reference1
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if reference.DeleteOption != nil || reference.Primary != nil {
 		result.Properties = &NetworkInterfaceReferenceProperties_ARM{}
 	}
@@ -11538,7 +11538,7 @@ func (reference *NetworkInterfaceReference) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -11547,7 +11547,7 @@ func (reference *NetworkInterfaceReference) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -11556,7 +11556,7 @@ func (reference *NetworkInterfaceReference) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -11690,7 +11690,7 @@ func (reference *NetworkInterfaceReference_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -11699,13 +11699,13 @@ func (reference *NetworkInterfaceReference_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -11863,25 +11863,25 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &OSDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if disk.DeleteOption != nil {
 		deleteOption := *disk.DeleteOption
 		result.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if disk.DiffDiskSettings != nil {
 		diffDiskSettings_ARM, err := (*disk.DiffDiskSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -11891,13 +11891,13 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	if disk.EncryptionSettings != nil {
 		encryptionSettings_ARM, err := (*disk.EncryptionSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -11907,7 +11907,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.EncryptionSettings = &encryptionSettings
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if disk.Image != nil {
 		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
 		if err != nil {
@@ -11917,7 +11917,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -11927,19 +11927,19 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if disk.OsType != nil {
 		osType := *disk.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if disk.Vhd != nil {
 		vhd_ARM, err := (*disk.Vhd).ConvertToARM(resolved)
 		if err != nil {
@@ -11949,7 +11949,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -11969,25 +11969,25 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -11998,13 +11998,13 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	if typedInput.EncryptionSettings != nil {
 		var encryptionSettings1 DiskEncryptionSettings
 		err := encryptionSettings1.PopulateFromARM(owner, *typedInput.EncryptionSettings)
@@ -12015,7 +12015,7 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.EncryptionSettings = &encryptionSettings
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -12026,7 +12026,7 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -12037,19 +12037,19 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -12060,7 +12060,7 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -12497,25 +12497,25 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings_STATUS
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -12526,13 +12526,13 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	if typedInput.EncryptionSettings != nil {
 		var encryptionSettings1 DiskEncryptionSettings_STATUS
 		err := encryptionSettings1.PopulateFromARM(owner, *typedInput.EncryptionSettings)
@@ -12543,7 +12543,7 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.EncryptionSettings = &encryptionSettings
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk_STATUS
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -12554,7 +12554,7 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -12565,19 +12565,19 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk_STATUS
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -12588,7 +12588,7 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -12867,13 +12867,13 @@ func (profile *TerminateNotificationProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &TerminateNotificationProfile_ARM{}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if profile.Enable != nil {
 		enable := *profile.Enable
 		result.Enable = &enable
 	}
 
-	// Set property ‘NotBeforeTimeout’:
+	// Set property "NotBeforeTimeout":
 	if profile.NotBeforeTimeout != nil {
 		notBeforeTimeout := *profile.NotBeforeTimeout
 		result.NotBeforeTimeout = &notBeforeTimeout
@@ -12893,13 +12893,13 @@ func (profile *TerminateNotificationProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TerminateNotificationProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		profile.Enable = &enable
 	}
 
-	// Set property ‘NotBeforeTimeout’:
+	// Set property "NotBeforeTimeout":
 	if typedInput.NotBeforeTimeout != nil {
 		notBeforeTimeout := *typedInput.NotBeforeTimeout
 		profile.NotBeforeTimeout = &notBeforeTimeout
@@ -12996,13 +12996,13 @@ func (profile *TerminateNotificationProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TerminateNotificationProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		profile.Enable = &enable
 	}
 
-	// Set property ‘NotBeforeTimeout’:
+	// Set property "NotBeforeTimeout":
 	if typedInput.NotBeforeTimeout != nil {
 		notBeforeTimeout := *typedInput.NotBeforeTimeout
 		profile.NotBeforeTimeout = &notBeforeTimeout
@@ -13079,13 +13079,13 @@ func (settings *UefiSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &UefiSettings_ARM{}
 
-	// Set property ‘SecureBootEnabled’:
+	// Set property "SecureBootEnabled":
 	if settings.SecureBootEnabled != nil {
 		secureBootEnabled := *settings.SecureBootEnabled
 		result.SecureBootEnabled = &secureBootEnabled
 	}
 
-	// Set property ‘VTpmEnabled’:
+	// Set property "VTpmEnabled":
 	if settings.VTpmEnabled != nil {
 		vTpmEnabled := *settings.VTpmEnabled
 		result.VTpmEnabled = &vTpmEnabled
@@ -13105,13 +13105,13 @@ func (settings *UefiSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UefiSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecureBootEnabled’:
+	// Set property "SecureBootEnabled":
 	if typedInput.SecureBootEnabled != nil {
 		secureBootEnabled := *typedInput.SecureBootEnabled
 		settings.SecureBootEnabled = &secureBootEnabled
 	}
 
-	// Set property ‘VTpmEnabled’:
+	// Set property "VTpmEnabled":
 	if typedInput.VTpmEnabled != nil {
 		vTpmEnabled := *typedInput.VTpmEnabled
 		settings.VTpmEnabled = &vTpmEnabled
@@ -13226,13 +13226,13 @@ func (settings *UefiSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UefiSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecureBootEnabled’:
+	// Set property "SecureBootEnabled":
 	if typedInput.SecureBootEnabled != nil {
 		secureBootEnabled := *typedInput.SecureBootEnabled
 		settings.SecureBootEnabled = &secureBootEnabled
 	}
 
-	// Set property ‘VTpmEnabled’:
+	// Set property "VTpmEnabled":
 	if typedInput.VTpmEnabled != nil {
 		vTpmEnabled := *typedInput.VTpmEnabled
 		settings.VTpmEnabled = &vTpmEnabled
@@ -13349,7 +13349,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &VaultSecretGroup_ARM{}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if group.SourceVault != nil {
 		sourceVault_ARM, err := (*group.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -13359,7 +13359,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.SourceVault = &sourceVault
 	}
 
-	// Set property ‘VaultCertificates’:
+	// Set property "VaultCertificates":
 	for _, item := range group.VaultCertificates {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -13382,7 +13382,7 @@ func (group *VaultSecretGroup) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultSecretGroup_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -13393,7 +13393,7 @@ func (group *VaultSecretGroup) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		group.SourceVault = &sourceVault
 	}
 
-	// Set property ‘VaultCertificates’:
+	// Set property "VaultCertificates":
 	for _, item := range typedInput.VaultCertificates {
 		var item1 VaultCertificate
 		err := item1.PopulateFromARM(owner, item)
@@ -13550,7 +13550,7 @@ func (group *VaultSecretGroup_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultSecretGroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -13561,7 +13561,7 @@ func (group *VaultSecretGroup_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		group.SourceVault = &sourceVault
 	}
 
-	// Set property ‘VaultCertificates’:
+	// Set property "VaultCertificates":
 	for _, item := range typedInput.VaultCertificates {
 		var item1 VaultCertificate_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -13684,7 +13684,7 @@ func (view *VirtualMachineAgentInstanceView_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineAgentInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExtensionHandlers’:
+	// Set property "ExtensionHandlers":
 	for _, item := range typedInput.ExtensionHandlers {
 		var item1 VirtualMachineExtensionHandlerInstanceView_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -13694,7 +13694,7 @@ func (view *VirtualMachineAgentInstanceView_STATUS) PopulateFromARM(owner genrun
 		view.ExtensionHandlers = append(view.ExtensionHandlers, item1)
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -13704,7 +13704,7 @@ func (view *VirtualMachineAgentInstanceView_STATUS) PopulateFromARM(owner genrun
 		view.Statuses = append(view.Statuses, item1)
 	}
 
-	// Set property ‘VmAgentVersion’:
+	// Set property "VmAgentVersion":
 	if typedInput.VmAgentVersion != nil {
 		vmAgentVersion := *typedInput.VmAgentVersion
 		view.VmAgentVersion = &vmAgentVersion
@@ -13847,13 +13847,13 @@ func (view *VirtualMachineExtensionInstanceView_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineExtensionInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		view.Name = &name
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -13863,7 +13863,7 @@ func (view *VirtualMachineExtensionInstanceView_STATUS) PopulateFromARM(owner ge
 		view.Statuses = append(view.Statuses, item1)
 	}
 
-	// Set property ‘Substatuses’:
+	// Set property "Substatuses":
 	for _, item := range typedInput.Substatuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -13873,13 +13873,13 @@ func (view *VirtualMachineExtensionInstanceView_STATUS) PopulateFromARM(owner ge
 		view.Substatuses = append(view.Substatuses, item1)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		view.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	if typedInput.TypeHandlerVersion != nil {
 		typeHandlerVersion := *typedInput.TypeHandlerVersion
 		view.TypeHandlerVersion = &typeHandlerVersion
@@ -14022,7 +14022,7 @@ func (status *VirtualMachineHealthStatus_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineHealthStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		var status2 InstanceViewStatus_STATUS
 		err := status2.PopulateFromARM(owner, *typedInput.Status)
@@ -14106,13 +14106,13 @@ func (identities *VirtualMachineIdentity_UserAssignedIdentities_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -14206,13 +14206,13 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) ConvertToARM(r
 	}
 	result := &VirtualMachineNetworkInterfaceConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.DeleteOption != nil ||
 		configuration.DnsSettings != nil ||
 		configuration.DscpConfiguration != nil ||
@@ -14290,7 +14290,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineNetworkInterfaceConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -14299,7 +14299,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -14313,7 +14313,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘DscpConfiguration’:
+	// Set property "DscpConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DscpConfiguration != nil {
@@ -14327,7 +14327,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -14336,7 +14336,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘EnableFpga’:
+	// Set property "EnableFpga":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFpga != nil {
@@ -14345,7 +14345,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -14354,7 +14354,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -14367,13 +14367,13 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -14387,7 +14387,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -14766,7 +14766,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineNetworkInterfaceConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -14775,7 +14775,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -14789,7 +14789,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘DscpConfiguration’:
+	// Set property "DscpConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DscpConfiguration != nil {
@@ -14803,7 +14803,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -14812,7 +14812,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘EnableFpga’:
+	// Set property "EnableFpga":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFpga != nil {
@@ -14821,7 +14821,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -14830,7 +14830,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -14843,13 +14843,13 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -14863,7 +14863,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -15119,7 +15119,7 @@ func (status *VirtualMachinePatchStatus_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachinePatchStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailablePatchSummary’:
+	// Set property "AvailablePatchSummary":
 	if typedInput.AvailablePatchSummary != nil {
 		var availablePatchSummary1 AvailablePatchSummary_STATUS
 		err := availablePatchSummary1.PopulateFromARM(owner, *typedInput.AvailablePatchSummary)
@@ -15130,7 +15130,7 @@ func (status *VirtualMachinePatchStatus_STATUS) PopulateFromARM(owner genruntime
 		status.AvailablePatchSummary = &availablePatchSummary
 	}
 
-	// Set property ‘ConfigurationStatuses’:
+	// Set property "ConfigurationStatuses":
 	for _, item := range typedInput.ConfigurationStatuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -15140,7 +15140,7 @@ func (status *VirtualMachinePatchStatus_STATUS) PopulateFromARM(owner genruntime
 		status.ConfigurationStatuses = append(status.ConfigurationStatuses, item1)
 	}
 
-	// Set property ‘LastPatchInstallationSummary’:
+	// Set property "LastPatchInstallationSummary":
 	if typedInput.LastPatchInstallationSummary != nil {
 		var lastPatchInstallationSummary1 LastPatchInstallationSummary_STATUS
 		err := lastPatchInstallationSummary1.PopulateFromARM(owner, *typedInput.LastPatchInstallationSummary)
@@ -15297,25 +15297,25 @@ func (application *VMGalleryApplication) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &VMGalleryApplication_ARM{}
 
-	// Set property ‘ConfigurationReference’:
+	// Set property "ConfigurationReference":
 	if application.ConfigurationReference != nil {
 		configurationReference := *application.ConfigurationReference
 		result.ConfigurationReference = &configurationReference
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	if application.EnableAutomaticUpgrade != nil {
 		enableAutomaticUpgrade := *application.EnableAutomaticUpgrade
 		result.EnableAutomaticUpgrade = &enableAutomaticUpgrade
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if application.Order != nil {
 		order := *application.Order
 		result.Order = &order
 	}
 
-	// Set property ‘PackageReferenceId’:
+	// Set property "PackageReferenceId":
 	if application.PackageReferenceReference != nil {
 		packageReferenceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*application.PackageReferenceReference)
 		if err != nil {
@@ -15325,13 +15325,13 @@ func (application *VMGalleryApplication) ConvertToARM(resolved genruntime.Conver
 		result.PackageReferenceId = &packageReferenceReference
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if application.Tags != nil {
 		tags := *application.Tags
 		result.Tags = &tags
 	}
 
-	// Set property ‘TreatFailureAsDeploymentFailure’:
+	// Set property "TreatFailureAsDeploymentFailure":
 	if application.TreatFailureAsDeploymentFailure != nil {
 		treatFailureAsDeploymentFailure := *application.TreatFailureAsDeploymentFailure
 		result.TreatFailureAsDeploymentFailure = &treatFailureAsDeploymentFailure
@@ -15351,33 +15351,33 @@ func (application *VMGalleryApplication) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VMGalleryApplication_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConfigurationReference’:
+	// Set property "ConfigurationReference":
 	if typedInput.ConfigurationReference != nil {
 		configurationReference := *typedInput.ConfigurationReference
 		application.ConfigurationReference = &configurationReference
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	if typedInput.EnableAutomaticUpgrade != nil {
 		enableAutomaticUpgrade := *typedInput.EnableAutomaticUpgrade
 		application.EnableAutomaticUpgrade = &enableAutomaticUpgrade
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if typedInput.Order != nil {
 		order := *typedInput.Order
 		application.Order = &order
 	}
 
-	// no assignment for property ‘PackageReferenceReference’
+	// no assignment for property "PackageReferenceReference"
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		tags := *typedInput.Tags
 		application.Tags = &tags
 	}
 
-	// Set property ‘TreatFailureAsDeploymentFailure’:
+	// Set property "TreatFailureAsDeploymentFailure":
 	if typedInput.TreatFailureAsDeploymentFailure != nil {
 		treatFailureAsDeploymentFailure := *typedInput.TreatFailureAsDeploymentFailure
 		application.TreatFailureAsDeploymentFailure = &treatFailureAsDeploymentFailure
@@ -15555,37 +15555,37 @@ func (application *VMGalleryApplication_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VMGalleryApplication_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConfigurationReference’:
+	// Set property "ConfigurationReference":
 	if typedInput.ConfigurationReference != nil {
 		configurationReference := *typedInput.ConfigurationReference
 		application.ConfigurationReference = &configurationReference
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	if typedInput.EnableAutomaticUpgrade != nil {
 		enableAutomaticUpgrade := *typedInput.EnableAutomaticUpgrade
 		application.EnableAutomaticUpgrade = &enableAutomaticUpgrade
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if typedInput.Order != nil {
 		order := *typedInput.Order
 		application.Order = &order
 	}
 
-	// Set property ‘PackageReferenceId’:
+	// Set property "PackageReferenceId":
 	if typedInput.PackageReferenceId != nil {
 		packageReferenceId := *typedInput.PackageReferenceId
 		application.PackageReferenceId = &packageReferenceId
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		tags := *typedInput.Tags
 		application.Tags = &tags
 	}
 
-	// Set property ‘TreatFailureAsDeploymentFailure’:
+	// Set property "TreatFailureAsDeploymentFailure":
 	if typedInput.TreatFailureAsDeploymentFailure != nil {
 		treatFailureAsDeploymentFailure := *typedInput.TreatFailureAsDeploymentFailure
 		application.TreatFailureAsDeploymentFailure = &treatFailureAsDeploymentFailure
@@ -15699,13 +15699,13 @@ func (properties *VMSizeProperties) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &VMSizeProperties_ARM{}
 
-	// Set property ‘VCPUsAvailable’:
+	// Set property "VCPUsAvailable":
 	if properties.VCPUsAvailable != nil {
 		vcpUsAvailable := *properties.VCPUsAvailable
 		result.VCPUsAvailable = &vcpUsAvailable
 	}
 
-	// Set property ‘VCPUsPerCore’:
+	// Set property "VCPUsPerCore":
 	if properties.VCPUsPerCore != nil {
 		vcpUsPerCore := *properties.VCPUsPerCore
 		result.VCPUsPerCore = &vcpUsPerCore
@@ -15725,13 +15725,13 @@ func (properties *VMSizeProperties) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VMSizeProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VCPUsAvailable’:
+	// Set property "VCPUsAvailable":
 	if typedInput.VCPUsAvailable != nil {
 		vcpUsAvailable := *typedInput.VCPUsAvailable
 		properties.VCPUsAvailable = &vcpUsAvailable
 	}
 
-	// Set property ‘VCPUsPerCore’:
+	// Set property "VCPUsPerCore":
 	if typedInput.VCPUsPerCore != nil {
 		vcpUsPerCore := *typedInput.VCPUsPerCore
 		properties.VCPUsPerCore = &vcpUsPerCore
@@ -15819,13 +15819,13 @@ func (properties *VMSizeProperties_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VMSizeProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VCPUsAvailable’:
+	// Set property "VCPUsAvailable":
 	if typedInput.VCPUsAvailable != nil {
 		vcpUsAvailable := *typedInput.VCPUsAvailable
 		properties.VCPUsAvailable = &vcpUsAvailable
 	}
 
-	// Set property ‘VCPUsPerCore’:
+	// Set property "VCPUsPerCore":
 	if typedInput.VCPUsPerCore != nil {
 		vcpUsPerCore := *typedInput.VCPUsPerCore
 		properties.VCPUsPerCore = &vcpUsPerCore
@@ -15909,7 +15909,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &WindowsConfiguration_ARM{}
 
-	// Set property ‘AdditionalUnattendContent’:
+	// Set property "AdditionalUnattendContent":
 	for _, item := range configuration.AdditionalUnattendContent {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -15918,13 +15918,13 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		result.AdditionalUnattendContent = append(result.AdditionalUnattendContent, *item_ARM.(*AdditionalUnattendContent_ARM))
 	}
 
-	// Set property ‘EnableAutomaticUpdates’:
+	// Set property "EnableAutomaticUpdates":
 	if configuration.EnableAutomaticUpdates != nil {
 		enableAutomaticUpdates := *configuration.EnableAutomaticUpdates
 		result.EnableAutomaticUpdates = &enableAutomaticUpdates
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if configuration.PatchSettings != nil {
 		patchSettings_ARM, err := (*configuration.PatchSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -15934,19 +15934,19 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		result.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if configuration.ProvisionVMAgent != nil {
 		provisionVMAgent := *configuration.ProvisionVMAgent
 		result.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if configuration.TimeZone != nil {
 		timeZone := *configuration.TimeZone
 		result.TimeZone = &timeZone
 	}
 
-	// Set property ‘WinRM’:
+	// Set property "WinRM":
 	if configuration.WinRM != nil {
 		winRM_ARM, err := (*configuration.WinRM).ConvertToARM(resolved)
 		if err != nil {
@@ -15970,7 +15970,7 @@ func (configuration *WindowsConfiguration) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalUnattendContent’:
+	// Set property "AdditionalUnattendContent":
 	for _, item := range typedInput.AdditionalUnattendContent {
 		var item1 AdditionalUnattendContent
 		err := item1.PopulateFromARM(owner, item)
@@ -15980,13 +15980,13 @@ func (configuration *WindowsConfiguration) PopulateFromARM(owner genruntime.Arbi
 		configuration.AdditionalUnattendContent = append(configuration.AdditionalUnattendContent, item1)
 	}
 
-	// Set property ‘EnableAutomaticUpdates’:
+	// Set property "EnableAutomaticUpdates":
 	if typedInput.EnableAutomaticUpdates != nil {
 		enableAutomaticUpdates := *typedInput.EnableAutomaticUpdates
 		configuration.EnableAutomaticUpdates = &enableAutomaticUpdates
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 PatchSettings
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -15997,19 +15997,19 @@ func (configuration *WindowsConfiguration) PopulateFromARM(owner genruntime.Arbi
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if typedInput.TimeZone != nil {
 		timeZone := *typedInput.TimeZone
 		configuration.TimeZone = &timeZone
 	}
 
-	// Set property ‘WinRM’:
+	// Set property "WinRM":
 	if typedInput.WinRM != nil {
 		var winRM1 WinRMConfiguration
 		err := winRM1.PopulateFromARM(owner, *typedInput.WinRM)
@@ -16281,7 +16281,7 @@ func (configuration *WindowsConfiguration_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalUnattendContent’:
+	// Set property "AdditionalUnattendContent":
 	for _, item := range typedInput.AdditionalUnattendContent {
 		var item1 AdditionalUnattendContent_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -16291,13 +16291,13 @@ func (configuration *WindowsConfiguration_STATUS) PopulateFromARM(owner genrunti
 		configuration.AdditionalUnattendContent = append(configuration.AdditionalUnattendContent, item1)
 	}
 
-	// Set property ‘EnableAutomaticUpdates’:
+	// Set property "EnableAutomaticUpdates":
 	if typedInput.EnableAutomaticUpdates != nil {
 		enableAutomaticUpdates := *typedInput.EnableAutomaticUpdates
 		configuration.EnableAutomaticUpdates = &enableAutomaticUpdates
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 PatchSettings_STATUS
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -16308,19 +16308,19 @@ func (configuration *WindowsConfiguration_STATUS) PopulateFromARM(owner genrunti
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if typedInput.TimeZone != nil {
 		timeZone := *typedInput.TimeZone
 		configuration.TimeZone = &timeZone
 	}
 
-	// Set property ‘WinRM’:
+	// Set property "WinRM":
 	if typedInput.WinRM != nil {
 		var winRM1 WinRMConfiguration_STATUS
 		err := winRM1.PopulateFromARM(owner, *typedInput.WinRM)
@@ -16508,25 +16508,25 @@ func (content *AdditionalUnattendContent) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &AdditionalUnattendContent_ARM{}
 
-	// Set property ‘ComponentName’:
+	// Set property "ComponentName":
 	if content.ComponentName != nil {
 		componentName := *content.ComponentName
 		result.ComponentName = &componentName
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if content.Content != nil {
 		content1 := *content.Content
 		result.Content = &content1
 	}
 
-	// Set property ‘PassName’:
+	// Set property "PassName":
 	if content.PassName != nil {
 		passName := *content.PassName
 		result.PassName = &passName
 	}
 
-	// Set property ‘SettingName’:
+	// Set property "SettingName":
 	if content.SettingName != nil {
 		settingName := *content.SettingName
 		result.SettingName = &settingName
@@ -16546,25 +16546,25 @@ func (content *AdditionalUnattendContent) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalUnattendContent_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComponentName’:
+	// Set property "ComponentName":
 	if typedInput.ComponentName != nil {
 		componentName := *typedInput.ComponentName
 		content.ComponentName = &componentName
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if typedInput.Content != nil {
 		content1 := *typedInput.Content
 		content.Content = &content1
 	}
 
-	// Set property ‘PassName’:
+	// Set property "PassName":
 	if typedInput.PassName != nil {
 		passName := *typedInput.PassName
 		content.PassName = &passName
 	}
 
-	// Set property ‘SettingName’:
+	// Set property "SettingName":
 	if typedInput.SettingName != nil {
 		settingName := *typedInput.SettingName
 		content.SettingName = &settingName
@@ -16718,25 +16718,25 @@ func (content *AdditionalUnattendContent_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalUnattendContent_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComponentName’:
+	// Set property "ComponentName":
 	if typedInput.ComponentName != nil {
 		componentName := *typedInput.ComponentName
 		content.ComponentName = &componentName
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if typedInput.Content != nil {
 		content1 := *typedInput.Content
 		content.Content = &content1
 	}
 
-	// Set property ‘PassName’:
+	// Set property "PassName":
 	if typedInput.PassName != nil {
 		passName := *typedInput.PassName
 		content.PassName = &passName
 	}
 
-	// Set property ‘SettingName’:
+	// Set property "SettingName":
 	if typedInput.SettingName != nil {
 		settingName := *typedInput.SettingName
 		content.SettingName = &settingName
@@ -16868,19 +16868,19 @@ func (summary *AvailablePatchSummary_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AvailablePatchSummary_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssessmentActivityId’:
+	// Set property "AssessmentActivityId":
 	if typedInput.AssessmentActivityId != nil {
 		assessmentActivityId := *typedInput.AssessmentActivityId
 		summary.AssessmentActivityId = &assessmentActivityId
 	}
 
-	// Set property ‘CriticalAndSecurityPatchCount’:
+	// Set property "CriticalAndSecurityPatchCount":
 	if typedInput.CriticalAndSecurityPatchCount != nil {
 		criticalAndSecurityPatchCount := *typedInput.CriticalAndSecurityPatchCount
 		summary.CriticalAndSecurityPatchCount = &criticalAndSecurityPatchCount
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ApiError_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -16891,31 +16891,31 @@ func (summary *AvailablePatchSummary_STATUS) PopulateFromARM(owner genruntime.Ar
 		summary.Error = &error
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	if typedInput.LastModifiedTime != nil {
 		lastModifiedTime := *typedInput.LastModifiedTime
 		summary.LastModifiedTime = &lastModifiedTime
 	}
 
-	// Set property ‘OtherPatchCount’:
+	// Set property "OtherPatchCount":
 	if typedInput.OtherPatchCount != nil {
 		otherPatchCount := *typedInput.OtherPatchCount
 		summary.OtherPatchCount = &otherPatchCount
 	}
 
-	// Set property ‘RebootPending’:
+	// Set property "RebootPending":
 	if typedInput.RebootPending != nil {
 		rebootPending := *typedInput.RebootPending
 		summary.RebootPending = &rebootPending
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		summary.StartTime = &startTime
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		summary.Status = &status
@@ -17176,13 +17176,13 @@ func (settings *DiffDiskSettings) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &DiffDiskSettings_ARM{}
 
-	// Set property ‘Option’:
+	// Set property "Option":
 	if settings.Option != nil {
 		option := *settings.Option
 		result.Option = &option
 	}
 
-	// Set property ‘Placement’:
+	// Set property "Placement":
 	if settings.Placement != nil {
 		placement := *settings.Placement
 		result.Placement = &placement
@@ -17202,13 +17202,13 @@ func (settings *DiffDiskSettings) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiffDiskSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Option’:
+	// Set property "Option":
 	if typedInput.Option != nil {
 		option := *typedInput.Option
 		settings.Option = &option
 	}
 
-	// Set property ‘Placement’:
+	// Set property "Placement":
 	if typedInput.Placement != nil {
 		placement := *typedInput.Placement
 		settings.Placement = &placement
@@ -17327,13 +17327,13 @@ func (settings *DiffDiskSettings_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiffDiskSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Option’:
+	// Set property "Option":
 	if typedInput.Option != nil {
 		option := *typedInput.Option
 		settings.Option = &option
 	}
 
-	// Set property ‘Placement’:
+	// Set property "Placement":
 	if typedInput.Placement != nil {
 		placement := *typedInput.Placement
 		settings.Placement = &placement
@@ -17419,7 +17419,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &DiskEncryptionSettings_ARM{}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if settings.DiskEncryptionKey != nil {
 		diskEncryptionKey_ARM, err := (*settings.DiskEncryptionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -17429,13 +17429,13 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 		result.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if settings.Enabled != nil {
 		enabled := *settings.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if settings.KeyEncryptionKey != nil {
 		keyEncryptionKey_ARM, err := (*settings.KeyEncryptionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -17459,7 +17459,7 @@ func (settings *DiskEncryptionSettings) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskEncryptionSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if typedInput.DiskEncryptionKey != nil {
 		var diskEncryptionKey1 KeyVaultSecretReference
 		err := diskEncryptionKey1.PopulateFromARM(owner, *typedInput.DiskEncryptionKey)
@@ -17470,13 +17470,13 @@ func (settings *DiskEncryptionSettings) PopulateFromARM(owner genruntime.Arbitra
 		settings.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		settings.Enabled = &enabled
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if typedInput.KeyEncryptionKey != nil {
 		var keyEncryptionKey1 KeyVaultKeyReference
 		err := keyEncryptionKey1.PopulateFromARM(owner, *typedInput.KeyEncryptionKey)
@@ -17643,7 +17643,7 @@ func (settings *DiskEncryptionSettings_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskEncryptionSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if typedInput.DiskEncryptionKey != nil {
 		var diskEncryptionKey1 KeyVaultSecretReference_STATUS
 		err := diskEncryptionKey1.PopulateFromARM(owner, *typedInput.DiskEncryptionKey)
@@ -17654,13 +17654,13 @@ func (settings *DiskEncryptionSettings_STATUS) PopulateFromARM(owner genruntime.
 		settings.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		settings.Enabled = &enabled
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if typedInput.KeyEncryptionKey != nil {
 		var keyEncryptionKey1 KeyVaultKeyReference_STATUS
 		err := keyEncryptionKey1.PopulateFromARM(owner, *typedInput.KeyEncryptionKey)
@@ -17825,7 +17825,7 @@ func (summary *LastPatchInstallationSummary_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LastPatchInstallationSummary_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ApiError_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -17836,61 +17836,61 @@ func (summary *LastPatchInstallationSummary_STATUS) PopulateFromARM(owner genrun
 		summary.Error = &error
 	}
 
-	// Set property ‘ExcludedPatchCount’:
+	// Set property "ExcludedPatchCount":
 	if typedInput.ExcludedPatchCount != nil {
 		excludedPatchCount := *typedInput.ExcludedPatchCount
 		summary.ExcludedPatchCount = &excludedPatchCount
 	}
 
-	// Set property ‘FailedPatchCount’:
+	// Set property "FailedPatchCount":
 	if typedInput.FailedPatchCount != nil {
 		failedPatchCount := *typedInput.FailedPatchCount
 		summary.FailedPatchCount = &failedPatchCount
 	}
 
-	// Set property ‘InstallationActivityId’:
+	// Set property "InstallationActivityId":
 	if typedInput.InstallationActivityId != nil {
 		installationActivityId := *typedInput.InstallationActivityId
 		summary.InstallationActivityId = &installationActivityId
 	}
 
-	// Set property ‘InstalledPatchCount’:
+	// Set property "InstalledPatchCount":
 	if typedInput.InstalledPatchCount != nil {
 		installedPatchCount := *typedInput.InstalledPatchCount
 		summary.InstalledPatchCount = &installedPatchCount
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	if typedInput.LastModifiedTime != nil {
 		lastModifiedTime := *typedInput.LastModifiedTime
 		summary.LastModifiedTime = &lastModifiedTime
 	}
 
-	// Set property ‘MaintenanceWindowExceeded’:
+	// Set property "MaintenanceWindowExceeded":
 	if typedInput.MaintenanceWindowExceeded != nil {
 		maintenanceWindowExceeded := *typedInput.MaintenanceWindowExceeded
 		summary.MaintenanceWindowExceeded = &maintenanceWindowExceeded
 	}
 
-	// Set property ‘NotSelectedPatchCount’:
+	// Set property "NotSelectedPatchCount":
 	if typedInput.NotSelectedPatchCount != nil {
 		notSelectedPatchCount := *typedInput.NotSelectedPatchCount
 		summary.NotSelectedPatchCount = &notSelectedPatchCount
 	}
 
-	// Set property ‘PendingPatchCount’:
+	// Set property "PendingPatchCount":
 	if typedInput.PendingPatchCount != nil {
 		pendingPatchCount := *typedInput.PendingPatchCount
 		summary.PendingPatchCount = &pendingPatchCount
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		summary.StartTime = &startTime
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		summary.Status = &status
@@ -18057,13 +18057,13 @@ func (settings *LinuxPatchSettings) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &LinuxPatchSettings_ARM{}
 
-	// Set property ‘AssessmentMode’:
+	// Set property "AssessmentMode":
 	if settings.AssessmentMode != nil {
 		assessmentMode := *settings.AssessmentMode
 		result.AssessmentMode = &assessmentMode
 	}
 
-	// Set property ‘AutomaticByPlatformSettings’:
+	// Set property "AutomaticByPlatformSettings":
 	if settings.AutomaticByPlatformSettings != nil {
 		automaticByPlatformSettings_ARM, err := (*settings.AutomaticByPlatformSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -18073,7 +18073,7 @@ func (settings *LinuxPatchSettings) ConvertToARM(resolved genruntime.ConvertToAR
 		result.AutomaticByPlatformSettings = &automaticByPlatformSettings
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if settings.PatchMode != nil {
 		patchMode := *settings.PatchMode
 		result.PatchMode = &patchMode
@@ -18093,13 +18093,13 @@ func (settings *LinuxPatchSettings) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxPatchSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssessmentMode’:
+	// Set property "AssessmentMode":
 	if typedInput.AssessmentMode != nil {
 		assessmentMode := *typedInput.AssessmentMode
 		settings.AssessmentMode = &assessmentMode
 	}
 
-	// Set property ‘AutomaticByPlatformSettings’:
+	// Set property "AutomaticByPlatformSettings":
 	if typedInput.AutomaticByPlatformSettings != nil {
 		var automaticByPlatformSettings1 LinuxVMGuestPatchAutomaticByPlatformSettings
 		err := automaticByPlatformSettings1.PopulateFromARM(owner, *typedInput.AutomaticByPlatformSettings)
@@ -18110,7 +18110,7 @@ func (settings *LinuxPatchSettings) PopulateFromARM(owner genruntime.ArbitraryOw
 		settings.AutomaticByPlatformSettings = &automaticByPlatformSettings
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -18269,13 +18269,13 @@ func (settings *LinuxPatchSettings_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxPatchSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssessmentMode’:
+	// Set property "AssessmentMode":
 	if typedInput.AssessmentMode != nil {
 		assessmentMode := *typedInput.AssessmentMode
 		settings.AssessmentMode = &assessmentMode
 	}
 
-	// Set property ‘AutomaticByPlatformSettings’:
+	// Set property "AutomaticByPlatformSettings":
 	if typedInput.AutomaticByPlatformSettings != nil {
 		var automaticByPlatformSettings1 LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS
 		err := automaticByPlatformSettings1.PopulateFromARM(owner, *typedInput.AutomaticByPlatformSettings)
@@ -18286,7 +18286,7 @@ func (settings *LinuxPatchSettings_STATUS) PopulateFromARM(owner genruntime.Arbi
 		settings.AutomaticByPlatformSettings = &automaticByPlatformSettings
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -18409,7 +18409,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &ManagedDiskParameters_ARM{}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if parameters.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*parameters.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -18419,7 +18419,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if parameters.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*parameters.Reference)
 		if err != nil {
@@ -18429,7 +18429,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 		result.Id = &reference
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if parameters.SecurityProfile != nil {
 		securityProfile_ARM, err := (*parameters.SecurityProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -18439,7 +18439,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 		result.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if parameters.StorageAccountType != nil {
 		storageAccountType := *parameters.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -18459,7 +18459,7 @@ func (parameters *ManagedDiskParameters) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedDiskParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -18470,9 +18470,9 @@ func (parameters *ManagedDiskParameters) PopulateFromARM(owner genruntime.Arbitr
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 VMDiskSecurityProfile
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -18483,7 +18483,7 @@ func (parameters *ManagedDiskParameters) PopulateFromARM(owner genruntime.Arbitr
 		parameters.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -18673,7 +18673,7 @@ func (parameters *ManagedDiskParameters_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedDiskParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -18684,13 +18684,13 @@ func (parameters *ManagedDiskParameters_STATUS) PopulateFromARM(owner genruntime
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		parameters.Id = &id
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 VMDiskSecurityProfile_STATUS
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -18701,7 +18701,7 @@ func (parameters *ManagedDiskParameters_STATUS) PopulateFromARM(owner genruntime
 		parameters.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -18872,13 +18872,13 @@ func (settings *PatchSettings) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &PatchSettings_ARM{}
 
-	// Set property ‘AssessmentMode’:
+	// Set property "AssessmentMode":
 	if settings.AssessmentMode != nil {
 		assessmentMode := *settings.AssessmentMode
 		result.AssessmentMode = &assessmentMode
 	}
 
-	// Set property ‘AutomaticByPlatformSettings’:
+	// Set property "AutomaticByPlatformSettings":
 	if settings.AutomaticByPlatformSettings != nil {
 		automaticByPlatformSettings_ARM, err := (*settings.AutomaticByPlatformSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -18888,13 +18888,13 @@ func (settings *PatchSettings) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.AutomaticByPlatformSettings = &automaticByPlatformSettings
 	}
 
-	// Set property ‘EnableHotpatching’:
+	// Set property "EnableHotpatching":
 	if settings.EnableHotpatching != nil {
 		enableHotpatching := *settings.EnableHotpatching
 		result.EnableHotpatching = &enableHotpatching
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if settings.PatchMode != nil {
 		patchMode := *settings.PatchMode
 		result.PatchMode = &patchMode
@@ -18914,13 +18914,13 @@ func (settings *PatchSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PatchSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssessmentMode’:
+	// Set property "AssessmentMode":
 	if typedInput.AssessmentMode != nil {
 		assessmentMode := *typedInput.AssessmentMode
 		settings.AssessmentMode = &assessmentMode
 	}
 
-	// Set property ‘AutomaticByPlatformSettings’:
+	// Set property "AutomaticByPlatformSettings":
 	if typedInput.AutomaticByPlatformSettings != nil {
 		var automaticByPlatformSettings1 WindowsVMGuestPatchAutomaticByPlatformSettings
 		err := automaticByPlatformSettings1.PopulateFromARM(owner, *typedInput.AutomaticByPlatformSettings)
@@ -18931,13 +18931,13 @@ func (settings *PatchSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		settings.AutomaticByPlatformSettings = &automaticByPlatformSettings
 	}
 
-	// Set property ‘EnableHotpatching’:
+	// Set property "EnableHotpatching":
 	if typedInput.EnableHotpatching != nil {
 		enableHotpatching := *typedInput.EnableHotpatching
 		settings.EnableHotpatching = &enableHotpatching
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -19128,13 +19128,13 @@ func (settings *PatchSettings_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PatchSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssessmentMode’:
+	// Set property "AssessmentMode":
 	if typedInput.AssessmentMode != nil {
 		assessmentMode := *typedInput.AssessmentMode
 		settings.AssessmentMode = &assessmentMode
 	}
 
-	// Set property ‘AutomaticByPlatformSettings’:
+	// Set property "AutomaticByPlatformSettings":
 	if typedInput.AutomaticByPlatformSettings != nil {
 		var automaticByPlatformSettings1 WindowsVMGuestPatchAutomaticByPlatformSettings_STATUS
 		err := automaticByPlatformSettings1.PopulateFromARM(owner, *typedInput.AutomaticByPlatformSettings)
@@ -19145,13 +19145,13 @@ func (settings *PatchSettings_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		settings.AutomaticByPlatformSettings = &automaticByPlatformSettings
 	}
 
-	// Set property ‘EnableHotpatching’:
+	// Set property "EnableHotpatching":
 	if typedInput.EnableHotpatching != nil {
 		enableHotpatching := *typedInput.EnableHotpatching
 		settings.EnableHotpatching = &enableHotpatching
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -19271,7 +19271,7 @@ func (configuration *SshConfiguration) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &SshConfiguration_ARM{}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range configuration.PublicKeys {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -19294,7 +19294,7 @@ func (configuration *SshConfiguration) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 SshPublicKeySpec
 		err := item1.PopulateFromARM(owner, item)
@@ -19412,7 +19412,7 @@ func (configuration *SshConfiguration_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 SshPublicKey_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -19518,13 +19518,13 @@ func (certificate *VaultCertificate) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &VaultCertificate_ARM{}
 
-	// Set property ‘CertificateStore’:
+	// Set property "CertificateStore":
 	if certificate.CertificateStore != nil {
 		certificateStore := *certificate.CertificateStore
 		result.CertificateStore = &certificateStore
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if certificate.CertificateUrl != nil {
 		certificateUrl := *certificate.CertificateUrl
 		result.CertificateUrl = &certificateUrl
@@ -19544,13 +19544,13 @@ func (certificate *VaultCertificate) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultCertificate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateStore’:
+	// Set property "CertificateStore":
 	if typedInput.CertificateStore != nil {
 		certificateStore := *typedInput.CertificateStore
 		certificate.CertificateStore = &certificateStore
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		certificate.CertificateUrl = &certificateUrl
@@ -19646,13 +19646,13 @@ func (certificate *VaultCertificate_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultCertificate_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateStore’:
+	// Set property "CertificateStore":
 	if typedInput.CertificateStore != nil {
 		certificateStore := *typedInput.CertificateStore
 		certificate.CertificateStore = &certificateStore
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		certificate.CertificateUrl = &certificateUrl
@@ -19712,7 +19712,7 @@ func (disk *VirtualHardDisk) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &VirtualHardDisk_ARM{}
 
-	// Set property ‘Uri’:
+	// Set property "Uri":
 	if disk.Uri != nil {
 		uri := *disk.Uri
 		result.Uri = &uri
@@ -19732,7 +19732,7 @@ func (disk *VirtualHardDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualHardDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Uri’:
+	// Set property "Uri":
 	if typedInput.Uri != nil {
 		uri := *typedInput.Uri
 		disk.Uri = &uri
@@ -19801,7 +19801,7 @@ func (disk *VirtualHardDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualHardDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Uri’:
+	// Set property "Uri":
 	if typedInput.Uri != nil {
 		uri := *typedInput.Uri
 		disk.Uri = &uri
@@ -19866,7 +19866,7 @@ func (view *VirtualMachineExtensionHandlerInstanceView_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineExtensionHandlerInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		var status1 InstanceViewStatus_STATUS
 		err := status1.PopulateFromARM(owner, *typedInput.Status)
@@ -19877,13 +19877,13 @@ func (view *VirtualMachineExtensionHandlerInstanceView_STATUS) PopulateFromARM(o
 		view.Status = &status
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		view.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	if typedInput.TypeHandlerVersion != nil {
 		typeHandlerVersion := *typedInput.TypeHandlerVersion
 		view.TypeHandlerVersion = &typeHandlerVersion
@@ -19982,7 +19982,7 @@ func (configuration *VirtualMachineNetworkInterfaceDnsSettingsConfiguration) Con
 	}
 	result := &VirtualMachineNetworkInterfaceDnsSettingsConfiguration_ARM{}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range configuration.DnsServers {
 		result.DnsServers = append(result.DnsServers, item)
 	}
@@ -20001,7 +20001,7 @@ func (configuration *VirtualMachineNetworkInterfaceDnsSettingsConfiguration) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineNetworkInterfaceDnsSettingsConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		configuration.DnsServers = append(configuration.DnsServers, item)
 	}
@@ -20069,7 +20069,7 @@ func (configuration *VirtualMachineNetworkInterfaceDnsSettingsConfiguration_STAT
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineNetworkInterfaceDnsSettingsConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		configuration.DnsServers = append(configuration.DnsServers, item)
 	}
@@ -20149,13 +20149,13 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) ConvertToARM
 	}
 	result := &VirtualMachineNetworkInterfaceIPConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.ApplicationGatewayBackendAddressPools != nil ||
 		configuration.ApplicationSecurityGroups != nil ||
 		configuration.LoadBalancerBackendAddressPools != nil ||
@@ -20225,7 +20225,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineNetworkInterfaceIPConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -20238,7 +20238,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -20251,7 +20251,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		}
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -20264,13 +20264,13 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -20279,7 +20279,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -20288,7 +20288,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		}
 	}
 
-	// Set property ‘PublicIPAddressConfiguration’:
+	// Set property "PublicIPAddressConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressConfiguration != nil {
@@ -20302,7 +20302,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -20687,7 +20687,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineNetworkInterfaceIPConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -20700,7 +20700,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -20713,7 +20713,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		}
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -20726,13 +20726,13 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -20741,7 +20741,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -20750,7 +20750,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		}
 	}
 
-	// Set property ‘PublicIPAddressConfiguration’:
+	// Set property "PublicIPAddressConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressConfiguration != nil {
@@ -20764,7 +20764,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -21014,7 +21014,7 @@ func (configuration *WinRMConfiguration) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &WinRMConfiguration_ARM{}
 
-	// Set property ‘Listeners’:
+	// Set property "Listeners":
 	for _, item := range configuration.Listeners {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -21037,7 +21037,7 @@ func (configuration *WinRMConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Listeners’:
+	// Set property "Listeners":
 	for _, item := range typedInput.Listeners {
 		var item1 WinRMListener
 		err := item1.PopulateFromARM(owner, item)
@@ -21155,7 +21155,7 @@ func (configuration *WinRMConfiguration_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Listeners’:
+	// Set property "Listeners":
 	for _, item := range typedInput.Listeners {
 		var item1 WinRMListener_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -21293,13 +21293,13 @@ func (error *ApiError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		error.Code = &code
 	}
 
-	// Set property ‘Details’:
+	// Set property "Details":
 	for _, item := range typedInput.Details {
 		var item1 ApiErrorBase_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -21309,7 +21309,7 @@ func (error *ApiError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		error.Details = append(error.Details, item1)
 	}
 
-	// Set property ‘Innererror’:
+	// Set property "Innererror":
 	if typedInput.Innererror != nil {
 		var innererror1 InnerError_STATUS
 		err := innererror1.PopulateFromARM(owner, *typedInput.Innererror)
@@ -21320,13 +21320,13 @@ func (error *ApiError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		error.Innererror = &innererror
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		error.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		error.Target = &target
@@ -21503,13 +21503,13 @@ func (reference *KeyVaultKeyReference) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &KeyVaultKeyReference_ARM{}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if reference.KeyUrl != nil {
 		keyUrl := *reference.KeyUrl
 		result.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if reference.SourceVault != nil {
 		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -21533,13 +21533,13 @@ func (reference *KeyVaultKeyReference) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultKeyReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if typedInput.KeyUrl != nil {
 		keyUrl := *typedInput.KeyUrl
 		reference.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -21652,13 +21652,13 @@ func (reference *KeyVaultKeyReference_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultKeyReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if typedInput.KeyUrl != nil {
 		keyUrl := *typedInput.KeyUrl
 		reference.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -21746,13 +21746,13 @@ func (reference *KeyVaultSecretReference) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &KeyVaultSecretReference_ARM{}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if reference.SecretUrl != nil {
 		secretUrl := *reference.SecretUrl
 		result.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if reference.SourceVault != nil {
 		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -21776,13 +21776,13 @@ func (reference *KeyVaultSecretReference) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultSecretReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if typedInput.SecretUrl != nil {
 		secretUrl := *typedInput.SecretUrl
 		reference.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -21927,7 +21927,7 @@ func (settings *LinuxVMGuestPatchAutomaticByPlatformSettings) ConvertToARM(resol
 	}
 	result := &LinuxVMGuestPatchAutomaticByPlatformSettings_ARM{}
 
-	// Set property ‘RebootSetting’:
+	// Set property "RebootSetting":
 	if settings.RebootSetting != nil {
 		rebootSetting := *settings.RebootSetting
 		result.RebootSetting = &rebootSetting
@@ -21947,7 +21947,7 @@ func (settings *LinuxVMGuestPatchAutomaticByPlatformSettings) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxVMGuestPatchAutomaticByPlatformSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RebootSetting’:
+	// Set property "RebootSetting":
 	if typedInput.RebootSetting != nil {
 		rebootSetting := *typedInput.RebootSetting
 		settings.RebootSetting = &rebootSetting
@@ -22031,7 +22031,7 @@ func (settings *LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RebootSetting’:
+	// Set property "RebootSetting":
 	if typedInput.RebootSetting != nil {
 		rebootSetting := *typedInput.RebootSetting
 		settings.RebootSetting = &rebootSetting
@@ -22139,13 +22139,13 @@ func (publicKey *SshPublicKey_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshPublicKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		publicKey.Path = &path
@@ -22212,13 +22212,13 @@ func (publicKey *SshPublicKeySpec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &SshPublicKeySpec_ARM{}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if publicKey.KeyData != nil {
 		keyData := *publicKey.KeyData
 		result.KeyData = &keyData
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if publicKey.Path != nil {
 		path := *publicKey.Path
 		result.Path = &path
@@ -22238,13 +22238,13 @@ func (publicKey *SshPublicKeySpec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshPublicKeySpec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		publicKey.Path = &path
@@ -22358,13 +22358,13 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) ConvertToARM(re
 	}
 	result := &VirtualMachinePublicIPAddressConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.DeleteOption != nil ||
 		configuration.DnsSettings != nil ||
 		configuration.IdleTimeoutInMinutes != nil ||
@@ -22414,7 +22414,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) ConvertToARM(re
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if configuration.Sku != nil {
 		sku_ARM, err := (*configuration.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -22438,7 +22438,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachinePublicIPAddressConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -22447,7 +22447,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -22461,7 +22461,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -22470,7 +22470,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -22483,13 +22483,13 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -22498,7 +22498,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘PublicIPAllocationMethod’:
+	// Set property "PublicIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAllocationMethod != nil {
@@ -22507,7 +22507,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -22521,7 +22521,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPAddressSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -22863,7 +22863,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachinePublicIPAddressConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -22872,7 +22872,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -22886,7 +22886,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -22895,7 +22895,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -22908,13 +22908,13 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -22923,7 +22923,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘PublicIPAllocationMethod’:
+	// Set property "PublicIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAllocationMethod != nil {
@@ -22932,7 +22932,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -22946,7 +22946,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPAddressSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -23175,7 +23175,7 @@ func (profile *VMDiskSecurityProfile) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &VMDiskSecurityProfile_ARM{}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if profile.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*profile.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -23185,7 +23185,7 @@ func (profile *VMDiskSecurityProfile) ConvertToARM(resolved genruntime.ConvertTo
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘SecurityEncryptionType’:
+	// Set property "SecurityEncryptionType":
 	if profile.SecurityEncryptionType != nil {
 		securityEncryptionType := *profile.SecurityEncryptionType
 		result.SecurityEncryptionType = &securityEncryptionType
@@ -23205,7 +23205,7 @@ func (profile *VMDiskSecurityProfile) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VMDiskSecurityProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -23216,7 +23216,7 @@ func (profile *VMDiskSecurityProfile) PopulateFromARM(owner genruntime.Arbitrary
 		profile.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘SecurityEncryptionType’:
+	// Set property "SecurityEncryptionType":
 	if typedInput.SecurityEncryptionType != nil {
 		securityEncryptionType := *typedInput.SecurityEncryptionType
 		profile.SecurityEncryptionType = &securityEncryptionType
@@ -23344,7 +23344,7 @@ func (profile *VMDiskSecurityProfile_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VMDiskSecurityProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -23355,7 +23355,7 @@ func (profile *VMDiskSecurityProfile_STATUS) PopulateFromARM(owner genruntime.Ar
 		profile.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘SecurityEncryptionType’:
+	// Set property "SecurityEncryptionType":
 	if typedInput.SecurityEncryptionType != nil {
 		securityEncryptionType := *typedInput.SecurityEncryptionType
 		profile.SecurityEncryptionType = &securityEncryptionType
@@ -23443,7 +23443,7 @@ func (settings *WindowsVMGuestPatchAutomaticByPlatformSettings) ConvertToARM(res
 	}
 	result := &WindowsVMGuestPatchAutomaticByPlatformSettings_ARM{}
 
-	// Set property ‘RebootSetting’:
+	// Set property "RebootSetting":
 	if settings.RebootSetting != nil {
 		rebootSetting := *settings.RebootSetting
 		result.RebootSetting = &rebootSetting
@@ -23463,7 +23463,7 @@ func (settings *WindowsVMGuestPatchAutomaticByPlatformSettings) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsVMGuestPatchAutomaticByPlatformSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RebootSetting’:
+	// Set property "RebootSetting":
 	if typedInput.RebootSetting != nil {
 		rebootSetting := *typedInput.RebootSetting
 		settings.RebootSetting = &rebootSetting
@@ -23547,7 +23547,7 @@ func (settings *WindowsVMGuestPatchAutomaticByPlatformSettings_STATUS) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsVMGuestPatchAutomaticByPlatformSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RebootSetting’:
+	// Set property "RebootSetting":
 	if typedInput.RebootSetting != nil {
 		rebootSetting := *typedInput.RebootSetting
 		settings.RebootSetting = &rebootSetting
@@ -23628,13 +23628,13 @@ func (listener *WinRMListener) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &WinRMListener_ARM{}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if listener.CertificateUrl != nil {
 		certificateUrl := *listener.CertificateUrl
 		result.CertificateUrl = &certificateUrl
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if listener.Protocol != nil {
 		protocol := *listener.Protocol
 		result.Protocol = &protocol
@@ -23654,13 +23654,13 @@ func (listener *WinRMListener) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMListener_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		listener.CertificateUrl = &certificateUrl
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		listener.Protocol = &protocol
@@ -23770,13 +23770,13 @@ func (listener *WinRMListener_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMListener_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		listener.CertificateUrl = &certificateUrl
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		listener.Protocol = &protocol
@@ -23857,19 +23857,19 @@ func (base *ApiErrorBase_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiErrorBase_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		base.Code = &code
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		base.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		base.Target = &target
@@ -23943,13 +23943,13 @@ func (error *InnerError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InnerError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Errordetail’:
+	// Set property "Errordetail":
 	if typedInput.Errordetail != nil {
 		errordetail := *typedInput.Errordetail
 		error.Errordetail = &errordetail
 	}
 
-	// Set property ‘Exceptiontype’:
+	// Set property "Exceptiontype":
 	if typedInput.Exceptiontype != nil {
 		exceptiontype := *typedInput.Exceptiontype
 		error.Exceptiontype = &exceptiontype
@@ -24031,13 +24031,13 @@ func (addressSku *PublicIPAddressSku) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &PublicIPAddressSku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if addressSku.Name != nil {
 		name := *addressSku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if addressSku.Tier != nil {
 		tier := *addressSku.Tier
 		result.Tier = &tier
@@ -24057,13 +24057,13 @@ func (addressSku *PublicIPAddressSku) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		addressSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		addressSku.Tier = &tier
@@ -24174,13 +24174,13 @@ func (addressSku *PublicIPAddressSku_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		addressSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		addressSku.Tier = &tier
@@ -24263,13 +24263,13 @@ func (ipTag *VirtualMachineIpTag) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &VirtualMachineIpTag_ARM{}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if ipTag.IpTagType != nil {
 		ipTagType := *ipTag.IpTagType
 		result.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if ipTag.Tag != nil {
 		tag := *ipTag.Tag
 		result.Tag = &tag
@@ -24289,13 +24289,13 @@ func (ipTag *VirtualMachineIpTag) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIpTag_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -24376,13 +24376,13 @@ func (ipTag *VirtualMachineIpTag_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIpTag_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -24489,7 +24489,7 @@ func (configuration *VirtualMachinePublicIPAddressDnsSettingsConfiguration) Conv
 	}
 	result := &VirtualMachinePublicIPAddressDnsSettingsConfiguration_ARM{}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if configuration.DomainNameLabel != nil {
 		domainNameLabel := *configuration.DomainNameLabel
 		result.DomainNameLabel = &domainNameLabel
@@ -24509,7 +24509,7 @@ func (configuration *VirtualMachinePublicIPAddressDnsSettingsConfiguration) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachinePublicIPAddressDnsSettingsConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		configuration.DomainNameLabel = &domainNameLabel
@@ -24579,7 +24579,7 @@ func (configuration *VirtualMachinePublicIPAddressDnsSettingsConfiguration_STATU
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachinePublicIPAddressDnsSettingsConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		configuration.DomainNameLabel = &domainNameLabel

--- a/v2/api/compute/v1beta20200930/disk_types_gen.go
+++ b/v2/api/compute/v1beta20200930/disk_types_gen.go
@@ -361,7 +361,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 	}
 	result := &Disk_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if disk.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*disk.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -371,16 +371,16 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if disk.Location != nil {
 		location := *disk.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if disk.BurstingEnabled != nil ||
 		disk.CreationData != nil ||
 		disk.DiskAccessReference != nil ||
@@ -484,7 +484,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.Tier = &tier
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if disk.Sku != nil {
 		sku_ARM, err := (*disk.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -494,7 +494,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if disk.Tags != nil {
 		result.Tags = make(map[string]string, len(disk.Tags))
 		for key, value := range disk.Tags {
@@ -502,7 +502,7 @@ func (disk *Disk_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range disk.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -521,10 +521,10 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Disk_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	disk.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BurstingEnabled’:
+	// Set property "BurstingEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BurstingEnabled != nil {
@@ -533,7 +533,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -547,9 +547,9 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// no assignment for property ‘DiskAccessReference’
+	// no assignment for property "DiskAccessReference"
 
-	// Set property ‘DiskIOPSReadOnly’:
+	// Set property "DiskIOPSReadOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskIOPSReadOnly != nil {
@@ -558,7 +558,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskIOPSReadWrite != nil {
@@ -567,7 +567,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘DiskMBpsReadOnly’:
+	// Set property "DiskMBpsReadOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskMBpsReadOnly != nil {
@@ -576,7 +576,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskMBpsReadWrite != nil {
@@ -585,7 +585,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskSizeGB != nil {
@@ -594,7 +594,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -608,7 +608,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘EncryptionSettingsCollection’:
+	// Set property "EncryptionSettingsCollection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionSettingsCollection != nil {
@@ -622,7 +622,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -633,7 +633,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		disk.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -642,13 +642,13 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		disk.Location = &location
 	}
 
-	// Set property ‘MaxShares’:
+	// Set property "MaxShares":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxShares != nil {
@@ -657,7 +657,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘NetworkAccessPolicy’:
+	// Set property "NetworkAccessPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAccessPolicy != nil {
@@ -666,7 +666,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -675,10 +675,10 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	disk.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PurchasePlan’:
+	// Set property "PurchasePlan":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PurchasePlan != nil {
@@ -692,7 +692,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 DiskSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -703,7 +703,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		disk.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		disk.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -711,7 +711,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tier != nil {
@@ -720,7 +720,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		disk.Zones = append(disk.Zones, item)
 	}
@@ -1222,7 +1222,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Disk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BurstingEnabled’:
+	// Set property "BurstingEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BurstingEnabled != nil {
@@ -1231,9 +1231,9 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -1247,7 +1247,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskAccessId’:
+	// Set property "DiskAccessId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskAccessId != nil {
@@ -1256,7 +1256,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskIOPSReadOnly’:
+	// Set property "DiskIOPSReadOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskIOPSReadOnly != nil {
@@ -1265,7 +1265,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskIOPSReadWrite != nil {
@@ -1274,7 +1274,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskMBpsReadOnly’:
+	// Set property "DiskMBpsReadOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskMBpsReadOnly != nil {
@@ -1283,7 +1283,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskMBpsReadWrite != nil {
@@ -1292,7 +1292,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskSizeBytes’:
+	// Set property "DiskSizeBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskSizeBytes != nil {
@@ -1301,7 +1301,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskSizeGB != nil {
@@ -1310,7 +1310,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DiskState’:
+	// Set property "DiskState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskState != nil {
@@ -1319,7 +1319,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1333,7 +1333,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘EncryptionSettingsCollection’:
+	// Set property "EncryptionSettingsCollection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionSettingsCollection != nil {
@@ -1347,7 +1347,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1358,7 +1358,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -1367,30 +1367,30 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		disk.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		disk.Location = &location
 	}
 
-	// Set property ‘ManagedBy’:
+	// Set property "ManagedBy":
 	if typedInput.ManagedBy != nil {
 		managedBy := *typedInput.ManagedBy
 		disk.ManagedBy = &managedBy
 	}
 
-	// Set property ‘ManagedByExtended’:
+	// Set property "ManagedByExtended":
 	for _, item := range typedInput.ManagedByExtended {
 		disk.ManagedByExtended = append(disk.ManagedByExtended, item)
 	}
 
-	// Set property ‘MaxShares’:
+	// Set property "MaxShares":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxShares != nil {
@@ -1399,13 +1399,13 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘NetworkAccessPolicy’:
+	// Set property "NetworkAccessPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAccessPolicy != nil {
@@ -1414,7 +1414,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -1423,7 +1423,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1432,7 +1432,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘PurchasePlan’:
+	// Set property "PurchasePlan":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PurchasePlan != nil {
@@ -1446,7 +1446,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ShareInfo’:
+	// Set property "ShareInfo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ShareInfo {
@@ -1459,7 +1459,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 DiskSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1470,7 +1470,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		disk.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1478,7 +1478,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tier != nil {
@@ -1487,7 +1487,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘TimeCreated’:
+	// Set property "TimeCreated":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TimeCreated != nil {
@@ -1496,13 +1496,13 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		disk.Type = &typeVar
 	}
 
-	// Set property ‘UniqueId’:
+	// Set property "UniqueId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UniqueId != nil {
@@ -1511,7 +1511,7 @@ func (disk *Disk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		disk.Zones = append(disk.Zones, item)
 	}
@@ -1951,13 +1951,13 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &CreationData_ARM{}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if data.CreateOption != nil {
 		createOption := *data.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘GalleryImageReference’:
+	// Set property "GalleryImageReference":
 	if data.GalleryImageReference != nil {
 		galleryImageReference_ARM, err := (*data.GalleryImageReference).ConvertToARM(resolved)
 		if err != nil {
@@ -1967,7 +1967,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.GalleryImageReference = &galleryImageReference
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if data.ImageReference != nil {
 		imageReference_ARM, err := (*data.ImageReference).ConvertToARM(resolved)
 		if err != nil {
@@ -1977,13 +1977,13 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.ImageReference = &imageReference
 	}
 
-	// Set property ‘LogicalSectorSize’:
+	// Set property "LogicalSectorSize":
 	if data.LogicalSectorSize != nil {
 		logicalSectorSize := *data.LogicalSectorSize
 		result.LogicalSectorSize = &logicalSectorSize
 	}
 
-	// Set property ‘SourceResourceId’:
+	// Set property "SourceResourceId":
 	if data.SourceResourceReference != nil {
 		sourceResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*data.SourceResourceReference)
 		if err != nil {
@@ -1993,19 +1993,19 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.SourceResourceId = &sourceResourceReference
 	}
 
-	// Set property ‘SourceUri’:
+	// Set property "SourceUri":
 	if data.SourceUri != nil {
 		sourceUri := *data.SourceUri
 		result.SourceUri = &sourceUri
 	}
 
-	// Set property ‘StorageAccountId’:
+	// Set property "StorageAccountId":
 	if data.StorageAccountId != nil {
 		storageAccountId := *data.StorageAccountId
 		result.StorageAccountId = &storageAccountId
 	}
 
-	// Set property ‘UploadSizeBytes’:
+	// Set property "UploadSizeBytes":
 	if data.UploadSizeBytes != nil {
 		uploadSizeBytes := *data.UploadSizeBytes
 		result.UploadSizeBytes = &uploadSizeBytes
@@ -2025,13 +2025,13 @@ func (data *CreationData) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CreationData_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		data.CreateOption = &createOption
 	}
 
-	// Set property ‘GalleryImageReference’:
+	// Set property "GalleryImageReference":
 	if typedInput.GalleryImageReference != nil {
 		var galleryImageReference1 ImageDiskReference
 		err := galleryImageReference1.PopulateFromARM(owner, *typedInput.GalleryImageReference)
@@ -2042,7 +2042,7 @@ func (data *CreationData) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		data.GalleryImageReference = &galleryImageReference
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageDiskReference
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -2053,27 +2053,27 @@ func (data *CreationData) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		data.ImageReference = &imageReference
 	}
 
-	// Set property ‘LogicalSectorSize’:
+	// Set property "LogicalSectorSize":
 	if typedInput.LogicalSectorSize != nil {
 		logicalSectorSize := *typedInput.LogicalSectorSize
 		data.LogicalSectorSize = &logicalSectorSize
 	}
 
-	// no assignment for property ‘SourceResourceReference’
+	// no assignment for property "SourceResourceReference"
 
-	// Set property ‘SourceUri’:
+	// Set property "SourceUri":
 	if typedInput.SourceUri != nil {
 		sourceUri := *typedInput.SourceUri
 		data.SourceUri = &sourceUri
 	}
 
-	// Set property ‘StorageAccountId’:
+	// Set property "StorageAccountId":
 	if typedInput.StorageAccountId != nil {
 		storageAccountId := *typedInput.StorageAccountId
 		data.StorageAccountId = &storageAccountId
 	}
 
-	// Set property ‘UploadSizeBytes’:
+	// Set property "UploadSizeBytes":
 	if typedInput.UploadSizeBytes != nil {
 		uploadSizeBytes := *typedInput.UploadSizeBytes
 		data.UploadSizeBytes = &uploadSizeBytes
@@ -2237,13 +2237,13 @@ func (data *CreationData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CreationData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		data.CreateOption = &createOption
 	}
 
-	// Set property ‘GalleryImageReference’:
+	// Set property "GalleryImageReference":
 	if typedInput.GalleryImageReference != nil {
 		var galleryImageReference1 ImageDiskReference_STATUS
 		err := galleryImageReference1.PopulateFromARM(owner, *typedInput.GalleryImageReference)
@@ -2254,7 +2254,7 @@ func (data *CreationData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		data.GalleryImageReference = &galleryImageReference
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageDiskReference_STATUS
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -2265,37 +2265,37 @@ func (data *CreationData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		data.ImageReference = &imageReference
 	}
 
-	// Set property ‘LogicalSectorSize’:
+	// Set property "LogicalSectorSize":
 	if typedInput.LogicalSectorSize != nil {
 		logicalSectorSize := *typedInput.LogicalSectorSize
 		data.LogicalSectorSize = &logicalSectorSize
 	}
 
-	// Set property ‘SourceResourceId’:
+	// Set property "SourceResourceId":
 	if typedInput.SourceResourceId != nil {
 		sourceResourceId := *typedInput.SourceResourceId
 		data.SourceResourceId = &sourceResourceId
 	}
 
-	// Set property ‘SourceUniqueId’:
+	// Set property "SourceUniqueId":
 	if typedInput.SourceUniqueId != nil {
 		sourceUniqueId := *typedInput.SourceUniqueId
 		data.SourceUniqueId = &sourceUniqueId
 	}
 
-	// Set property ‘SourceUri’:
+	// Set property "SourceUri":
 	if typedInput.SourceUri != nil {
 		sourceUri := *typedInput.SourceUri
 		data.SourceUri = &sourceUri
 	}
 
-	// Set property ‘StorageAccountId’:
+	// Set property "StorageAccountId":
 	if typedInput.StorageAccountId != nil {
 		storageAccountId := *typedInput.StorageAccountId
 		data.StorageAccountId = &storageAccountId
 	}
 
-	// Set property ‘UploadSizeBytes’:
+	// Set property "UploadSizeBytes":
 	if typedInput.UploadSizeBytes != nil {
 		uploadSizeBytes := *typedInput.UploadSizeBytes
 		data.UploadSizeBytes = &uploadSizeBytes
@@ -2477,7 +2477,7 @@ func (diskSku *DiskSku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &DiskSku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if diskSku.Name != nil {
 		name := *diskSku.Name
 		result.Name = &name
@@ -2497,7 +2497,7 @@ func (diskSku *DiskSku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		diskSku.Name = &name
@@ -2566,13 +2566,13 @@ func (diskSku *DiskSku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		diskSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		diskSku.Tier = &tier
@@ -2654,7 +2654,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Encryption_ARM{}
 
-	// Set property ‘DiskEncryptionSetId’:
+	// Set property "DiskEncryptionSetId":
 	if encryption.DiskEncryptionSetReference != nil {
 		diskEncryptionSetReferenceARMID, err := resolved.ResolvedReferences.Lookup(*encryption.DiskEncryptionSetReference)
 		if err != nil {
@@ -2664,7 +2664,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.DiskEncryptionSetId = &diskEncryptionSetReference
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if encryption.Type != nil {
 		typeVar := *encryption.Type
 		result.Type = &typeVar
@@ -2684,9 +2684,9 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘DiskEncryptionSetReference’
+	// no assignment for property "DiskEncryptionSetReference"
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		encryption.Type = &typeVar
@@ -2771,13 +2771,13 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSetId’:
+	// Set property "DiskEncryptionSetId":
 	if typedInput.DiskEncryptionSetId != nil {
 		diskEncryptionSetId := *typedInput.DiskEncryptionSetId
 		encryption.DiskEncryptionSetId = &diskEncryptionSetId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		encryption.Type = &typeVar
@@ -2849,13 +2849,13 @@ func (collection *EncryptionSettingsCollection) ConvertToARM(resolved genruntime
 	}
 	result := &EncryptionSettingsCollection_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if collection.Enabled != nil {
 		enabled := *collection.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	for _, item := range collection.EncryptionSettings {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2864,7 +2864,7 @@ func (collection *EncryptionSettingsCollection) ConvertToARM(resolved genruntime
 		result.EncryptionSettings = append(result.EncryptionSettings, *item_ARM.(*EncryptionSettingsElement_ARM))
 	}
 
-	// Set property ‘EncryptionSettingsVersion’:
+	// Set property "EncryptionSettingsVersion":
 	if collection.EncryptionSettingsVersion != nil {
 		encryptionSettingsVersion := *collection.EncryptionSettingsVersion
 		result.EncryptionSettingsVersion = &encryptionSettingsVersion
@@ -2884,13 +2884,13 @@ func (collection *EncryptionSettingsCollection) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionSettingsCollection_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		collection.Enabled = &enabled
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	for _, item := range typedInput.EncryptionSettings {
 		var item1 EncryptionSettingsElement
 		err := item1.PopulateFromARM(owner, item)
@@ -2900,7 +2900,7 @@ func (collection *EncryptionSettingsCollection) PopulateFromARM(owner genruntime
 		collection.EncryptionSettings = append(collection.EncryptionSettings, item1)
 	}
 
-	// Set property ‘EncryptionSettingsVersion’:
+	// Set property "EncryptionSettingsVersion":
 	if typedInput.EncryptionSettingsVersion != nil {
 		encryptionSettingsVersion := *typedInput.EncryptionSettingsVersion
 		collection.EncryptionSettingsVersion = &encryptionSettingsVersion
@@ -3012,13 +3012,13 @@ func (collection *EncryptionSettingsCollection_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionSettingsCollection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		collection.Enabled = &enabled
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	for _, item := range typedInput.EncryptionSettings {
 		var item1 EncryptionSettingsElement_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3028,7 +3028,7 @@ func (collection *EncryptionSettingsCollection_STATUS) PopulateFromARM(owner gen
 		collection.EncryptionSettings = append(collection.EncryptionSettings, item1)
 	}
 
-	// Set property ‘EncryptionSettingsVersion’:
+	// Set property "EncryptionSettingsVersion":
 	if typedInput.EncryptionSettingsVersion != nil {
 		encryptionSettingsVersion := *typedInput.EncryptionSettingsVersion
 		collection.EncryptionSettingsVersion = &encryptionSettingsVersion
@@ -3134,13 +3134,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -3160,13 +3160,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -3241,13 +3241,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -3343,25 +3343,25 @@ func (plan *PurchasePlan) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &PurchasePlan_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if plan.Name != nil {
 		name := *plan.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if plan.Product != nil {
 		product := *plan.Product
 		result.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if plan.PromotionCode != nil {
 		promotionCode := *plan.PromotionCode
 		result.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if plan.Publisher != nil {
 		publisher := *plan.Publisher
 		result.Publisher = &publisher
@@ -3381,25 +3381,25 @@ func (plan *PurchasePlan) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PurchasePlan_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		plan.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if typedInput.Product != nil {
 		product := *typedInput.Product
 		plan.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if typedInput.PromotionCode != nil {
 		promotionCode := *typedInput.PromotionCode
 		plan.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		plan.Publisher = &publisher
@@ -3478,25 +3478,25 @@ func (plan *PurchasePlan_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PurchasePlan_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		plan.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if typedInput.Product != nil {
 		product := *typedInput.Product
 		plan.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if typedInput.PromotionCode != nil {
 		promotionCode := *typedInput.PromotionCode
 		plan.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		plan.Publisher = &publisher
@@ -3572,7 +3572,7 @@ func (element *ShareInfoElement_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ShareInfoElement_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmUri’:
+	// Set property "VmUri":
 	if typedInput.VmUri != nil {
 		vmUri := *typedInput.VmUri
 		element.VmUri = &vmUri
@@ -3653,7 +3653,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &EncryptionSettingsElement_ARM{}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if element.DiskEncryptionKey != nil {
 		diskEncryptionKey_ARM, err := (*element.DiskEncryptionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -3663,7 +3663,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 		result.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if element.KeyEncryptionKey != nil {
 		keyEncryptionKey_ARM, err := (*element.KeyEncryptionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -3687,7 +3687,7 @@ func (element *EncryptionSettingsElement) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionSettingsElement_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if typedInput.DiskEncryptionKey != nil {
 		var diskEncryptionKey1 KeyVaultAndSecretReference
 		err := diskEncryptionKey1.PopulateFromARM(owner, *typedInput.DiskEncryptionKey)
@@ -3698,7 +3698,7 @@ func (element *EncryptionSettingsElement) PopulateFromARM(owner genruntime.Arbit
 		element.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if typedInput.KeyEncryptionKey != nil {
 		var keyEncryptionKey1 KeyVaultAndKeyReference
 		err := keyEncryptionKey1.PopulateFromARM(owner, *typedInput.KeyEncryptionKey)
@@ -3804,7 +3804,7 @@ func (element *EncryptionSettingsElement_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionSettingsElement_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if typedInput.DiskEncryptionKey != nil {
 		var diskEncryptionKey1 KeyVaultAndSecretReference_STATUS
 		err := diskEncryptionKey1.PopulateFromARM(owner, *typedInput.DiskEncryptionKey)
@@ -3815,7 +3815,7 @@ func (element *EncryptionSettingsElement_STATUS) PopulateFromARM(owner genruntim
 		element.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if typedInput.KeyEncryptionKey != nil {
 		var keyEncryptionKey1 KeyVaultAndKeyReference_STATUS
 		err := keyEncryptionKey1.PopulateFromARM(owner, *typedInput.KeyEncryptionKey)
@@ -3937,7 +3937,7 @@ func (reference *ImageDiskReference) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &ImageDiskReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -3947,7 +3947,7 @@ func (reference *ImageDiskReference) ConvertToARM(resolved genruntime.ConvertToA
 		result.Id = &reference1
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if reference.Lun != nil {
 		lun := *reference.Lun
 		result.Lun = &lun
@@ -3967,13 +3967,13 @@ func (reference *ImageDiskReference) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageDiskReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		reference.Lun = &lun
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -4044,13 +4044,13 @@ func (reference *ImageDiskReference_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageDiskReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		reference.Lun = &lun
@@ -4113,13 +4113,13 @@ func (reference *KeyVaultAndKeyReference) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &KeyVaultAndKeyReference_ARM{}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if reference.KeyUrl != nil {
 		keyUrl := *reference.KeyUrl
 		result.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if reference.SourceVault != nil {
 		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -4143,13 +4143,13 @@ func (reference *KeyVaultAndKeyReference) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultAndKeyReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if typedInput.KeyUrl != nil {
 		keyUrl := *typedInput.KeyUrl
 		reference.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SourceVault
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -4237,13 +4237,13 @@ func (reference *KeyVaultAndKeyReference_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultAndKeyReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if typedInput.KeyUrl != nil {
 		keyUrl := *typedInput.KeyUrl
 		reference.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SourceVault_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -4329,13 +4329,13 @@ func (reference *KeyVaultAndSecretReference) ConvertToARM(resolved genruntime.Co
 	}
 	result := &KeyVaultAndSecretReference_ARM{}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if reference.SecretUrl != nil {
 		secretUrl := *reference.SecretUrl
 		result.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if reference.SourceVault != nil {
 		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -4359,13 +4359,13 @@ func (reference *KeyVaultAndSecretReference) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultAndSecretReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if typedInput.SecretUrl != nil {
 		secretUrl := *typedInput.SecretUrl
 		reference.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SourceVault
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -4453,13 +4453,13 @@ func (reference *KeyVaultAndSecretReference_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultAndSecretReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if typedInput.SecretUrl != nil {
 		secretUrl := *typedInput.SecretUrl
 		reference.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SourceVault_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -4541,7 +4541,7 @@ func (vault *SourceVault) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &SourceVault_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if vault.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*vault.Reference)
 		if err != nil {
@@ -4565,7 +4565,7 @@ func (vault *SourceVault) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SourceVault_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -4629,7 +4629,7 @@ func (vault *SourceVault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SourceVault_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		vault.Id = &id

--- a/v2/api/compute/v1beta20200930/snapshot_types_gen.go
+++ b/v2/api/compute/v1beta20200930/snapshot_types_gen.go
@@ -349,7 +349,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &Snapshot_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if snapshot.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*snapshot.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -359,16 +359,16 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if snapshot.Location != nil {
 		location := *snapshot.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if snapshot.CreationData != nil ||
 		snapshot.DiskAccessReference != nil ||
 		snapshot.DiskSizeGB != nil ||
@@ -447,7 +447,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.PurchasePlan = &purchasePlan
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if snapshot.Sku != nil {
 		sku_ARM, err := (*snapshot.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -457,7 +457,7 @@ func (snapshot *Snapshot_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if snapshot.Tags != nil {
 		result.Tags = make(map[string]string, len(snapshot.Tags))
 		for key, value := range snapshot.Tags {
@@ -479,10 +479,10 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Snapshot_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	snapshot.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -496,9 +496,9 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// no assignment for property ‘DiskAccessReference’
+	// no assignment for property "DiskAccessReference"
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskSizeGB != nil {
@@ -507,7 +507,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘DiskState’:
+	// Set property "DiskState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskState != nil {
@@ -516,7 +516,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -530,7 +530,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘EncryptionSettingsCollection’:
+	// Set property "EncryptionSettingsCollection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionSettingsCollection != nil {
@@ -544,7 +544,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -555,7 +555,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		snapshot.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -564,7 +564,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Incremental’:
+	// Set property "Incremental":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Incremental != nil {
@@ -573,13 +573,13 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		snapshot.Location = &location
 	}
 
-	// Set property ‘NetworkAccessPolicy’:
+	// Set property "NetworkAccessPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAccessPolicy != nil {
@@ -588,7 +588,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -597,10 +597,10 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	snapshot.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PurchasePlan’:
+	// Set property "PurchasePlan":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PurchasePlan != nil {
@@ -614,7 +614,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 SnapshotSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -625,7 +625,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		snapshot.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		snapshot.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1094,9 +1094,9 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Snapshot_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -1110,7 +1110,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DiskAccessId’:
+	// Set property "DiskAccessId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskAccessId != nil {
@@ -1119,7 +1119,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DiskSizeBytes’:
+	// Set property "DiskSizeBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskSizeBytes != nil {
@@ -1128,7 +1128,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskSizeGB != nil {
@@ -1137,7 +1137,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DiskState’:
+	// Set property "DiskState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskState != nil {
@@ -1146,7 +1146,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1160,7 +1160,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘EncryptionSettingsCollection’:
+	// Set property "EncryptionSettingsCollection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionSettingsCollection != nil {
@@ -1174,7 +1174,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1185,7 +1185,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		snapshot.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -1194,13 +1194,13 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		snapshot.Id = &id
 	}
 
-	// Set property ‘Incremental’:
+	// Set property "Incremental":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Incremental != nil {
@@ -1209,25 +1209,25 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		snapshot.Location = &location
 	}
 
-	// Set property ‘ManagedBy’:
+	// Set property "ManagedBy":
 	if typedInput.ManagedBy != nil {
 		managedBy := *typedInput.ManagedBy
 		snapshot.ManagedBy = &managedBy
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		snapshot.Name = &name
 	}
 
-	// Set property ‘NetworkAccessPolicy’:
+	// Set property "NetworkAccessPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAccessPolicy != nil {
@@ -1236,7 +1236,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -1245,7 +1245,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1254,7 +1254,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PurchasePlan’:
+	// Set property "PurchasePlan":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PurchasePlan != nil {
@@ -1268,7 +1268,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 SnapshotSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1279,7 +1279,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		snapshot.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		snapshot.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1287,7 +1287,7 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘TimeCreated’:
+	// Set property "TimeCreated":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TimeCreated != nil {
@@ -1296,13 +1296,13 @@ func (snapshot *Snapshot_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		snapshot.Type = &typeVar
 	}
 
-	// Set property ‘UniqueId’:
+	// Set property "UniqueId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UniqueId != nil {
@@ -1702,7 +1702,7 @@ func (snapshotSku *SnapshotSku) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &SnapshotSku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if snapshotSku.Name != nil {
 		name := *snapshotSku.Name
 		result.Name = &name
@@ -1722,7 +1722,7 @@ func (snapshotSku *SnapshotSku) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SnapshotSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		snapshotSku.Name = &name
@@ -1791,13 +1791,13 @@ func (snapshotSku *SnapshotSku_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SnapshotSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		snapshotSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		snapshotSku.Tier = &tier

--- a/v2/api/compute/v1beta20201201/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/compute/v1beta20201201/virtual_machine_scale_set_types_gen.go
@@ -354,7 +354,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 	}
 	result := &VirtualMachineScaleSet_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if scaleSet.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*scaleSet.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -364,7 +364,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if scaleSet.Identity != nil {
 		identity_ARM, err := (*scaleSet.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -374,16 +374,16 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if scaleSet.Location != nil {
 		location := *scaleSet.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if scaleSet.Plan != nil {
 		plan_ARM, err := (*scaleSet.Plan).ConvertToARM(resolved)
 		if err != nil {
@@ -393,7 +393,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Plan = &plan
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if scaleSet.AdditionalCapabilities != nil ||
 		scaleSet.AutomaticRepairsPolicy != nil ||
 		scaleSet.DoNotRunExtensionsOnOverprovisionedVMs != nil ||
@@ -490,7 +490,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.ZoneBalance = &zoneBalance
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if scaleSet.Sku != nil {
 		sku_ARM, err := (*scaleSet.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -500,7 +500,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if scaleSet.Tags != nil {
 		result.Tags = make(map[string]string, len(scaleSet.Tags))
 		for key, value := range scaleSet.Tags {
@@ -508,7 +508,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range scaleSet.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -527,7 +527,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSet_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -541,7 +541,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘AutomaticRepairsPolicy’:
+	// Set property "AutomaticRepairsPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticRepairsPolicy != nil {
@@ -555,10 +555,10 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	scaleSet.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DoNotRunExtensionsOnOverprovisionedVMs’:
+	// Set property "DoNotRunExtensionsOnOverprovisionedVMs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DoNotRunExtensionsOnOverprovisionedVMs != nil {
@@ -567,7 +567,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -578,7 +578,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -592,7 +592,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineScaleSetIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -603,13 +603,13 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		scaleSet.Location = &location
 	}
 
-	// Set property ‘OrchestrationMode’:
+	// Set property "OrchestrationMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestrationMode != nil {
@@ -618,7 +618,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Overprovision’:
+	// Set property "Overprovision":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Overprovision != nil {
@@ -627,10 +627,10 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	scaleSet.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -641,7 +641,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomainCount’:
+	// Set property "PlatformFaultDomainCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomainCount != nil {
@@ -650,7 +650,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -664,7 +664,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ScaleInPolicy’:
+	// Set property "ScaleInPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleInPolicy != nil {
@@ -678,7 +678,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘SinglePlacementGroup’:
+	// Set property "SinglePlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SinglePlacementGroup != nil {
@@ -687,7 +687,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -698,7 +698,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		scaleSet.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -706,7 +706,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘UpgradePolicy’:
+	// Set property "UpgradePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradePolicy != nil {
@@ -720,7 +720,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘VirtualMachineProfile’:
+	// Set property "VirtualMachineProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineProfile != nil {
@@ -734,7 +734,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ZoneBalance’:
+	// Set property "ZoneBalance":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneBalance != nil {
@@ -743,7 +743,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		scaleSet.Zones = append(scaleSet.Zones, item)
 	}
@@ -1324,7 +1324,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -1338,7 +1338,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘AutomaticRepairsPolicy’:
+	// Set property "AutomaticRepairsPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticRepairsPolicy != nil {
@@ -1352,9 +1352,9 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DoNotRunExtensionsOnOverprovisionedVMs’:
+	// Set property "DoNotRunExtensionsOnOverprovisionedVMs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DoNotRunExtensionsOnOverprovisionedVMs != nil {
@@ -1363,7 +1363,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1374,7 +1374,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -1388,13 +1388,13 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		scaleSet.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineScaleSetIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1405,19 +1405,19 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		scaleSet.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		scaleSet.Name = &name
 	}
 
-	// Set property ‘OrchestrationMode’:
+	// Set property "OrchestrationMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestrationMode != nil {
@@ -1426,7 +1426,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Overprovision’:
+	// Set property "Overprovision":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Overprovision != nil {
@@ -1435,7 +1435,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan_STATUS
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -1446,7 +1446,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomainCount’:
+	// Set property "PlatformFaultDomainCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomainCount != nil {
@@ -1455,7 +1455,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1464,7 +1464,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -1478,7 +1478,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ScaleInPolicy’:
+	// Set property "ScaleInPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleInPolicy != nil {
@@ -1492,7 +1492,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘SinglePlacementGroup’:
+	// Set property "SinglePlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SinglePlacementGroup != nil {
@@ -1501,7 +1501,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1512,7 +1512,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		scaleSet.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1520,13 +1520,13 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		scaleSet.Type = &typeVar
 	}
 
-	// Set property ‘UniqueId’:
+	// Set property "UniqueId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UniqueId != nil {
@@ -1535,7 +1535,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘UpgradePolicy’:
+	// Set property "UpgradePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradePolicy != nil {
@@ -1549,7 +1549,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘VirtualMachineProfile’:
+	// Set property "VirtualMachineProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineProfile != nil {
@@ -1563,7 +1563,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ZoneBalance’:
+	// Set property "ZoneBalance":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneBalance != nil {
@@ -1572,7 +1572,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		scaleSet.Zones = append(scaleSet.Zones, item)
 	}
@@ -2023,13 +2023,13 @@ func (policy *AutomaticRepairsPolicy) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &AutomaticRepairsPolicy_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if policy.Enabled != nil {
 		enabled := *policy.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘GracePeriod’:
+	// Set property "GracePeriod":
 	if policy.GracePeriod != nil {
 		gracePeriod := *policy.GracePeriod
 		result.GracePeriod = &gracePeriod
@@ -2049,13 +2049,13 @@ func (policy *AutomaticRepairsPolicy) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticRepairsPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
 	}
 
-	// Set property ‘GracePeriod’:
+	// Set property "GracePeriod":
 	if typedInput.GracePeriod != nil {
 		gracePeriod := *typedInput.GracePeriod
 		policy.GracePeriod = &gracePeriod
@@ -2130,13 +2130,13 @@ func (policy *AutomaticRepairsPolicy_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticRepairsPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
 	}
 
-	// Set property ‘GracePeriod’:
+	// Set property "GracePeriod":
 	if typedInput.GracePeriod != nil {
 		gracePeriod := *typedInput.GracePeriod
 		policy.GracePeriod = &gracePeriod
@@ -2222,7 +2222,7 @@ func (policy *ScaleInPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &ScaleInPolicy_ARM{}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range policy.Rules {
 		result.Rules = append(result.Rules, item)
 	}
@@ -2241,7 +2241,7 @@ func (policy *ScaleInPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScaleInPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		policy.Rules = append(policy.Rules, item)
 	}
@@ -2318,7 +2318,7 @@ func (policy *ScaleInPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScaleInPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		policy.Rules = append(policy.Rules, item)
 	}
@@ -2392,19 +2392,19 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sku.Capacity != nil {
 		capacity := *sku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -2424,19 +2424,19 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2508,19 +2508,19 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2587,7 +2587,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &UpgradePolicy_ARM{}
 
-	// Set property ‘AutomaticOSUpgradePolicy’:
+	// Set property "AutomaticOSUpgradePolicy":
 	if policy.AutomaticOSUpgradePolicy != nil {
 		automaticOSUpgradePolicy_ARM, err := (*policy.AutomaticOSUpgradePolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -2597,13 +2597,13 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if policy.Mode != nil {
 		mode := *policy.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘RollingUpgradePolicy’:
+	// Set property "RollingUpgradePolicy":
 	if policy.RollingUpgradePolicy != nil {
 		rollingUpgradePolicy_ARM, err := (*policy.RollingUpgradePolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -2627,7 +2627,7 @@ func (policy *UpgradePolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpgradePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticOSUpgradePolicy’:
+	// Set property "AutomaticOSUpgradePolicy":
 	if typedInput.AutomaticOSUpgradePolicy != nil {
 		var automaticOSUpgradePolicy1 AutomaticOSUpgradePolicy
 		err := automaticOSUpgradePolicy1.PopulateFromARM(owner, *typedInput.AutomaticOSUpgradePolicy)
@@ -2638,13 +2638,13 @@ func (policy *UpgradePolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		policy.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		policy.Mode = &mode
 	}
 
-	// Set property ‘RollingUpgradePolicy’:
+	// Set property "RollingUpgradePolicy":
 	if typedInput.RollingUpgradePolicy != nil {
 		var rollingUpgradePolicy1 RollingUpgradePolicy
 		err := rollingUpgradePolicy1.PopulateFromARM(owner, *typedInput.RollingUpgradePolicy)
@@ -2767,7 +2767,7 @@ func (policy *UpgradePolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpgradePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticOSUpgradePolicy’:
+	// Set property "AutomaticOSUpgradePolicy":
 	if typedInput.AutomaticOSUpgradePolicy != nil {
 		var automaticOSUpgradePolicy1 AutomaticOSUpgradePolicy_STATUS
 		err := automaticOSUpgradePolicy1.PopulateFromARM(owner, *typedInput.AutomaticOSUpgradePolicy)
@@ -2778,13 +2778,13 @@ func (policy *UpgradePolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		policy.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		policy.Mode = &mode
 	}
 
-	// Set property ‘RollingUpgradePolicy’:
+	// Set property "RollingUpgradePolicy":
 	if typedInput.RollingUpgradePolicy != nil {
 		var rollingUpgradePolicy1 RollingUpgradePolicy_STATUS
 		err := rollingUpgradePolicy1.PopulateFromARM(owner, *typedInput.RollingUpgradePolicy)
@@ -2901,13 +2901,13 @@ func (identity *VirtualMachineScaleSetIdentity) ConvertToARM(resolved genruntime
 	}
 	result := &VirtualMachineScaleSetIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -2932,13 +2932,13 @@ func (identity *VirtualMachineScaleSetIdentity) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -3041,25 +3041,25 @@ func (identity *VirtualMachineScaleSetIdentity_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -3187,7 +3187,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 	}
 	result := &VirtualMachineScaleSetVMProfile_ARM{}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	if profile.BillingProfile != nil {
 		billingProfile_ARM, err := (*profile.BillingProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3197,7 +3197,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.BillingProfile = &billingProfile
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	if profile.DiagnosticsProfile != nil {
 		diagnosticsProfile_ARM, err := (*profile.DiagnosticsProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3207,13 +3207,13 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.DiagnosticsProfile = &diagnosticsProfile
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	if profile.EvictionPolicy != nil {
 		evictionPolicy := *profile.EvictionPolicy
 		result.EvictionPolicy = &evictionPolicy
 	}
 
-	// Set property ‘ExtensionProfile’:
+	// Set property "ExtensionProfile":
 	if profile.ExtensionProfile != nil {
 		extensionProfile_ARM, err := (*profile.ExtensionProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3223,13 +3223,13 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.ExtensionProfile = &extensionProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if profile.LicenseType != nil {
 		licenseType := *profile.LicenseType
 		result.LicenseType = &licenseType
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if profile.NetworkProfile != nil {
 		networkProfile_ARM, err := (*profile.NetworkProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3239,7 +3239,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	if profile.OsProfile != nil {
 		osProfile_ARM, err := (*profile.OsProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3249,13 +3249,13 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.OsProfile = &osProfile
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if profile.Priority != nil {
 		priority := *profile.Priority
 		result.Priority = &priority
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	if profile.ScheduledEventsProfile != nil {
 		scheduledEventsProfile_ARM, err := (*profile.ScheduledEventsProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3265,7 +3265,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if profile.SecurityProfile != nil {
 		securityProfile_ARM, err := (*profile.SecurityProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3275,7 +3275,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if profile.StorageProfile != nil {
 		storageProfile_ARM, err := (*profile.StorageProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3299,7 +3299,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetVMProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	if typedInput.BillingProfile != nil {
 		var billingProfile1 BillingProfile
 		err := billingProfile1.PopulateFromARM(owner, *typedInput.BillingProfile)
@@ -3310,7 +3310,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.BillingProfile = &billingProfile
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	if typedInput.DiagnosticsProfile != nil {
 		var diagnosticsProfile1 DiagnosticsProfile
 		err := diagnosticsProfile1.PopulateFromARM(owner, *typedInput.DiagnosticsProfile)
@@ -3321,13 +3321,13 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.DiagnosticsProfile = &diagnosticsProfile
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	if typedInput.EvictionPolicy != nil {
 		evictionPolicy := *typedInput.EvictionPolicy
 		profile.EvictionPolicy = &evictionPolicy
 	}
 
-	// Set property ‘ExtensionProfile’:
+	// Set property "ExtensionProfile":
 	if typedInput.ExtensionProfile != nil {
 		var extensionProfile1 VirtualMachineScaleSetExtensionProfile
 		err := extensionProfile1.PopulateFromARM(owner, *typedInput.ExtensionProfile)
@@ -3338,13 +3338,13 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.ExtensionProfile = &extensionProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if typedInput.NetworkProfile != nil {
 		var networkProfile1 VirtualMachineScaleSetNetworkProfile
 		err := networkProfile1.PopulateFromARM(owner, *typedInput.NetworkProfile)
@@ -3355,7 +3355,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	if typedInput.OsProfile != nil {
 		var osProfile1 VirtualMachineScaleSetOSProfile
 		err := osProfile1.PopulateFromARM(owner, *typedInput.OsProfile)
@@ -3366,13 +3366,13 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.OsProfile = &osProfile
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		profile.Priority = &priority
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	if typedInput.ScheduledEventsProfile != nil {
 		var scheduledEventsProfile1 ScheduledEventsProfile
 		err := scheduledEventsProfile1.PopulateFromARM(owner, *typedInput.ScheduledEventsProfile)
@@ -3383,7 +3383,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 SecurityProfile
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -3394,7 +3394,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 VirtualMachineScaleSetStorageProfile
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -3691,7 +3691,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetVMProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	if typedInput.BillingProfile != nil {
 		var billingProfile1 BillingProfile_STATUS
 		err := billingProfile1.PopulateFromARM(owner, *typedInput.BillingProfile)
@@ -3702,7 +3702,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.BillingProfile = &billingProfile
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	if typedInput.DiagnosticsProfile != nil {
 		var diagnosticsProfile1 DiagnosticsProfile_STATUS
 		err := diagnosticsProfile1.PopulateFromARM(owner, *typedInput.DiagnosticsProfile)
@@ -3713,13 +3713,13 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.DiagnosticsProfile = &diagnosticsProfile
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	if typedInput.EvictionPolicy != nil {
 		evictionPolicy := *typedInput.EvictionPolicy
 		profile.EvictionPolicy = &evictionPolicy
 	}
 
-	// Set property ‘ExtensionProfile’:
+	// Set property "ExtensionProfile":
 	if typedInput.ExtensionProfile != nil {
 		var extensionProfile1 VirtualMachineScaleSetExtensionProfile_STATUS
 		err := extensionProfile1.PopulateFromARM(owner, *typedInput.ExtensionProfile)
@@ -3730,13 +3730,13 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.ExtensionProfile = &extensionProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if typedInput.NetworkProfile != nil {
 		var networkProfile1 VirtualMachineScaleSetNetworkProfile_STATUS
 		err := networkProfile1.PopulateFromARM(owner, *typedInput.NetworkProfile)
@@ -3747,7 +3747,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	if typedInput.OsProfile != nil {
 		var osProfile1 VirtualMachineScaleSetOSProfile_STATUS
 		err := osProfile1.PopulateFromARM(owner, *typedInput.OsProfile)
@@ -3758,13 +3758,13 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.OsProfile = &osProfile
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		profile.Priority = &priority
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	if typedInput.ScheduledEventsProfile != nil {
 		var scheduledEventsProfile1 ScheduledEventsProfile_STATUS
 		err := scheduledEventsProfile1.PopulateFromARM(owner, *typedInput.ScheduledEventsProfile)
@@ -3775,7 +3775,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 SecurityProfile_STATUS
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -3786,7 +3786,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 VirtualMachineScaleSetStorageProfile_STATUS
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -4069,13 +4069,13 @@ func (policy *AutomaticOSUpgradePolicy) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &AutomaticOSUpgradePolicy_ARM{}
 
-	// Set property ‘DisableAutomaticRollback’:
+	// Set property "DisableAutomaticRollback":
 	if policy.DisableAutomaticRollback != nil {
 		disableAutomaticRollback := *policy.DisableAutomaticRollback
 		result.DisableAutomaticRollback = &disableAutomaticRollback
 	}
 
-	// Set property ‘EnableAutomaticOSUpgrade’:
+	// Set property "EnableAutomaticOSUpgrade":
 	if policy.EnableAutomaticOSUpgrade != nil {
 		enableAutomaticOSUpgrade := *policy.EnableAutomaticOSUpgrade
 		result.EnableAutomaticOSUpgrade = &enableAutomaticOSUpgrade
@@ -4095,13 +4095,13 @@ func (policy *AutomaticOSUpgradePolicy) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticOSUpgradePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisableAutomaticRollback’:
+	// Set property "DisableAutomaticRollback":
 	if typedInput.DisableAutomaticRollback != nil {
 		disableAutomaticRollback := *typedInput.DisableAutomaticRollback
 		policy.DisableAutomaticRollback = &disableAutomaticRollback
 	}
 
-	// Set property ‘EnableAutomaticOSUpgrade’:
+	// Set property "EnableAutomaticOSUpgrade":
 	if typedInput.EnableAutomaticOSUpgrade != nil {
 		enableAutomaticOSUpgrade := *typedInput.EnableAutomaticOSUpgrade
 		policy.EnableAutomaticOSUpgrade = &enableAutomaticOSUpgrade
@@ -4186,13 +4186,13 @@ func (policy *AutomaticOSUpgradePolicy_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticOSUpgradePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisableAutomaticRollback’:
+	// Set property "DisableAutomaticRollback":
 	if typedInput.DisableAutomaticRollback != nil {
 		disableAutomaticRollback := *typedInput.DisableAutomaticRollback
 		policy.DisableAutomaticRollback = &disableAutomaticRollback
 	}
 
-	// Set property ‘EnableAutomaticOSUpgrade’:
+	// Set property "EnableAutomaticOSUpgrade":
 	if typedInput.EnableAutomaticOSUpgrade != nil {
 		enableAutomaticOSUpgrade := *typedInput.EnableAutomaticOSUpgrade
 		policy.EnableAutomaticOSUpgrade = &enableAutomaticOSUpgrade
@@ -4285,37 +4285,37 @@ func (policy *RollingUpgradePolicy) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &RollingUpgradePolicy_ARM{}
 
-	// Set property ‘EnableCrossZoneUpgrade’:
+	// Set property "EnableCrossZoneUpgrade":
 	if policy.EnableCrossZoneUpgrade != nil {
 		enableCrossZoneUpgrade := *policy.EnableCrossZoneUpgrade
 		result.EnableCrossZoneUpgrade = &enableCrossZoneUpgrade
 	}
 
-	// Set property ‘MaxBatchInstancePercent’:
+	// Set property "MaxBatchInstancePercent":
 	if policy.MaxBatchInstancePercent != nil {
 		maxBatchInstancePercent := *policy.MaxBatchInstancePercent
 		result.MaxBatchInstancePercent = &maxBatchInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyInstancePercent’:
+	// Set property "MaxUnhealthyInstancePercent":
 	if policy.MaxUnhealthyInstancePercent != nil {
 		maxUnhealthyInstancePercent := *policy.MaxUnhealthyInstancePercent
 		result.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyUpgradedInstancePercent’:
+	// Set property "MaxUnhealthyUpgradedInstancePercent":
 	if policy.MaxUnhealthyUpgradedInstancePercent != nil {
 		maxUnhealthyUpgradedInstancePercent := *policy.MaxUnhealthyUpgradedInstancePercent
 		result.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
 	}
 
-	// Set property ‘PauseTimeBetweenBatches’:
+	// Set property "PauseTimeBetweenBatches":
 	if policy.PauseTimeBetweenBatches != nil {
 		pauseTimeBetweenBatches := *policy.PauseTimeBetweenBatches
 		result.PauseTimeBetweenBatches = &pauseTimeBetweenBatches
 	}
 
-	// Set property ‘PrioritizeUnhealthyInstances’:
+	// Set property "PrioritizeUnhealthyInstances":
 	if policy.PrioritizeUnhealthyInstances != nil {
 		prioritizeUnhealthyInstances := *policy.PrioritizeUnhealthyInstances
 		result.PrioritizeUnhealthyInstances = &prioritizeUnhealthyInstances
@@ -4335,37 +4335,37 @@ func (policy *RollingUpgradePolicy) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RollingUpgradePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableCrossZoneUpgrade’:
+	// Set property "EnableCrossZoneUpgrade":
 	if typedInput.EnableCrossZoneUpgrade != nil {
 		enableCrossZoneUpgrade := *typedInput.EnableCrossZoneUpgrade
 		policy.EnableCrossZoneUpgrade = &enableCrossZoneUpgrade
 	}
 
-	// Set property ‘MaxBatchInstancePercent’:
+	// Set property "MaxBatchInstancePercent":
 	if typedInput.MaxBatchInstancePercent != nil {
 		maxBatchInstancePercent := *typedInput.MaxBatchInstancePercent
 		policy.MaxBatchInstancePercent = &maxBatchInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyInstancePercent’:
+	// Set property "MaxUnhealthyInstancePercent":
 	if typedInput.MaxUnhealthyInstancePercent != nil {
 		maxUnhealthyInstancePercent := *typedInput.MaxUnhealthyInstancePercent
 		policy.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyUpgradedInstancePercent’:
+	// Set property "MaxUnhealthyUpgradedInstancePercent":
 	if typedInput.MaxUnhealthyUpgradedInstancePercent != nil {
 		maxUnhealthyUpgradedInstancePercent := *typedInput.MaxUnhealthyUpgradedInstancePercent
 		policy.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
 	}
 
-	// Set property ‘PauseTimeBetweenBatches’:
+	// Set property "PauseTimeBetweenBatches":
 	if typedInput.PauseTimeBetweenBatches != nil {
 		pauseTimeBetweenBatches := *typedInput.PauseTimeBetweenBatches
 		policy.PauseTimeBetweenBatches = &pauseTimeBetweenBatches
 	}
 
-	// Set property ‘PrioritizeUnhealthyInstances’:
+	// Set property "PrioritizeUnhealthyInstances":
 	if typedInput.PrioritizeUnhealthyInstances != nil {
 		prioritizeUnhealthyInstances := *typedInput.PrioritizeUnhealthyInstances
 		policy.PrioritizeUnhealthyInstances = &prioritizeUnhealthyInstances
@@ -4508,37 +4508,37 @@ func (policy *RollingUpgradePolicy_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RollingUpgradePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableCrossZoneUpgrade’:
+	// Set property "EnableCrossZoneUpgrade":
 	if typedInput.EnableCrossZoneUpgrade != nil {
 		enableCrossZoneUpgrade := *typedInput.EnableCrossZoneUpgrade
 		policy.EnableCrossZoneUpgrade = &enableCrossZoneUpgrade
 	}
 
-	// Set property ‘MaxBatchInstancePercent’:
+	// Set property "MaxBatchInstancePercent":
 	if typedInput.MaxBatchInstancePercent != nil {
 		maxBatchInstancePercent := *typedInput.MaxBatchInstancePercent
 		policy.MaxBatchInstancePercent = &maxBatchInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyInstancePercent’:
+	// Set property "MaxUnhealthyInstancePercent":
 	if typedInput.MaxUnhealthyInstancePercent != nil {
 		maxUnhealthyInstancePercent := *typedInput.MaxUnhealthyInstancePercent
 		policy.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyUpgradedInstancePercent’:
+	// Set property "MaxUnhealthyUpgradedInstancePercent":
 	if typedInput.MaxUnhealthyUpgradedInstancePercent != nil {
 		maxUnhealthyUpgradedInstancePercent := *typedInput.MaxUnhealthyUpgradedInstancePercent
 		policy.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
 	}
 
-	// Set property ‘PauseTimeBetweenBatches’:
+	// Set property "PauseTimeBetweenBatches":
 	if typedInput.PauseTimeBetweenBatches != nil {
 		pauseTimeBetweenBatches := *typedInput.PauseTimeBetweenBatches
 		policy.PauseTimeBetweenBatches = &pauseTimeBetweenBatches
 	}
 
-	// Set property ‘PrioritizeUnhealthyInstances’:
+	// Set property "PrioritizeUnhealthyInstances":
 	if typedInput.PrioritizeUnhealthyInstances != nil {
 		prioritizeUnhealthyInstances := *typedInput.PrioritizeUnhealthyInstances
 		policy.PrioritizeUnhealthyInstances = &prioritizeUnhealthyInstances
@@ -4660,7 +4660,7 @@ func (profile *ScheduledEventsProfile) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &ScheduledEventsProfile_ARM{}
 
-	// Set property ‘TerminateNotificationProfile’:
+	// Set property "TerminateNotificationProfile":
 	if profile.TerminateNotificationProfile != nil {
 		terminateNotificationProfile_ARM, err := (*profile.TerminateNotificationProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4684,7 +4684,7 @@ func (profile *ScheduledEventsProfile) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduledEventsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘TerminateNotificationProfile’:
+	// Set property "TerminateNotificationProfile":
 	if typedInput.TerminateNotificationProfile != nil {
 		var terminateNotificationProfile1 TerminateNotificationProfile
 		err := terminateNotificationProfile1.PopulateFromARM(owner, *typedInput.TerminateNotificationProfile)
@@ -4765,7 +4765,7 @@ func (profile *ScheduledEventsProfile_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduledEventsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘TerminateNotificationProfile’:
+	// Set property "TerminateNotificationProfile":
 	if typedInput.TerminateNotificationProfile != nil {
 		var terminateNotificationProfile1 TerminateNotificationProfile_STATUS
 		err := terminateNotificationProfile1.PopulateFromARM(owner, *typedInput.TerminateNotificationProfile)
@@ -4861,7 +4861,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) ConvertToARM(resolved gen
 	}
 	result := &VirtualMachineScaleSetExtensionProfile_ARM{}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range profile.Extensions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4870,7 +4870,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) ConvertToARM(resolved gen
 		result.Extensions = append(result.Extensions, *item_ARM.(*VirtualMachineScaleSetExtension_ARM))
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	if profile.ExtensionsTimeBudget != nil {
 		extensionsTimeBudget := *profile.ExtensionsTimeBudget
 		result.ExtensionsTimeBudget = &extensionsTimeBudget
@@ -4890,7 +4890,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtensionProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range typedInput.Extensions {
 		var item1 VirtualMachineScaleSetExtension
 		err := item1.PopulateFromARM(owner, item)
@@ -4900,7 +4900,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) PopulateFromARM(owner gen
 		profile.Extensions = append(profile.Extensions, item1)
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	if typedInput.ExtensionsTimeBudget != nil {
 		extensionsTimeBudget := *typedInput.ExtensionsTimeBudget
 		profile.ExtensionsTimeBudget = &extensionsTimeBudget
@@ -4995,7 +4995,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtensionProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range typedInput.Extensions {
 		var item1 VirtualMachineScaleSetExtension_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5005,7 +5005,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile_STATUS) PopulateFromARM(ow
 		profile.Extensions = append(profile.Extensions, item1)
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	if typedInput.ExtensionsTimeBudget != nil {
 		extensionsTimeBudget := *typedInput.ExtensionsTimeBudget
 		profile.ExtensionsTimeBudget = &extensionsTimeBudget
@@ -5100,13 +5100,13 @@ func (identities *VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -5166,7 +5166,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) ConvertToARM(resolved genru
 	}
 	result := &VirtualMachineScaleSetNetworkProfile_ARM{}
 
-	// Set property ‘HealthProbe’:
+	// Set property "HealthProbe":
 	if profile.HealthProbe != nil {
 		healthProbe_ARM, err := (*profile.HealthProbe).ConvertToARM(resolved)
 		if err != nil {
@@ -5176,7 +5176,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) ConvertToARM(resolved genru
 		result.HealthProbe = &healthProbe
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range profile.NetworkInterfaceConfigurations {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5199,7 +5199,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HealthProbe’:
+	// Set property "HealthProbe":
 	if typedInput.HealthProbe != nil {
 		var healthProbe1 ApiEntityReference
 		err := healthProbe1.PopulateFromARM(owner, *typedInput.HealthProbe)
@@ -5210,7 +5210,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) PopulateFromARM(owner genru
 		profile.HealthProbe = &healthProbe
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range typedInput.NetworkInterfaceConfigurations {
 		var item1 VirtualMachineScaleSetNetworkConfiguration
 		err := item1.PopulateFromARM(owner, item)
@@ -5327,7 +5327,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HealthProbe’:
+	// Set property "HealthProbe":
 	if typedInput.HealthProbe != nil {
 		var healthProbe1 ApiEntityReference_STATUS
 		err := healthProbe1.PopulateFromARM(owner, *typedInput.HealthProbe)
@@ -5338,7 +5338,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile_STATUS) PopulateFromARM(owne
 		profile.HealthProbe = &healthProbe
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range typedInput.NetworkInterfaceConfigurations {
 		var item1 VirtualMachineScaleSetNetworkConfiguration_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5455,7 +5455,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 	}
 	result := &VirtualMachineScaleSetOSProfile_ARM{}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if profile.AdminPassword != nil {
 		adminPasswordSecret, err := resolved.ResolvedSecrets.Lookup(*profile.AdminPassword)
 		if err != nil {
@@ -5465,25 +5465,25 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 		result.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘ComputerNamePrefix’:
+	// Set property "ComputerNamePrefix":
 	if profile.ComputerNamePrefix != nil {
 		computerNamePrefix := *profile.ComputerNamePrefix
 		result.ComputerNamePrefix = &computerNamePrefix
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if profile.CustomData != nil {
 		customData := *profile.CustomData
 		result.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if profile.LinuxConfiguration != nil {
 		linuxConfiguration_ARM, err := (*profile.LinuxConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -5493,7 +5493,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 		result.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range profile.Secrets {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5502,7 +5502,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 		result.Secrets = append(result.Secrets, *item_ARM.(*VaultSecretGroup_ARM))
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if profile.WindowsConfiguration != nil {
 		windowsConfiguration_ARM, err := (*profile.WindowsConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -5526,27 +5526,27 @@ func (profile *VirtualMachineScaleSetOSProfile) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSProfile_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘AdminPassword’
+	// no assignment for property "AdminPassword"
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘ComputerNamePrefix’:
+	// Set property "ComputerNamePrefix":
 	if typedInput.ComputerNamePrefix != nil {
 		computerNamePrefix := *typedInput.ComputerNamePrefix
 		profile.ComputerNamePrefix = &computerNamePrefix
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -5557,7 +5557,7 @@ func (profile *VirtualMachineScaleSetOSProfile) PopulateFromARM(owner genruntime
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup
 		err := item1.PopulateFromARM(owner, item)
@@ -5567,7 +5567,7 @@ func (profile *VirtualMachineScaleSetOSProfile) PopulateFromARM(owner genruntime
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -5747,25 +5747,25 @@ func (profile *VirtualMachineScaleSetOSProfile_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘ComputerNamePrefix’:
+	// Set property "ComputerNamePrefix":
 	if typedInput.ComputerNamePrefix != nil {
 		computerNamePrefix := *typedInput.ComputerNamePrefix
 		profile.ComputerNamePrefix = &computerNamePrefix
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration_STATUS
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -5776,7 +5776,7 @@ func (profile *VirtualMachineScaleSetOSProfile_STATUS) PopulateFromARM(owner gen
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5786,7 +5786,7 @@ func (profile *VirtualMachineScaleSetOSProfile_STATUS) PopulateFromARM(owner gen
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration_STATUS
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -5942,7 +5942,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 	}
 	result := &VirtualMachineScaleSetStorageProfile_ARM{}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range profile.DataDisks {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5951,7 +5951,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		result.DataDisks = append(result.DataDisks, *item_ARM.(*VirtualMachineScaleSetDataDisk_ARM))
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if profile.ImageReference != nil {
 		imageReference_ARM, err := (*profile.ImageReference).ConvertToARM(resolved)
 		if err != nil {
@@ -5961,7 +5961,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		result.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if profile.OsDisk != nil {
 		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -5985,7 +5985,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetStorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 VirtualMachineScaleSetDataDisk
 		err := item1.PopulateFromARM(owner, item)
@@ -5995,7 +5995,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) PopulateFromARM(owner genru
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -6006,7 +6006,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) PopulateFromARM(owner genru
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 VirtualMachineScaleSetOSDisk
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -6149,7 +6149,7 @@ func (profile *VirtualMachineScaleSetStorageProfile_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetStorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 VirtualMachineScaleSetDataDisk_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6159,7 +6159,7 @@ func (profile *VirtualMachineScaleSetStorageProfile_STATUS) PopulateFromARM(owne
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference_STATUS
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -6170,7 +6170,7 @@ func (profile *VirtualMachineScaleSetStorageProfile_STATUS) PopulateFromARM(owne
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 VirtualMachineScaleSetOSDisk_STATUS
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -6306,7 +6306,7 @@ func (reference *ApiEntityReference) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &ApiEntityReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -6330,7 +6330,7 @@ func (reference *ApiEntityReference) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiEntityReference_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -6394,7 +6394,7 @@ func (reference *ApiEntityReference_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiEntityReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
@@ -6448,13 +6448,13 @@ func (profile *TerminateNotificationProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &TerminateNotificationProfile_ARM{}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if profile.Enable != nil {
 		enable := *profile.Enable
 		result.Enable = &enable
 	}
 
-	// Set property ‘NotBeforeTimeout’:
+	// Set property "NotBeforeTimeout":
 	if profile.NotBeforeTimeout != nil {
 		notBeforeTimeout := *profile.NotBeforeTimeout
 		result.NotBeforeTimeout = &notBeforeTimeout
@@ -6474,13 +6474,13 @@ func (profile *TerminateNotificationProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TerminateNotificationProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		profile.Enable = &enable
 	}
 
-	// Set property ‘NotBeforeTimeout’:
+	// Set property "NotBeforeTimeout":
 	if typedInput.NotBeforeTimeout != nil {
 		notBeforeTimeout := *typedInput.NotBeforeTimeout
 		profile.NotBeforeTimeout = &notBeforeTimeout
@@ -6555,13 +6555,13 @@ func (profile *TerminateNotificationProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TerminateNotificationProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		profile.Enable = &enable
 	}
 
-	// Set property ‘NotBeforeTimeout’:
+	// Set property "NotBeforeTimeout":
 	if typedInput.NotBeforeTimeout != nil {
 		notBeforeTimeout := *typedInput.NotBeforeTimeout
 		profile.NotBeforeTimeout = &notBeforeTimeout
@@ -6642,43 +6642,43 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 	}
 	result := &VirtualMachineScaleSetDataDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if disk.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *disk.DiskIOPSReadWrite
 		result.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if disk.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *disk.DiskMBpsReadWrite
 		result.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if disk.Lun != nil {
 		lun := *disk.Lun
 		result.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -6688,13 +6688,13 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -6714,43 +6714,43 @@ func (disk *VirtualMachineScaleSetDataDisk) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetDataDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if typedInput.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *typedInput.DiskIOPSReadWrite
 		disk.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if typedInput.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *typedInput.DiskMBpsReadWrite
 		disk.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -6761,13 +6761,13 @@ func (disk *VirtualMachineScaleSetDataDisk) PopulateFromARM(owner genruntime.Arb
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -6929,43 +6929,43 @@ func (disk *VirtualMachineScaleSetDataDisk_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetDataDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if typedInput.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *typedInput.DiskIOPSReadWrite
 		disk.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if typedInput.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *typedInput.DiskMBpsReadWrite
 		disk.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -6976,13 +6976,13 @@ func (disk *VirtualMachineScaleSetDataDisk_STATUS) PopulateFromARM(owner genrunt
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -7140,13 +7140,13 @@ func (extension *VirtualMachineScaleSetExtension) ConvertToARM(resolved genrunti
 	}
 	result := &VirtualMachineScaleSetExtension_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if extension.Name != nil {
 		name := *extension.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if extension.AutoUpgradeMinorVersion != nil ||
 		extension.EnableAutomaticUpgrade != nil ||
 		extension.ForceUpdateTag != nil ||
@@ -7212,7 +7212,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtension_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradeMinorVersion’:
+	// Set property "AutoUpgradeMinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeMinorVersion != nil {
@@ -7221,7 +7221,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticUpgrade != nil {
@@ -7230,7 +7230,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘ForceUpdateTag’:
+	// Set property "ForceUpdateTag":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceUpdateTag != nil {
@@ -7239,13 +7239,13 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		extension.Name = &name
 	}
 
-	// Set property ‘ProtectedSettings’:
+	// Set property "ProtectedSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettings != nil {
@@ -7256,7 +7256,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘ProvisionAfterExtensions’:
+	// Set property "ProvisionAfterExtensions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ProvisionAfterExtensions {
@@ -7264,7 +7264,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Publisher != nil {
@@ -7273,7 +7273,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Settings’:
+	// Set property "Settings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Settings != nil {
@@ -7284,7 +7284,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -7293,7 +7293,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TypeHandlerVersion != nil {
@@ -7480,7 +7480,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtension_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradeMinorVersion’:
+	// Set property "AutoUpgradeMinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeMinorVersion != nil {
@@ -7489,7 +7489,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticUpgrade != nil {
@@ -7498,7 +7498,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ForceUpdateTag’:
+	// Set property "ForceUpdateTag":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceUpdateTag != nil {
@@ -7507,19 +7507,19 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		extension.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		extension.Name = &name
 	}
 
-	// Set property ‘PropertiesType’:
+	// Set property "PropertiesType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -7528,7 +7528,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProtectedSettings’:
+	// Set property "ProtectedSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettings != nil {
@@ -7539,7 +7539,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProvisionAfterExtensions’:
+	// Set property "ProvisionAfterExtensions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ProvisionAfterExtensions {
@@ -7547,7 +7547,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -7556,7 +7556,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Publisher != nil {
@@ -7565,7 +7565,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Settings’:
+	// Set property "Settings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Settings != nil {
@@ -7576,13 +7576,13 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		extension.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TypeHandlerVersion != nil {
@@ -7782,7 +7782,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) ConvertToARM(re
 	}
 	result := &VirtualMachineScaleSetNetworkConfiguration_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if configuration.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*configuration.Reference)
 		if err != nil {
@@ -7792,13 +7792,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) ConvertToARM(re
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.DnsSettings != nil ||
 		configuration.EnableAcceleratedNetworking != nil ||
 		configuration.EnableFpga != nil ||
@@ -7862,7 +7862,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -7876,7 +7876,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -7885,7 +7885,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableFpga’:
+	// Set property "EnableFpga":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFpga != nil {
@@ -7894,7 +7894,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -7903,7 +7903,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -7916,13 +7916,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -7936,7 +7936,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -7945,7 +7945,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -8171,7 +8171,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -8185,7 +8185,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -8194,7 +8194,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘EnableFpga’:
+	// Set property "EnableFpga":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFpga != nil {
@@ -8203,7 +8203,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -8212,13 +8212,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -8231,13 +8231,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -8251,7 +8251,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -8472,19 +8472,19 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &VirtualMachineScaleSetOSDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if disk.DiffDiskSettings != nil {
 		diffDiskSettings_ARM, err := (*disk.DiffDiskSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -8494,13 +8494,13 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		result.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if disk.Image != nil {
 		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
 		if err != nil {
@@ -8510,7 +8510,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		result.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -8520,24 +8520,24 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if disk.OsType != nil {
 		osType := *disk.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘VhdContainers’:
+	// Set property "VhdContainers":
 	for _, item := range disk.VhdContainers {
 		result.VhdContainers = append(result.VhdContainers, item)
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -8557,19 +8557,19 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -8580,13 +8580,13 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -8597,7 +8597,7 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -8608,24 +8608,24 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘VhdContainers’:
+	// Set property "VhdContainers":
 	for _, item := range typedInput.VhdContainers {
 		disk.VhdContainers = append(disk.VhdContainers, item)
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -8840,19 +8840,19 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings_STATUS
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -8863,13 +8863,13 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk_STATUS
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -8880,7 +8880,7 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -8891,24 +8891,24 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘VhdContainers’:
+	// Set property "VhdContainers":
 	for _, item := range typedInput.VhdContainers {
 		disk.VhdContainers = append(disk.VhdContainers, item)
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -9120,7 +9120,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) ConvertToARM(resolve
 	}
 	result := &VirtualMachineScaleSetIPConfiguration_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if configuration.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*configuration.Reference)
 		if err != nil {
@@ -9130,13 +9130,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) ConvertToARM(resolve
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.ApplicationGatewayBackendAddressPools != nil ||
 		configuration.ApplicationSecurityGroups != nil ||
 		configuration.LoadBalancerBackendAddressPools != nil ||
@@ -9214,7 +9214,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIPConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -9227,7 +9227,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -9240,7 +9240,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -9253,7 +9253,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘LoadBalancerInboundNatPools’:
+	// Set property "LoadBalancerInboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerInboundNatPools {
@@ -9266,13 +9266,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -9281,7 +9281,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -9290,7 +9290,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘PublicIPAddressConfiguration’:
+	// Set property "PublicIPAddressConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressConfiguration != nil {
@@ -9304,9 +9304,9 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -9621,7 +9621,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIPConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -9634,7 +9634,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -9647,13 +9647,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -9666,7 +9666,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘LoadBalancerInboundNatPools’:
+	// Set property "LoadBalancerInboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerInboundNatPools {
@@ -9679,13 +9679,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -9694,7 +9694,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -9703,7 +9703,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘PublicIPAddressConfiguration’:
+	// Set property "PublicIPAddressConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressConfiguration != nil {
@@ -9717,7 +9717,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -10009,7 +10009,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 	}
 	result := &VirtualMachineScaleSetManagedDiskParameters_ARM{}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if parameters.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*parameters.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -10019,7 +10019,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if parameters.StorageAccountType != nil {
 		storageAccountType := *parameters.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -10039,7 +10039,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetManagedDiskParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -10050,7 +10050,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) PopulateFromARM(o
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -10143,7 +10143,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters_STATUS) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetManagedDiskParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -10154,7 +10154,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters_STATUS) PopulateFr
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -10241,7 +10241,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings) ConvertTo
 	}
 	result := &VirtualMachineScaleSetNetworkConfigurationDnsSettings_ARM{}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range settings.DnsServers {
 		result.DnsServers = append(result.DnsServers, item)
 	}
@@ -10260,7 +10260,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfigurationDnsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		settings.DnsServers = append(settings.DnsServers, item)
 	}
@@ -10317,7 +10317,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS) Po
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		settings.DnsServers = append(settings.DnsServers, item)
 	}
@@ -10413,13 +10413,13 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Convert
 	}
 	result := &VirtualMachineScaleSetPublicIPAddressConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.DnsSettings != nil ||
 		configuration.IdleTimeoutInMinutes != nil ||
 		configuration.IpTags != nil ||
@@ -10473,7 +10473,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -10487,7 +10487,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -10496,7 +10496,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -10509,13 +10509,13 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -10524,7 +10524,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -10701,7 +10701,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -10715,7 +10715,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -10724,7 +10724,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -10737,13 +10737,13 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -10752,7 +10752,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -10920,13 +10920,13 @@ func (ipTag *VirtualMachineScaleSetIpTag) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &VirtualMachineScaleSetIpTag_ARM{}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if ipTag.IpTagType != nil {
 		ipTagType := *ipTag.IpTagType
 		result.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if ipTag.Tag != nil {
 		tag := *ipTag.Tag
 		result.Tag = &tag
@@ -10946,13 +10946,13 @@ func (ipTag *VirtualMachineScaleSetIpTag) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIpTag_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -11017,13 +11017,13 @@ func (ipTag *VirtualMachineScaleSetIpTag_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIpTag_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -11083,7 +11083,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings) C
 	}
 	result := &VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_ARM{}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if settings.DomainNameLabel != nil {
 		domainNameLabel := *settings.DomainNameLabel
 		result.DomainNameLabel = &domainNameLabel
@@ -11103,7 +11103,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings) P
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		settings.DomainNameLabel = &domainNameLabel
@@ -11161,7 +11161,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_ST
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		settings.DomainNameLabel = &domainNameLabel

--- a/v2/api/compute/v1beta20201201/virtual_machine_types_gen.go
+++ b/v2/api/compute/v1beta20201201/virtual_machine_types_gen.go
@@ -364,7 +364,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &VirtualMachine_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if machine.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*machine.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -374,7 +374,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if machine.Identity != nil {
 		identity_ARM, err := (*machine.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -384,16 +384,16 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if machine.Location != nil {
 		location := *machine.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if machine.Plan != nil {
 		plan_ARM, err := (*machine.Plan).ConvertToARM(resolved)
 		if err != nil {
@@ -403,7 +403,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Plan = &plan
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if machine.AdditionalCapabilities != nil ||
 		machine.AvailabilitySet != nil ||
 		machine.BillingProfile != nil ||
@@ -549,7 +549,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.VirtualMachineScaleSet = &virtualMachineScaleSet
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if machine.Tags != nil {
 		result.Tags = make(map[string]string, len(machine.Tags))
 		for key, value := range machine.Tags {
@@ -557,7 +557,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range machine.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -576,7 +576,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -590,7 +590,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AvailabilitySet’:
+	// Set property "AvailabilitySet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilitySet != nil {
@@ -604,10 +604,10 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	machine.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BillingProfile != nil {
@@ -621,7 +621,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiagnosticsProfile != nil {
@@ -635,7 +635,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EvictionPolicy != nil {
@@ -644,7 +644,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -655,7 +655,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		machine.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExtensionsTimeBudget != nil {
@@ -664,7 +664,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HardwareProfile != nil {
@@ -678,7 +678,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Host != nil {
@@ -692,7 +692,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -706,7 +706,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -717,7 +717,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		machine.Identity = &identity
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LicenseType != nil {
@@ -726,13 +726,13 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		machine.Location = &location
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -746,7 +746,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsProfile != nil {
@@ -760,10 +760,10 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	machine.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -774,7 +774,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		machine.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomain’:
+	// Set property "PlatformFaultDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomain != nil {
@@ -783,7 +783,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -792,7 +792,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -806,7 +806,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecurityProfile != nil {
@@ -820,7 +820,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -834,7 +834,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		machine.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -842,7 +842,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘VirtualMachineScaleSet’:
+	// Set property "VirtualMachineScaleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineScaleSet != nil {
@@ -856,7 +856,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		machine.Zones = append(machine.Zones, item)
 	}
@@ -1525,7 +1525,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -1539,7 +1539,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AvailabilitySet’:
+	// Set property "AvailabilitySet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilitySet != nil {
@@ -1553,7 +1553,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BillingProfile != nil {
@@ -1567,9 +1567,9 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiagnosticsProfile != nil {
@@ -1583,7 +1583,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EvictionPolicy != nil {
@@ -1592,7 +1592,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1603,7 +1603,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExtensionsTimeBudget != nil {
@@ -1612,7 +1612,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HardwareProfile != nil {
@@ -1626,7 +1626,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Host != nil {
@@ -1640,7 +1640,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -1654,13 +1654,13 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		machine.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1671,7 +1671,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Identity = &identity
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -1685,7 +1685,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LicenseType != nil {
@@ -1694,19 +1694,19 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		machine.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		machine.Name = &name
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -1720,7 +1720,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsProfile != nil {
@@ -1734,7 +1734,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan_STATUS
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -1745,7 +1745,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomain’:
+	// Set property "PlatformFaultDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomain != nil {
@@ -1754,7 +1754,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -1763,7 +1763,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1772,7 +1772,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -1786,7 +1786,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	for _, item := range typedInput.Resources {
 		var item1 VirtualMachineExtension_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1796,7 +1796,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Resources = append(machine.Resources, item1)
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecurityProfile != nil {
@@ -1810,7 +1810,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -1824,7 +1824,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		machine.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1832,13 +1832,13 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		machine.Type = &typeVar
 	}
 
-	// Set property ‘VirtualMachineScaleSet’:
+	// Set property "VirtualMachineScaleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineScaleSet != nil {
@@ -1852,7 +1852,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘VmId’:
+	// Set property "VmId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VmId != nil {
@@ -1861,7 +1861,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		machine.Zones = append(machine.Zones, item)
 	}
@@ -2455,7 +2455,7 @@ func (capabilities *AdditionalCapabilities) ConvertToARM(resolved genruntime.Con
 	}
 	result := &AdditionalCapabilities_ARM{}
 
-	// Set property ‘UltraSSDEnabled’:
+	// Set property "UltraSSDEnabled":
 	if capabilities.UltraSSDEnabled != nil {
 		ultraSSDEnabled := *capabilities.UltraSSDEnabled
 		result.UltraSSDEnabled = &ultraSSDEnabled
@@ -2475,7 +2475,7 @@ func (capabilities *AdditionalCapabilities) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalCapabilities_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UltraSSDEnabled’:
+	// Set property "UltraSSDEnabled":
 	if typedInput.UltraSSDEnabled != nil {
 		ultraSSDEnabled := *typedInput.UltraSSDEnabled
 		capabilities.UltraSSDEnabled = &ultraSSDEnabled
@@ -2543,7 +2543,7 @@ func (capabilities *AdditionalCapabilities_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalCapabilities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UltraSSDEnabled’:
+	// Set property "UltraSSDEnabled":
 	if typedInput.UltraSSDEnabled != nil {
 		ultraSSDEnabled := *typedInput.UltraSSDEnabled
 		capabilities.UltraSSDEnabled = &ultraSSDEnabled
@@ -2606,7 +2606,7 @@ func (profile *BillingProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &BillingProfile_ARM{}
 
-	// Set property ‘MaxPrice’:
+	// Set property "MaxPrice":
 	if profile.MaxPrice != nil {
 		maxPrice := *profile.MaxPrice
 		result.MaxPrice = &maxPrice
@@ -2626,7 +2626,7 @@ func (profile *BillingProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BillingProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxPrice’:
+	// Set property "MaxPrice":
 	if typedInput.MaxPrice != nil {
 		maxPrice := *typedInput.MaxPrice
 		profile.MaxPrice = &maxPrice
@@ -2694,7 +2694,7 @@ func (profile *BillingProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BillingProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxPrice’:
+	// Set property "MaxPrice":
 	if typedInput.MaxPrice != nil {
 		maxPrice := *typedInput.MaxPrice
 		profile.MaxPrice = &maxPrice
@@ -2757,7 +2757,7 @@ func (profile *DiagnosticsProfile) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &DiagnosticsProfile_ARM{}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if profile.BootDiagnostics != nil {
 		bootDiagnostics_ARM, err := (*profile.BootDiagnostics).ConvertToARM(resolved)
 		if err != nil {
@@ -2781,7 +2781,7 @@ func (profile *DiagnosticsProfile) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiagnosticsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if typedInput.BootDiagnostics != nil {
 		var bootDiagnostics1 BootDiagnostics
 		err := bootDiagnostics1.PopulateFromARM(owner, *typedInput.BootDiagnostics)
@@ -2862,7 +2862,7 @@ func (profile *DiagnosticsProfile_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiagnosticsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if typedInput.BootDiagnostics != nil {
 		var bootDiagnostics1 BootDiagnostics_STATUS
 		err := bootDiagnostics1.PopulateFromARM(owner, *typedInput.BootDiagnostics)
@@ -2956,13 +2956,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -2982,13 +2982,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -3063,13 +3063,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -3138,7 +3138,7 @@ func (profile *HardwareProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &HardwareProfile_ARM{}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if profile.VmSize != nil {
 		vmSize := *profile.VmSize
 		result.VmSize = &vmSize
@@ -3158,7 +3158,7 @@ func (profile *HardwareProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HardwareProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
@@ -3226,7 +3226,7 @@ func (profile *HardwareProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HardwareProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
@@ -3289,7 +3289,7 @@ func (profile *NetworkProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &NetworkProfile_ARM{}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	for _, item := range profile.NetworkInterfaces {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3312,7 +3312,7 @@ func (profile *NetworkProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	for _, item := range typedInput.NetworkInterfaces {
 		var item1 NetworkInterfaceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -3404,7 +3404,7 @@ func (profile *NetworkProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	for _, item := range typedInput.NetworkInterfaces {
 		var item1 NetworkInterfaceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3499,7 +3499,7 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &OSProfile_ARM{}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if profile.AdminPassword != nil {
 		adminPasswordSecret, err := resolved.ResolvedSecrets.Lookup(*profile.AdminPassword)
 		if err != nil {
@@ -3509,31 +3509,31 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if profile.AllowExtensionOperations != nil {
 		allowExtensionOperations := *profile.AllowExtensionOperations
 		result.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if profile.ComputerName != nil {
 		computerName := *profile.ComputerName
 		result.ComputerName = &computerName
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if profile.CustomData != nil {
 		customData := *profile.CustomData
 		result.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if profile.LinuxConfiguration != nil {
 		linuxConfiguration_ARM, err := (*profile.LinuxConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -3543,13 +3543,13 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘RequireGuestProvisionSignal’:
+	// Set property "RequireGuestProvisionSignal":
 	if profile.RequireGuestProvisionSignal != nil {
 		requireGuestProvisionSignal := *profile.RequireGuestProvisionSignal
 		result.RequireGuestProvisionSignal = &requireGuestProvisionSignal
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range profile.Secrets {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3558,7 +3558,7 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Secrets = append(result.Secrets, *item_ARM.(*VaultSecretGroup_ARM))
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if profile.WindowsConfiguration != nil {
 		windowsConfiguration_ARM, err := (*profile.WindowsConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -3582,33 +3582,33 @@ func (profile *OSProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSProfile_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘AdminPassword’
+	// no assignment for property "AdminPassword"
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if typedInput.AllowExtensionOperations != nil {
 		allowExtensionOperations := *typedInput.AllowExtensionOperations
 		profile.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if typedInput.ComputerName != nil {
 		computerName := *typedInput.ComputerName
 		profile.ComputerName = &computerName
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -3619,13 +3619,13 @@ func (profile *OSProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘RequireGuestProvisionSignal’:
+	// Set property "RequireGuestProvisionSignal":
 	if typedInput.RequireGuestProvisionSignal != nil {
 		requireGuestProvisionSignal := *typedInput.RequireGuestProvisionSignal
 		profile.RequireGuestProvisionSignal = &requireGuestProvisionSignal
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup
 		err := item1.PopulateFromARM(owner, item)
@@ -3635,7 +3635,7 @@ func (profile *OSProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -3849,31 +3849,31 @@ func (profile *OSProfile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if typedInput.AllowExtensionOperations != nil {
 		allowExtensionOperations := *typedInput.AllowExtensionOperations
 		profile.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if typedInput.ComputerName != nil {
 		computerName := *typedInput.ComputerName
 		profile.ComputerName = &computerName
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration_STATUS
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -3884,13 +3884,13 @@ func (profile *OSProfile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘RequireGuestProvisionSignal’:
+	// Set property "RequireGuestProvisionSignal":
 	if typedInput.RequireGuestProvisionSignal != nil {
 		requireGuestProvisionSignal := *typedInput.RequireGuestProvisionSignal
 		profile.RequireGuestProvisionSignal = &requireGuestProvisionSignal
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3900,7 +3900,7 @@ func (profile *OSProfile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration_STATUS
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -4089,25 +4089,25 @@ func (plan *Plan) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) 
 	}
 	result := &Plan_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if plan.Name != nil {
 		name := *plan.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if plan.Product != nil {
 		product := *plan.Product
 		result.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if plan.PromotionCode != nil {
 		promotionCode := *plan.PromotionCode
 		result.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if plan.Publisher != nil {
 		publisher := *plan.Publisher
 		result.Publisher = &publisher
@@ -4127,25 +4127,25 @@ func (plan *Plan) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armI
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Plan_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		plan.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if typedInput.Product != nil {
 		product := *typedInput.Product
 		plan.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if typedInput.PromotionCode != nil {
 		promotionCode := *typedInput.PromotionCode
 		plan.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		plan.Publisher = &publisher
@@ -4224,25 +4224,25 @@ func (plan *Plan_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Plan_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		plan.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if typedInput.Product != nil {
 		product := *typedInput.Product
 		plan.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if typedInput.PromotionCode != nil {
 		promotionCode := *typedInput.PromotionCode
 		plan.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		plan.Publisher = &publisher
@@ -4334,19 +4334,19 @@ func (profile *SecurityProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &SecurityProfile_ARM{}
 
-	// Set property ‘EncryptionAtHost’:
+	// Set property "EncryptionAtHost":
 	if profile.EncryptionAtHost != nil {
 		encryptionAtHost := *profile.EncryptionAtHost
 		result.EncryptionAtHost = &encryptionAtHost
 	}
 
-	// Set property ‘SecurityType’:
+	// Set property "SecurityType":
 	if profile.SecurityType != nil {
 		securityType := *profile.SecurityType
 		result.SecurityType = &securityType
 	}
 
-	// Set property ‘UefiSettings’:
+	// Set property "UefiSettings":
 	if profile.UefiSettings != nil {
 		uefiSettings_ARM, err := (*profile.UefiSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -4370,19 +4370,19 @@ func (profile *SecurityProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SecurityProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EncryptionAtHost’:
+	// Set property "EncryptionAtHost":
 	if typedInput.EncryptionAtHost != nil {
 		encryptionAtHost := *typedInput.EncryptionAtHost
 		profile.EncryptionAtHost = &encryptionAtHost
 	}
 
-	// Set property ‘SecurityType’:
+	// Set property "SecurityType":
 	if typedInput.SecurityType != nil {
 		securityType := *typedInput.SecurityType
 		profile.SecurityType = &securityType
 	}
 
-	// Set property ‘UefiSettings’:
+	// Set property "UefiSettings":
 	if typedInput.UefiSettings != nil {
 		var uefiSettings1 UefiSettings
 		err := uefiSettings1.PopulateFromARM(owner, *typedInput.UefiSettings)
@@ -4497,19 +4497,19 @@ func (profile *SecurityProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SecurityProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EncryptionAtHost’:
+	// Set property "EncryptionAtHost":
 	if typedInput.EncryptionAtHost != nil {
 		encryptionAtHost := *typedInput.EncryptionAtHost
 		profile.EncryptionAtHost = &encryptionAtHost
 	}
 
-	// Set property ‘SecurityType’:
+	// Set property "SecurityType":
 	if typedInput.SecurityType != nil {
 		securityType := *typedInput.SecurityType
 		profile.SecurityType = &securityType
 	}
 
-	// Set property ‘UefiSettings’:
+	// Set property "UefiSettings":
 	if typedInput.UefiSettings != nil {
 		var uefiSettings1 UefiSettings_STATUS
 		err := uefiSettings1.PopulateFromARM(owner, *typedInput.UefiSettings)
@@ -4619,7 +4619,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &StorageProfile_ARM{}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range profile.DataDisks {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4628,7 +4628,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.DataDisks = append(result.DataDisks, *item_ARM.(*DataDisk_ARM))
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if profile.ImageReference != nil {
 		imageReference_ARM, err := (*profile.ImageReference).ConvertToARM(resolved)
 		if err != nil {
@@ -4638,7 +4638,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if profile.OsDisk != nil {
 		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -4662,7 +4662,7 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 DataDisk
 		err := item1.PopulateFromARM(owner, item)
@@ -4672,7 +4672,7 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -4683,7 +4683,7 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 OSDisk
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -4826,7 +4826,7 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 DataDisk_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4836,7 +4836,7 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference_STATUS
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -4847,7 +4847,7 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 OSDisk_STATUS
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -4983,7 +4983,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -5007,7 +5007,7 @@ func (resource *SubResource) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -5071,7 +5071,7 @@ func (resource *SubResource_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
@@ -5143,7 +5143,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineExtension_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradeMinorVersion’:
+	// Set property "AutoUpgradeMinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeMinorVersion != nil {
@@ -5152,7 +5152,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticUpgrade != nil {
@@ -5161,7 +5161,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ForceUpdateTag’:
+	// Set property "ForceUpdateTag":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceUpdateTag != nil {
@@ -5170,13 +5170,13 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		extension.Id = &id
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -5190,19 +5190,19 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		extension.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		extension.Name = &name
 	}
 
-	// Set property ‘PropertiesType’:
+	// Set property "PropertiesType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -5211,7 +5211,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ProtectedSettings’:
+	// Set property "ProtectedSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettings != nil {
@@ -5222,7 +5222,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -5231,7 +5231,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Publisher != nil {
@@ -5240,7 +5240,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Settings’:
+	// Set property "Settings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Settings != nil {
@@ -5251,7 +5251,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		extension.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -5259,13 +5259,13 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		extension.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TypeHandlerVersion != nil {
@@ -5484,13 +5484,13 @@ func (identity *VirtualMachineIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &VirtualMachineIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -5515,13 +5515,13 @@ func (identity *VirtualMachineIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -5624,25 +5624,25 @@ func (identity *VirtualMachineIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]VirtualMachineIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -5780,13 +5780,13 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssignedHost’:
+	// Set property "AssignedHost":
 	if typedInput.AssignedHost != nil {
 		assignedHost := *typedInput.AssignedHost
 		view.AssignedHost = &assignedHost
 	}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if typedInput.BootDiagnostics != nil {
 		var bootDiagnostics1 BootDiagnosticsInstanceView_STATUS
 		err := bootDiagnostics1.PopulateFromARM(owner, *typedInput.BootDiagnostics)
@@ -5797,13 +5797,13 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.BootDiagnostics = &bootDiagnostics
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if typedInput.ComputerName != nil {
 		computerName := *typedInput.ComputerName
 		view.ComputerName = &computerName
 	}
 
-	// Set property ‘Disks’:
+	// Set property "Disks":
 	for _, item := range typedInput.Disks {
 		var item1 DiskInstanceView_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5813,7 +5813,7 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.Disks = append(view.Disks, item1)
 	}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range typedInput.Extensions {
 		var item1 VirtualMachineExtensionInstanceView_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5823,13 +5823,13 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.Extensions = append(view.Extensions, item1)
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	if typedInput.HyperVGeneration != nil {
 		hyperVGeneration := *typedInput.HyperVGeneration
 		view.HyperVGeneration = &hyperVGeneration
 	}
 
-	// Set property ‘MaintenanceRedeployStatus’:
+	// Set property "MaintenanceRedeployStatus":
 	if typedInput.MaintenanceRedeployStatus != nil {
 		var maintenanceRedeployStatus1 MaintenanceRedeployStatus_STATUS
 		err := maintenanceRedeployStatus1.PopulateFromARM(owner, *typedInput.MaintenanceRedeployStatus)
@@ -5840,19 +5840,19 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.MaintenanceRedeployStatus = &maintenanceRedeployStatus
 	}
 
-	// Set property ‘OsName’:
+	// Set property "OsName":
 	if typedInput.OsName != nil {
 		osName := *typedInput.OsName
 		view.OsName = &osName
 	}
 
-	// Set property ‘OsVersion’:
+	// Set property "OsVersion":
 	if typedInput.OsVersion != nil {
 		osVersion := *typedInput.OsVersion
 		view.OsVersion = &osVersion
 	}
 
-	// Set property ‘PatchStatus’:
+	// Set property "PatchStatus":
 	if typedInput.PatchStatus != nil {
 		var patchStatus1 VirtualMachinePatchStatus_STATUS
 		err := patchStatus1.PopulateFromARM(owner, *typedInput.PatchStatus)
@@ -5863,25 +5863,25 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.PatchStatus = &patchStatus
 	}
 
-	// Set property ‘PlatformFaultDomain’:
+	// Set property "PlatformFaultDomain":
 	if typedInput.PlatformFaultDomain != nil {
 		platformFaultDomain := *typedInput.PlatformFaultDomain
 		view.PlatformFaultDomain = &platformFaultDomain
 	}
 
-	// Set property ‘PlatformUpdateDomain’:
+	// Set property "PlatformUpdateDomain":
 	if typedInput.PlatformUpdateDomain != nil {
 		platformUpdateDomain := *typedInput.PlatformUpdateDomain
 		view.PlatformUpdateDomain = &platformUpdateDomain
 	}
 
-	// Set property ‘RdpThumbPrint’:
+	// Set property "RdpThumbPrint":
 	if typedInput.RdpThumbPrint != nil {
 		rdpThumbPrint := *typedInput.RdpThumbPrint
 		view.RdpThumbPrint = &rdpThumbPrint
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5891,7 +5891,7 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.Statuses = append(view.Statuses, item1)
 	}
 
-	// Set property ‘VmAgent’:
+	// Set property "VmAgent":
 	if typedInput.VmAgent != nil {
 		var vmAgent1 VirtualMachineAgentInstanceView_STATUS
 		err := vmAgent1.PopulateFromARM(owner, *typedInput.VmAgent)
@@ -5902,7 +5902,7 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.VmAgent = &vmAgent
 	}
 
-	// Set property ‘VmHealth’:
+	// Set property "VmHealth":
 	if typedInput.VmHealth != nil {
 		var vmHealth1 VirtualMachineHealthStatus_STATUS
 		err := vmHealth1.PopulateFromARM(owner, *typedInput.VmHealth)
@@ -6241,13 +6241,13 @@ func (diagnostics *BootDiagnostics) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &BootDiagnostics_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if diagnostics.Enabled != nil {
 		enabled := *diagnostics.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘StorageUri’:
+	// Set property "StorageUri":
 	if diagnostics.StorageUri != nil {
 		storageUri := *diagnostics.StorageUri
 		result.StorageUri = &storageUri
@@ -6267,13 +6267,13 @@ func (diagnostics *BootDiagnostics) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BootDiagnostics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		diagnostics.Enabled = &enabled
 	}
 
-	// Set property ‘StorageUri’:
+	// Set property "StorageUri":
 	if typedInput.StorageUri != nil {
 		storageUri := *typedInput.StorageUri
 		diagnostics.StorageUri = &storageUri
@@ -6348,13 +6348,13 @@ func (diagnostics *BootDiagnostics_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BootDiagnostics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		diagnostics.Enabled = &enabled
 	}
 
-	// Set property ‘StorageUri’:
+	// Set property "StorageUri":
 	if typedInput.StorageUri != nil {
 		storageUri := *typedInput.StorageUri
 		diagnostics.StorageUri = &storageUri
@@ -6430,19 +6430,19 @@ func (view *BootDiagnosticsInstanceView_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BootDiagnosticsInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConsoleScreenshotBlobUri’:
+	// Set property "ConsoleScreenshotBlobUri":
 	if typedInput.ConsoleScreenshotBlobUri != nil {
 		consoleScreenshotBlobUri := *typedInput.ConsoleScreenshotBlobUri
 		view.ConsoleScreenshotBlobUri = &consoleScreenshotBlobUri
 	}
 
-	// Set property ‘SerialConsoleLogBlobUri’:
+	// Set property "SerialConsoleLogBlobUri":
 	if typedInput.SerialConsoleLogBlobUri != nil {
 		serialConsoleLogBlobUri := *typedInput.SerialConsoleLogBlobUri
 		view.SerialConsoleLogBlobUri = &serialConsoleLogBlobUri
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		var status1 InstanceViewStatus_STATUS
 		err := status1.PopulateFromARM(owner, *typedInput.Status)
@@ -6544,31 +6544,31 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &DataDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DetachOption’:
+	// Set property "DetachOption":
 	if disk.DetachOption != nil {
 		detachOption := *disk.DetachOption
 		result.DetachOption = &detachOption
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if disk.Image != nil {
 		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
 		if err != nil {
@@ -6578,13 +6578,13 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.Image = &image
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if disk.Lun != nil {
 		lun := *disk.Lun
 		result.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -6594,19 +6594,19 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ToBeDetached’:
+	// Set property "ToBeDetached":
 	if disk.ToBeDetached != nil {
 		toBeDetached := *disk.ToBeDetached
 		result.ToBeDetached = &toBeDetached
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if disk.Vhd != nil {
 		vhd_ARM, err := (*disk.Vhd).ConvertToARM(resolved)
 		if err != nil {
@@ -6616,7 +6616,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -6636,31 +6636,31 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DetachOption’:
+	// Set property "DetachOption":
 	if typedInput.DetachOption != nil {
 		detachOption := *typedInput.DetachOption
 		disk.DetachOption = &detachOption
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -6671,13 +6671,13 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		disk.Image = &image
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -6688,19 +6688,19 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘ToBeDetached’:
+	// Set property "ToBeDetached":
 	if typedInput.ToBeDetached != nil {
 		toBeDetached := *typedInput.ToBeDetached
 		disk.ToBeDetached = &toBeDetached
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -6711,7 +6711,7 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -6945,43 +6945,43 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DetachOption’:
+	// Set property "DetachOption":
 	if typedInput.DetachOption != nil {
 		detachOption := *typedInput.DetachOption
 		disk.DetachOption = &detachOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if typedInput.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *typedInput.DiskIOPSReadWrite
 		disk.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if typedInput.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *typedInput.DiskMBpsReadWrite
 		disk.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk_STATUS
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -6992,13 +6992,13 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		disk.Image = &image
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -7009,19 +7009,19 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘ToBeDetached’:
+	// Set property "ToBeDetached":
 	if typedInput.ToBeDetached != nil {
 		toBeDetached := *typedInput.ToBeDetached
 		disk.ToBeDetached = &toBeDetached
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk_STATUS
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -7032,7 +7032,7 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -7268,7 +7268,7 @@ func (view *DiskInstanceView_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	for _, item := range typedInput.EncryptionSettings {
 		var item1 DiskEncryptionSettings_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7278,13 +7278,13 @@ func (view *DiskInstanceView_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		view.EncryptionSettings = append(view.EncryptionSettings, item1)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		view.Name = &name
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7762,7 +7762,7 @@ func (reference *ImageReference) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ImageReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -7772,25 +7772,25 @@ func (reference *ImageReference) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Id = &reference1
 	}
 
-	// Set property ‘Offer’:
+	// Set property "Offer":
 	if reference.Offer != nil {
 		offer := *reference.Offer
 		result.Offer = &offer
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if reference.Publisher != nil {
 		publisher := *reference.Publisher
 		result.Publisher = &publisher
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if reference.Sku != nil {
 		sku := *reference.Sku
 		result.Sku = &sku
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if reference.Version != nil {
 		version := *reference.Version
 		result.Version = &version
@@ -7810,27 +7810,27 @@ func (reference *ImageReference) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Offer’:
+	// Set property "Offer":
 	if typedInput.Offer != nil {
 		offer := *typedInput.Offer
 		reference.Offer = &offer
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		reference.Publisher = &publisher
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		sku := *typedInput.Sku
 		reference.Sku = &sku
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		reference.Version = &version
@@ -7927,37 +7927,37 @@ func (reference *ImageReference_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExactVersion’:
+	// Set property "ExactVersion":
 	if typedInput.ExactVersion != nil {
 		exactVersion := *typedInput.ExactVersion
 		reference.ExactVersion = &exactVersion
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
 	}
 
-	// Set property ‘Offer’:
+	// Set property "Offer":
 	if typedInput.Offer != nil {
 		offer := *typedInput.Offer
 		reference.Offer = &offer
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		reference.Publisher = &publisher
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		sku := *typedInput.Sku
 		reference.Sku = &sku
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		reference.Version = &version
@@ -8049,31 +8049,31 @@ func (status *InstanceViewStatus_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InstanceViewStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		status.Code = &code
 	}
 
-	// Set property ‘DisplayStatus’:
+	// Set property "DisplayStatus":
 	if typedInput.DisplayStatus != nil {
 		displayStatus := *typedInput.DisplayStatus
 		status.DisplayStatus = &displayStatus
 	}
 
-	// Set property ‘Level’:
+	// Set property "Level":
 	if typedInput.Level != nil {
 		level := *typedInput.Level
 		status.Level = &level
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		status.Message = &message
 	}
 
-	// Set property ‘Time’:
+	// Set property "Time":
 	if typedInput.Time != nil {
 		time := *typedInput.Time
 		status.Time = &time
@@ -8163,13 +8163,13 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &LinuxConfiguration_ARM{}
 
-	// Set property ‘DisablePasswordAuthentication’:
+	// Set property "DisablePasswordAuthentication":
 	if configuration.DisablePasswordAuthentication != nil {
 		disablePasswordAuthentication := *configuration.DisablePasswordAuthentication
 		result.DisablePasswordAuthentication = &disablePasswordAuthentication
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if configuration.PatchSettings != nil {
 		patchSettings_ARM, err := (*configuration.PatchSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -8179,13 +8179,13 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 		result.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if configuration.ProvisionVMAgent != nil {
 		provisionVMAgent := *configuration.ProvisionVMAgent
 		result.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if configuration.Ssh != nil {
 		ssh_ARM, err := (*configuration.Ssh).ConvertToARM(resolved)
 		if err != nil {
@@ -8209,13 +8209,13 @@ func (configuration *LinuxConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisablePasswordAuthentication’:
+	// Set property "DisablePasswordAuthentication":
 	if typedInput.DisablePasswordAuthentication != nil {
 		disablePasswordAuthentication := *typedInput.DisablePasswordAuthentication
 		configuration.DisablePasswordAuthentication = &disablePasswordAuthentication
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 LinuxPatchSettings
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -8226,13 +8226,13 @@ func (configuration *LinuxConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 SshConfiguration
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -8372,13 +8372,13 @@ func (configuration *LinuxConfiguration_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisablePasswordAuthentication’:
+	// Set property "DisablePasswordAuthentication":
 	if typedInput.DisablePasswordAuthentication != nil {
 		disablePasswordAuthentication := *typedInput.DisablePasswordAuthentication
 		configuration.DisablePasswordAuthentication = &disablePasswordAuthentication
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 LinuxPatchSettings_STATUS
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -8389,13 +8389,13 @@ func (configuration *LinuxConfiguration_STATUS) PopulateFromARM(owner genruntime
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 SshConfiguration_STATUS
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -8538,43 +8538,43 @@ func (status *MaintenanceRedeployStatus_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceRedeployStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IsCustomerInitiatedMaintenanceAllowed’:
+	// Set property "IsCustomerInitiatedMaintenanceAllowed":
 	if typedInput.IsCustomerInitiatedMaintenanceAllowed != nil {
 		isCustomerInitiatedMaintenanceAllowed := *typedInput.IsCustomerInitiatedMaintenanceAllowed
 		status.IsCustomerInitiatedMaintenanceAllowed = &isCustomerInitiatedMaintenanceAllowed
 	}
 
-	// Set property ‘LastOperationMessage’:
+	// Set property "LastOperationMessage":
 	if typedInput.LastOperationMessage != nil {
 		lastOperationMessage := *typedInput.LastOperationMessage
 		status.LastOperationMessage = &lastOperationMessage
 	}
 
-	// Set property ‘LastOperationResultCode’:
+	// Set property "LastOperationResultCode":
 	if typedInput.LastOperationResultCode != nil {
 		lastOperationResultCode := *typedInput.LastOperationResultCode
 		status.LastOperationResultCode = &lastOperationResultCode
 	}
 
-	// Set property ‘MaintenanceWindowEndTime’:
+	// Set property "MaintenanceWindowEndTime":
 	if typedInput.MaintenanceWindowEndTime != nil {
 		maintenanceWindowEndTime := *typedInput.MaintenanceWindowEndTime
 		status.MaintenanceWindowEndTime = &maintenanceWindowEndTime
 	}
 
-	// Set property ‘MaintenanceWindowStartTime’:
+	// Set property "MaintenanceWindowStartTime":
 	if typedInput.MaintenanceWindowStartTime != nil {
 		maintenanceWindowStartTime := *typedInput.MaintenanceWindowStartTime
 		status.MaintenanceWindowStartTime = &maintenanceWindowStartTime
 	}
 
-	// Set property ‘PreMaintenanceWindowEndTime’:
+	// Set property "PreMaintenanceWindowEndTime":
 	if typedInput.PreMaintenanceWindowEndTime != nil {
 		preMaintenanceWindowEndTime := *typedInput.PreMaintenanceWindowEndTime
 		status.PreMaintenanceWindowEndTime = &preMaintenanceWindowEndTime
 	}
 
-	// Set property ‘PreMaintenanceWindowStartTime’:
+	// Set property "PreMaintenanceWindowStartTime":
 	if typedInput.PreMaintenanceWindowStartTime != nil {
 		preMaintenanceWindowStartTime := *typedInput.PreMaintenanceWindowStartTime
 		status.PreMaintenanceWindowStartTime = &preMaintenanceWindowStartTime
@@ -8684,7 +8684,7 @@ func (reference *NetworkInterfaceReference) ConvertToARM(resolved genruntime.Con
 	}
 	result := &NetworkInterfaceReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -8694,7 +8694,7 @@ func (reference *NetworkInterfaceReference) ConvertToARM(resolved genruntime.Con
 		result.Id = &reference1
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if reference.Primary != nil {
 		result.Properties = &NetworkInterfaceReferenceProperties_ARM{}
 	}
@@ -8717,7 +8717,7 @@ func (reference *NetworkInterfaceReference) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -8726,7 +8726,7 @@ func (reference *NetworkInterfaceReference) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -8807,13 +8807,13 @@ func (reference *NetworkInterfaceReference_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -8897,19 +8897,19 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &OSDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if disk.DiffDiskSettings != nil {
 		diffDiskSettings_ARM, err := (*disk.DiffDiskSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -8919,13 +8919,13 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	if disk.EncryptionSettings != nil {
 		encryptionSettings_ARM, err := (*disk.EncryptionSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -8935,7 +8935,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.EncryptionSettings = &encryptionSettings
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if disk.Image != nil {
 		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
 		if err != nil {
@@ -8945,7 +8945,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -8955,19 +8955,19 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if disk.OsType != nil {
 		osType := *disk.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if disk.Vhd != nil {
 		vhd_ARM, err := (*disk.Vhd).ConvertToARM(resolved)
 		if err != nil {
@@ -8977,7 +8977,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -8997,19 +8997,19 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -9020,13 +9020,13 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	if typedInput.EncryptionSettings != nil {
 		var encryptionSettings1 DiskEncryptionSettings
 		err := encryptionSettings1.PopulateFromARM(owner, *typedInput.EncryptionSettings)
@@ -9037,7 +9037,7 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.EncryptionSettings = &encryptionSettings
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -9048,7 +9048,7 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -9059,19 +9059,19 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -9082,7 +9082,7 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -9340,19 +9340,19 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings_STATUS
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -9363,13 +9363,13 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	if typedInput.EncryptionSettings != nil {
 		var encryptionSettings1 DiskEncryptionSettings_STATUS
 		err := encryptionSettings1.PopulateFromARM(owner, *typedInput.EncryptionSettings)
@@ -9380,7 +9380,7 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.EncryptionSettings = &encryptionSettings
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk_STATUS
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -9391,7 +9391,7 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -9402,19 +9402,19 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk_STATUS
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -9425,7 +9425,7 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -9680,13 +9680,13 @@ func (settings *UefiSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &UefiSettings_ARM{}
 
-	// Set property ‘SecureBootEnabled’:
+	// Set property "SecureBootEnabled":
 	if settings.SecureBootEnabled != nil {
 		secureBootEnabled := *settings.SecureBootEnabled
 		result.SecureBootEnabled = &secureBootEnabled
 	}
 
-	// Set property ‘VTpmEnabled’:
+	// Set property "VTpmEnabled":
 	if settings.VTpmEnabled != nil {
 		vTpmEnabled := *settings.VTpmEnabled
 		result.VTpmEnabled = &vTpmEnabled
@@ -9706,13 +9706,13 @@ func (settings *UefiSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UefiSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecureBootEnabled’:
+	// Set property "SecureBootEnabled":
 	if typedInput.SecureBootEnabled != nil {
 		secureBootEnabled := *typedInput.SecureBootEnabled
 		settings.SecureBootEnabled = &secureBootEnabled
 	}
 
-	// Set property ‘VTpmEnabled’:
+	// Set property "VTpmEnabled":
 	if typedInput.VTpmEnabled != nil {
 		vTpmEnabled := *typedInput.VTpmEnabled
 		settings.VTpmEnabled = &vTpmEnabled
@@ -9797,13 +9797,13 @@ func (settings *UefiSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UefiSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecureBootEnabled’:
+	// Set property "SecureBootEnabled":
 	if typedInput.SecureBootEnabled != nil {
 		secureBootEnabled := *typedInput.SecureBootEnabled
 		settings.SecureBootEnabled = &secureBootEnabled
 	}
 
-	// Set property ‘VTpmEnabled’:
+	// Set property "VTpmEnabled":
 	if typedInput.VTpmEnabled != nil {
 		vTpmEnabled := *typedInput.VTpmEnabled
 		settings.VTpmEnabled = &vTpmEnabled
@@ -9917,7 +9917,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &VaultSecretGroup_ARM{}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if group.SourceVault != nil {
 		sourceVault_ARM, err := (*group.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -9927,7 +9927,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.SourceVault = &sourceVault
 	}
 
-	// Set property ‘VaultCertificates’:
+	// Set property "VaultCertificates":
 	for _, item := range group.VaultCertificates {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -9950,7 +9950,7 @@ func (group *VaultSecretGroup) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultSecretGroup_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -9961,7 +9961,7 @@ func (group *VaultSecretGroup) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		group.SourceVault = &sourceVault
 	}
 
-	// Set property ‘VaultCertificates’:
+	// Set property "VaultCertificates":
 	for _, item := range typedInput.VaultCertificates {
 		var item1 VaultCertificate
 		err := item1.PopulateFromARM(owner, item)
@@ -10078,7 +10078,7 @@ func (group *VaultSecretGroup_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultSecretGroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -10089,7 +10089,7 @@ func (group *VaultSecretGroup_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		group.SourceVault = &sourceVault
 	}
 
-	// Set property ‘VaultCertificates’:
+	// Set property "VaultCertificates":
 	for _, item := range typedInput.VaultCertificates {
 		var item1 VaultCertificate_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10207,7 +10207,7 @@ func (view *VirtualMachineAgentInstanceView_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineAgentInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExtensionHandlers’:
+	// Set property "ExtensionHandlers":
 	for _, item := range typedInput.ExtensionHandlers {
 		var item1 VirtualMachineExtensionHandlerInstanceView_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10217,7 +10217,7 @@ func (view *VirtualMachineAgentInstanceView_STATUS) PopulateFromARM(owner genrun
 		view.ExtensionHandlers = append(view.ExtensionHandlers, item1)
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10227,7 +10227,7 @@ func (view *VirtualMachineAgentInstanceView_STATUS) PopulateFromARM(owner genrun
 		view.Statuses = append(view.Statuses, item1)
 	}
 
-	// Set property ‘VmAgentVersion’:
+	// Set property "VmAgentVersion":
 	if typedInput.VmAgentVersion != nil {
 		vmAgentVersion := *typedInput.VmAgentVersion
 		view.VmAgentVersion = &vmAgentVersion
@@ -10361,13 +10361,13 @@ func (view *VirtualMachineExtensionInstanceView_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineExtensionInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		view.Name = &name
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10377,7 +10377,7 @@ func (view *VirtualMachineExtensionInstanceView_STATUS) PopulateFromARM(owner ge
 		view.Statuses = append(view.Statuses, item1)
 	}
 
-	// Set property ‘Substatuses’:
+	// Set property "Substatuses":
 	for _, item := range typedInput.Substatuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10387,13 +10387,13 @@ func (view *VirtualMachineExtensionInstanceView_STATUS) PopulateFromARM(owner ge
 		view.Substatuses = append(view.Substatuses, item1)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		view.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	if typedInput.TypeHandlerVersion != nil {
 		typeHandlerVersion := *typedInput.TypeHandlerVersion
 		view.TypeHandlerVersion = &typeHandlerVersion
@@ -10535,7 +10535,7 @@ func (status *VirtualMachineHealthStatus_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineHealthStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		var status2 InstanceViewStatus_STATUS
 		err := status2.PopulateFromARM(owner, *typedInput.Status)
@@ -10617,13 +10617,13 @@ func (identities *VirtualMachineIdentity_UserAssignedIdentities_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -10698,7 +10698,7 @@ func (status *VirtualMachinePatchStatus_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachinePatchStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailablePatchSummary’:
+	// Set property "AvailablePatchSummary":
 	if typedInput.AvailablePatchSummary != nil {
 		var availablePatchSummary1 AvailablePatchSummary_STATUS
 		err := availablePatchSummary1.PopulateFromARM(owner, *typedInput.AvailablePatchSummary)
@@ -10709,7 +10709,7 @@ func (status *VirtualMachinePatchStatus_STATUS) PopulateFromARM(owner genruntime
 		status.AvailablePatchSummary = &availablePatchSummary
 	}
 
-	// Set property ‘ConfigurationStatuses’:
+	// Set property "ConfigurationStatuses":
 	for _, item := range typedInput.ConfigurationStatuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10719,7 +10719,7 @@ func (status *VirtualMachinePatchStatus_STATUS) PopulateFromARM(owner genruntime
 		status.ConfigurationStatuses = append(status.ConfigurationStatuses, item1)
 	}
 
-	// Set property ‘LastPatchInstallationSummary’:
+	// Set property "LastPatchInstallationSummary":
 	if typedInput.LastPatchInstallationSummary != nil {
 		var lastPatchInstallationSummary1 LastPatchInstallationSummary_STATUS
 		err := lastPatchInstallationSummary1.PopulateFromARM(owner, *typedInput.LastPatchInstallationSummary)
@@ -10860,7 +10860,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &WindowsConfiguration_ARM{}
 
-	// Set property ‘AdditionalUnattendContent’:
+	// Set property "AdditionalUnattendContent":
 	for _, item := range configuration.AdditionalUnattendContent {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -10869,13 +10869,13 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		result.AdditionalUnattendContent = append(result.AdditionalUnattendContent, *item_ARM.(*AdditionalUnattendContent_ARM))
 	}
 
-	// Set property ‘EnableAutomaticUpdates’:
+	// Set property "EnableAutomaticUpdates":
 	if configuration.EnableAutomaticUpdates != nil {
 		enableAutomaticUpdates := *configuration.EnableAutomaticUpdates
 		result.EnableAutomaticUpdates = &enableAutomaticUpdates
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if configuration.PatchSettings != nil {
 		patchSettings_ARM, err := (*configuration.PatchSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -10885,19 +10885,19 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		result.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if configuration.ProvisionVMAgent != nil {
 		provisionVMAgent := *configuration.ProvisionVMAgent
 		result.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if configuration.TimeZone != nil {
 		timeZone := *configuration.TimeZone
 		result.TimeZone = &timeZone
 	}
 
-	// Set property ‘WinRM’:
+	// Set property "WinRM":
 	if configuration.WinRM != nil {
 		winRM_ARM, err := (*configuration.WinRM).ConvertToARM(resolved)
 		if err != nil {
@@ -10921,7 +10921,7 @@ func (configuration *WindowsConfiguration) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalUnattendContent’:
+	// Set property "AdditionalUnattendContent":
 	for _, item := range typedInput.AdditionalUnattendContent {
 		var item1 AdditionalUnattendContent
 		err := item1.PopulateFromARM(owner, item)
@@ -10931,13 +10931,13 @@ func (configuration *WindowsConfiguration) PopulateFromARM(owner genruntime.Arbi
 		configuration.AdditionalUnattendContent = append(configuration.AdditionalUnattendContent, item1)
 	}
 
-	// Set property ‘EnableAutomaticUpdates’:
+	// Set property "EnableAutomaticUpdates":
 	if typedInput.EnableAutomaticUpdates != nil {
 		enableAutomaticUpdates := *typedInput.EnableAutomaticUpdates
 		configuration.EnableAutomaticUpdates = &enableAutomaticUpdates
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 PatchSettings
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -10948,19 +10948,19 @@ func (configuration *WindowsConfiguration) PopulateFromARM(owner genruntime.Arbi
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if typedInput.TimeZone != nil {
 		timeZone := *typedInput.TimeZone
 		configuration.TimeZone = &timeZone
 	}
 
-	// Set property ‘WinRM’:
+	// Set property "WinRM":
 	if typedInput.WinRM != nil {
 		var winRM1 WinRMConfiguration
 		err := winRM1.PopulateFromARM(owner, *typedInput.WinRM)
@@ -11144,7 +11144,7 @@ func (configuration *WindowsConfiguration_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalUnattendContent’:
+	// Set property "AdditionalUnattendContent":
 	for _, item := range typedInput.AdditionalUnattendContent {
 		var item1 AdditionalUnattendContent_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11154,13 +11154,13 @@ func (configuration *WindowsConfiguration_STATUS) PopulateFromARM(owner genrunti
 		configuration.AdditionalUnattendContent = append(configuration.AdditionalUnattendContent, item1)
 	}
 
-	// Set property ‘EnableAutomaticUpdates’:
+	// Set property "EnableAutomaticUpdates":
 	if typedInput.EnableAutomaticUpdates != nil {
 		enableAutomaticUpdates := *typedInput.EnableAutomaticUpdates
 		configuration.EnableAutomaticUpdates = &enableAutomaticUpdates
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 PatchSettings_STATUS
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -11171,19 +11171,19 @@ func (configuration *WindowsConfiguration_STATUS) PopulateFromARM(owner genrunti
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if typedInput.TimeZone != nil {
 		timeZone := *typedInput.TimeZone
 		configuration.TimeZone = &timeZone
 	}
 
-	// Set property ‘WinRM’:
+	// Set property "WinRM":
 	if typedInput.WinRM != nil {
 		var winRM1 WinRMConfiguration_STATUS
 		err := winRM1.PopulateFromARM(owner, *typedInput.WinRM)
@@ -11360,25 +11360,25 @@ func (content *AdditionalUnattendContent) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &AdditionalUnattendContent_ARM{}
 
-	// Set property ‘ComponentName’:
+	// Set property "ComponentName":
 	if content.ComponentName != nil {
 		componentName := *content.ComponentName
 		result.ComponentName = &componentName
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if content.Content != nil {
 		content1 := *content.Content
 		result.Content = &content1
 	}
 
-	// Set property ‘PassName’:
+	// Set property "PassName":
 	if content.PassName != nil {
 		passName := *content.PassName
 		result.PassName = &passName
 	}
 
-	// Set property ‘SettingName’:
+	// Set property "SettingName":
 	if content.SettingName != nil {
 		settingName := *content.SettingName
 		result.SettingName = &settingName
@@ -11398,25 +11398,25 @@ func (content *AdditionalUnattendContent) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalUnattendContent_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComponentName’:
+	// Set property "ComponentName":
 	if typedInput.ComponentName != nil {
 		componentName := *typedInput.ComponentName
 		content.ComponentName = &componentName
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if typedInput.Content != nil {
 		content1 := *typedInput.Content
 		content.Content = &content1
 	}
 
-	// Set property ‘PassName’:
+	// Set property "PassName":
 	if typedInput.PassName != nil {
 		passName := *typedInput.PassName
 		content.PassName = &passName
 	}
 
-	// Set property ‘SettingName’:
+	// Set property "SettingName":
 	if typedInput.SettingName != nil {
 		settingName := *typedInput.SettingName
 		content.SettingName = &settingName
@@ -11525,25 +11525,25 @@ func (content *AdditionalUnattendContent_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalUnattendContent_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComponentName’:
+	// Set property "ComponentName":
 	if typedInput.ComponentName != nil {
 		componentName := *typedInput.ComponentName
 		content.ComponentName = &componentName
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if typedInput.Content != nil {
 		content1 := *typedInput.Content
 		content.Content = &content1
 	}
 
-	// Set property ‘PassName’:
+	// Set property "PassName":
 	if typedInput.PassName != nil {
 		passName := *typedInput.PassName
 		content.PassName = &passName
 	}
 
-	// Set property ‘SettingName’:
+	// Set property "SettingName":
 	if typedInput.SettingName != nil {
 		settingName := *typedInput.SettingName
 		content.SettingName = &settingName
@@ -11656,19 +11656,19 @@ func (summary *AvailablePatchSummary_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AvailablePatchSummary_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssessmentActivityId’:
+	// Set property "AssessmentActivityId":
 	if typedInput.AssessmentActivityId != nil {
 		assessmentActivityId := *typedInput.AssessmentActivityId
 		summary.AssessmentActivityId = &assessmentActivityId
 	}
 
-	// Set property ‘CriticalAndSecurityPatchCount’:
+	// Set property "CriticalAndSecurityPatchCount":
 	if typedInput.CriticalAndSecurityPatchCount != nil {
 		criticalAndSecurityPatchCount := *typedInput.CriticalAndSecurityPatchCount
 		summary.CriticalAndSecurityPatchCount = &criticalAndSecurityPatchCount
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ApiError_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -11679,31 +11679,31 @@ func (summary *AvailablePatchSummary_STATUS) PopulateFromARM(owner genruntime.Ar
 		summary.Error = &error
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	if typedInput.LastModifiedTime != nil {
 		lastModifiedTime := *typedInput.LastModifiedTime
 		summary.LastModifiedTime = &lastModifiedTime
 	}
 
-	// Set property ‘OtherPatchCount’:
+	// Set property "OtherPatchCount":
 	if typedInput.OtherPatchCount != nil {
 		otherPatchCount := *typedInput.OtherPatchCount
 		summary.OtherPatchCount = &otherPatchCount
 	}
 
-	// Set property ‘RebootPending’:
+	// Set property "RebootPending":
 	if typedInput.RebootPending != nil {
 		rebootPending := *typedInput.RebootPending
 		summary.RebootPending = &rebootPending
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		summary.StartTime = &startTime
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		summary.Status = &status
@@ -11886,13 +11886,13 @@ func (settings *DiffDiskSettings) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &DiffDiskSettings_ARM{}
 
-	// Set property ‘Option’:
+	// Set property "Option":
 	if settings.Option != nil {
 		option := *settings.Option
 		result.Option = &option
 	}
 
-	// Set property ‘Placement’:
+	// Set property "Placement":
 	if settings.Placement != nil {
 		placement := *settings.Placement
 		result.Placement = &placement
@@ -11912,13 +11912,13 @@ func (settings *DiffDiskSettings) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiffDiskSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Option’:
+	// Set property "Option":
 	if typedInput.Option != nil {
 		option := *typedInput.Option
 		settings.Option = &option
 	}
 
-	// Set property ‘Placement’:
+	// Set property "Placement":
 	if typedInput.Placement != nil {
 		placement := *typedInput.Placement
 		settings.Placement = &placement
@@ -12003,13 +12003,13 @@ func (settings *DiffDiskSettings_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiffDiskSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Option’:
+	// Set property "Option":
 	if typedInput.Option != nil {
 		option := *typedInput.Option
 		settings.Option = &option
 	}
 
-	// Set property ‘Placement’:
+	// Set property "Placement":
 	if typedInput.Placement != nil {
 		placement := *typedInput.Placement
 		settings.Placement = &placement
@@ -12090,7 +12090,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &DiskEncryptionSettings_ARM{}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if settings.DiskEncryptionKey != nil {
 		diskEncryptionKey_ARM, err := (*settings.DiskEncryptionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -12100,13 +12100,13 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 		result.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if settings.Enabled != nil {
 		enabled := *settings.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if settings.KeyEncryptionKey != nil {
 		keyEncryptionKey_ARM, err := (*settings.KeyEncryptionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -12130,7 +12130,7 @@ func (settings *DiskEncryptionSettings) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskEncryptionSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if typedInput.DiskEncryptionKey != nil {
 		var diskEncryptionKey1 KeyVaultSecretReference
 		err := diskEncryptionKey1.PopulateFromARM(owner, *typedInput.DiskEncryptionKey)
@@ -12141,13 +12141,13 @@ func (settings *DiskEncryptionSettings) PopulateFromARM(owner genruntime.Arbitra
 		settings.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		settings.Enabled = &enabled
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if typedInput.KeyEncryptionKey != nil {
 		var keyEncryptionKey1 KeyVaultKeyReference
 		err := keyEncryptionKey1.PopulateFromARM(owner, *typedInput.KeyEncryptionKey)
@@ -12270,7 +12270,7 @@ func (settings *DiskEncryptionSettings_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskEncryptionSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if typedInput.DiskEncryptionKey != nil {
 		var diskEncryptionKey1 KeyVaultSecretReference_STATUS
 		err := diskEncryptionKey1.PopulateFromARM(owner, *typedInput.DiskEncryptionKey)
@@ -12281,13 +12281,13 @@ func (settings *DiskEncryptionSettings_STATUS) PopulateFromARM(owner genruntime.
 		settings.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		settings.Enabled = &enabled
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if typedInput.KeyEncryptionKey != nil {
 		var keyEncryptionKey1 KeyVaultKeyReference_STATUS
 		err := keyEncryptionKey1.PopulateFromARM(owner, *typedInput.KeyEncryptionKey)
@@ -12427,7 +12427,7 @@ func (summary *LastPatchInstallationSummary_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LastPatchInstallationSummary_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ApiError_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -12438,61 +12438,61 @@ func (summary *LastPatchInstallationSummary_STATUS) PopulateFromARM(owner genrun
 		summary.Error = &error
 	}
 
-	// Set property ‘ExcludedPatchCount’:
+	// Set property "ExcludedPatchCount":
 	if typedInput.ExcludedPatchCount != nil {
 		excludedPatchCount := *typedInput.ExcludedPatchCount
 		summary.ExcludedPatchCount = &excludedPatchCount
 	}
 
-	// Set property ‘FailedPatchCount’:
+	// Set property "FailedPatchCount":
 	if typedInput.FailedPatchCount != nil {
 		failedPatchCount := *typedInput.FailedPatchCount
 		summary.FailedPatchCount = &failedPatchCount
 	}
 
-	// Set property ‘InstallationActivityId’:
+	// Set property "InstallationActivityId":
 	if typedInput.InstallationActivityId != nil {
 		installationActivityId := *typedInput.InstallationActivityId
 		summary.InstallationActivityId = &installationActivityId
 	}
 
-	// Set property ‘InstalledPatchCount’:
+	// Set property "InstalledPatchCount":
 	if typedInput.InstalledPatchCount != nil {
 		installedPatchCount := *typedInput.InstalledPatchCount
 		summary.InstalledPatchCount = &installedPatchCount
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	if typedInput.LastModifiedTime != nil {
 		lastModifiedTime := *typedInput.LastModifiedTime
 		summary.LastModifiedTime = &lastModifiedTime
 	}
 
-	// Set property ‘MaintenanceWindowExceeded’:
+	// Set property "MaintenanceWindowExceeded":
 	if typedInput.MaintenanceWindowExceeded != nil {
 		maintenanceWindowExceeded := *typedInput.MaintenanceWindowExceeded
 		summary.MaintenanceWindowExceeded = &maintenanceWindowExceeded
 	}
 
-	// Set property ‘NotSelectedPatchCount’:
+	// Set property "NotSelectedPatchCount":
 	if typedInput.NotSelectedPatchCount != nil {
 		notSelectedPatchCount := *typedInput.NotSelectedPatchCount
 		summary.NotSelectedPatchCount = &notSelectedPatchCount
 	}
 
-	// Set property ‘PendingPatchCount’:
+	// Set property "PendingPatchCount":
 	if typedInput.PendingPatchCount != nil {
 		pendingPatchCount := *typedInput.PendingPatchCount
 		summary.PendingPatchCount = &pendingPatchCount
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		summary.StartTime = &startTime
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		summary.Status = &status
@@ -12643,7 +12643,7 @@ func (settings *LinuxPatchSettings) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &LinuxPatchSettings_ARM{}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if settings.PatchMode != nil {
 		patchMode := *settings.PatchMode
 		result.PatchMode = &patchMode
@@ -12663,7 +12663,7 @@ func (settings *LinuxPatchSettings) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxPatchSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -12731,7 +12731,7 @@ func (settings *LinuxPatchSettings_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxPatchSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -12807,7 +12807,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &ManagedDiskParameters_ARM{}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if parameters.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*parameters.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -12817,7 +12817,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if parameters.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*parameters.Reference)
 		if err != nil {
@@ -12827,7 +12827,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 		result.Id = &reference
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if parameters.StorageAccountType != nil {
 		storageAccountType := *parameters.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -12847,7 +12847,7 @@ func (parameters *ManagedDiskParameters) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedDiskParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -12858,9 +12858,9 @@ func (parameters *ManagedDiskParameters) PopulateFromARM(owner genruntime.Arbitr
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -12970,7 +12970,7 @@ func (parameters *ManagedDiskParameters_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedDiskParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -12981,13 +12981,13 @@ func (parameters *ManagedDiskParameters_STATUS) PopulateFromARM(owner genruntime
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		parameters.Id = &id
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -13098,13 +13098,13 @@ func (settings *PatchSettings) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &PatchSettings_ARM{}
 
-	// Set property ‘EnableHotpatching’:
+	// Set property "EnableHotpatching":
 	if settings.EnableHotpatching != nil {
 		enableHotpatching := *settings.EnableHotpatching
 		result.EnableHotpatching = &enableHotpatching
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if settings.PatchMode != nil {
 		patchMode := *settings.PatchMode
 		result.PatchMode = &patchMode
@@ -13124,13 +13124,13 @@ func (settings *PatchSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PatchSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableHotpatching’:
+	// Set property "EnableHotpatching":
 	if typedInput.EnableHotpatching != nil {
 		enableHotpatching := *typedInput.EnableHotpatching
 		settings.EnableHotpatching = &enableHotpatching
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -13215,13 +13215,13 @@ func (settings *PatchSettings_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PatchSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableHotpatching’:
+	// Set property "EnableHotpatching":
 	if typedInput.EnableHotpatching != nil {
 		enableHotpatching := *typedInput.EnableHotpatching
 		settings.EnableHotpatching = &enableHotpatching
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -13300,7 +13300,7 @@ func (configuration *SshConfiguration) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &SshConfiguration_ARM{}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range configuration.PublicKeys {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -13323,7 +13323,7 @@ func (configuration *SshConfiguration) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 SshPublicKeySpec
 		err := item1.PopulateFromARM(owner, item)
@@ -13415,7 +13415,7 @@ func (configuration *SshConfiguration_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 SshPublicKey_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -13503,13 +13503,13 @@ func (certificate *VaultCertificate) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &VaultCertificate_ARM{}
 
-	// Set property ‘CertificateStore’:
+	// Set property "CertificateStore":
 	if certificate.CertificateStore != nil {
 		certificateStore := *certificate.CertificateStore
 		result.CertificateStore = &certificateStore
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if certificate.CertificateUrl != nil {
 		certificateUrl := *certificate.CertificateUrl
 		result.CertificateUrl = &certificateUrl
@@ -13529,13 +13529,13 @@ func (certificate *VaultCertificate) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultCertificate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateStore’:
+	// Set property "CertificateStore":
 	if typedInput.CertificateStore != nil {
 		certificateStore := *typedInput.CertificateStore
 		certificate.CertificateStore = &certificateStore
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		certificate.CertificateUrl = &certificateUrl
@@ -13600,13 +13600,13 @@ func (certificate *VaultCertificate_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultCertificate_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateStore’:
+	// Set property "CertificateStore":
 	if typedInput.CertificateStore != nil {
 		certificateStore := *typedInput.CertificateStore
 		certificate.CertificateStore = &certificateStore
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		certificate.CertificateUrl = &certificateUrl
@@ -13665,7 +13665,7 @@ func (disk *VirtualHardDisk) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &VirtualHardDisk_ARM{}
 
-	// Set property ‘Uri’:
+	// Set property "Uri":
 	if disk.Uri != nil {
 		uri := *disk.Uri
 		result.Uri = &uri
@@ -13685,7 +13685,7 @@ func (disk *VirtualHardDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualHardDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Uri’:
+	// Set property "Uri":
 	if typedInput.Uri != nil {
 		uri := *typedInput.Uri
 		disk.Uri = &uri
@@ -13743,7 +13743,7 @@ func (disk *VirtualHardDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualHardDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Uri’:
+	// Set property "Uri":
 	if typedInput.Uri != nil {
 		uri := *typedInput.Uri
 		disk.Uri = &uri
@@ -13803,7 +13803,7 @@ func (view *VirtualMachineExtensionHandlerInstanceView_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineExtensionHandlerInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		var status1 InstanceViewStatus_STATUS
 		err := status1.PopulateFromARM(owner, *typedInput.Status)
@@ -13814,13 +13814,13 @@ func (view *VirtualMachineExtensionHandlerInstanceView_STATUS) PopulateFromARM(o
 		view.Status = &status
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		view.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	if typedInput.TypeHandlerVersion != nil {
 		typeHandlerVersion := *typedInput.TypeHandlerVersion
 		view.TypeHandlerVersion = &typeHandlerVersion
@@ -13903,7 +13903,7 @@ func (configuration *WinRMConfiguration) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &WinRMConfiguration_ARM{}
 
-	// Set property ‘Listeners’:
+	// Set property "Listeners":
 	for _, item := range configuration.Listeners {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -13926,7 +13926,7 @@ func (configuration *WinRMConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Listeners’:
+	// Set property "Listeners":
 	for _, item := range typedInput.Listeners {
 		var item1 WinRMListener
 		err := item1.PopulateFromARM(owner, item)
@@ -14018,7 +14018,7 @@ func (configuration *WinRMConfiguration_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Listeners’:
+	// Set property "Listeners":
 	for _, item := range typedInput.Listeners {
 		var item1 WinRMListener_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -14158,13 +14158,13 @@ func (error *ApiError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		error.Code = &code
 	}
 
-	// Set property ‘Details’:
+	// Set property "Details":
 	for _, item := range typedInput.Details {
 		var item1 ApiErrorBase_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -14174,7 +14174,7 @@ func (error *ApiError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		error.Details = append(error.Details, item1)
 	}
 
-	// Set property ‘Innererror’:
+	// Set property "Innererror":
 	if typedInput.Innererror != nil {
 		var innererror1 InnerError_STATUS
 		err := innererror1.PopulateFromARM(owner, *typedInput.Innererror)
@@ -14185,13 +14185,13 @@ func (error *ApiError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		error.Innererror = &innererror
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		error.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		error.Target = &target
@@ -14359,13 +14359,13 @@ func (reference *KeyVaultKeyReference) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &KeyVaultKeyReference_ARM{}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if reference.KeyUrl != nil {
 		keyUrl := *reference.KeyUrl
 		result.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if reference.SourceVault != nil {
 		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -14389,13 +14389,13 @@ func (reference *KeyVaultKeyReference) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultKeyReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if typedInput.KeyUrl != nil {
 		keyUrl := *typedInput.KeyUrl
 		reference.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -14483,13 +14483,13 @@ func (reference *KeyVaultKeyReference_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultKeyReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if typedInput.KeyUrl != nil {
 		keyUrl := *typedInput.KeyUrl
 		reference.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -14575,13 +14575,13 @@ func (reference *KeyVaultSecretReference) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &KeyVaultSecretReference_ARM{}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if reference.SecretUrl != nil {
 		secretUrl := *reference.SecretUrl
 		result.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if reference.SourceVault != nil {
 		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -14605,13 +14605,13 @@ func (reference *KeyVaultSecretReference) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultSecretReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if typedInput.SecretUrl != nil {
 		secretUrl := *typedInput.SecretUrl
 		reference.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -14699,13 +14699,13 @@ func (reference *KeyVaultSecretReference_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultSecretReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if typedInput.SecretUrl != nil {
 		secretUrl := *typedInput.SecretUrl
 		reference.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -14841,13 +14841,13 @@ func (publicKey *SshPublicKey_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshPublicKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		publicKey.Path = &path
@@ -14907,13 +14907,13 @@ func (publicKey *SshPublicKeySpec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &SshPublicKeySpec_ARM{}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if publicKey.KeyData != nil {
 		keyData := *publicKey.KeyData
 		result.KeyData = &keyData
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if publicKey.Path != nil {
 		path := *publicKey.Path
 		result.Path = &path
@@ -14933,13 +14933,13 @@ func (publicKey *SshPublicKeySpec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshPublicKeySpec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		publicKey.Path = &path
@@ -15024,13 +15024,13 @@ func (listener *WinRMListener) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &WinRMListener_ARM{}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if listener.CertificateUrl != nil {
 		certificateUrl := *listener.CertificateUrl
 		result.CertificateUrl = &certificateUrl
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if listener.Protocol != nil {
 		protocol := *listener.Protocol
 		result.Protocol = &protocol
@@ -15050,13 +15050,13 @@ func (listener *WinRMListener) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMListener_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		listener.CertificateUrl = &certificateUrl
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		listener.Protocol = &protocol
@@ -15131,13 +15131,13 @@ func (listener *WinRMListener_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMListener_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		listener.CertificateUrl = &certificateUrl
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		listener.Protocol = &protocol
@@ -15213,19 +15213,19 @@ func (base *ApiErrorBase_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiErrorBase_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		base.Code = &code
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		base.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		base.Target = &target
@@ -15296,13 +15296,13 @@ func (error *InnerError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InnerError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Errordetail’:
+	// Set property "Errordetail":
 	if typedInput.Errordetail != nil {
 		errordetail := *typedInput.Errordetail
 		error.Errordetail = &errordetail
 	}
 
-	// Set property ‘Exceptiontype’:
+	// Set property "Exceptiontype":
 	if typedInput.Exceptiontype != nil {
 		exceptiontype := *typedInput.Exceptiontype
 		error.Exceptiontype = &exceptiontype

--- a/v2/api/compute/v1beta20210701/image_types_gen.go
+++ b/v2/api/compute/v1beta20210701/image_types_gen.go
@@ -344,7 +344,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &Image_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if image.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*image.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -354,16 +354,16 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if image.Location != nil {
 		location := *image.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if image.HyperVGeneration != nil ||
 		image.SourceVirtualMachine != nil ||
 		image.StorageProfile != nil {
@@ -390,7 +390,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if image.Tags != nil {
 		result.Tags = make(map[string]string, len(image.Tags))
 		for key, value := range image.Tags {
@@ -412,10 +412,10 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Image_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	image.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -426,7 +426,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		image.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -435,16 +435,16 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		image.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	image.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘SourceVirtualMachine’:
+	// Set property "SourceVirtualMachine":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceVirtualMachine != nil {
@@ -458,7 +458,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -472,7 +472,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		image.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -770,9 +770,9 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Image_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -783,7 +783,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		image.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -792,25 +792,25 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		image.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		image.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		image.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -819,7 +819,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘SourceVirtualMachine’:
+	// Set property "SourceVirtualMachine":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceVirtualMachine != nil {
@@ -833,7 +833,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -847,7 +847,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		image.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -855,7 +855,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		image.Type = &typeVar
@@ -1033,13 +1033,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -1059,13 +1059,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -1140,13 +1140,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -1234,7 +1234,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ImageStorageProfile_ARM{}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range profile.DataDisks {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1243,7 +1243,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 		result.DataDisks = append(result.DataDisks, *item_ARM.(*ImageDataDisk_ARM))
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if profile.OsDisk != nil {
 		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -1253,7 +1253,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 		result.OsDisk = &osDisk
 	}
 
-	// Set property ‘ZoneResilient’:
+	// Set property "ZoneResilient":
 	if profile.ZoneResilient != nil {
 		zoneResilient := *profile.ZoneResilient
 		result.ZoneResilient = &zoneResilient
@@ -1273,7 +1273,7 @@ func (profile *ImageStorageProfile) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageStorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 ImageDataDisk
 		err := item1.PopulateFromARM(owner, item)
@@ -1283,7 +1283,7 @@ func (profile *ImageStorageProfile) PopulateFromARM(owner genruntime.ArbitraryOw
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 ImageOSDisk
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -1294,7 +1294,7 @@ func (profile *ImageStorageProfile) PopulateFromARM(owner genruntime.ArbitraryOw
 		profile.OsDisk = &osDisk
 	}
 
-	// Set property ‘ZoneResilient’:
+	// Set property "ZoneResilient":
 	if typedInput.ZoneResilient != nil {
 		zoneResilient := *typedInput.ZoneResilient
 		profile.ZoneResilient = &zoneResilient
@@ -1424,7 +1424,7 @@ func (profile *ImageStorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageStorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 ImageDataDisk_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1434,7 +1434,7 @@ func (profile *ImageStorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbi
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 ImageOSDisk_STATUS
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -1445,7 +1445,7 @@ func (profile *ImageStorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbi
 		profile.OsDisk = &osDisk
 	}
 
-	// Set property ‘ZoneResilient’:
+	// Set property "ZoneResilient":
 	if typedInput.ZoneResilient != nil {
 		zoneResilient := *typedInput.ZoneResilient
 		profile.ZoneResilient = &zoneResilient
@@ -1568,7 +1568,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -1592,7 +1592,7 @@ func (resource *SubResource) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1656,7 +1656,7 @@ func (resource *SubResource_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
@@ -1718,19 +1718,19 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &ImageDataDisk_ARM{}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if disk.BlobUri != nil {
 		blobUri := *disk.BlobUri
 		result.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if disk.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*disk.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -1740,19 +1740,19 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if disk.Lun != nil {
 		lun := *disk.Lun
 		result.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -1762,7 +1762,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if disk.Snapshot != nil {
 		snapshot_ARM, err := (*disk.Snapshot).ConvertToARM(resolved)
 		if err != nil {
@@ -1772,7 +1772,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if disk.StorageAccountType != nil {
 		storageAccountType := *disk.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -1792,19 +1792,19 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageDataDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -1815,19 +1815,19 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -1838,7 +1838,7 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -1849,7 +1849,7 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType
@@ -2030,19 +2030,19 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageDataDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -2053,19 +2053,19 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -2076,7 +2076,7 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource_STATUS
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -2087,7 +2087,7 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType
@@ -2268,19 +2268,19 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &ImageOSDisk_ARM{}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if disk.BlobUri != nil {
 		blobUri := *disk.BlobUri
 		result.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if disk.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*disk.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -2290,13 +2290,13 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -2306,19 +2306,19 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘OsState’:
+	// Set property "OsState":
 	if disk.OsState != nil {
 		osState := *disk.OsState
 		result.OsState = &osState
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if disk.OsType != nil {
 		osType := *disk.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if disk.Snapshot != nil {
 		snapshot_ARM, err := (*disk.Snapshot).ConvertToARM(resolved)
 		if err != nil {
@@ -2328,7 +2328,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if disk.StorageAccountType != nil {
 		storageAccountType := *disk.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -2348,19 +2348,19 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageOSDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -2371,13 +2371,13 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -2388,19 +2388,19 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘OsState’:
+	// Set property "OsState":
 	if typedInput.OsState != nil {
 		osState := *typedInput.OsState
 		disk.OsState = &osState
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -2411,7 +2411,7 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType
@@ -2619,19 +2619,19 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageOSDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -2642,13 +2642,13 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -2659,19 +2659,19 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘OsState’:
+	// Set property "OsState":
 	if typedInput.OsState != nil {
 		osState := *typedInput.OsState
 		disk.OsState = &osState
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource_STATUS
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -2682,7 +2682,7 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType

--- a/v2/api/compute/v1beta20220301/image_types_gen.go
+++ b/v2/api/compute/v1beta20220301/image_types_gen.go
@@ -344,7 +344,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &Image_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if image.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*image.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -354,16 +354,16 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if image.Location != nil {
 		location := *image.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if image.HyperVGeneration != nil ||
 		image.SourceVirtualMachine != nil ||
 		image.StorageProfile != nil {
@@ -390,7 +390,7 @@ func (image *Image_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if image.Tags != nil {
 		result.Tags = make(map[string]string, len(image.Tags))
 		for key, value := range image.Tags {
@@ -412,10 +412,10 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Image_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	image.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -426,7 +426,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		image.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -435,16 +435,16 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		image.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	image.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘SourceVirtualMachine’:
+	// Set property "SourceVirtualMachine":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceVirtualMachine != nil {
@@ -458,7 +458,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -472,7 +472,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		image.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -770,9 +770,9 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Image_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -783,7 +783,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		image.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperVGeneration != nil {
@@ -792,25 +792,25 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		image.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		image.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		image.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -819,7 +819,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘SourceVirtualMachine’:
+	// Set property "SourceVirtualMachine":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceVirtualMachine != nil {
@@ -833,7 +833,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -847,7 +847,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		image.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -855,7 +855,7 @@ func (image *Image_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		image.Type = &typeVar
@@ -1033,13 +1033,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -1059,13 +1059,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -1140,13 +1140,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -1234,7 +1234,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ImageStorageProfile_ARM{}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range profile.DataDisks {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1243,7 +1243,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 		result.DataDisks = append(result.DataDisks, *item_ARM.(*ImageDataDisk_ARM))
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if profile.OsDisk != nil {
 		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -1253,7 +1253,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 		result.OsDisk = &osDisk
 	}
 
-	// Set property ‘ZoneResilient’:
+	// Set property "ZoneResilient":
 	if profile.ZoneResilient != nil {
 		zoneResilient := *profile.ZoneResilient
 		result.ZoneResilient = &zoneResilient
@@ -1273,7 +1273,7 @@ func (profile *ImageStorageProfile) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageStorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 ImageDataDisk
 		err := item1.PopulateFromARM(owner, item)
@@ -1283,7 +1283,7 @@ func (profile *ImageStorageProfile) PopulateFromARM(owner genruntime.ArbitraryOw
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 ImageOSDisk
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -1294,7 +1294,7 @@ func (profile *ImageStorageProfile) PopulateFromARM(owner genruntime.ArbitraryOw
 		profile.OsDisk = &osDisk
 	}
 
-	// Set property ‘ZoneResilient’:
+	// Set property "ZoneResilient":
 	if typedInput.ZoneResilient != nil {
 		zoneResilient := *typedInput.ZoneResilient
 		profile.ZoneResilient = &zoneResilient
@@ -1424,7 +1424,7 @@ func (profile *ImageStorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageStorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 ImageDataDisk_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1434,7 +1434,7 @@ func (profile *ImageStorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbi
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 ImageOSDisk_STATUS
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -1445,7 +1445,7 @@ func (profile *ImageStorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbi
 		profile.OsDisk = &osDisk
 	}
 
-	// Set property ‘ZoneResilient’:
+	// Set property "ZoneResilient":
 	if typedInput.ZoneResilient != nil {
 		zoneResilient := *typedInput.ZoneResilient
 		profile.ZoneResilient = &zoneResilient
@@ -1568,7 +1568,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -1592,7 +1592,7 @@ func (resource *SubResource) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1656,7 +1656,7 @@ func (resource *SubResource_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
@@ -1718,19 +1718,19 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &ImageDataDisk_ARM{}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if disk.BlobUri != nil {
 		blobUri := *disk.BlobUri
 		result.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if disk.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*disk.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -1740,19 +1740,19 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if disk.Lun != nil {
 		lun := *disk.Lun
 		result.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -1762,7 +1762,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if disk.Snapshot != nil {
 		snapshot_ARM, err := (*disk.Snapshot).ConvertToARM(resolved)
 		if err != nil {
@@ -1772,7 +1772,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if disk.StorageAccountType != nil {
 		storageAccountType := *disk.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -1792,19 +1792,19 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageDataDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -1815,19 +1815,19 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -1838,7 +1838,7 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -1849,7 +1849,7 @@ func (disk *ImageDataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType
@@ -2030,19 +2030,19 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageDataDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -2053,19 +2053,19 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -2076,7 +2076,7 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource_STATUS
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -2087,7 +2087,7 @@ func (disk *ImageDataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType
@@ -2268,19 +2268,19 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &ImageOSDisk_ARM{}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if disk.BlobUri != nil {
 		blobUri := *disk.BlobUri
 		result.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if disk.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*disk.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -2290,13 +2290,13 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -2306,19 +2306,19 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘OsState’:
+	// Set property "OsState":
 	if disk.OsState != nil {
 		osState := *disk.OsState
 		result.OsState = &osState
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if disk.OsType != nil {
 		osType := *disk.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if disk.Snapshot != nil {
 		snapshot_ARM, err := (*disk.Snapshot).ConvertToARM(resolved)
 		if err != nil {
@@ -2328,7 +2328,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if disk.StorageAccountType != nil {
 		storageAccountType := *disk.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -2348,19 +2348,19 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageOSDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -2371,13 +2371,13 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -2388,19 +2388,19 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘OsState’:
+	// Set property "OsState":
 	if typedInput.OsState != nil {
 		osState := *typedInput.OsState
 		disk.OsState = &osState
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -2411,7 +2411,7 @@ func (disk *ImageOSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType
@@ -2619,19 +2619,19 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageOSDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobUri’:
+	// Set property "BlobUri":
 	if typedInput.BlobUri != nil {
 		blobUri := *typedInput.BlobUri
 		disk.BlobUri = &blobUri
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -2642,13 +2642,13 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		disk.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 SubResource_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -2659,19 +2659,19 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘OsState’:
+	// Set property "OsState":
 	if typedInput.OsState != nil {
 		osState := *typedInput.OsState
 		disk.OsState = &osState
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 SubResource_STATUS
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -2682,7 +2682,7 @@ func (disk *ImageOSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		disk.Snapshot = &snapshot
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		disk.StorageAccountType = &storageAccountType

--- a/v2/api/compute/v1beta20220301/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/compute/v1beta20220301/virtual_machine_scale_set_types_gen.go
@@ -355,7 +355,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 	}
 	result := &VirtualMachineScaleSet_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if scaleSet.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*scaleSet.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -365,7 +365,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if scaleSet.Identity != nil {
 		identity_ARM, err := (*scaleSet.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -375,16 +375,16 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if scaleSet.Location != nil {
 		location := *scaleSet.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if scaleSet.Plan != nil {
 		plan_ARM, err := (*scaleSet.Plan).ConvertToARM(resolved)
 		if err != nil {
@@ -394,7 +394,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Plan = &plan
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if scaleSet.AdditionalCapabilities != nil ||
 		scaleSet.AutomaticRepairsPolicy != nil ||
 		scaleSet.DoNotRunExtensionsOnOverprovisionedVMs != nil ||
@@ -500,7 +500,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Properties.ZoneBalance = &zoneBalance
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if scaleSet.Sku != nil {
 		sku_ARM, err := (*scaleSet.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -510,7 +510,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if scaleSet.Tags != nil {
 		result.Tags = make(map[string]string, len(scaleSet.Tags))
 		for key, value := range scaleSet.Tags {
@@ -518,7 +518,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) ConvertToARM(resolved genruntime.Co
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range scaleSet.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -537,7 +537,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSet_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -551,7 +551,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘AutomaticRepairsPolicy’:
+	// Set property "AutomaticRepairsPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticRepairsPolicy != nil {
@@ -565,10 +565,10 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	scaleSet.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DoNotRunExtensionsOnOverprovisionedVMs’:
+	// Set property "DoNotRunExtensionsOnOverprovisionedVMs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DoNotRunExtensionsOnOverprovisionedVMs != nil {
@@ -577,7 +577,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -588,7 +588,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -602,7 +602,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineScaleSetIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -613,13 +613,13 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		scaleSet.Location = &location
 	}
 
-	// Set property ‘OrchestrationMode’:
+	// Set property "OrchestrationMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestrationMode != nil {
@@ -628,7 +628,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Overprovision’:
+	// Set property "Overprovision":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Overprovision != nil {
@@ -637,10 +637,10 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	scaleSet.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -651,7 +651,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomainCount’:
+	// Set property "PlatformFaultDomainCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomainCount != nil {
@@ -660,7 +660,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -674,7 +674,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ScaleInPolicy’:
+	// Set property "ScaleInPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleInPolicy != nil {
@@ -688,7 +688,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘SinglePlacementGroup’:
+	// Set property "SinglePlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SinglePlacementGroup != nil {
@@ -697,7 +697,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -708,7 +708,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		scaleSet.Sku = &sku
 	}
 
-	// Set property ‘SpotRestorePolicy’:
+	// Set property "SpotRestorePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotRestorePolicy != nil {
@@ -722,7 +722,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		scaleSet.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -730,7 +730,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘UpgradePolicy’:
+	// Set property "UpgradePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradePolicy != nil {
@@ -744,7 +744,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘VirtualMachineProfile’:
+	// Set property "VirtualMachineProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineProfile != nil {
@@ -758,7 +758,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ZoneBalance’:
+	// Set property "ZoneBalance":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneBalance != nil {
@@ -767,7 +767,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		scaleSet.Zones = append(scaleSet.Zones, item)
 	}
@@ -1374,7 +1374,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -1388,7 +1388,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘AutomaticRepairsPolicy’:
+	// Set property "AutomaticRepairsPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticRepairsPolicy != nil {
@@ -1402,9 +1402,9 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DoNotRunExtensionsOnOverprovisionedVMs’:
+	// Set property "DoNotRunExtensionsOnOverprovisionedVMs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DoNotRunExtensionsOnOverprovisionedVMs != nil {
@@ -1413,7 +1413,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1424,7 +1424,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -1438,13 +1438,13 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		scaleSet.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineScaleSetIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1455,19 +1455,19 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		scaleSet.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		scaleSet.Name = &name
 	}
 
-	// Set property ‘OrchestrationMode’:
+	// Set property "OrchestrationMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestrationMode != nil {
@@ -1476,7 +1476,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Overprovision’:
+	// Set property "Overprovision":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Overprovision != nil {
@@ -1485,7 +1485,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan_STATUS
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -1496,7 +1496,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomainCount’:
+	// Set property "PlatformFaultDomainCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomainCount != nil {
@@ -1505,7 +1505,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1514,7 +1514,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -1528,7 +1528,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ScaleInPolicy’:
+	// Set property "ScaleInPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleInPolicy != nil {
@@ -1542,7 +1542,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘SinglePlacementGroup’:
+	// Set property "SinglePlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SinglePlacementGroup != nil {
@@ -1551,7 +1551,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1562,7 +1562,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		scaleSet.Sku = &sku
 	}
 
-	// Set property ‘SpotRestorePolicy’:
+	// Set property "SpotRestorePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotRestorePolicy != nil {
@@ -1576,7 +1576,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		scaleSet.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1584,7 +1584,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘TimeCreated’:
+	// Set property "TimeCreated":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TimeCreated != nil {
@@ -1593,13 +1593,13 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		scaleSet.Type = &typeVar
 	}
 
-	// Set property ‘UniqueId’:
+	// Set property "UniqueId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UniqueId != nil {
@@ -1608,7 +1608,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘UpgradePolicy’:
+	// Set property "UpgradePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradePolicy != nil {
@@ -1622,7 +1622,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘VirtualMachineProfile’:
+	// Set property "VirtualMachineProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineProfile != nil {
@@ -1636,7 +1636,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ZoneBalance’:
+	// Set property "ZoneBalance":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneBalance != nil {
@@ -1645,7 +1645,7 @@ func (scaleSet *VirtualMachineScaleSet_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		scaleSet.Zones = append(scaleSet.Zones, item)
 	}
@@ -2127,19 +2127,19 @@ func (policy *AutomaticRepairsPolicy) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &AutomaticRepairsPolicy_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if policy.Enabled != nil {
 		enabled := *policy.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘GracePeriod’:
+	// Set property "GracePeriod":
 	if policy.GracePeriod != nil {
 		gracePeriod := *policy.GracePeriod
 		result.GracePeriod = &gracePeriod
 	}
 
-	// Set property ‘RepairAction’:
+	// Set property "RepairAction":
 	if policy.RepairAction != nil {
 		repairAction := *policy.RepairAction
 		result.RepairAction = &repairAction
@@ -2159,19 +2159,19 @@ func (policy *AutomaticRepairsPolicy) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticRepairsPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
 	}
 
-	// Set property ‘GracePeriod’:
+	// Set property "GracePeriod":
 	if typedInput.GracePeriod != nil {
 		gracePeriod := *typedInput.GracePeriod
 		policy.GracePeriod = &gracePeriod
 	}
 
-	// Set property ‘RepairAction’:
+	// Set property "RepairAction":
 	if typedInput.RepairAction != nil {
 		repairAction := *typedInput.RepairAction
 		policy.RepairAction = &repairAction
@@ -2263,19 +2263,19 @@ func (policy *AutomaticRepairsPolicy_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticRepairsPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
 	}
 
-	// Set property ‘GracePeriod’:
+	// Set property "GracePeriod":
 	if typedInput.GracePeriod != nil {
 		gracePeriod := *typedInput.GracePeriod
 		policy.GracePeriod = &gracePeriod
 	}
 
-	// Set property ‘RepairAction’:
+	// Set property "RepairAction":
 	if typedInput.RepairAction != nil {
 		repairAction := *typedInput.RepairAction
 		policy.RepairAction = &repairAction
@@ -2378,13 +2378,13 @@ func (policy *ScaleInPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &ScaleInPolicy_ARM{}
 
-	// Set property ‘ForceDeletion’:
+	// Set property "ForceDeletion":
 	if policy.ForceDeletion != nil {
 		forceDeletion := *policy.ForceDeletion
 		result.ForceDeletion = &forceDeletion
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range policy.Rules {
 		result.Rules = append(result.Rules, item)
 	}
@@ -2403,13 +2403,13 @@ func (policy *ScaleInPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScaleInPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ForceDeletion’:
+	// Set property "ForceDeletion":
 	if typedInput.ForceDeletion != nil {
 		forceDeletion := *typedInput.ForceDeletion
 		policy.ForceDeletion = &forceDeletion
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		policy.Rules = append(policy.Rules, item)
 	}
@@ -2503,13 +2503,13 @@ func (policy *ScaleInPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScaleInPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ForceDeletion’:
+	// Set property "ForceDeletion":
 	if typedInput.ForceDeletion != nil {
 		forceDeletion := *typedInput.ForceDeletion
 		policy.ForceDeletion = &forceDeletion
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		policy.Rules = append(policy.Rules, item)
 	}
@@ -2599,19 +2599,19 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sku.Capacity != nil {
 		capacity := *sku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -2631,19 +2631,19 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2715,19 +2715,19 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2793,13 +2793,13 @@ func (policy *SpotRestorePolicy) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &SpotRestorePolicy_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if policy.Enabled != nil {
 		enabled := *policy.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘RestoreTimeout’:
+	// Set property "RestoreTimeout":
 	if policy.RestoreTimeout != nil {
 		restoreTimeout := *policy.RestoreTimeout
 		result.RestoreTimeout = &restoreTimeout
@@ -2819,13 +2819,13 @@ func (policy *SpotRestorePolicy) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SpotRestorePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
 	}
 
-	// Set property ‘RestoreTimeout’:
+	// Set property "RestoreTimeout":
 	if typedInput.RestoreTimeout != nil {
 		restoreTimeout := *typedInput.RestoreTimeout
 		policy.RestoreTimeout = &restoreTimeout
@@ -2900,13 +2900,13 @@ func (policy *SpotRestorePolicy_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SpotRestorePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
 	}
 
-	// Set property ‘RestoreTimeout’:
+	// Set property "RestoreTimeout":
 	if typedInput.RestoreTimeout != nil {
 		restoreTimeout := *typedInput.RestoreTimeout
 		policy.RestoreTimeout = &restoreTimeout
@@ -2977,7 +2977,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &UpgradePolicy_ARM{}
 
-	// Set property ‘AutomaticOSUpgradePolicy’:
+	// Set property "AutomaticOSUpgradePolicy":
 	if policy.AutomaticOSUpgradePolicy != nil {
 		automaticOSUpgradePolicy_ARM, err := (*policy.AutomaticOSUpgradePolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -2987,13 +2987,13 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if policy.Mode != nil {
 		mode := *policy.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘RollingUpgradePolicy’:
+	// Set property "RollingUpgradePolicy":
 	if policy.RollingUpgradePolicy != nil {
 		rollingUpgradePolicy_ARM, err := (*policy.RollingUpgradePolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -3017,7 +3017,7 @@ func (policy *UpgradePolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpgradePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticOSUpgradePolicy’:
+	// Set property "AutomaticOSUpgradePolicy":
 	if typedInput.AutomaticOSUpgradePolicy != nil {
 		var automaticOSUpgradePolicy1 AutomaticOSUpgradePolicy
 		err := automaticOSUpgradePolicy1.PopulateFromARM(owner, *typedInput.AutomaticOSUpgradePolicy)
@@ -3028,13 +3028,13 @@ func (policy *UpgradePolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		policy.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		policy.Mode = &mode
 	}
 
-	// Set property ‘RollingUpgradePolicy’:
+	// Set property "RollingUpgradePolicy":
 	if typedInput.RollingUpgradePolicy != nil {
 		var rollingUpgradePolicy1 RollingUpgradePolicy
 		err := rollingUpgradePolicy1.PopulateFromARM(owner, *typedInput.RollingUpgradePolicy)
@@ -3157,7 +3157,7 @@ func (policy *UpgradePolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpgradePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticOSUpgradePolicy’:
+	// Set property "AutomaticOSUpgradePolicy":
 	if typedInput.AutomaticOSUpgradePolicy != nil {
 		var automaticOSUpgradePolicy1 AutomaticOSUpgradePolicy_STATUS
 		err := automaticOSUpgradePolicy1.PopulateFromARM(owner, *typedInput.AutomaticOSUpgradePolicy)
@@ -3168,13 +3168,13 @@ func (policy *UpgradePolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		policy.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		policy.Mode = &mode
 	}
 
-	// Set property ‘RollingUpgradePolicy’:
+	// Set property "RollingUpgradePolicy":
 	if typedInput.RollingUpgradePolicy != nil {
 		var rollingUpgradePolicy1 RollingUpgradePolicy_STATUS
 		err := rollingUpgradePolicy1.PopulateFromARM(owner, *typedInput.RollingUpgradePolicy)
@@ -3291,13 +3291,13 @@ func (identity *VirtualMachineScaleSetIdentity) ConvertToARM(resolved genruntime
 	}
 	result := &VirtualMachineScaleSetIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -3322,13 +3322,13 @@ func (identity *VirtualMachineScaleSetIdentity) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -3431,25 +3431,25 @@ func (identity *VirtualMachineScaleSetIdentity_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -3581,7 +3581,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 	}
 	result := &VirtualMachineScaleSetVMProfile_ARM{}
 
-	// Set property ‘ApplicationProfile’:
+	// Set property "ApplicationProfile":
 	if profile.ApplicationProfile != nil {
 		applicationProfile_ARM, err := (*profile.ApplicationProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3591,7 +3591,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.ApplicationProfile = &applicationProfile
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	if profile.BillingProfile != nil {
 		billingProfile_ARM, err := (*profile.BillingProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3601,7 +3601,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.BillingProfile = &billingProfile
 	}
 
-	// Set property ‘CapacityReservation’:
+	// Set property "CapacityReservation":
 	if profile.CapacityReservation != nil {
 		capacityReservation_ARM, err := (*profile.CapacityReservation).ConvertToARM(resolved)
 		if err != nil {
@@ -3611,7 +3611,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.CapacityReservation = &capacityReservation
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	if profile.DiagnosticsProfile != nil {
 		diagnosticsProfile_ARM, err := (*profile.DiagnosticsProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3621,13 +3621,13 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.DiagnosticsProfile = &diagnosticsProfile
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	if profile.EvictionPolicy != nil {
 		evictionPolicy := *profile.EvictionPolicy
 		result.EvictionPolicy = &evictionPolicy
 	}
 
-	// Set property ‘ExtensionProfile’:
+	// Set property "ExtensionProfile":
 	if profile.ExtensionProfile != nil {
 		extensionProfile_ARM, err := (*profile.ExtensionProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3637,7 +3637,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.ExtensionProfile = &extensionProfile
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	if profile.HardwareProfile != nil {
 		hardwareProfile_ARM, err := (*profile.HardwareProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3647,13 +3647,13 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.HardwareProfile = &hardwareProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if profile.LicenseType != nil {
 		licenseType := *profile.LicenseType
 		result.LicenseType = &licenseType
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if profile.NetworkProfile != nil {
 		networkProfile_ARM, err := (*profile.NetworkProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3663,7 +3663,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	if profile.OsProfile != nil {
 		osProfile_ARM, err := (*profile.OsProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3673,13 +3673,13 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.OsProfile = &osProfile
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if profile.Priority != nil {
 		priority := *profile.Priority
 		result.Priority = &priority
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	if profile.ScheduledEventsProfile != nil {
 		scheduledEventsProfile_ARM, err := (*profile.ScheduledEventsProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3689,7 +3689,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if profile.SecurityProfile != nil {
 		securityProfile_ARM, err := (*profile.SecurityProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3699,7 +3699,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if profile.StorageProfile != nil {
 		storageProfile_ARM, err := (*profile.StorageProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3709,7 +3709,7 @@ func (profile *VirtualMachineScaleSetVMProfile) ConvertToARM(resolved genruntime
 		result.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘UserData’:
+	// Set property "UserData":
 	if profile.UserData != nil {
 		userData := *profile.UserData
 		result.UserData = &userData
@@ -3729,7 +3729,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetVMProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationProfile’:
+	// Set property "ApplicationProfile":
 	if typedInput.ApplicationProfile != nil {
 		var applicationProfile1 ApplicationProfile
 		err := applicationProfile1.PopulateFromARM(owner, *typedInput.ApplicationProfile)
@@ -3740,7 +3740,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.ApplicationProfile = &applicationProfile
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	if typedInput.BillingProfile != nil {
 		var billingProfile1 BillingProfile
 		err := billingProfile1.PopulateFromARM(owner, *typedInput.BillingProfile)
@@ -3751,7 +3751,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.BillingProfile = &billingProfile
 	}
 
-	// Set property ‘CapacityReservation’:
+	// Set property "CapacityReservation":
 	if typedInput.CapacityReservation != nil {
 		var capacityReservation1 CapacityReservationProfile
 		err := capacityReservation1.PopulateFromARM(owner, *typedInput.CapacityReservation)
@@ -3762,7 +3762,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.CapacityReservation = &capacityReservation
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	if typedInput.DiagnosticsProfile != nil {
 		var diagnosticsProfile1 DiagnosticsProfile
 		err := diagnosticsProfile1.PopulateFromARM(owner, *typedInput.DiagnosticsProfile)
@@ -3773,13 +3773,13 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.DiagnosticsProfile = &diagnosticsProfile
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	if typedInput.EvictionPolicy != nil {
 		evictionPolicy := *typedInput.EvictionPolicy
 		profile.EvictionPolicy = &evictionPolicy
 	}
 
-	// Set property ‘ExtensionProfile’:
+	// Set property "ExtensionProfile":
 	if typedInput.ExtensionProfile != nil {
 		var extensionProfile1 VirtualMachineScaleSetExtensionProfile
 		err := extensionProfile1.PopulateFromARM(owner, *typedInput.ExtensionProfile)
@@ -3790,7 +3790,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.ExtensionProfile = &extensionProfile
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	if typedInput.HardwareProfile != nil {
 		var hardwareProfile1 VirtualMachineScaleSetHardwareProfile
 		err := hardwareProfile1.PopulateFromARM(owner, *typedInput.HardwareProfile)
@@ -3801,13 +3801,13 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.HardwareProfile = &hardwareProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if typedInput.NetworkProfile != nil {
 		var networkProfile1 VirtualMachineScaleSetNetworkProfile
 		err := networkProfile1.PopulateFromARM(owner, *typedInput.NetworkProfile)
@@ -3818,7 +3818,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	if typedInput.OsProfile != nil {
 		var osProfile1 VirtualMachineScaleSetOSProfile
 		err := osProfile1.PopulateFromARM(owner, *typedInput.OsProfile)
@@ -3829,13 +3829,13 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.OsProfile = &osProfile
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		profile.Priority = &priority
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	if typedInput.ScheduledEventsProfile != nil {
 		var scheduledEventsProfile1 ScheduledEventsProfile
 		err := scheduledEventsProfile1.PopulateFromARM(owner, *typedInput.ScheduledEventsProfile)
@@ -3846,7 +3846,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 SecurityProfile
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -3857,7 +3857,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 VirtualMachineScaleSetStorageProfile
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -3868,7 +3868,7 @@ func (profile *VirtualMachineScaleSetVMProfile) PopulateFromARM(owner genruntime
 		profile.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘UserData’:
+	// Set property "UserData":
 	if typedInput.UserData != nil {
 		userData := *typedInput.UserData
 		profile.UserData = &userData
@@ -4242,7 +4242,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetVMProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationProfile’:
+	// Set property "ApplicationProfile":
 	if typedInput.ApplicationProfile != nil {
 		var applicationProfile1 ApplicationProfile_STATUS
 		err := applicationProfile1.PopulateFromARM(owner, *typedInput.ApplicationProfile)
@@ -4253,7 +4253,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.ApplicationProfile = &applicationProfile
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	if typedInput.BillingProfile != nil {
 		var billingProfile1 BillingProfile_STATUS
 		err := billingProfile1.PopulateFromARM(owner, *typedInput.BillingProfile)
@@ -4264,7 +4264,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.BillingProfile = &billingProfile
 	}
 
-	// Set property ‘CapacityReservation’:
+	// Set property "CapacityReservation":
 	if typedInput.CapacityReservation != nil {
 		var capacityReservation1 CapacityReservationProfile_STATUS
 		err := capacityReservation1.PopulateFromARM(owner, *typedInput.CapacityReservation)
@@ -4275,7 +4275,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.CapacityReservation = &capacityReservation
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	if typedInput.DiagnosticsProfile != nil {
 		var diagnosticsProfile1 DiagnosticsProfile_STATUS
 		err := diagnosticsProfile1.PopulateFromARM(owner, *typedInput.DiagnosticsProfile)
@@ -4286,13 +4286,13 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.DiagnosticsProfile = &diagnosticsProfile
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	if typedInput.EvictionPolicy != nil {
 		evictionPolicy := *typedInput.EvictionPolicy
 		profile.EvictionPolicy = &evictionPolicy
 	}
 
-	// Set property ‘ExtensionProfile’:
+	// Set property "ExtensionProfile":
 	if typedInput.ExtensionProfile != nil {
 		var extensionProfile1 VirtualMachineScaleSetExtensionProfile_STATUS
 		err := extensionProfile1.PopulateFromARM(owner, *typedInput.ExtensionProfile)
@@ -4303,7 +4303,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.ExtensionProfile = &extensionProfile
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	if typedInput.HardwareProfile != nil {
 		var hardwareProfile1 VirtualMachineScaleSetHardwareProfile_STATUS
 		err := hardwareProfile1.PopulateFromARM(owner, *typedInput.HardwareProfile)
@@ -4314,13 +4314,13 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.HardwareProfile = &hardwareProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if typedInput.NetworkProfile != nil {
 		var networkProfile1 VirtualMachineScaleSetNetworkProfile_STATUS
 		err := networkProfile1.PopulateFromARM(owner, *typedInput.NetworkProfile)
@@ -4331,7 +4331,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	if typedInput.OsProfile != nil {
 		var osProfile1 VirtualMachineScaleSetOSProfile_STATUS
 		err := osProfile1.PopulateFromARM(owner, *typedInput.OsProfile)
@@ -4342,13 +4342,13 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.OsProfile = &osProfile
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		profile.Priority = &priority
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	if typedInput.ScheduledEventsProfile != nil {
 		var scheduledEventsProfile1 ScheduledEventsProfile_STATUS
 		err := scheduledEventsProfile1.PopulateFromARM(owner, *typedInput.ScheduledEventsProfile)
@@ -4359,7 +4359,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 SecurityProfile_STATUS
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -4370,7 +4370,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 VirtualMachineScaleSetStorageProfile_STATUS
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -4381,7 +4381,7 @@ func (profile *VirtualMachineScaleSetVMProfile_STATUS) PopulateFromARM(owner gen
 		profile.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘UserData’:
+	// Set property "UserData":
 	if typedInput.UserData != nil {
 		userData := *typedInput.UserData
 		profile.UserData = &userData
@@ -4738,19 +4738,19 @@ func (policy *AutomaticOSUpgradePolicy) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &AutomaticOSUpgradePolicy_ARM{}
 
-	// Set property ‘DisableAutomaticRollback’:
+	// Set property "DisableAutomaticRollback":
 	if policy.DisableAutomaticRollback != nil {
 		disableAutomaticRollback := *policy.DisableAutomaticRollback
 		result.DisableAutomaticRollback = &disableAutomaticRollback
 	}
 
-	// Set property ‘EnableAutomaticOSUpgrade’:
+	// Set property "EnableAutomaticOSUpgrade":
 	if policy.EnableAutomaticOSUpgrade != nil {
 		enableAutomaticOSUpgrade := *policy.EnableAutomaticOSUpgrade
 		result.EnableAutomaticOSUpgrade = &enableAutomaticOSUpgrade
 	}
 
-	// Set property ‘UseRollingUpgradePolicy’:
+	// Set property "UseRollingUpgradePolicy":
 	if policy.UseRollingUpgradePolicy != nil {
 		useRollingUpgradePolicy := *policy.UseRollingUpgradePolicy
 		result.UseRollingUpgradePolicy = &useRollingUpgradePolicy
@@ -4770,19 +4770,19 @@ func (policy *AutomaticOSUpgradePolicy) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticOSUpgradePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisableAutomaticRollback’:
+	// Set property "DisableAutomaticRollback":
 	if typedInput.DisableAutomaticRollback != nil {
 		disableAutomaticRollback := *typedInput.DisableAutomaticRollback
 		policy.DisableAutomaticRollback = &disableAutomaticRollback
 	}
 
-	// Set property ‘EnableAutomaticOSUpgrade’:
+	// Set property "EnableAutomaticOSUpgrade":
 	if typedInput.EnableAutomaticOSUpgrade != nil {
 		enableAutomaticOSUpgrade := *typedInput.EnableAutomaticOSUpgrade
 		policy.EnableAutomaticOSUpgrade = &enableAutomaticOSUpgrade
 	}
 
-	// Set property ‘UseRollingUpgradePolicy’:
+	// Set property "UseRollingUpgradePolicy":
 	if typedInput.UseRollingUpgradePolicy != nil {
 		useRollingUpgradePolicy := *typedInput.UseRollingUpgradePolicy
 		policy.UseRollingUpgradePolicy = &useRollingUpgradePolicy
@@ -4884,19 +4884,19 @@ func (policy *AutomaticOSUpgradePolicy_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutomaticOSUpgradePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisableAutomaticRollback’:
+	// Set property "DisableAutomaticRollback":
 	if typedInput.DisableAutomaticRollback != nil {
 		disableAutomaticRollback := *typedInput.DisableAutomaticRollback
 		policy.DisableAutomaticRollback = &disableAutomaticRollback
 	}
 
-	// Set property ‘EnableAutomaticOSUpgrade’:
+	// Set property "EnableAutomaticOSUpgrade":
 	if typedInput.EnableAutomaticOSUpgrade != nil {
 		enableAutomaticOSUpgrade := *typedInput.EnableAutomaticOSUpgrade
 		policy.EnableAutomaticOSUpgrade = &enableAutomaticOSUpgrade
 	}
 
-	// Set property ‘UseRollingUpgradePolicy’:
+	// Set property "UseRollingUpgradePolicy":
 	if typedInput.UseRollingUpgradePolicy != nil {
 		useRollingUpgradePolicy := *typedInput.UseRollingUpgradePolicy
 		policy.UseRollingUpgradePolicy = &useRollingUpgradePolicy
@@ -5025,37 +5025,37 @@ func (policy *RollingUpgradePolicy) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &RollingUpgradePolicy_ARM{}
 
-	// Set property ‘EnableCrossZoneUpgrade’:
+	// Set property "EnableCrossZoneUpgrade":
 	if policy.EnableCrossZoneUpgrade != nil {
 		enableCrossZoneUpgrade := *policy.EnableCrossZoneUpgrade
 		result.EnableCrossZoneUpgrade = &enableCrossZoneUpgrade
 	}
 
-	// Set property ‘MaxBatchInstancePercent’:
+	// Set property "MaxBatchInstancePercent":
 	if policy.MaxBatchInstancePercent != nil {
 		maxBatchInstancePercent := *policy.MaxBatchInstancePercent
 		result.MaxBatchInstancePercent = &maxBatchInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyInstancePercent’:
+	// Set property "MaxUnhealthyInstancePercent":
 	if policy.MaxUnhealthyInstancePercent != nil {
 		maxUnhealthyInstancePercent := *policy.MaxUnhealthyInstancePercent
 		result.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyUpgradedInstancePercent’:
+	// Set property "MaxUnhealthyUpgradedInstancePercent":
 	if policy.MaxUnhealthyUpgradedInstancePercent != nil {
 		maxUnhealthyUpgradedInstancePercent := *policy.MaxUnhealthyUpgradedInstancePercent
 		result.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
 	}
 
-	// Set property ‘PauseTimeBetweenBatches’:
+	// Set property "PauseTimeBetweenBatches":
 	if policy.PauseTimeBetweenBatches != nil {
 		pauseTimeBetweenBatches := *policy.PauseTimeBetweenBatches
 		result.PauseTimeBetweenBatches = &pauseTimeBetweenBatches
 	}
 
-	// Set property ‘PrioritizeUnhealthyInstances’:
+	// Set property "PrioritizeUnhealthyInstances":
 	if policy.PrioritizeUnhealthyInstances != nil {
 		prioritizeUnhealthyInstances := *policy.PrioritizeUnhealthyInstances
 		result.PrioritizeUnhealthyInstances = &prioritizeUnhealthyInstances
@@ -5075,37 +5075,37 @@ func (policy *RollingUpgradePolicy) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RollingUpgradePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableCrossZoneUpgrade’:
+	// Set property "EnableCrossZoneUpgrade":
 	if typedInput.EnableCrossZoneUpgrade != nil {
 		enableCrossZoneUpgrade := *typedInput.EnableCrossZoneUpgrade
 		policy.EnableCrossZoneUpgrade = &enableCrossZoneUpgrade
 	}
 
-	// Set property ‘MaxBatchInstancePercent’:
+	// Set property "MaxBatchInstancePercent":
 	if typedInput.MaxBatchInstancePercent != nil {
 		maxBatchInstancePercent := *typedInput.MaxBatchInstancePercent
 		policy.MaxBatchInstancePercent = &maxBatchInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyInstancePercent’:
+	// Set property "MaxUnhealthyInstancePercent":
 	if typedInput.MaxUnhealthyInstancePercent != nil {
 		maxUnhealthyInstancePercent := *typedInput.MaxUnhealthyInstancePercent
 		policy.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyUpgradedInstancePercent’:
+	// Set property "MaxUnhealthyUpgradedInstancePercent":
 	if typedInput.MaxUnhealthyUpgradedInstancePercent != nil {
 		maxUnhealthyUpgradedInstancePercent := *typedInput.MaxUnhealthyUpgradedInstancePercent
 		policy.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
 	}
 
-	// Set property ‘PauseTimeBetweenBatches’:
+	// Set property "PauseTimeBetweenBatches":
 	if typedInput.PauseTimeBetweenBatches != nil {
 		pauseTimeBetweenBatches := *typedInput.PauseTimeBetweenBatches
 		policy.PauseTimeBetweenBatches = &pauseTimeBetweenBatches
 	}
 
-	// Set property ‘PrioritizeUnhealthyInstances’:
+	// Set property "PrioritizeUnhealthyInstances":
 	if typedInput.PrioritizeUnhealthyInstances != nil {
 		prioritizeUnhealthyInstances := *typedInput.PrioritizeUnhealthyInstances
 		policy.PrioritizeUnhealthyInstances = &prioritizeUnhealthyInstances
@@ -5248,37 +5248,37 @@ func (policy *RollingUpgradePolicy_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RollingUpgradePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableCrossZoneUpgrade’:
+	// Set property "EnableCrossZoneUpgrade":
 	if typedInput.EnableCrossZoneUpgrade != nil {
 		enableCrossZoneUpgrade := *typedInput.EnableCrossZoneUpgrade
 		policy.EnableCrossZoneUpgrade = &enableCrossZoneUpgrade
 	}
 
-	// Set property ‘MaxBatchInstancePercent’:
+	// Set property "MaxBatchInstancePercent":
 	if typedInput.MaxBatchInstancePercent != nil {
 		maxBatchInstancePercent := *typedInput.MaxBatchInstancePercent
 		policy.MaxBatchInstancePercent = &maxBatchInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyInstancePercent’:
+	// Set property "MaxUnhealthyInstancePercent":
 	if typedInput.MaxUnhealthyInstancePercent != nil {
 		maxUnhealthyInstancePercent := *typedInput.MaxUnhealthyInstancePercent
 		policy.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
 	}
 
-	// Set property ‘MaxUnhealthyUpgradedInstancePercent’:
+	// Set property "MaxUnhealthyUpgradedInstancePercent":
 	if typedInput.MaxUnhealthyUpgradedInstancePercent != nil {
 		maxUnhealthyUpgradedInstancePercent := *typedInput.MaxUnhealthyUpgradedInstancePercent
 		policy.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
 	}
 
-	// Set property ‘PauseTimeBetweenBatches’:
+	// Set property "PauseTimeBetweenBatches":
 	if typedInput.PauseTimeBetweenBatches != nil {
 		pauseTimeBetweenBatches := *typedInput.PauseTimeBetweenBatches
 		policy.PauseTimeBetweenBatches = &pauseTimeBetweenBatches
 	}
 
-	// Set property ‘PrioritizeUnhealthyInstances’:
+	// Set property "PrioritizeUnhealthyInstances":
 	if typedInput.PrioritizeUnhealthyInstances != nil {
 		prioritizeUnhealthyInstances := *typedInput.PrioritizeUnhealthyInstances
 		policy.PrioritizeUnhealthyInstances = &prioritizeUnhealthyInstances
@@ -5420,7 +5420,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) ConvertToARM(resolved gen
 	}
 	result := &VirtualMachineScaleSetExtensionProfile_ARM{}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range profile.Extensions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5429,7 +5429,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) ConvertToARM(resolved gen
 		result.Extensions = append(result.Extensions, *item_ARM.(*VirtualMachineScaleSetExtension_ARM))
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	if profile.ExtensionsTimeBudget != nil {
 		extensionsTimeBudget := *profile.ExtensionsTimeBudget
 		result.ExtensionsTimeBudget = &extensionsTimeBudget
@@ -5449,7 +5449,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtensionProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range typedInput.Extensions {
 		var item1 VirtualMachineScaleSetExtension
 		err := item1.PopulateFromARM(owner, item)
@@ -5459,7 +5459,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile) PopulateFromARM(owner gen
 		profile.Extensions = append(profile.Extensions, item1)
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	if typedInput.ExtensionsTimeBudget != nil {
 		extensionsTimeBudget := *typedInput.ExtensionsTimeBudget
 		profile.ExtensionsTimeBudget = &extensionsTimeBudget
@@ -5554,7 +5554,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtensionProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range typedInput.Extensions {
 		var item1 VirtualMachineScaleSetExtension_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5564,7 +5564,7 @@ func (profile *VirtualMachineScaleSetExtensionProfile_STATUS) PopulateFromARM(ow
 		profile.Extensions = append(profile.Extensions, item1)
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	if typedInput.ExtensionsTimeBudget != nil {
 		extensionsTimeBudget := *typedInput.ExtensionsTimeBudget
 		profile.ExtensionsTimeBudget = &extensionsTimeBudget
@@ -5653,7 +5653,7 @@ func (profile *VirtualMachineScaleSetHardwareProfile) ConvertToARM(resolved genr
 	}
 	result := &VirtualMachineScaleSetHardwareProfile_ARM{}
 
-	// Set property ‘VmSizeProperties’:
+	// Set property "VmSizeProperties":
 	if profile.VmSizeProperties != nil {
 		vmSizeProperties_ARM, err := (*profile.VmSizeProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -5677,7 +5677,7 @@ func (profile *VirtualMachineScaleSetHardwareProfile) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetHardwareProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmSizeProperties’:
+	// Set property "VmSizeProperties":
 	if typedInput.VmSizeProperties != nil {
 		var vmSizeProperties1 VMSizeProperties
 		err := vmSizeProperties1.PopulateFromARM(owner, *typedInput.VmSizeProperties)
@@ -5758,7 +5758,7 @@ func (profile *VirtualMachineScaleSetHardwareProfile_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetHardwareProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmSizeProperties’:
+	// Set property "VmSizeProperties":
 	if typedInput.VmSizeProperties != nil {
 		var vmSizeProperties1 VMSizeProperties_STATUS
 		err := vmSizeProperties1.PopulateFromARM(owner, *typedInput.VmSizeProperties)
@@ -5840,13 +5840,13 @@ func (identities *VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -5907,7 +5907,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) ConvertToARM(resolved genru
 	}
 	result := &VirtualMachineScaleSetNetworkProfile_ARM{}
 
-	// Set property ‘HealthProbe’:
+	// Set property "HealthProbe":
 	if profile.HealthProbe != nil {
 		healthProbe_ARM, err := (*profile.HealthProbe).ConvertToARM(resolved)
 		if err != nil {
@@ -5917,13 +5917,13 @@ func (profile *VirtualMachineScaleSetNetworkProfile) ConvertToARM(resolved genru
 		result.HealthProbe = &healthProbe
 	}
 
-	// Set property ‘NetworkApiVersion’:
+	// Set property "NetworkApiVersion":
 	if profile.NetworkApiVersion != nil {
 		networkApiVersion := *profile.NetworkApiVersion
 		result.NetworkApiVersion = &networkApiVersion
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range profile.NetworkInterfaceConfigurations {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5946,7 +5946,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HealthProbe’:
+	// Set property "HealthProbe":
 	if typedInput.HealthProbe != nil {
 		var healthProbe1 ApiEntityReference
 		err := healthProbe1.PopulateFromARM(owner, *typedInput.HealthProbe)
@@ -5957,13 +5957,13 @@ func (profile *VirtualMachineScaleSetNetworkProfile) PopulateFromARM(owner genru
 		profile.HealthProbe = &healthProbe
 	}
 
-	// Set property ‘NetworkApiVersion’:
+	// Set property "NetworkApiVersion":
 	if typedInput.NetworkApiVersion != nil {
 		networkApiVersion := *typedInput.NetworkApiVersion
 		profile.NetworkApiVersion = &networkApiVersion
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range typedInput.NetworkInterfaceConfigurations {
 		var item1 VirtualMachineScaleSetNetworkConfiguration
 		err := item1.PopulateFromARM(owner, item)
@@ -6097,7 +6097,7 @@ func (profile *VirtualMachineScaleSetNetworkProfile_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HealthProbe’:
+	// Set property "HealthProbe":
 	if typedInput.HealthProbe != nil {
 		var healthProbe1 ApiEntityReference_STATUS
 		err := healthProbe1.PopulateFromARM(owner, *typedInput.HealthProbe)
@@ -6108,13 +6108,13 @@ func (profile *VirtualMachineScaleSetNetworkProfile_STATUS) PopulateFromARM(owne
 		profile.HealthProbe = &healthProbe
 	}
 
-	// Set property ‘NetworkApiVersion’:
+	// Set property "NetworkApiVersion":
 	if typedInput.NetworkApiVersion != nil {
 		networkApiVersion := *typedInput.NetworkApiVersion
 		profile.NetworkApiVersion = &networkApiVersion
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range typedInput.NetworkInterfaceConfigurations {
 		var item1 VirtualMachineScaleSetNetworkConfiguration_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6248,7 +6248,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 	}
 	result := &VirtualMachineScaleSetOSProfile_ARM{}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if profile.AdminPassword != nil {
 		adminPasswordSecret, err := resolved.ResolvedSecrets.Lookup(*profile.AdminPassword)
 		if err != nil {
@@ -6258,31 +6258,31 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 		result.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if profile.AllowExtensionOperations != nil {
 		allowExtensionOperations := *profile.AllowExtensionOperations
 		result.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerNamePrefix’:
+	// Set property "ComputerNamePrefix":
 	if profile.ComputerNamePrefix != nil {
 		computerNamePrefix := *profile.ComputerNamePrefix
 		result.ComputerNamePrefix = &computerNamePrefix
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if profile.CustomData != nil {
 		customData := *profile.CustomData
 		result.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if profile.LinuxConfiguration != nil {
 		linuxConfiguration_ARM, err := (*profile.LinuxConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -6292,7 +6292,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 		result.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range profile.Secrets {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -6301,7 +6301,7 @@ func (profile *VirtualMachineScaleSetOSProfile) ConvertToARM(resolved genruntime
 		result.Secrets = append(result.Secrets, *item_ARM.(*VaultSecretGroup_ARM))
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if profile.WindowsConfiguration != nil {
 		windowsConfiguration_ARM, err := (*profile.WindowsConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -6325,33 +6325,33 @@ func (profile *VirtualMachineScaleSetOSProfile) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSProfile_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘AdminPassword’
+	// no assignment for property "AdminPassword"
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if typedInput.AllowExtensionOperations != nil {
 		allowExtensionOperations := *typedInput.AllowExtensionOperations
 		profile.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerNamePrefix’:
+	// Set property "ComputerNamePrefix":
 	if typedInput.ComputerNamePrefix != nil {
 		computerNamePrefix := *typedInput.ComputerNamePrefix
 		profile.ComputerNamePrefix = &computerNamePrefix
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -6362,7 +6362,7 @@ func (profile *VirtualMachineScaleSetOSProfile) PopulateFromARM(owner genruntime
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup
 		err := item1.PopulateFromARM(owner, item)
@@ -6372,7 +6372,7 @@ func (profile *VirtualMachineScaleSetOSProfile) PopulateFromARM(owner genruntime
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -6569,31 +6569,31 @@ func (profile *VirtualMachineScaleSetOSProfile_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if typedInput.AllowExtensionOperations != nil {
 		allowExtensionOperations := *typedInput.AllowExtensionOperations
 		profile.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerNamePrefix’:
+	// Set property "ComputerNamePrefix":
 	if typedInput.ComputerNamePrefix != nil {
 		computerNamePrefix := *typedInput.ComputerNamePrefix
 		profile.ComputerNamePrefix = &computerNamePrefix
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration_STATUS
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -6604,7 +6604,7 @@ func (profile *VirtualMachineScaleSetOSProfile_STATUS) PopulateFromARM(owner gen
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6614,7 +6614,7 @@ func (profile *VirtualMachineScaleSetOSProfile_STATUS) PopulateFromARM(owner gen
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration_STATUS
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -6786,7 +6786,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 	}
 	result := &VirtualMachineScaleSetStorageProfile_ARM{}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range profile.DataDisks {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -6795,7 +6795,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		result.DataDisks = append(result.DataDisks, *item_ARM.(*VirtualMachineScaleSetDataDisk_ARM))
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if profile.ImageReference != nil {
 		imageReference_ARM, err := (*profile.ImageReference).ConvertToARM(resolved)
 		if err != nil {
@@ -6805,7 +6805,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		result.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if profile.OsDisk != nil {
 		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -6829,7 +6829,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetStorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 VirtualMachineScaleSetDataDisk
 		err := item1.PopulateFromARM(owner, item)
@@ -6839,7 +6839,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) PopulateFromARM(owner genru
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -6850,7 +6850,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) PopulateFromARM(owner genru
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 VirtualMachineScaleSetOSDisk
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -6993,7 +6993,7 @@ func (profile *VirtualMachineScaleSetStorageProfile_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetStorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 VirtualMachineScaleSetDataDisk_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7003,7 +7003,7 @@ func (profile *VirtualMachineScaleSetStorageProfile_STATUS) PopulateFromARM(owne
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference_STATUS
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -7014,7 +7014,7 @@ func (profile *VirtualMachineScaleSetStorageProfile_STATUS) PopulateFromARM(owne
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 VirtualMachineScaleSetOSDisk_STATUS
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -7150,7 +7150,7 @@ func (reference *ApiEntityReference) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &ApiEntityReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -7174,7 +7174,7 @@ func (reference *ApiEntityReference) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiEntityReference_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -7238,7 +7238,7 @@ func (reference *ApiEntityReference_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiEntityReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
@@ -7304,49 +7304,49 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 	}
 	result := &VirtualMachineScaleSetDataDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if disk.DeleteOption != nil {
 		deleteOption := *disk.DeleteOption
 		result.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if disk.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *disk.DiskIOPSReadWrite
 		result.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if disk.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *disk.DiskMBpsReadWrite
 		result.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if disk.Lun != nil {
 		lun := *disk.Lun
 		result.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -7356,13 +7356,13 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -7382,49 +7382,49 @@ func (disk *VirtualMachineScaleSetDataDisk) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetDataDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if typedInput.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *typedInput.DiskIOPSReadWrite
 		disk.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if typedInput.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *typedInput.DiskMBpsReadWrite
 		disk.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -7435,13 +7435,13 @@ func (disk *VirtualMachineScaleSetDataDisk) PopulateFromARM(owner genruntime.Arb
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -7620,49 +7620,49 @@ func (disk *VirtualMachineScaleSetDataDisk_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetDataDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if typedInput.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *typedInput.DiskIOPSReadWrite
 		disk.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if typedInput.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *typedInput.DiskMBpsReadWrite
 		disk.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -7673,13 +7673,13 @@ func (disk *VirtualMachineScaleSetDataDisk_STATUS) PopulateFromARM(owner genrunt
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -7855,13 +7855,13 @@ func (extension *VirtualMachineScaleSetExtension) ConvertToARM(resolved genrunti
 	}
 	result := &VirtualMachineScaleSetExtension_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if extension.Name != nil {
 		name := *extension.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if extension.AutoUpgradeMinorVersion != nil ||
 		extension.EnableAutomaticUpgrade != nil ||
 		extension.ForceUpdateTag != nil ||
@@ -7941,7 +7941,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtension_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradeMinorVersion’:
+	// Set property "AutoUpgradeMinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeMinorVersion != nil {
@@ -7950,7 +7950,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticUpgrade != nil {
@@ -7959,7 +7959,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘ForceUpdateTag’:
+	// Set property "ForceUpdateTag":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceUpdateTag != nil {
@@ -7968,13 +7968,13 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		extension.Name = &name
 	}
 
-	// Set property ‘ProtectedSettings’:
+	// Set property "ProtectedSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettings != nil {
@@ -7985,7 +7985,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘ProtectedSettingsFromKeyVault’:
+	// Set property "ProtectedSettingsFromKeyVault":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettingsFromKeyVault != nil {
@@ -7999,7 +7999,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘ProvisionAfterExtensions’:
+	// Set property "ProvisionAfterExtensions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ProvisionAfterExtensions {
@@ -8007,7 +8007,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Publisher != nil {
@@ -8016,7 +8016,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Settings’:
+	// Set property "Settings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Settings != nil {
@@ -8027,7 +8027,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘SuppressFailures’:
+	// Set property "SuppressFailures":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SuppressFailures != nil {
@@ -8036,7 +8036,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -8045,7 +8045,7 @@ func (extension *VirtualMachineScaleSetExtension) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TypeHandlerVersion != nil {
@@ -8274,7 +8274,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetExtension_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradeMinorVersion’:
+	// Set property "AutoUpgradeMinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeMinorVersion != nil {
@@ -8283,7 +8283,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticUpgrade != nil {
@@ -8292,7 +8292,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ForceUpdateTag’:
+	// Set property "ForceUpdateTag":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceUpdateTag != nil {
@@ -8301,19 +8301,19 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		extension.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		extension.Name = &name
 	}
 
-	// Set property ‘PropertiesType’:
+	// Set property "PropertiesType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -8322,7 +8322,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProtectedSettings’:
+	// Set property "ProtectedSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettings != nil {
@@ -8333,7 +8333,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProtectedSettingsFromKeyVault’:
+	// Set property "ProtectedSettingsFromKeyVault":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettingsFromKeyVault != nil {
@@ -8347,7 +8347,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProvisionAfterExtensions’:
+	// Set property "ProvisionAfterExtensions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ProvisionAfterExtensions {
@@ -8355,7 +8355,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -8364,7 +8364,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Publisher != nil {
@@ -8373,7 +8373,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Settings’:
+	// Set property "Settings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Settings != nil {
@@ -8384,7 +8384,7 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘SuppressFailures’:
+	// Set property "SuppressFailures":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SuppressFailures != nil {
@@ -8393,13 +8393,13 @@ func (extension *VirtualMachineScaleSetExtension_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		extension.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TypeHandlerVersion != nil {
@@ -8640,7 +8640,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) ConvertToARM(re
 	}
 	result := &VirtualMachineScaleSetNetworkConfiguration_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if configuration.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*configuration.Reference)
 		if err != nil {
@@ -8650,13 +8650,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) ConvertToARM(re
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.DeleteOption != nil ||
 		configuration.DnsSettings != nil ||
 		configuration.EnableAcceleratedNetworking != nil ||
@@ -8725,7 +8725,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -8734,7 +8734,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -8748,7 +8748,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -8757,7 +8757,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableFpga’:
+	// Set property "EnableFpga":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFpga != nil {
@@ -8766,7 +8766,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -8775,7 +8775,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -8788,13 +8788,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -8808,7 +8808,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -8817,7 +8817,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration) PopulateFromARM
 		}
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -9060,7 +9060,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -9069,7 +9069,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -9083,7 +9083,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -9092,7 +9092,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘EnableFpga’:
+	// Set property "EnableFpga":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFpga != nil {
@@ -9101,7 +9101,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -9110,13 +9110,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -9129,13 +9129,13 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -9149,7 +9149,7 @@ func (configuration *VirtualMachineScaleSetNetworkConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -9400,25 +9400,25 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &VirtualMachineScaleSetOSDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if disk.DeleteOption != nil {
 		deleteOption := *disk.DeleteOption
 		result.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if disk.DiffDiskSettings != nil {
 		diffDiskSettings_ARM, err := (*disk.DiffDiskSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -9428,13 +9428,13 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		result.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if disk.Image != nil {
 		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
 		if err != nil {
@@ -9444,7 +9444,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		result.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -9454,24 +9454,24 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if disk.OsType != nil {
 		osType := *disk.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘VhdContainers’:
+	// Set property "VhdContainers":
 	for _, item := range disk.VhdContainers {
 		result.VhdContainers = append(result.VhdContainers, item)
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -9491,25 +9491,25 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -9520,13 +9520,13 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -9537,7 +9537,7 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -9548,24 +9548,24 @@ func (disk *VirtualMachineScaleSetOSDisk) PopulateFromARM(owner genruntime.Arbit
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘VhdContainers’:
+	// Set property "VhdContainers":
 	for _, item := range typedInput.VhdContainers {
 		disk.VhdContainers = append(disk.VhdContainers, item)
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -9797,25 +9797,25 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetOSDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings_STATUS
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -9826,13 +9826,13 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk_STATUS
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -9843,7 +9843,7 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 VirtualMachineScaleSetManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -9854,24 +9854,24 @@ func (disk *VirtualMachineScaleSetOSDisk_STATUS) PopulateFromARM(owner genruntim
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘VhdContainers’:
+	// Set property "VhdContainers":
 	for _, item := range typedInput.VhdContainers {
 		disk.VhdContainers = append(disk.VhdContainers, item)
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -10099,7 +10099,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) ConvertToARM(resolve
 	}
 	result := &VirtualMachineScaleSetIPConfiguration_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if configuration.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*configuration.Reference)
 		if err != nil {
@@ -10109,13 +10109,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) ConvertToARM(resolve
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.ApplicationGatewayBackendAddressPools != nil ||
 		configuration.ApplicationSecurityGroups != nil ||
 		configuration.LoadBalancerBackendAddressPools != nil ||
@@ -10193,7 +10193,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIPConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -10206,7 +10206,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -10219,7 +10219,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -10232,7 +10232,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘LoadBalancerInboundNatPools’:
+	// Set property "LoadBalancerInboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerInboundNatPools {
@@ -10245,13 +10245,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -10260,7 +10260,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -10269,7 +10269,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘PublicIPAddressConfiguration’:
+	// Set property "PublicIPAddressConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressConfiguration != nil {
@@ -10283,9 +10283,9 @@ func (configuration *VirtualMachineScaleSetIPConfiguration) PopulateFromARM(owne
 		}
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -10600,7 +10600,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIPConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -10613,7 +10613,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -10626,13 +10626,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -10645,7 +10645,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘LoadBalancerInboundNatPools’:
+	// Set property "LoadBalancerInboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerInboundNatPools {
@@ -10658,13 +10658,13 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -10673,7 +10673,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -10682,7 +10682,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘PublicIPAddressConfiguration’:
+	// Set property "PublicIPAddressConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressConfiguration != nil {
@@ -10696,7 +10696,7 @@ func (configuration *VirtualMachineScaleSetIPConfiguration_STATUS) PopulateFromA
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -10989,7 +10989,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 	}
 	result := &VirtualMachineScaleSetManagedDiskParameters_ARM{}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if parameters.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*parameters.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -10999,7 +10999,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if parameters.SecurityProfile != nil {
 		securityProfile_ARM, err := (*parameters.SecurityProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -11009,7 +11009,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 		result.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if parameters.StorageAccountType != nil {
 		storageAccountType := *parameters.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -11029,7 +11029,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetManagedDiskParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -11040,7 +11040,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) PopulateFromARM(o
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 VMDiskSecurityProfile
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -11051,7 +11051,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) PopulateFromARM(o
 		parameters.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -11169,7 +11169,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters_STATUS) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetManagedDiskParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -11180,7 +11180,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters_STATUS) PopulateFr
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 VMDiskSecurityProfile_STATUS
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -11191,7 +11191,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters_STATUS) PopulateFr
 		parameters.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -11302,7 +11302,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings) ConvertTo
 	}
 	result := &VirtualMachineScaleSetNetworkConfigurationDnsSettings_ARM{}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range settings.DnsServers {
 		result.DnsServers = append(result.DnsServers, item)
 	}
@@ -11321,7 +11321,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfigurationDnsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		settings.DnsServers = append(settings.DnsServers, item)
 	}
@@ -11378,7 +11378,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS) Po
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetNetworkConfigurationDnsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		settings.DnsServers = append(settings.DnsServers, item)
 	}
@@ -11495,13 +11495,13 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Convert
 	}
 	result := &VirtualMachineScaleSetPublicIPAddressConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.DeleteOption != nil ||
 		configuration.DnsSettings != nil ||
 		configuration.IdleTimeoutInMinutes != nil ||
@@ -11546,7 +11546,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Convert
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if configuration.Sku != nil {
 		sku_ARM, err := (*configuration.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -11570,7 +11570,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -11579,7 +11579,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -11593,7 +11593,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -11602,7 +11602,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -11615,13 +11615,13 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -11630,7 +11630,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -11644,7 +11644,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration) Populat
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPAddressSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -11860,7 +11860,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -11869,7 +11869,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -11883,7 +11883,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -11892,7 +11892,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -11905,13 +11905,13 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -11920,7 +11920,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -11934,7 +11934,7 @@ func (configuration *VirtualMachineScaleSetPublicIPAddressConfiguration_STATUS) 
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPAddressSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -12139,13 +12139,13 @@ func (ipTag *VirtualMachineScaleSetIpTag) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &VirtualMachineScaleSetIpTag_ARM{}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if ipTag.IpTagType != nil {
 		ipTagType := *ipTag.IpTagType
 		result.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if ipTag.Tag != nil {
 		tag := *ipTag.Tag
 		result.Tag = &tag
@@ -12165,13 +12165,13 @@ func (ipTag *VirtualMachineScaleSetIpTag) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIpTag_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -12236,13 +12236,13 @@ func (ipTag *VirtualMachineScaleSetIpTag_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetIpTag_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -12302,7 +12302,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings) C
 	}
 	result := &VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_ARM{}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if settings.DomainNameLabel != nil {
 		domainNameLabel := *settings.DomainNameLabel
 		result.DomainNameLabel = &domainNameLabel
@@ -12322,7 +12322,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings) P
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		settings.DomainNameLabel = &domainNameLabel
@@ -12380,7 +12380,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_ST
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		settings.DomainNameLabel = &domainNameLabel

--- a/v2/api/compute/v1beta20220301/virtual_machine_types_gen.go
+++ b/v2/api/compute/v1beta20220301/virtual_machine_types_gen.go
@@ -362,7 +362,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &VirtualMachine_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if machine.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*machine.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -372,7 +372,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if machine.Identity != nil {
 		identity_ARM, err := (*machine.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -382,16 +382,16 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if machine.Location != nil {
 		location := *machine.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if machine.Plan != nil {
 		plan_ARM, err := (*machine.Plan).ConvertToARM(resolved)
 		if err != nil {
@@ -401,7 +401,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Plan = &plan
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if machine.AdditionalCapabilities != nil ||
 		machine.ApplicationProfile != nil ||
 		machine.AvailabilitySet != nil ||
@@ -579,7 +579,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.VirtualMachineScaleSet = &virtualMachineScaleSet
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if machine.Tags != nil {
 		result.Tags = make(map[string]string, len(machine.Tags))
 		for key, value := range machine.Tags {
@@ -587,7 +587,7 @@ func (machine *VirtualMachine_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range machine.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -606,7 +606,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -620,7 +620,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ApplicationProfile’:
+	// Set property "ApplicationProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApplicationProfile != nil {
@@ -634,7 +634,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AvailabilitySet’:
+	// Set property "AvailabilitySet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilitySet != nil {
@@ -648,10 +648,10 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	machine.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BillingProfile != nil {
@@ -665,7 +665,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘CapacityReservation’:
+	// Set property "CapacityReservation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CapacityReservation != nil {
@@ -679,7 +679,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiagnosticsProfile != nil {
@@ -693,7 +693,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EvictionPolicy != nil {
@@ -702,7 +702,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -713,7 +713,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		machine.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExtensionsTimeBudget != nil {
@@ -722,7 +722,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HardwareProfile != nil {
@@ -736,7 +736,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Host != nil {
@@ -750,7 +750,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -764,7 +764,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -775,7 +775,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		machine.Identity = &identity
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LicenseType != nil {
@@ -784,13 +784,13 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		machine.Location = &location
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -804,7 +804,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsProfile != nil {
@@ -818,10 +818,10 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	machine.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -832,7 +832,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		machine.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomain’:
+	// Set property "PlatformFaultDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomain != nil {
@@ -841,7 +841,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -850,7 +850,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -864,7 +864,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScheduledEventsProfile != nil {
@@ -878,7 +878,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecurityProfile != nil {
@@ -892,7 +892,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -906,7 +906,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		machine.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -914,7 +914,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘UserData’:
+	// Set property "UserData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UserData != nil {
@@ -923,7 +923,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘VirtualMachineScaleSet’:
+	// Set property "VirtualMachineScaleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineScaleSet != nil {
@@ -937,7 +937,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		machine.Zones = append(machine.Zones, item)
 	}
@@ -1689,7 +1689,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalCapabilities’:
+	// Set property "AdditionalCapabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdditionalCapabilities != nil {
@@ -1703,7 +1703,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ApplicationProfile’:
+	// Set property "ApplicationProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApplicationProfile != nil {
@@ -1717,7 +1717,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AvailabilitySet’:
+	// Set property "AvailabilitySet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilitySet != nil {
@@ -1731,7 +1731,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘BillingProfile’:
+	// Set property "BillingProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BillingProfile != nil {
@@ -1745,7 +1745,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘CapacityReservation’:
+	// Set property "CapacityReservation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CapacityReservation != nil {
@@ -1759,9 +1759,9 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DiagnosticsProfile’:
+	// Set property "DiagnosticsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiagnosticsProfile != nil {
@@ -1775,7 +1775,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EvictionPolicy’:
+	// Set property "EvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EvictionPolicy != nil {
@@ -1784,7 +1784,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1795,7 +1795,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘ExtensionsTimeBudget’:
+	// Set property "ExtensionsTimeBudget":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExtensionsTimeBudget != nil {
@@ -1804,7 +1804,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘HardwareProfile’:
+	// Set property "HardwareProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HardwareProfile != nil {
@@ -1818,7 +1818,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Host != nil {
@@ -1832,7 +1832,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘HostGroup’:
+	// Set property "HostGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroup != nil {
@@ -1846,13 +1846,13 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		machine.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 VirtualMachineIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1863,7 +1863,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Identity = &identity
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -1877,7 +1877,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LicenseType != nil {
@@ -1886,19 +1886,19 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		machine.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		machine.Name = &name
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -1912,7 +1912,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘OsProfile’:
+	// Set property "OsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsProfile != nil {
@@ -1926,7 +1926,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Plan’:
+	// Set property "Plan":
 	if typedInput.Plan != nil {
 		var plan1 Plan_STATUS
 		err := plan1.PopulateFromARM(owner, *typedInput.Plan)
@@ -1937,7 +1937,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Plan = &plan
 	}
 
-	// Set property ‘PlatformFaultDomain’:
+	// Set property "PlatformFaultDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PlatformFaultDomain != nil {
@@ -1946,7 +1946,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -1955,7 +1955,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1964,7 +1964,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroup’:
+	// Set property "ProximityPlacementGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroup != nil {
@@ -1978,7 +1978,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	for _, item := range typedInput.Resources {
 		var item1 VirtualMachineExtension_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1988,7 +1988,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Resources = append(machine.Resources, item1)
 	}
 
-	// Set property ‘ScheduledEventsProfile’:
+	// Set property "ScheduledEventsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScheduledEventsProfile != nil {
@@ -2002,7 +2002,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecurityProfile != nil {
@@ -2016,7 +2016,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -2030,7 +2030,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		machine.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -2038,7 +2038,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘TimeCreated’:
+	// Set property "TimeCreated":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TimeCreated != nil {
@@ -2047,13 +2047,13 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		machine.Type = &typeVar
 	}
 
-	// Set property ‘UserData’:
+	// Set property "UserData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UserData != nil {
@@ -2062,7 +2062,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘VirtualMachineScaleSet’:
+	// Set property "VirtualMachineScaleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachineScaleSet != nil {
@@ -2076,7 +2076,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘VmId’:
+	// Set property "VmId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VmId != nil {
@@ -2085,7 +2085,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		machine.Zones = append(machine.Zones, item)
 	}
@@ -2764,13 +2764,13 @@ func (capabilities *AdditionalCapabilities) ConvertToARM(resolved genruntime.Con
 	}
 	result := &AdditionalCapabilities_ARM{}
 
-	// Set property ‘HibernationEnabled’:
+	// Set property "HibernationEnabled":
 	if capabilities.HibernationEnabled != nil {
 		hibernationEnabled := *capabilities.HibernationEnabled
 		result.HibernationEnabled = &hibernationEnabled
 	}
 
-	// Set property ‘UltraSSDEnabled’:
+	// Set property "UltraSSDEnabled":
 	if capabilities.UltraSSDEnabled != nil {
 		ultraSSDEnabled := *capabilities.UltraSSDEnabled
 		result.UltraSSDEnabled = &ultraSSDEnabled
@@ -2790,13 +2790,13 @@ func (capabilities *AdditionalCapabilities) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalCapabilities_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HibernationEnabled’:
+	// Set property "HibernationEnabled":
 	if typedInput.HibernationEnabled != nil {
 		hibernationEnabled := *typedInput.HibernationEnabled
 		capabilities.HibernationEnabled = &hibernationEnabled
 	}
 
-	// Set property ‘UltraSSDEnabled’:
+	// Set property "UltraSSDEnabled":
 	if typedInput.UltraSSDEnabled != nil {
 		ultraSSDEnabled := *typedInput.UltraSSDEnabled
 		capabilities.UltraSSDEnabled = &ultraSSDEnabled
@@ -2881,13 +2881,13 @@ func (capabilities *AdditionalCapabilities_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalCapabilities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HibernationEnabled’:
+	// Set property "HibernationEnabled":
 	if typedInput.HibernationEnabled != nil {
 		hibernationEnabled := *typedInput.HibernationEnabled
 		capabilities.HibernationEnabled = &hibernationEnabled
 	}
 
-	// Set property ‘UltraSSDEnabled’:
+	// Set property "UltraSSDEnabled":
 	if typedInput.UltraSSDEnabled != nil {
 		ultraSSDEnabled := *typedInput.UltraSSDEnabled
 		capabilities.UltraSSDEnabled = &ultraSSDEnabled
@@ -2966,7 +2966,7 @@ func (profile *ApplicationProfile) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &ApplicationProfile_ARM{}
 
-	// Set property ‘GalleryApplications’:
+	// Set property "GalleryApplications":
 	for _, item := range profile.GalleryApplications {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2989,7 +2989,7 @@ func (profile *ApplicationProfile) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GalleryApplications’:
+	// Set property "GalleryApplications":
 	for _, item := range typedInput.GalleryApplications {
 		var item1 VMGalleryApplication
 		err := item1.PopulateFromARM(owner, item)
@@ -3081,7 +3081,7 @@ func (profile *ApplicationProfile_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GalleryApplications’:
+	// Set property "GalleryApplications":
 	for _, item := range typedInput.GalleryApplications {
 		var item1 VMGalleryApplication_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3168,7 +3168,7 @@ func (profile *BillingProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &BillingProfile_ARM{}
 
-	// Set property ‘MaxPrice’:
+	// Set property "MaxPrice":
 	if profile.MaxPrice != nil {
 		maxPrice := *profile.MaxPrice
 		result.MaxPrice = &maxPrice
@@ -3188,7 +3188,7 @@ func (profile *BillingProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BillingProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxPrice’:
+	// Set property "MaxPrice":
 	if typedInput.MaxPrice != nil {
 		maxPrice := *typedInput.MaxPrice
 		profile.MaxPrice = &maxPrice
@@ -3256,7 +3256,7 @@ func (profile *BillingProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BillingProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxPrice’:
+	// Set property "MaxPrice":
 	if typedInput.MaxPrice != nil {
 		maxPrice := *typedInput.MaxPrice
 		profile.MaxPrice = &maxPrice
@@ -3319,7 +3319,7 @@ func (profile *CapacityReservationProfile) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &CapacityReservationProfile_ARM{}
 
-	// Set property ‘CapacityReservationGroup’:
+	// Set property "CapacityReservationGroup":
 	if profile.CapacityReservationGroup != nil {
 		capacityReservationGroup_ARM, err := (*profile.CapacityReservationGroup).ConvertToARM(resolved)
 		if err != nil {
@@ -3343,7 +3343,7 @@ func (profile *CapacityReservationProfile) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CapacityReservationProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CapacityReservationGroup’:
+	// Set property "CapacityReservationGroup":
 	if typedInput.CapacityReservationGroup != nil {
 		var capacityReservationGroup1 SubResource
 		err := capacityReservationGroup1.PopulateFromARM(owner, *typedInput.CapacityReservationGroup)
@@ -3424,7 +3424,7 @@ func (profile *CapacityReservationProfile_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CapacityReservationProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CapacityReservationGroup’:
+	// Set property "CapacityReservationGroup":
 	if typedInput.CapacityReservationGroup != nil {
 		var capacityReservationGroup1 SubResource_STATUS
 		err := capacityReservationGroup1.PopulateFromARM(owner, *typedInput.CapacityReservationGroup)
@@ -3500,7 +3500,7 @@ func (profile *DiagnosticsProfile) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &DiagnosticsProfile_ARM{}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if profile.BootDiagnostics != nil {
 		bootDiagnostics_ARM, err := (*profile.BootDiagnostics).ConvertToARM(resolved)
 		if err != nil {
@@ -3524,7 +3524,7 @@ func (profile *DiagnosticsProfile) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiagnosticsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if typedInput.BootDiagnostics != nil {
 		var bootDiagnostics1 BootDiagnostics
 		err := bootDiagnostics1.PopulateFromARM(owner, *typedInput.BootDiagnostics)
@@ -3605,7 +3605,7 @@ func (profile *DiagnosticsProfile_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiagnosticsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if typedInput.BootDiagnostics != nil {
 		var bootDiagnostics1 BootDiagnostics_STATUS
 		err := bootDiagnostics1.PopulateFromARM(owner, *typedInput.BootDiagnostics)
@@ -3699,13 +3699,13 @@ func (profile *HardwareProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &HardwareProfile_ARM{}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if profile.VmSize != nil {
 		vmSize := *profile.VmSize
 		result.VmSize = &vmSize
 	}
 
-	// Set property ‘VmSizeProperties’:
+	// Set property "VmSizeProperties":
 	if profile.VmSizeProperties != nil {
 		vmSizeProperties_ARM, err := (*profile.VmSizeProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -3729,13 +3729,13 @@ func (profile *HardwareProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HardwareProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
 	}
 
-	// Set property ‘VmSizeProperties’:
+	// Set property "VmSizeProperties":
 	if typedInput.VmSizeProperties != nil {
 		var vmSizeProperties1 VMSizeProperties
 		err := vmSizeProperties1.PopulateFromARM(owner, *typedInput.VmSizeProperties)
@@ -3833,13 +3833,13 @@ func (profile *HardwareProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HardwareProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
 	}
 
-	// Set property ‘VmSizeProperties’:
+	// Set property "VmSizeProperties":
 	if typedInput.VmSizeProperties != nil {
 		var vmSizeProperties1 VMSizeProperties_STATUS
 		err := vmSizeProperties1.PopulateFromARM(owner, *typedInput.VmSizeProperties)
@@ -3933,13 +3933,13 @@ func (profile *NetworkProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &NetworkProfile_ARM{}
 
-	// Set property ‘NetworkApiVersion’:
+	// Set property "NetworkApiVersion":
 	if profile.NetworkApiVersion != nil {
 		networkApiVersion := *profile.NetworkApiVersion
 		result.NetworkApiVersion = &networkApiVersion
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range profile.NetworkInterfaceConfigurations {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3948,7 +3948,7 @@ func (profile *NetworkProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.NetworkInterfaceConfigurations = append(result.NetworkInterfaceConfigurations, *item_ARM.(*VirtualMachineNetworkInterfaceConfiguration_ARM))
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	for _, item := range profile.NetworkInterfaces {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3971,13 +3971,13 @@ func (profile *NetworkProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NetworkApiVersion’:
+	// Set property "NetworkApiVersion":
 	if typedInput.NetworkApiVersion != nil {
 		networkApiVersion := *typedInput.NetworkApiVersion
 		profile.NetworkApiVersion = &networkApiVersion
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range typedInput.NetworkInterfaceConfigurations {
 		var item1 VirtualMachineNetworkInterfaceConfiguration
 		err := item1.PopulateFromARM(owner, item)
@@ -3987,7 +3987,7 @@ func (profile *NetworkProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.NetworkInterfaceConfigurations = append(profile.NetworkInterfaceConfigurations, item1)
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	for _, item := range typedInput.NetworkInterfaces {
 		var item1 NetworkInterfaceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -4133,13 +4133,13 @@ func (profile *NetworkProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NetworkApiVersion’:
+	// Set property "NetworkApiVersion":
 	if typedInput.NetworkApiVersion != nil {
 		networkApiVersion := *typedInput.NetworkApiVersion
 		profile.NetworkApiVersion = &networkApiVersion
 	}
 
-	// Set property ‘NetworkInterfaceConfigurations’:
+	// Set property "NetworkInterfaceConfigurations":
 	for _, item := range typedInput.NetworkInterfaceConfigurations {
 		var item1 VirtualMachineNetworkInterfaceConfiguration_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4149,7 +4149,7 @@ func (profile *NetworkProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		profile.NetworkInterfaceConfigurations = append(profile.NetworkInterfaceConfigurations, item1)
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	for _, item := range typedInput.NetworkInterfaces {
 		var item1 NetworkInterfaceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4296,7 +4296,7 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &OSProfile_ARM{}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if profile.AdminPassword != nil {
 		adminPasswordSecret, err := resolved.ResolvedSecrets.Lookup(*profile.AdminPassword)
 		if err != nil {
@@ -4306,31 +4306,31 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if profile.AllowExtensionOperations != nil {
 		allowExtensionOperations := *profile.AllowExtensionOperations
 		result.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if profile.ComputerName != nil {
 		computerName := *profile.ComputerName
 		result.ComputerName = &computerName
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if profile.CustomData != nil {
 		customData := *profile.CustomData
 		result.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if profile.LinuxConfiguration != nil {
 		linuxConfiguration_ARM, err := (*profile.LinuxConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -4340,13 +4340,13 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘RequireGuestProvisionSignal’:
+	// Set property "RequireGuestProvisionSignal":
 	if profile.RequireGuestProvisionSignal != nil {
 		requireGuestProvisionSignal := *profile.RequireGuestProvisionSignal
 		result.RequireGuestProvisionSignal = &requireGuestProvisionSignal
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range profile.Secrets {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4355,7 +4355,7 @@ func (profile *OSProfile) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Secrets = append(result.Secrets, *item_ARM.(*VaultSecretGroup_ARM))
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if profile.WindowsConfiguration != nil {
 		windowsConfiguration_ARM, err := (*profile.WindowsConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -4379,33 +4379,33 @@ func (profile *OSProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSProfile_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘AdminPassword’
+	// no assignment for property "AdminPassword"
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if typedInput.AllowExtensionOperations != nil {
 		allowExtensionOperations := *typedInput.AllowExtensionOperations
 		profile.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if typedInput.ComputerName != nil {
 		computerName := *typedInput.ComputerName
 		profile.ComputerName = &computerName
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -4416,13 +4416,13 @@ func (profile *OSProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘RequireGuestProvisionSignal’:
+	// Set property "RequireGuestProvisionSignal":
 	if typedInput.RequireGuestProvisionSignal != nil {
 		requireGuestProvisionSignal := *typedInput.RequireGuestProvisionSignal
 		profile.RequireGuestProvisionSignal = &requireGuestProvisionSignal
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup
 		err := item1.PopulateFromARM(owner, item)
@@ -4432,7 +4432,7 @@ func (profile *OSProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -4646,31 +4646,31 @@ func (profile *OSProfile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘AllowExtensionOperations’:
+	// Set property "AllowExtensionOperations":
 	if typedInput.AllowExtensionOperations != nil {
 		allowExtensionOperations := *typedInput.AllowExtensionOperations
 		profile.AllowExtensionOperations = &allowExtensionOperations
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if typedInput.ComputerName != nil {
 		computerName := *typedInput.ComputerName
 		profile.ComputerName = &computerName
 	}
 
-	// Set property ‘CustomData’:
+	// Set property "CustomData":
 	if typedInput.CustomData != nil {
 		customData := *typedInput.CustomData
 		profile.CustomData = &customData
 	}
 
-	// Set property ‘LinuxConfiguration’:
+	// Set property "LinuxConfiguration":
 	if typedInput.LinuxConfiguration != nil {
 		var linuxConfiguration1 LinuxConfiguration_STATUS
 		err := linuxConfiguration1.PopulateFromARM(owner, *typedInput.LinuxConfiguration)
@@ -4681,13 +4681,13 @@ func (profile *OSProfile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		profile.LinuxConfiguration = &linuxConfiguration
 	}
 
-	// Set property ‘RequireGuestProvisionSignal’:
+	// Set property "RequireGuestProvisionSignal":
 	if typedInput.RequireGuestProvisionSignal != nil {
 		requireGuestProvisionSignal := *typedInput.RequireGuestProvisionSignal
 		profile.RequireGuestProvisionSignal = &requireGuestProvisionSignal
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		var item1 VaultSecretGroup_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4697,7 +4697,7 @@ func (profile *OSProfile_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		profile.Secrets = append(profile.Secrets, item1)
 	}
 
-	// Set property ‘WindowsConfiguration’:
+	// Set property "WindowsConfiguration":
 	if typedInput.WindowsConfiguration != nil {
 		var windowsConfiguration1 WindowsConfiguration_STATUS
 		err := windowsConfiguration1.PopulateFromARM(owner, *typedInput.WindowsConfiguration)
@@ -4886,25 +4886,25 @@ func (plan *Plan) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) 
 	}
 	result := &Plan_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if plan.Name != nil {
 		name := *plan.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if plan.Product != nil {
 		product := *plan.Product
 		result.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if plan.PromotionCode != nil {
 		promotionCode := *plan.PromotionCode
 		result.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if plan.Publisher != nil {
 		publisher := *plan.Publisher
 		result.Publisher = &publisher
@@ -4924,25 +4924,25 @@ func (plan *Plan) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armI
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Plan_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		plan.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if typedInput.Product != nil {
 		product := *typedInput.Product
 		plan.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if typedInput.PromotionCode != nil {
 		promotionCode := *typedInput.PromotionCode
 		plan.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		plan.Publisher = &publisher
@@ -5021,25 +5021,25 @@ func (plan *Plan_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Plan_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		plan.Name = &name
 	}
 
-	// Set property ‘Product’:
+	// Set property "Product":
 	if typedInput.Product != nil {
 		product := *typedInput.Product
 		plan.Product = &product
 	}
 
-	// Set property ‘PromotionCode’:
+	// Set property "PromotionCode":
 	if typedInput.PromotionCode != nil {
 		promotionCode := *typedInput.PromotionCode
 		plan.PromotionCode = &promotionCode
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		plan.Publisher = &publisher
@@ -5129,7 +5129,7 @@ func (profile *ScheduledEventsProfile) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &ScheduledEventsProfile_ARM{}
 
-	// Set property ‘TerminateNotificationProfile’:
+	// Set property "TerminateNotificationProfile":
 	if profile.TerminateNotificationProfile != nil {
 		terminateNotificationProfile_ARM, err := (*profile.TerminateNotificationProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -5153,7 +5153,7 @@ func (profile *ScheduledEventsProfile) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduledEventsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘TerminateNotificationProfile’:
+	// Set property "TerminateNotificationProfile":
 	if typedInput.TerminateNotificationProfile != nil {
 		var terminateNotificationProfile1 TerminateNotificationProfile
 		err := terminateNotificationProfile1.PopulateFromARM(owner, *typedInput.TerminateNotificationProfile)
@@ -5234,7 +5234,7 @@ func (profile *ScheduledEventsProfile_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduledEventsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘TerminateNotificationProfile’:
+	// Set property "TerminateNotificationProfile":
 	if typedInput.TerminateNotificationProfile != nil {
 		var terminateNotificationProfile1 TerminateNotificationProfile_STATUS
 		err := terminateNotificationProfile1.PopulateFromARM(owner, *typedInput.TerminateNotificationProfile)
@@ -5312,19 +5312,19 @@ func (profile *SecurityProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &SecurityProfile_ARM{}
 
-	// Set property ‘EncryptionAtHost’:
+	// Set property "EncryptionAtHost":
 	if profile.EncryptionAtHost != nil {
 		encryptionAtHost := *profile.EncryptionAtHost
 		result.EncryptionAtHost = &encryptionAtHost
 	}
 
-	// Set property ‘SecurityType’:
+	// Set property "SecurityType":
 	if profile.SecurityType != nil {
 		securityType := *profile.SecurityType
 		result.SecurityType = &securityType
 	}
 
-	// Set property ‘UefiSettings’:
+	// Set property "UefiSettings":
 	if profile.UefiSettings != nil {
 		uefiSettings_ARM, err := (*profile.UefiSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -5348,19 +5348,19 @@ func (profile *SecurityProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SecurityProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EncryptionAtHost’:
+	// Set property "EncryptionAtHost":
 	if typedInput.EncryptionAtHost != nil {
 		encryptionAtHost := *typedInput.EncryptionAtHost
 		profile.EncryptionAtHost = &encryptionAtHost
 	}
 
-	// Set property ‘SecurityType’:
+	// Set property "SecurityType":
 	if typedInput.SecurityType != nil {
 		securityType := *typedInput.SecurityType
 		profile.SecurityType = &securityType
 	}
 
-	// Set property ‘UefiSettings’:
+	// Set property "UefiSettings":
 	if typedInput.UefiSettings != nil {
 		var uefiSettings1 UefiSettings
 		err := uefiSettings1.PopulateFromARM(owner, *typedInput.UefiSettings)
@@ -5475,19 +5475,19 @@ func (profile *SecurityProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SecurityProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EncryptionAtHost’:
+	// Set property "EncryptionAtHost":
 	if typedInput.EncryptionAtHost != nil {
 		encryptionAtHost := *typedInput.EncryptionAtHost
 		profile.EncryptionAtHost = &encryptionAtHost
 	}
 
-	// Set property ‘SecurityType’:
+	// Set property "SecurityType":
 	if typedInput.SecurityType != nil {
 		securityType := *typedInput.SecurityType
 		profile.SecurityType = &securityType
 	}
 
-	// Set property ‘UefiSettings’:
+	// Set property "UefiSettings":
 	if typedInput.UefiSettings != nil {
 		var uefiSettings1 UefiSettings_STATUS
 		err := uefiSettings1.PopulateFromARM(owner, *typedInput.UefiSettings)
@@ -5597,7 +5597,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &StorageProfile_ARM{}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range profile.DataDisks {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5606,7 +5606,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.DataDisks = append(result.DataDisks, *item_ARM.(*DataDisk_ARM))
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if profile.ImageReference != nil {
 		imageReference_ARM, err := (*profile.ImageReference).ConvertToARM(resolved)
 		if err != nil {
@@ -5616,7 +5616,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if profile.OsDisk != nil {
 		osDisk_ARM, err := (*profile.OsDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -5640,7 +5640,7 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 DataDisk
 		err := item1.PopulateFromARM(owner, item)
@@ -5650,7 +5650,7 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -5661,7 +5661,7 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 OSDisk
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -5804,7 +5804,7 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataDisks’:
+	// Set property "DataDisks":
 	for _, item := range typedInput.DataDisks {
 		var item1 DataDisk_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5814,7 +5814,7 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		profile.DataDisks = append(profile.DataDisks, item1)
 	}
 
-	// Set property ‘ImageReference’:
+	// Set property "ImageReference":
 	if typedInput.ImageReference != nil {
 		var imageReference1 ImageReference_STATUS
 		err := imageReference1.PopulateFromARM(owner, *typedInput.ImageReference)
@@ -5825,7 +5825,7 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		profile.ImageReference = &imageReference
 	}
 
-	// Set property ‘OsDisk’:
+	// Set property "OsDisk":
 	if typedInput.OsDisk != nil {
 		var osDisk1 OSDisk_STATUS
 		err := osDisk1.PopulateFromARM(owner, *typedInput.OsDisk)
@@ -5982,7 +5982,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineExtension_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradeMinorVersion’:
+	// Set property "AutoUpgradeMinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeMinorVersion != nil {
@@ -5991,7 +5991,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticUpgrade != nil {
@@ -6000,7 +6000,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ForceUpdateTag’:
+	// Set property "ForceUpdateTag":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceUpdateTag != nil {
@@ -6009,13 +6009,13 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		extension.Id = &id
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -6029,19 +6029,19 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		extension.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		extension.Name = &name
 	}
 
-	// Set property ‘PropertiesType’:
+	// Set property "PropertiesType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -6050,7 +6050,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ProtectedSettings’:
+	// Set property "ProtectedSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettings != nil {
@@ -6061,7 +6061,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ProtectedSettingsFromKeyVault’:
+	// Set property "ProtectedSettingsFromKeyVault":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtectedSettingsFromKeyVault != nil {
@@ -6075,7 +6075,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -6084,7 +6084,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Publisher != nil {
@@ -6093,7 +6093,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Settings’:
+	// Set property "Settings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Settings != nil {
@@ -6104,7 +6104,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘SuppressFailures’:
+	// Set property "SuppressFailures":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SuppressFailures != nil {
@@ -6113,7 +6113,7 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		extension.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -6121,13 +6121,13 @@ func (extension *VirtualMachineExtension_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		extension.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TypeHandlerVersion != nil {
@@ -6386,13 +6386,13 @@ func (identity *VirtualMachineIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &VirtualMachineIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -6417,13 +6417,13 @@ func (identity *VirtualMachineIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -6526,25 +6526,25 @@ func (identity *VirtualMachineIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]VirtualMachineIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -6682,13 +6682,13 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssignedHost’:
+	// Set property "AssignedHost":
 	if typedInput.AssignedHost != nil {
 		assignedHost := *typedInput.AssignedHost
 		view.AssignedHost = &assignedHost
 	}
 
-	// Set property ‘BootDiagnostics’:
+	// Set property "BootDiagnostics":
 	if typedInput.BootDiagnostics != nil {
 		var bootDiagnostics1 BootDiagnosticsInstanceView_STATUS
 		err := bootDiagnostics1.PopulateFromARM(owner, *typedInput.BootDiagnostics)
@@ -6699,13 +6699,13 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.BootDiagnostics = &bootDiagnostics
 	}
 
-	// Set property ‘ComputerName’:
+	// Set property "ComputerName":
 	if typedInput.ComputerName != nil {
 		computerName := *typedInput.ComputerName
 		view.ComputerName = &computerName
 	}
 
-	// Set property ‘Disks’:
+	// Set property "Disks":
 	for _, item := range typedInput.Disks {
 		var item1 DiskInstanceView_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6715,7 +6715,7 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.Disks = append(view.Disks, item1)
 	}
 
-	// Set property ‘Extensions’:
+	// Set property "Extensions":
 	for _, item := range typedInput.Extensions {
 		var item1 VirtualMachineExtensionInstanceView_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6725,13 +6725,13 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.Extensions = append(view.Extensions, item1)
 	}
 
-	// Set property ‘HyperVGeneration’:
+	// Set property "HyperVGeneration":
 	if typedInput.HyperVGeneration != nil {
 		hyperVGeneration := *typedInput.HyperVGeneration
 		view.HyperVGeneration = &hyperVGeneration
 	}
 
-	// Set property ‘MaintenanceRedeployStatus’:
+	// Set property "MaintenanceRedeployStatus":
 	if typedInput.MaintenanceRedeployStatus != nil {
 		var maintenanceRedeployStatus1 MaintenanceRedeployStatus_STATUS
 		err := maintenanceRedeployStatus1.PopulateFromARM(owner, *typedInput.MaintenanceRedeployStatus)
@@ -6742,19 +6742,19 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.MaintenanceRedeployStatus = &maintenanceRedeployStatus
 	}
 
-	// Set property ‘OsName’:
+	// Set property "OsName":
 	if typedInput.OsName != nil {
 		osName := *typedInput.OsName
 		view.OsName = &osName
 	}
 
-	// Set property ‘OsVersion’:
+	// Set property "OsVersion":
 	if typedInput.OsVersion != nil {
 		osVersion := *typedInput.OsVersion
 		view.OsVersion = &osVersion
 	}
 
-	// Set property ‘PatchStatus’:
+	// Set property "PatchStatus":
 	if typedInput.PatchStatus != nil {
 		var patchStatus1 VirtualMachinePatchStatus_STATUS
 		err := patchStatus1.PopulateFromARM(owner, *typedInput.PatchStatus)
@@ -6765,25 +6765,25 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.PatchStatus = &patchStatus
 	}
 
-	// Set property ‘PlatformFaultDomain’:
+	// Set property "PlatformFaultDomain":
 	if typedInput.PlatformFaultDomain != nil {
 		platformFaultDomain := *typedInput.PlatformFaultDomain
 		view.PlatformFaultDomain = &platformFaultDomain
 	}
 
-	// Set property ‘PlatformUpdateDomain’:
+	// Set property "PlatformUpdateDomain":
 	if typedInput.PlatformUpdateDomain != nil {
 		platformUpdateDomain := *typedInput.PlatformUpdateDomain
 		view.PlatformUpdateDomain = &platformUpdateDomain
 	}
 
-	// Set property ‘RdpThumbPrint’:
+	// Set property "RdpThumbPrint":
 	if typedInput.RdpThumbPrint != nil {
 		rdpThumbPrint := *typedInput.RdpThumbPrint
 		view.RdpThumbPrint = &rdpThumbPrint
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6793,7 +6793,7 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.Statuses = append(view.Statuses, item1)
 	}
 
-	// Set property ‘VmAgent’:
+	// Set property "VmAgent":
 	if typedInput.VmAgent != nil {
 		var vmAgent1 VirtualMachineAgentInstanceView_STATUS
 		err := vmAgent1.PopulateFromARM(owner, *typedInput.VmAgent)
@@ -6804,7 +6804,7 @@ func (view *VirtualMachineInstanceView_STATUS) PopulateFromARM(owner genruntime.
 		view.VmAgent = &vmAgent
 	}
 
-	// Set property ‘VmHealth’:
+	// Set property "VmHealth":
 	if typedInput.VmHealth != nil {
 		var vmHealth1 VirtualMachineHealthStatus_STATUS
 		err := vmHealth1.PopulateFromARM(owner, *typedInput.VmHealth)
@@ -7143,13 +7143,13 @@ func (diagnostics *BootDiagnostics) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &BootDiagnostics_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if diagnostics.Enabled != nil {
 		enabled := *diagnostics.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘StorageUri’:
+	// Set property "StorageUri":
 	if diagnostics.StorageUri != nil {
 		storageUri := *diagnostics.StorageUri
 		result.StorageUri = &storageUri
@@ -7169,13 +7169,13 @@ func (diagnostics *BootDiagnostics) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BootDiagnostics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		diagnostics.Enabled = &enabled
 	}
 
-	// Set property ‘StorageUri’:
+	// Set property "StorageUri":
 	if typedInput.StorageUri != nil {
 		storageUri := *typedInput.StorageUri
 		diagnostics.StorageUri = &storageUri
@@ -7250,13 +7250,13 @@ func (diagnostics *BootDiagnostics_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BootDiagnostics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		diagnostics.Enabled = &enabled
 	}
 
-	// Set property ‘StorageUri’:
+	// Set property "StorageUri":
 	if typedInput.StorageUri != nil {
 		storageUri := *typedInput.StorageUri
 		diagnostics.StorageUri = &storageUri
@@ -7332,19 +7332,19 @@ func (view *BootDiagnosticsInstanceView_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BootDiagnosticsInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConsoleScreenshotBlobUri’:
+	// Set property "ConsoleScreenshotBlobUri":
 	if typedInput.ConsoleScreenshotBlobUri != nil {
 		consoleScreenshotBlobUri := *typedInput.ConsoleScreenshotBlobUri
 		view.ConsoleScreenshotBlobUri = &consoleScreenshotBlobUri
 	}
 
-	// Set property ‘SerialConsoleLogBlobUri’:
+	// Set property "SerialConsoleLogBlobUri":
 	if typedInput.SerialConsoleLogBlobUri != nil {
 		serialConsoleLogBlobUri := *typedInput.SerialConsoleLogBlobUri
 		view.SerialConsoleLogBlobUri = &serialConsoleLogBlobUri
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		var status1 InstanceViewStatus_STATUS
 		err := status1.PopulateFromARM(owner, *typedInput.Status)
@@ -7447,37 +7447,37 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &DataDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if disk.DeleteOption != nil {
 		deleteOption := *disk.DeleteOption
 		result.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DetachOption’:
+	// Set property "DetachOption":
 	if disk.DetachOption != nil {
 		detachOption := *disk.DetachOption
 		result.DetachOption = &detachOption
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if disk.Image != nil {
 		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
 		if err != nil {
@@ -7487,13 +7487,13 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.Image = &image
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if disk.Lun != nil {
 		lun := *disk.Lun
 		result.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -7503,19 +7503,19 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ToBeDetached’:
+	// Set property "ToBeDetached":
 	if disk.ToBeDetached != nil {
 		toBeDetached := *disk.ToBeDetached
 		result.ToBeDetached = &toBeDetached
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if disk.Vhd != nil {
 		vhd_ARM, err := (*disk.Vhd).ConvertToARM(resolved)
 		if err != nil {
@@ -7525,7 +7525,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -7545,37 +7545,37 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DetachOption’:
+	// Set property "DetachOption":
 	if typedInput.DetachOption != nil {
 		detachOption := *typedInput.DetachOption
 		disk.DetachOption = &detachOption
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -7586,13 +7586,13 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		disk.Image = &image
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -7603,19 +7603,19 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘ToBeDetached’:
+	// Set property "ToBeDetached":
 	if typedInput.ToBeDetached != nil {
 		toBeDetached := *typedInput.ToBeDetached
 		disk.ToBeDetached = &toBeDetached
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -7626,7 +7626,7 @@ func (disk *DataDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -7877,49 +7877,49 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DetachOption’:
+	// Set property "DetachOption":
 	if typedInput.DetachOption != nil {
 		detachOption := *typedInput.DetachOption
 		disk.DetachOption = &detachOption
 	}
 
-	// Set property ‘DiskIOPSReadWrite’:
+	// Set property "DiskIOPSReadWrite":
 	if typedInput.DiskIOPSReadWrite != nil {
 		diskIOPSReadWrite := *typedInput.DiskIOPSReadWrite
 		disk.DiskIOPSReadWrite = &diskIOPSReadWrite
 	}
 
-	// Set property ‘DiskMBpsReadWrite’:
+	// Set property "DiskMBpsReadWrite":
 	if typedInput.DiskMBpsReadWrite != nil {
 		diskMBpsReadWrite := *typedInput.DiskMBpsReadWrite
 		disk.DiskMBpsReadWrite = &diskMBpsReadWrite
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk_STATUS
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -7930,13 +7930,13 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		disk.Image = &image
 	}
 
-	// Set property ‘Lun’:
+	// Set property "Lun":
 	if typedInput.Lun != nil {
 		lun := *typedInput.Lun
 		disk.Lun = &lun
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -7947,19 +7947,19 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘ToBeDetached’:
+	// Set property "ToBeDetached":
 	if typedInput.ToBeDetached != nil {
 		toBeDetached := *typedInput.ToBeDetached
 		disk.ToBeDetached = &toBeDetached
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk_STATUS
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -7970,7 +7970,7 @@ func (disk *DataDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -8222,7 +8222,7 @@ func (view *DiskInstanceView_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	for _, item := range typedInput.EncryptionSettings {
 		var item1 DiskEncryptionSettings_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8232,13 +8232,13 @@ func (view *DiskInstanceView_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		view.EncryptionSettings = append(view.EncryptionSettings, item1)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		view.Name = &name
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8718,13 +8718,13 @@ func (reference *ImageReference) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ImageReference_ARM{}
 
-	// Set property ‘CommunityGalleryImageId’:
+	// Set property "CommunityGalleryImageId":
 	if reference.CommunityGalleryImageId != nil {
 		communityGalleryImageId := *reference.CommunityGalleryImageId
 		result.CommunityGalleryImageId = &communityGalleryImageId
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -8734,31 +8734,31 @@ func (reference *ImageReference) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Id = &reference1
 	}
 
-	// Set property ‘Offer’:
+	// Set property "Offer":
 	if reference.Offer != nil {
 		offer := *reference.Offer
 		result.Offer = &offer
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if reference.Publisher != nil {
 		publisher := *reference.Publisher
 		result.Publisher = &publisher
 	}
 
-	// Set property ‘SharedGalleryImageId’:
+	// Set property "SharedGalleryImageId":
 	if reference.SharedGalleryImageId != nil {
 		sharedGalleryImageId := *reference.SharedGalleryImageId
 		result.SharedGalleryImageId = &sharedGalleryImageId
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if reference.Sku != nil {
 		sku := *reference.Sku
 		result.Sku = &sku
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if reference.Version != nil {
 		version := *reference.Version
 		result.Version = &version
@@ -8778,39 +8778,39 @@ func (reference *ImageReference) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CommunityGalleryImageId’:
+	// Set property "CommunityGalleryImageId":
 	if typedInput.CommunityGalleryImageId != nil {
 		communityGalleryImageId := *typedInput.CommunityGalleryImageId
 		reference.CommunityGalleryImageId = &communityGalleryImageId
 	}
 
-	// Set property ‘Offer’:
+	// Set property "Offer":
 	if typedInput.Offer != nil {
 		offer := *typedInput.Offer
 		reference.Offer = &offer
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		reference.Publisher = &publisher
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘SharedGalleryImageId’:
+	// Set property "SharedGalleryImageId":
 	if typedInput.SharedGalleryImageId != nil {
 		sharedGalleryImageId := *typedInput.SharedGalleryImageId
 		reference.SharedGalleryImageId = &sharedGalleryImageId
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		sku := *typedInput.Sku
 		reference.Sku = &sku
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		reference.Version = &version
@@ -8921,49 +8921,49 @@ func (reference *ImageReference_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CommunityGalleryImageId’:
+	// Set property "CommunityGalleryImageId":
 	if typedInput.CommunityGalleryImageId != nil {
 		communityGalleryImageId := *typedInput.CommunityGalleryImageId
 		reference.CommunityGalleryImageId = &communityGalleryImageId
 	}
 
-	// Set property ‘ExactVersion’:
+	// Set property "ExactVersion":
 	if typedInput.ExactVersion != nil {
 		exactVersion := *typedInput.ExactVersion
 		reference.ExactVersion = &exactVersion
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
 	}
 
-	// Set property ‘Offer’:
+	// Set property "Offer":
 	if typedInput.Offer != nil {
 		offer := *typedInput.Offer
 		reference.Offer = &offer
 	}
 
-	// Set property ‘Publisher’:
+	// Set property "Publisher":
 	if typedInput.Publisher != nil {
 		publisher := *typedInput.Publisher
 		reference.Publisher = &publisher
 	}
 
-	// Set property ‘SharedGalleryImageId’:
+	// Set property "SharedGalleryImageId":
 	if typedInput.SharedGalleryImageId != nil {
 		sharedGalleryImageId := *typedInput.SharedGalleryImageId
 		reference.SharedGalleryImageId = &sharedGalleryImageId
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		sku := *typedInput.Sku
 		reference.Sku = &sku
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		reference.Version = &version
@@ -9067,31 +9067,31 @@ func (status *InstanceViewStatus_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InstanceViewStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		status.Code = &code
 	}
 
-	// Set property ‘DisplayStatus’:
+	// Set property "DisplayStatus":
 	if typedInput.DisplayStatus != nil {
 		displayStatus := *typedInput.DisplayStatus
 		status.DisplayStatus = &displayStatus
 	}
 
-	// Set property ‘Level’:
+	// Set property "Level":
 	if typedInput.Level != nil {
 		level := *typedInput.Level
 		status.Level = &level
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		status.Message = &message
 	}
 
-	// Set property ‘Time’:
+	// Set property "Time":
 	if typedInput.Time != nil {
 		time := *typedInput.Time
 		status.Time = &time
@@ -9184,13 +9184,13 @@ func (reference *KeyVaultSecretReference_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultSecretReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if typedInput.SecretUrl != nil {
 		secretUrl := *typedInput.SecretUrl
 		reference.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -9275,13 +9275,13 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &LinuxConfiguration_ARM{}
 
-	// Set property ‘DisablePasswordAuthentication’:
+	// Set property "DisablePasswordAuthentication":
 	if configuration.DisablePasswordAuthentication != nil {
 		disablePasswordAuthentication := *configuration.DisablePasswordAuthentication
 		result.DisablePasswordAuthentication = &disablePasswordAuthentication
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if configuration.PatchSettings != nil {
 		patchSettings_ARM, err := (*configuration.PatchSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -9291,13 +9291,13 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 		result.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if configuration.ProvisionVMAgent != nil {
 		provisionVMAgent := *configuration.ProvisionVMAgent
 		result.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if configuration.Ssh != nil {
 		ssh_ARM, err := (*configuration.Ssh).ConvertToARM(resolved)
 		if err != nil {
@@ -9321,13 +9321,13 @@ func (configuration *LinuxConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisablePasswordAuthentication’:
+	// Set property "DisablePasswordAuthentication":
 	if typedInput.DisablePasswordAuthentication != nil {
 		disablePasswordAuthentication := *typedInput.DisablePasswordAuthentication
 		configuration.DisablePasswordAuthentication = &disablePasswordAuthentication
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 LinuxPatchSettings
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -9338,13 +9338,13 @@ func (configuration *LinuxConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 SshConfiguration
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -9484,13 +9484,13 @@ func (configuration *LinuxConfiguration_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisablePasswordAuthentication’:
+	// Set property "DisablePasswordAuthentication":
 	if typedInput.DisablePasswordAuthentication != nil {
 		disablePasswordAuthentication := *typedInput.DisablePasswordAuthentication
 		configuration.DisablePasswordAuthentication = &disablePasswordAuthentication
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 LinuxPatchSettings_STATUS
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -9501,13 +9501,13 @@ func (configuration *LinuxConfiguration_STATUS) PopulateFromARM(owner genruntime
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 SshConfiguration_STATUS
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -9650,43 +9650,43 @@ func (status *MaintenanceRedeployStatus_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceRedeployStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IsCustomerInitiatedMaintenanceAllowed’:
+	// Set property "IsCustomerInitiatedMaintenanceAllowed":
 	if typedInput.IsCustomerInitiatedMaintenanceAllowed != nil {
 		isCustomerInitiatedMaintenanceAllowed := *typedInput.IsCustomerInitiatedMaintenanceAllowed
 		status.IsCustomerInitiatedMaintenanceAllowed = &isCustomerInitiatedMaintenanceAllowed
 	}
 
-	// Set property ‘LastOperationMessage’:
+	// Set property "LastOperationMessage":
 	if typedInput.LastOperationMessage != nil {
 		lastOperationMessage := *typedInput.LastOperationMessage
 		status.LastOperationMessage = &lastOperationMessage
 	}
 
-	// Set property ‘LastOperationResultCode’:
+	// Set property "LastOperationResultCode":
 	if typedInput.LastOperationResultCode != nil {
 		lastOperationResultCode := *typedInput.LastOperationResultCode
 		status.LastOperationResultCode = &lastOperationResultCode
 	}
 
-	// Set property ‘MaintenanceWindowEndTime’:
+	// Set property "MaintenanceWindowEndTime":
 	if typedInput.MaintenanceWindowEndTime != nil {
 		maintenanceWindowEndTime := *typedInput.MaintenanceWindowEndTime
 		status.MaintenanceWindowEndTime = &maintenanceWindowEndTime
 	}
 
-	// Set property ‘MaintenanceWindowStartTime’:
+	// Set property "MaintenanceWindowStartTime":
 	if typedInput.MaintenanceWindowStartTime != nil {
 		maintenanceWindowStartTime := *typedInput.MaintenanceWindowStartTime
 		status.MaintenanceWindowStartTime = &maintenanceWindowStartTime
 	}
 
-	// Set property ‘PreMaintenanceWindowEndTime’:
+	// Set property "PreMaintenanceWindowEndTime":
 	if typedInput.PreMaintenanceWindowEndTime != nil {
 		preMaintenanceWindowEndTime := *typedInput.PreMaintenanceWindowEndTime
 		status.PreMaintenanceWindowEndTime = &preMaintenanceWindowEndTime
 	}
 
-	// Set property ‘PreMaintenanceWindowStartTime’:
+	// Set property "PreMaintenanceWindowStartTime":
 	if typedInput.PreMaintenanceWindowStartTime != nil {
 		preMaintenanceWindowStartTime := *typedInput.PreMaintenanceWindowStartTime
 		status.PreMaintenanceWindowStartTime = &preMaintenanceWindowStartTime
@@ -9797,7 +9797,7 @@ func (reference *NetworkInterfaceReference) ConvertToARM(resolved genruntime.Con
 	}
 	result := &NetworkInterfaceReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -9807,7 +9807,7 @@ func (reference *NetworkInterfaceReference) ConvertToARM(resolved genruntime.Con
 		result.Id = &reference1
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if reference.DeleteOption != nil || reference.Primary != nil {
 		result.Properties = &NetworkInterfaceReferenceProperties_ARM{}
 	}
@@ -9834,7 +9834,7 @@ func (reference *NetworkInterfaceReference) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -9843,7 +9843,7 @@ func (reference *NetworkInterfaceReference) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -9852,7 +9852,7 @@ func (reference *NetworkInterfaceReference) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -9950,7 +9950,7 @@ func (reference *NetworkInterfaceReference_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -9959,13 +9959,13 @@ func (reference *NetworkInterfaceReference_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -10078,25 +10078,25 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &OSDisk_ARM{}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if disk.Caching != nil {
 		caching := *disk.Caching
 		result.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if disk.CreateOption != nil {
 		createOption := *disk.CreateOption
 		result.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if disk.DeleteOption != nil {
 		deleteOption := *disk.DeleteOption
 		result.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if disk.DiffDiskSettings != nil {
 		diffDiskSettings_ARM, err := (*disk.DiffDiskSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -10106,13 +10106,13 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if disk.DiskSizeGB != nil {
 		diskSizeGB := *disk.DiskSizeGB
 		result.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	if disk.EncryptionSettings != nil {
 		encryptionSettings_ARM, err := (*disk.EncryptionSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -10122,7 +10122,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.EncryptionSettings = &encryptionSettings
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if disk.Image != nil {
 		image_ARM, err := (*disk.Image).ConvertToARM(resolved)
 		if err != nil {
@@ -10132,7 +10132,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if disk.ManagedDisk != nil {
 		managedDisk_ARM, err := (*disk.ManagedDisk).ConvertToARM(resolved)
 		if err != nil {
@@ -10142,19 +10142,19 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if disk.Name != nil {
 		name := *disk.Name
 		result.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if disk.OsType != nil {
 		osType := *disk.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if disk.Vhd != nil {
 		vhd_ARM, err := (*disk.Vhd).ConvertToARM(resolved)
 		if err != nil {
@@ -10164,7 +10164,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		result.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if disk.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *disk.WriteAcceleratorEnabled
 		result.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -10184,25 +10184,25 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -10213,13 +10213,13 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	if typedInput.EncryptionSettings != nil {
 		var encryptionSettings1 DiskEncryptionSettings
 		err := encryptionSettings1.PopulateFromARM(owner, *typedInput.EncryptionSettings)
@@ -10230,7 +10230,7 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.EncryptionSettings = &encryptionSettings
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -10241,7 +10241,7 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -10252,19 +10252,19 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -10275,7 +10275,7 @@ func (disk *OSDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -10550,25 +10550,25 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OSDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Caching’:
+	// Set property "Caching":
 	if typedInput.Caching != nil {
 		caching := *typedInput.Caching
 		disk.Caching = &caching
 	}
 
-	// Set property ‘CreateOption’:
+	// Set property "CreateOption":
 	if typedInput.CreateOption != nil {
 		createOption := *typedInput.CreateOption
 		disk.CreateOption = &createOption
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	if typedInput.DeleteOption != nil {
 		deleteOption := *typedInput.DeleteOption
 		disk.DeleteOption = &deleteOption
 	}
 
-	// Set property ‘DiffDiskSettings’:
+	// Set property "DiffDiskSettings":
 	if typedInput.DiffDiskSettings != nil {
 		var diffDiskSettings1 DiffDiskSettings_STATUS
 		err := diffDiskSettings1.PopulateFromARM(owner, *typedInput.DiffDiskSettings)
@@ -10579,13 +10579,13 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.DiffDiskSettings = &diffDiskSettings
 	}
 
-	// Set property ‘DiskSizeGB’:
+	// Set property "DiskSizeGB":
 	if typedInput.DiskSizeGB != nil {
 		diskSizeGB := *typedInput.DiskSizeGB
 		disk.DiskSizeGB = &diskSizeGB
 	}
 
-	// Set property ‘EncryptionSettings’:
+	// Set property "EncryptionSettings":
 	if typedInput.EncryptionSettings != nil {
 		var encryptionSettings1 DiskEncryptionSettings_STATUS
 		err := encryptionSettings1.PopulateFromARM(owner, *typedInput.EncryptionSettings)
@@ -10596,7 +10596,7 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.EncryptionSettings = &encryptionSettings
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	if typedInput.Image != nil {
 		var image1 VirtualHardDisk_STATUS
 		err := image1.PopulateFromARM(owner, *typedInput.Image)
@@ -10607,7 +10607,7 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.Image = &image
 	}
 
-	// Set property ‘ManagedDisk’:
+	// Set property "ManagedDisk":
 	if typedInput.ManagedDisk != nil {
 		var managedDisk1 ManagedDiskParameters_STATUS
 		err := managedDisk1.PopulateFromARM(owner, *typedInput.ManagedDisk)
@@ -10618,19 +10618,19 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.ManagedDisk = &managedDisk
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		disk.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		disk.OsType = &osType
 	}
 
-	// Set property ‘Vhd’:
+	// Set property "Vhd":
 	if typedInput.Vhd != nil {
 		var vhd1 VirtualHardDisk_STATUS
 		err := vhd1.PopulateFromARM(owner, *typedInput.Vhd)
@@ -10641,7 +10641,7 @@ func (disk *OSDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		disk.Vhd = &vhd
 	}
 
-	// Set property ‘WriteAcceleratorEnabled’:
+	// Set property "WriteAcceleratorEnabled":
 	if typedInput.WriteAcceleratorEnabled != nil {
 		writeAcceleratorEnabled := *typedInput.WriteAcceleratorEnabled
 		disk.WriteAcceleratorEnabled = &writeAcceleratorEnabled
@@ -10918,13 +10918,13 @@ func (profile *TerminateNotificationProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &TerminateNotificationProfile_ARM{}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if profile.Enable != nil {
 		enable := *profile.Enable
 		result.Enable = &enable
 	}
 
-	// Set property ‘NotBeforeTimeout’:
+	// Set property "NotBeforeTimeout":
 	if profile.NotBeforeTimeout != nil {
 		notBeforeTimeout := *profile.NotBeforeTimeout
 		result.NotBeforeTimeout = &notBeforeTimeout
@@ -10944,13 +10944,13 @@ func (profile *TerminateNotificationProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TerminateNotificationProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		profile.Enable = &enable
 	}
 
-	// Set property ‘NotBeforeTimeout’:
+	// Set property "NotBeforeTimeout":
 	if typedInput.NotBeforeTimeout != nil {
 		notBeforeTimeout := *typedInput.NotBeforeTimeout
 		profile.NotBeforeTimeout = &notBeforeTimeout
@@ -11025,13 +11025,13 @@ func (profile *TerminateNotificationProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TerminateNotificationProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		profile.Enable = &enable
 	}
 
-	// Set property ‘NotBeforeTimeout’:
+	// Set property "NotBeforeTimeout":
 	if typedInput.NotBeforeTimeout != nil {
 		notBeforeTimeout := *typedInput.NotBeforeTimeout
 		profile.NotBeforeTimeout = &notBeforeTimeout
@@ -11101,13 +11101,13 @@ func (settings *UefiSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &UefiSettings_ARM{}
 
-	// Set property ‘SecureBootEnabled’:
+	// Set property "SecureBootEnabled":
 	if settings.SecureBootEnabled != nil {
 		secureBootEnabled := *settings.SecureBootEnabled
 		result.SecureBootEnabled = &secureBootEnabled
 	}
 
-	// Set property ‘VTpmEnabled’:
+	// Set property "VTpmEnabled":
 	if settings.VTpmEnabled != nil {
 		vTpmEnabled := *settings.VTpmEnabled
 		result.VTpmEnabled = &vTpmEnabled
@@ -11127,13 +11127,13 @@ func (settings *UefiSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UefiSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecureBootEnabled’:
+	// Set property "SecureBootEnabled":
 	if typedInput.SecureBootEnabled != nil {
 		secureBootEnabled := *typedInput.SecureBootEnabled
 		settings.SecureBootEnabled = &secureBootEnabled
 	}
 
-	// Set property ‘VTpmEnabled’:
+	// Set property "VTpmEnabled":
 	if typedInput.VTpmEnabled != nil {
 		vTpmEnabled := *typedInput.VTpmEnabled
 		settings.VTpmEnabled = &vTpmEnabled
@@ -11218,13 +11218,13 @@ func (settings *UefiSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UefiSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecureBootEnabled’:
+	// Set property "SecureBootEnabled":
 	if typedInput.SecureBootEnabled != nil {
 		secureBootEnabled := *typedInput.SecureBootEnabled
 		settings.SecureBootEnabled = &secureBootEnabled
 	}
 
-	// Set property ‘VTpmEnabled’:
+	// Set property "VTpmEnabled":
 	if typedInput.VTpmEnabled != nil {
 		vTpmEnabled := *typedInput.VTpmEnabled
 		settings.VTpmEnabled = &vTpmEnabled
@@ -11338,7 +11338,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &VaultSecretGroup_ARM{}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if group.SourceVault != nil {
 		sourceVault_ARM, err := (*group.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -11348,7 +11348,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.SourceVault = &sourceVault
 	}
 
-	// Set property ‘VaultCertificates’:
+	// Set property "VaultCertificates":
 	for _, item := range group.VaultCertificates {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -11371,7 +11371,7 @@ func (group *VaultSecretGroup) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultSecretGroup_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -11382,7 +11382,7 @@ func (group *VaultSecretGroup) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		group.SourceVault = &sourceVault
 	}
 
-	// Set property ‘VaultCertificates’:
+	// Set property "VaultCertificates":
 	for _, item := range typedInput.VaultCertificates {
 		var item1 VaultCertificate
 		err := item1.PopulateFromARM(owner, item)
@@ -11499,7 +11499,7 @@ func (group *VaultSecretGroup_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultSecretGroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -11510,7 +11510,7 @@ func (group *VaultSecretGroup_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		group.SourceVault = &sourceVault
 	}
 
-	// Set property ‘VaultCertificates’:
+	// Set property "VaultCertificates":
 	for _, item := range typedInput.VaultCertificates {
 		var item1 VaultCertificate_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11628,7 +11628,7 @@ func (view *VirtualMachineAgentInstanceView_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineAgentInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExtensionHandlers’:
+	// Set property "ExtensionHandlers":
 	for _, item := range typedInput.ExtensionHandlers {
 		var item1 VirtualMachineExtensionHandlerInstanceView_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11638,7 +11638,7 @@ func (view *VirtualMachineAgentInstanceView_STATUS) PopulateFromARM(owner genrun
 		view.ExtensionHandlers = append(view.ExtensionHandlers, item1)
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11648,7 +11648,7 @@ func (view *VirtualMachineAgentInstanceView_STATUS) PopulateFromARM(owner genrun
 		view.Statuses = append(view.Statuses, item1)
 	}
 
-	// Set property ‘VmAgentVersion’:
+	// Set property "VmAgentVersion":
 	if typedInput.VmAgentVersion != nil {
 		vmAgentVersion := *typedInput.VmAgentVersion
 		view.VmAgentVersion = &vmAgentVersion
@@ -11782,13 +11782,13 @@ func (view *VirtualMachineExtensionInstanceView_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineExtensionInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		view.Name = &name
 	}
 
-	// Set property ‘Statuses’:
+	// Set property "Statuses":
 	for _, item := range typedInput.Statuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11798,7 +11798,7 @@ func (view *VirtualMachineExtensionInstanceView_STATUS) PopulateFromARM(owner ge
 		view.Statuses = append(view.Statuses, item1)
 	}
 
-	// Set property ‘Substatuses’:
+	// Set property "Substatuses":
 	for _, item := range typedInput.Substatuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11808,13 +11808,13 @@ func (view *VirtualMachineExtensionInstanceView_STATUS) PopulateFromARM(owner ge
 		view.Substatuses = append(view.Substatuses, item1)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		view.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	if typedInput.TypeHandlerVersion != nil {
 		typeHandlerVersion := *typedInput.TypeHandlerVersion
 		view.TypeHandlerVersion = &typeHandlerVersion
@@ -11956,7 +11956,7 @@ func (status *VirtualMachineHealthStatus_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineHealthStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		var status2 InstanceViewStatus_STATUS
 		err := status2.PopulateFromARM(owner, *typedInput.Status)
@@ -12038,13 +12038,13 @@ func (identities *VirtualMachineIdentity_UserAssignedIdentities_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -12125,13 +12125,13 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) ConvertToARM(r
 	}
 	result := &VirtualMachineNetworkInterfaceConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.DeleteOption != nil ||
 		configuration.DnsSettings != nil ||
 		configuration.DscpConfiguration != nil ||
@@ -12209,7 +12209,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineNetworkInterfaceConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -12218,7 +12218,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -12232,7 +12232,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘DscpConfiguration’:
+	// Set property "DscpConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DscpConfiguration != nil {
@@ -12246,7 +12246,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -12255,7 +12255,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘EnableFpga’:
+	// Set property "EnableFpga":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFpga != nil {
@@ -12264,7 +12264,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -12273,7 +12273,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -12286,13 +12286,13 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -12306,7 +12306,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration) PopulateFromAR
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -12564,7 +12564,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineNetworkInterfaceConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -12573,7 +12573,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -12587,7 +12587,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘DscpConfiguration’:
+	// Set property "DscpConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DscpConfiguration != nil {
@@ -12601,7 +12601,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -12610,7 +12610,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘EnableFpga’:
+	// Set property "EnableFpga":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFpga != nil {
@@ -12619,7 +12619,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -12628,7 +12628,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -12641,13 +12641,13 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -12661,7 +12661,7 @@ func (configuration *VirtualMachineNetworkInterfaceConfiguration_STATUS) Populat
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -12912,7 +12912,7 @@ func (status *VirtualMachinePatchStatus_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachinePatchStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailablePatchSummary’:
+	// Set property "AvailablePatchSummary":
 	if typedInput.AvailablePatchSummary != nil {
 		var availablePatchSummary1 AvailablePatchSummary_STATUS
 		err := availablePatchSummary1.PopulateFromARM(owner, *typedInput.AvailablePatchSummary)
@@ -12923,7 +12923,7 @@ func (status *VirtualMachinePatchStatus_STATUS) PopulateFromARM(owner genruntime
 		status.AvailablePatchSummary = &availablePatchSummary
 	}
 
-	// Set property ‘ConfigurationStatuses’:
+	// Set property "ConfigurationStatuses":
 	for _, item := range typedInput.ConfigurationStatuses {
 		var item1 InstanceViewStatus_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -12933,7 +12933,7 @@ func (status *VirtualMachinePatchStatus_STATUS) PopulateFromARM(owner genruntime
 		status.ConfigurationStatuses = append(status.ConfigurationStatuses, item1)
 	}
 
-	// Set property ‘LastPatchInstallationSummary’:
+	// Set property "LastPatchInstallationSummary":
 	if typedInput.LastPatchInstallationSummary != nil {
 		var lastPatchInstallationSummary1 LastPatchInstallationSummary_STATUS
 		err := lastPatchInstallationSummary1.PopulateFromARM(owner, *typedInput.LastPatchInstallationSummary)
@@ -13076,25 +13076,25 @@ func (application *VMGalleryApplication) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &VMGalleryApplication_ARM{}
 
-	// Set property ‘ConfigurationReference’:
+	// Set property "ConfigurationReference":
 	if application.ConfigurationReference != nil {
 		configurationReference := *application.ConfigurationReference
 		result.ConfigurationReference = &configurationReference
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	if application.EnableAutomaticUpgrade != nil {
 		enableAutomaticUpgrade := *application.EnableAutomaticUpgrade
 		result.EnableAutomaticUpgrade = &enableAutomaticUpgrade
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if application.Order != nil {
 		order := *application.Order
 		result.Order = &order
 	}
 
-	// Set property ‘PackageReferenceId’:
+	// Set property "PackageReferenceId":
 	if application.PackageReferenceReference != nil {
 		packageReferenceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*application.PackageReferenceReference)
 		if err != nil {
@@ -13104,13 +13104,13 @@ func (application *VMGalleryApplication) ConvertToARM(resolved genruntime.Conver
 		result.PackageReferenceId = &packageReferenceReference
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if application.Tags != nil {
 		tags := *application.Tags
 		result.Tags = &tags
 	}
 
-	// Set property ‘TreatFailureAsDeploymentFailure’:
+	// Set property "TreatFailureAsDeploymentFailure":
 	if application.TreatFailureAsDeploymentFailure != nil {
 		treatFailureAsDeploymentFailure := *application.TreatFailureAsDeploymentFailure
 		result.TreatFailureAsDeploymentFailure = &treatFailureAsDeploymentFailure
@@ -13130,33 +13130,33 @@ func (application *VMGalleryApplication) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VMGalleryApplication_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConfigurationReference’:
+	// Set property "ConfigurationReference":
 	if typedInput.ConfigurationReference != nil {
 		configurationReference := *typedInput.ConfigurationReference
 		application.ConfigurationReference = &configurationReference
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	if typedInput.EnableAutomaticUpgrade != nil {
 		enableAutomaticUpgrade := *typedInput.EnableAutomaticUpgrade
 		application.EnableAutomaticUpgrade = &enableAutomaticUpgrade
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if typedInput.Order != nil {
 		order := *typedInput.Order
 		application.Order = &order
 	}
 
-	// no assignment for property ‘PackageReferenceReference’
+	// no assignment for property "PackageReferenceReference"
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		tags := *typedInput.Tags
 		application.Tags = &tags
 	}
 
-	// Set property ‘TreatFailureAsDeploymentFailure’:
+	// Set property "TreatFailureAsDeploymentFailure":
 	if typedInput.TreatFailureAsDeploymentFailure != nil {
 		treatFailureAsDeploymentFailure := *typedInput.TreatFailureAsDeploymentFailure
 		application.TreatFailureAsDeploymentFailure = &treatFailureAsDeploymentFailure
@@ -13279,37 +13279,37 @@ func (application *VMGalleryApplication_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VMGalleryApplication_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConfigurationReference’:
+	// Set property "ConfigurationReference":
 	if typedInput.ConfigurationReference != nil {
 		configurationReference := *typedInput.ConfigurationReference
 		application.ConfigurationReference = &configurationReference
 	}
 
-	// Set property ‘EnableAutomaticUpgrade’:
+	// Set property "EnableAutomaticUpgrade":
 	if typedInput.EnableAutomaticUpgrade != nil {
 		enableAutomaticUpgrade := *typedInput.EnableAutomaticUpgrade
 		application.EnableAutomaticUpgrade = &enableAutomaticUpgrade
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if typedInput.Order != nil {
 		order := *typedInput.Order
 		application.Order = &order
 	}
 
-	// Set property ‘PackageReferenceId’:
+	// Set property "PackageReferenceId":
 	if typedInput.PackageReferenceId != nil {
 		packageReferenceId := *typedInput.PackageReferenceId
 		application.PackageReferenceId = &packageReferenceId
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		tags := *typedInput.Tags
 		application.Tags = &tags
 	}
 
-	// Set property ‘TreatFailureAsDeploymentFailure’:
+	// Set property "TreatFailureAsDeploymentFailure":
 	if typedInput.TreatFailureAsDeploymentFailure != nil {
 		treatFailureAsDeploymentFailure := *typedInput.TreatFailureAsDeploymentFailure
 		application.TreatFailureAsDeploymentFailure = &treatFailureAsDeploymentFailure
@@ -13413,13 +13413,13 @@ func (properties *VMSizeProperties) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &VMSizeProperties_ARM{}
 
-	// Set property ‘VCPUsAvailable’:
+	// Set property "VCPUsAvailable":
 	if properties.VCPUsAvailable != nil {
 		vcpUsAvailable := *properties.VCPUsAvailable
 		result.VCPUsAvailable = &vcpUsAvailable
 	}
 
-	// Set property ‘VCPUsPerCore’:
+	// Set property "VCPUsPerCore":
 	if properties.VCPUsPerCore != nil {
 		vcpUsPerCore := *properties.VCPUsPerCore
 		result.VCPUsPerCore = &vcpUsPerCore
@@ -13439,13 +13439,13 @@ func (properties *VMSizeProperties) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VMSizeProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VCPUsAvailable’:
+	// Set property "VCPUsAvailable":
 	if typedInput.VCPUsAvailable != nil {
 		vcpUsAvailable := *typedInput.VCPUsAvailable
 		properties.VCPUsAvailable = &vcpUsAvailable
 	}
 
-	// Set property ‘VCPUsPerCore’:
+	// Set property "VCPUsPerCore":
 	if typedInput.VCPUsPerCore != nil {
 		vcpUsPerCore := *typedInput.VCPUsPerCore
 		properties.VCPUsPerCore = &vcpUsPerCore
@@ -13510,13 +13510,13 @@ func (properties *VMSizeProperties_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VMSizeProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VCPUsAvailable’:
+	// Set property "VCPUsAvailable":
 	if typedInput.VCPUsAvailable != nil {
 		vcpUsAvailable := *typedInput.VCPUsAvailable
 		properties.VCPUsAvailable = &vcpUsAvailable
 	}
 
-	// Set property ‘VCPUsPerCore’:
+	// Set property "VCPUsPerCore":
 	if typedInput.VCPUsPerCore != nil {
 		vcpUsPerCore := *typedInput.VCPUsPerCore
 		properties.VCPUsPerCore = &vcpUsPerCore
@@ -13580,7 +13580,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &WindowsConfiguration_ARM{}
 
-	// Set property ‘AdditionalUnattendContent’:
+	// Set property "AdditionalUnattendContent":
 	for _, item := range configuration.AdditionalUnattendContent {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -13589,13 +13589,13 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		result.AdditionalUnattendContent = append(result.AdditionalUnattendContent, *item_ARM.(*AdditionalUnattendContent_ARM))
 	}
 
-	// Set property ‘EnableAutomaticUpdates’:
+	// Set property "EnableAutomaticUpdates":
 	if configuration.EnableAutomaticUpdates != nil {
 		enableAutomaticUpdates := *configuration.EnableAutomaticUpdates
 		result.EnableAutomaticUpdates = &enableAutomaticUpdates
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if configuration.PatchSettings != nil {
 		patchSettings_ARM, err := (*configuration.PatchSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -13605,19 +13605,19 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		result.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if configuration.ProvisionVMAgent != nil {
 		provisionVMAgent := *configuration.ProvisionVMAgent
 		result.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if configuration.TimeZone != nil {
 		timeZone := *configuration.TimeZone
 		result.TimeZone = &timeZone
 	}
 
-	// Set property ‘WinRM’:
+	// Set property "WinRM":
 	if configuration.WinRM != nil {
 		winRM_ARM, err := (*configuration.WinRM).ConvertToARM(resolved)
 		if err != nil {
@@ -13641,7 +13641,7 @@ func (configuration *WindowsConfiguration) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalUnattendContent’:
+	// Set property "AdditionalUnattendContent":
 	for _, item := range typedInput.AdditionalUnattendContent {
 		var item1 AdditionalUnattendContent
 		err := item1.PopulateFromARM(owner, item)
@@ -13651,13 +13651,13 @@ func (configuration *WindowsConfiguration) PopulateFromARM(owner genruntime.Arbi
 		configuration.AdditionalUnattendContent = append(configuration.AdditionalUnattendContent, item1)
 	}
 
-	// Set property ‘EnableAutomaticUpdates’:
+	// Set property "EnableAutomaticUpdates":
 	if typedInput.EnableAutomaticUpdates != nil {
 		enableAutomaticUpdates := *typedInput.EnableAutomaticUpdates
 		configuration.EnableAutomaticUpdates = &enableAutomaticUpdates
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 PatchSettings
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -13668,19 +13668,19 @@ func (configuration *WindowsConfiguration) PopulateFromARM(owner genruntime.Arbi
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if typedInput.TimeZone != nil {
 		timeZone := *typedInput.TimeZone
 		configuration.TimeZone = &timeZone
 	}
 
-	// Set property ‘WinRM’:
+	// Set property "WinRM":
 	if typedInput.WinRM != nil {
 		var winRM1 WinRMConfiguration
 		err := winRM1.PopulateFromARM(owner, *typedInput.WinRM)
@@ -13864,7 +13864,7 @@ func (configuration *WindowsConfiguration_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalUnattendContent’:
+	// Set property "AdditionalUnattendContent":
 	for _, item := range typedInput.AdditionalUnattendContent {
 		var item1 AdditionalUnattendContent_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -13874,13 +13874,13 @@ func (configuration *WindowsConfiguration_STATUS) PopulateFromARM(owner genrunti
 		configuration.AdditionalUnattendContent = append(configuration.AdditionalUnattendContent, item1)
 	}
 
-	// Set property ‘EnableAutomaticUpdates’:
+	// Set property "EnableAutomaticUpdates":
 	if typedInput.EnableAutomaticUpdates != nil {
 		enableAutomaticUpdates := *typedInput.EnableAutomaticUpdates
 		configuration.EnableAutomaticUpdates = &enableAutomaticUpdates
 	}
 
-	// Set property ‘PatchSettings’:
+	// Set property "PatchSettings":
 	if typedInput.PatchSettings != nil {
 		var patchSettings1 PatchSettings_STATUS
 		err := patchSettings1.PopulateFromARM(owner, *typedInput.PatchSettings)
@@ -13891,19 +13891,19 @@ func (configuration *WindowsConfiguration_STATUS) PopulateFromARM(owner genrunti
 		configuration.PatchSettings = &patchSettings
 	}
 
-	// Set property ‘ProvisionVMAgent’:
+	// Set property "ProvisionVMAgent":
 	if typedInput.ProvisionVMAgent != nil {
 		provisionVMAgent := *typedInput.ProvisionVMAgent
 		configuration.ProvisionVMAgent = &provisionVMAgent
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if typedInput.TimeZone != nil {
 		timeZone := *typedInput.TimeZone
 		configuration.TimeZone = &timeZone
 	}
 
-	// Set property ‘WinRM’:
+	// Set property "WinRM":
 	if typedInput.WinRM != nil {
 		var winRM1 WinRMConfiguration_STATUS
 		err := winRM1.PopulateFromARM(owner, *typedInput.WinRM)
@@ -14080,25 +14080,25 @@ func (content *AdditionalUnattendContent) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &AdditionalUnattendContent_ARM{}
 
-	// Set property ‘ComponentName’:
+	// Set property "ComponentName":
 	if content.ComponentName != nil {
 		componentName := *content.ComponentName
 		result.ComponentName = &componentName
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if content.Content != nil {
 		content1 := *content.Content
 		result.Content = &content1
 	}
 
-	// Set property ‘PassName’:
+	// Set property "PassName":
 	if content.PassName != nil {
 		passName := *content.PassName
 		result.PassName = &passName
 	}
 
-	// Set property ‘SettingName’:
+	// Set property "SettingName":
 	if content.SettingName != nil {
 		settingName := *content.SettingName
 		result.SettingName = &settingName
@@ -14118,25 +14118,25 @@ func (content *AdditionalUnattendContent) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalUnattendContent_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComponentName’:
+	// Set property "ComponentName":
 	if typedInput.ComponentName != nil {
 		componentName := *typedInput.ComponentName
 		content.ComponentName = &componentName
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if typedInput.Content != nil {
 		content1 := *typedInput.Content
 		content.Content = &content1
 	}
 
-	// Set property ‘PassName’:
+	// Set property "PassName":
 	if typedInput.PassName != nil {
 		passName := *typedInput.PassName
 		content.PassName = &passName
 	}
 
-	// Set property ‘SettingName’:
+	// Set property "SettingName":
 	if typedInput.SettingName != nil {
 		settingName := *typedInput.SettingName
 		content.SettingName = &settingName
@@ -14245,25 +14245,25 @@ func (content *AdditionalUnattendContent_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdditionalUnattendContent_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComponentName’:
+	// Set property "ComponentName":
 	if typedInput.ComponentName != nil {
 		componentName := *typedInput.ComponentName
 		content.ComponentName = &componentName
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if typedInput.Content != nil {
 		content1 := *typedInput.Content
 		content.Content = &content1
 	}
 
-	// Set property ‘PassName’:
+	// Set property "PassName":
 	if typedInput.PassName != nil {
 		passName := *typedInput.PassName
 		content.PassName = &passName
 	}
 
-	// Set property ‘SettingName’:
+	// Set property "SettingName":
 	if typedInput.SettingName != nil {
 		settingName := *typedInput.SettingName
 		content.SettingName = &settingName
@@ -14376,19 +14376,19 @@ func (summary *AvailablePatchSummary_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AvailablePatchSummary_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssessmentActivityId’:
+	// Set property "AssessmentActivityId":
 	if typedInput.AssessmentActivityId != nil {
 		assessmentActivityId := *typedInput.AssessmentActivityId
 		summary.AssessmentActivityId = &assessmentActivityId
 	}
 
-	// Set property ‘CriticalAndSecurityPatchCount’:
+	// Set property "CriticalAndSecurityPatchCount":
 	if typedInput.CriticalAndSecurityPatchCount != nil {
 		criticalAndSecurityPatchCount := *typedInput.CriticalAndSecurityPatchCount
 		summary.CriticalAndSecurityPatchCount = &criticalAndSecurityPatchCount
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ApiError_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -14399,31 +14399,31 @@ func (summary *AvailablePatchSummary_STATUS) PopulateFromARM(owner genruntime.Ar
 		summary.Error = &error
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	if typedInput.LastModifiedTime != nil {
 		lastModifiedTime := *typedInput.LastModifiedTime
 		summary.LastModifiedTime = &lastModifiedTime
 	}
 
-	// Set property ‘OtherPatchCount’:
+	// Set property "OtherPatchCount":
 	if typedInput.OtherPatchCount != nil {
 		otherPatchCount := *typedInput.OtherPatchCount
 		summary.OtherPatchCount = &otherPatchCount
 	}
 
-	// Set property ‘RebootPending’:
+	// Set property "RebootPending":
 	if typedInput.RebootPending != nil {
 		rebootPending := *typedInput.RebootPending
 		summary.RebootPending = &rebootPending
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		summary.StartTime = &startTime
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		summary.Status = &status
@@ -14623,13 +14623,13 @@ func (settings *DiffDiskSettings) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &DiffDiskSettings_ARM{}
 
-	// Set property ‘Option’:
+	// Set property "Option":
 	if settings.Option != nil {
 		option := *settings.Option
 		result.Option = &option
 	}
 
-	// Set property ‘Placement’:
+	// Set property "Placement":
 	if settings.Placement != nil {
 		placement := *settings.Placement
 		result.Placement = &placement
@@ -14649,13 +14649,13 @@ func (settings *DiffDiskSettings) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiffDiskSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Option’:
+	// Set property "Option":
 	if typedInput.Option != nil {
 		option := *typedInput.Option
 		settings.Option = &option
 	}
 
-	// Set property ‘Placement’:
+	// Set property "Placement":
 	if typedInput.Placement != nil {
 		placement := *typedInput.Placement
 		settings.Placement = &placement
@@ -14740,13 +14740,13 @@ func (settings *DiffDiskSettings_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiffDiskSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Option’:
+	// Set property "Option":
 	if typedInput.Option != nil {
 		option := *typedInput.Option
 		settings.Option = &option
 	}
 
-	// Set property ‘Placement’:
+	// Set property "Placement":
 	if typedInput.Placement != nil {
 		placement := *typedInput.Placement
 		settings.Placement = &placement
@@ -14827,7 +14827,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &DiskEncryptionSettings_ARM{}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if settings.DiskEncryptionKey != nil {
 		diskEncryptionKey_ARM, err := (*settings.DiskEncryptionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -14837,13 +14837,13 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 		result.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if settings.Enabled != nil {
 		enabled := *settings.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if settings.KeyEncryptionKey != nil {
 		keyEncryptionKey_ARM, err := (*settings.KeyEncryptionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -14867,7 +14867,7 @@ func (settings *DiskEncryptionSettings) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskEncryptionSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if typedInput.DiskEncryptionKey != nil {
 		var diskEncryptionKey1 KeyVaultSecretReference
 		err := diskEncryptionKey1.PopulateFromARM(owner, *typedInput.DiskEncryptionKey)
@@ -14878,13 +14878,13 @@ func (settings *DiskEncryptionSettings) PopulateFromARM(owner genruntime.Arbitra
 		settings.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		settings.Enabled = &enabled
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if typedInput.KeyEncryptionKey != nil {
 		var keyEncryptionKey1 KeyVaultKeyReference
 		err := keyEncryptionKey1.PopulateFromARM(owner, *typedInput.KeyEncryptionKey)
@@ -15007,7 +15007,7 @@ func (settings *DiskEncryptionSettings_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DiskEncryptionSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionKey’:
+	// Set property "DiskEncryptionKey":
 	if typedInput.DiskEncryptionKey != nil {
 		var diskEncryptionKey1 KeyVaultSecretReference_STATUS
 		err := diskEncryptionKey1.PopulateFromARM(owner, *typedInput.DiskEncryptionKey)
@@ -15018,13 +15018,13 @@ func (settings *DiskEncryptionSettings_STATUS) PopulateFromARM(owner genruntime.
 		settings.DiskEncryptionKey = &diskEncryptionKey
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		settings.Enabled = &enabled
 	}
 
-	// Set property ‘KeyEncryptionKey’:
+	// Set property "KeyEncryptionKey":
 	if typedInput.KeyEncryptionKey != nil {
 		var keyEncryptionKey1 KeyVaultKeyReference_STATUS
 		err := keyEncryptionKey1.PopulateFromARM(owner, *typedInput.KeyEncryptionKey)
@@ -15164,7 +15164,7 @@ func (summary *LastPatchInstallationSummary_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LastPatchInstallationSummary_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ApiError_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -15175,61 +15175,61 @@ func (summary *LastPatchInstallationSummary_STATUS) PopulateFromARM(owner genrun
 		summary.Error = &error
 	}
 
-	// Set property ‘ExcludedPatchCount’:
+	// Set property "ExcludedPatchCount":
 	if typedInput.ExcludedPatchCount != nil {
 		excludedPatchCount := *typedInput.ExcludedPatchCount
 		summary.ExcludedPatchCount = &excludedPatchCount
 	}
 
-	// Set property ‘FailedPatchCount’:
+	// Set property "FailedPatchCount":
 	if typedInput.FailedPatchCount != nil {
 		failedPatchCount := *typedInput.FailedPatchCount
 		summary.FailedPatchCount = &failedPatchCount
 	}
 
-	// Set property ‘InstallationActivityId’:
+	// Set property "InstallationActivityId":
 	if typedInput.InstallationActivityId != nil {
 		installationActivityId := *typedInput.InstallationActivityId
 		summary.InstallationActivityId = &installationActivityId
 	}
 
-	// Set property ‘InstalledPatchCount’:
+	// Set property "InstalledPatchCount":
 	if typedInput.InstalledPatchCount != nil {
 		installedPatchCount := *typedInput.InstalledPatchCount
 		summary.InstalledPatchCount = &installedPatchCount
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	if typedInput.LastModifiedTime != nil {
 		lastModifiedTime := *typedInput.LastModifiedTime
 		summary.LastModifiedTime = &lastModifiedTime
 	}
 
-	// Set property ‘MaintenanceWindowExceeded’:
+	// Set property "MaintenanceWindowExceeded":
 	if typedInput.MaintenanceWindowExceeded != nil {
 		maintenanceWindowExceeded := *typedInput.MaintenanceWindowExceeded
 		summary.MaintenanceWindowExceeded = &maintenanceWindowExceeded
 	}
 
-	// Set property ‘NotSelectedPatchCount’:
+	// Set property "NotSelectedPatchCount":
 	if typedInput.NotSelectedPatchCount != nil {
 		notSelectedPatchCount := *typedInput.NotSelectedPatchCount
 		summary.NotSelectedPatchCount = &notSelectedPatchCount
 	}
 
-	// Set property ‘PendingPatchCount’:
+	// Set property "PendingPatchCount":
 	if typedInput.PendingPatchCount != nil {
 		pendingPatchCount := *typedInput.PendingPatchCount
 		summary.PendingPatchCount = &pendingPatchCount
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		summary.StartTime = &startTime
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		summary.Status = &status
@@ -15382,13 +15382,13 @@ func (settings *LinuxPatchSettings) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &LinuxPatchSettings_ARM{}
 
-	// Set property ‘AssessmentMode’:
+	// Set property "AssessmentMode":
 	if settings.AssessmentMode != nil {
 		assessmentMode := *settings.AssessmentMode
 		result.AssessmentMode = &assessmentMode
 	}
 
-	// Set property ‘AutomaticByPlatformSettings’:
+	// Set property "AutomaticByPlatformSettings":
 	if settings.AutomaticByPlatformSettings != nil {
 		automaticByPlatformSettings_ARM, err := (*settings.AutomaticByPlatformSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -15398,7 +15398,7 @@ func (settings *LinuxPatchSettings) ConvertToARM(resolved genruntime.ConvertToAR
 		result.AutomaticByPlatformSettings = &automaticByPlatformSettings
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if settings.PatchMode != nil {
 		patchMode := *settings.PatchMode
 		result.PatchMode = &patchMode
@@ -15418,13 +15418,13 @@ func (settings *LinuxPatchSettings) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxPatchSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssessmentMode’:
+	// Set property "AssessmentMode":
 	if typedInput.AssessmentMode != nil {
 		assessmentMode := *typedInput.AssessmentMode
 		settings.AssessmentMode = &assessmentMode
 	}
 
-	// Set property ‘AutomaticByPlatformSettings’:
+	// Set property "AutomaticByPlatformSettings":
 	if typedInput.AutomaticByPlatformSettings != nil {
 		var automaticByPlatformSettings1 LinuxVMGuestPatchAutomaticByPlatformSettings
 		err := automaticByPlatformSettings1.PopulateFromARM(owner, *typedInput.AutomaticByPlatformSettings)
@@ -15435,7 +15435,7 @@ func (settings *LinuxPatchSettings) PopulateFromARM(owner genruntime.ArbitraryOw
 		settings.AutomaticByPlatformSettings = &automaticByPlatformSettings
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -15545,13 +15545,13 @@ func (settings *LinuxPatchSettings_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxPatchSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssessmentMode’:
+	// Set property "AssessmentMode":
 	if typedInput.AssessmentMode != nil {
 		assessmentMode := *typedInput.AssessmentMode
 		settings.AssessmentMode = &assessmentMode
 	}
 
-	// Set property ‘AutomaticByPlatformSettings’:
+	// Set property "AutomaticByPlatformSettings":
 	if typedInput.AutomaticByPlatformSettings != nil {
 		var automaticByPlatformSettings1 LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS
 		err := automaticByPlatformSettings1.PopulateFromARM(owner, *typedInput.AutomaticByPlatformSettings)
@@ -15562,7 +15562,7 @@ func (settings *LinuxPatchSettings_STATUS) PopulateFromARM(owner genruntime.Arbi
 		settings.AutomaticByPlatformSettings = &automaticByPlatformSettings
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -15679,7 +15679,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &ManagedDiskParameters_ARM{}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if parameters.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*parameters.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -15689,7 +15689,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if parameters.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*parameters.Reference)
 		if err != nil {
@@ -15699,7 +15699,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 		result.Id = &reference
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if parameters.SecurityProfile != nil {
 		securityProfile_ARM, err := (*parameters.SecurityProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -15709,7 +15709,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 		result.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if parameters.StorageAccountType != nil {
 		storageAccountType := *parameters.StorageAccountType
 		result.StorageAccountType = &storageAccountType
@@ -15729,7 +15729,7 @@ func (parameters *ManagedDiskParameters) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedDiskParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -15740,9 +15740,9 @@ func (parameters *ManagedDiskParameters) PopulateFromARM(owner genruntime.Arbitr
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 VMDiskSecurityProfile
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -15753,7 +15753,7 @@ func (parameters *ManagedDiskParameters) PopulateFromARM(owner genruntime.Arbitr
 		parameters.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -15888,7 +15888,7 @@ func (parameters *ManagedDiskParameters_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedDiskParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -15899,13 +15899,13 @@ func (parameters *ManagedDiskParameters_STATUS) PopulateFromARM(owner genruntime
 		parameters.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		parameters.Id = &id
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	if typedInput.SecurityProfile != nil {
 		var securityProfile1 VMDiskSecurityProfile_STATUS
 		err := securityProfile1.PopulateFromARM(owner, *typedInput.SecurityProfile)
@@ -15916,7 +15916,7 @@ func (parameters *ManagedDiskParameters_STATUS) PopulateFromARM(owner genruntime
 		parameters.SecurityProfile = &securityProfile
 	}
 
-	// Set property ‘StorageAccountType’:
+	// Set property "StorageAccountType":
 	if typedInput.StorageAccountType != nil {
 		storageAccountType := *typedInput.StorageAccountType
 		parameters.StorageAccountType = &storageAccountType
@@ -16072,13 +16072,13 @@ func (settings *PatchSettings) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &PatchSettings_ARM{}
 
-	// Set property ‘AssessmentMode’:
+	// Set property "AssessmentMode":
 	if settings.AssessmentMode != nil {
 		assessmentMode := *settings.AssessmentMode
 		result.AssessmentMode = &assessmentMode
 	}
 
-	// Set property ‘AutomaticByPlatformSettings’:
+	// Set property "AutomaticByPlatformSettings":
 	if settings.AutomaticByPlatformSettings != nil {
 		automaticByPlatformSettings_ARM, err := (*settings.AutomaticByPlatformSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -16088,13 +16088,13 @@ func (settings *PatchSettings) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.AutomaticByPlatformSettings = &automaticByPlatformSettings
 	}
 
-	// Set property ‘EnableHotpatching’:
+	// Set property "EnableHotpatching":
 	if settings.EnableHotpatching != nil {
 		enableHotpatching := *settings.EnableHotpatching
 		result.EnableHotpatching = &enableHotpatching
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if settings.PatchMode != nil {
 		patchMode := *settings.PatchMode
 		result.PatchMode = &patchMode
@@ -16114,13 +16114,13 @@ func (settings *PatchSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PatchSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssessmentMode’:
+	// Set property "AssessmentMode":
 	if typedInput.AssessmentMode != nil {
 		assessmentMode := *typedInput.AssessmentMode
 		settings.AssessmentMode = &assessmentMode
 	}
 
-	// Set property ‘AutomaticByPlatformSettings’:
+	// Set property "AutomaticByPlatformSettings":
 	if typedInput.AutomaticByPlatformSettings != nil {
 		var automaticByPlatformSettings1 WindowsVMGuestPatchAutomaticByPlatformSettings
 		err := automaticByPlatformSettings1.PopulateFromARM(owner, *typedInput.AutomaticByPlatformSettings)
@@ -16131,13 +16131,13 @@ func (settings *PatchSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		settings.AutomaticByPlatformSettings = &automaticByPlatformSettings
 	}
 
-	// Set property ‘EnableHotpatching’:
+	// Set property "EnableHotpatching":
 	if typedInput.EnableHotpatching != nil {
 		enableHotpatching := *typedInput.EnableHotpatching
 		settings.EnableHotpatching = &enableHotpatching
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -16264,13 +16264,13 @@ func (settings *PatchSettings_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PatchSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssessmentMode’:
+	// Set property "AssessmentMode":
 	if typedInput.AssessmentMode != nil {
 		assessmentMode := *typedInput.AssessmentMode
 		settings.AssessmentMode = &assessmentMode
 	}
 
-	// Set property ‘AutomaticByPlatformSettings’:
+	// Set property "AutomaticByPlatformSettings":
 	if typedInput.AutomaticByPlatformSettings != nil {
 		var automaticByPlatformSettings1 WindowsVMGuestPatchAutomaticByPlatformSettings_STATUS
 		err := automaticByPlatformSettings1.PopulateFromARM(owner, *typedInput.AutomaticByPlatformSettings)
@@ -16281,13 +16281,13 @@ func (settings *PatchSettings_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		settings.AutomaticByPlatformSettings = &automaticByPlatformSettings
 	}
 
-	// Set property ‘EnableHotpatching’:
+	// Set property "EnableHotpatching":
 	if typedInput.EnableHotpatching != nil {
 		enableHotpatching := *typedInput.EnableHotpatching
 		settings.EnableHotpatching = &enableHotpatching
 	}
 
-	// Set property ‘PatchMode’:
+	// Set property "PatchMode":
 	if typedInput.PatchMode != nil {
 		patchMode := *typedInput.PatchMode
 		settings.PatchMode = &patchMode
@@ -16406,7 +16406,7 @@ func (configuration *SshConfiguration) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &SshConfiguration_ARM{}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range configuration.PublicKeys {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -16429,7 +16429,7 @@ func (configuration *SshConfiguration) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 SshPublicKeySpec
 		err := item1.PopulateFromARM(owner, item)
@@ -16521,7 +16521,7 @@ func (configuration *SshConfiguration_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 SshPublicKey_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -16609,13 +16609,13 @@ func (certificate *VaultCertificate) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &VaultCertificate_ARM{}
 
-	// Set property ‘CertificateStore’:
+	// Set property "CertificateStore":
 	if certificate.CertificateStore != nil {
 		certificateStore := *certificate.CertificateStore
 		result.CertificateStore = &certificateStore
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if certificate.CertificateUrl != nil {
 		certificateUrl := *certificate.CertificateUrl
 		result.CertificateUrl = &certificateUrl
@@ -16635,13 +16635,13 @@ func (certificate *VaultCertificate) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultCertificate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateStore’:
+	// Set property "CertificateStore":
 	if typedInput.CertificateStore != nil {
 		certificateStore := *typedInput.CertificateStore
 		certificate.CertificateStore = &certificateStore
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		certificate.CertificateUrl = &certificateUrl
@@ -16706,13 +16706,13 @@ func (certificate *VaultCertificate_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultCertificate_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateStore’:
+	// Set property "CertificateStore":
 	if typedInput.CertificateStore != nil {
 		certificateStore := *typedInput.CertificateStore
 		certificate.CertificateStore = &certificateStore
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		certificate.CertificateUrl = &certificateUrl
@@ -16771,7 +16771,7 @@ func (disk *VirtualHardDisk) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &VirtualHardDisk_ARM{}
 
-	// Set property ‘Uri’:
+	// Set property "Uri":
 	if disk.Uri != nil {
 		uri := *disk.Uri
 		result.Uri = &uri
@@ -16791,7 +16791,7 @@ func (disk *VirtualHardDisk) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualHardDisk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Uri’:
+	// Set property "Uri":
 	if typedInput.Uri != nil {
 		uri := *typedInput.Uri
 		disk.Uri = &uri
@@ -16849,7 +16849,7 @@ func (disk *VirtualHardDisk_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualHardDisk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Uri’:
+	// Set property "Uri":
 	if typedInput.Uri != nil {
 		uri := *typedInput.Uri
 		disk.Uri = &uri
@@ -16909,7 +16909,7 @@ func (view *VirtualMachineExtensionHandlerInstanceView_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineExtensionHandlerInstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		var status1 InstanceViewStatus_STATUS
 		err := status1.PopulateFromARM(owner, *typedInput.Status)
@@ -16920,13 +16920,13 @@ func (view *VirtualMachineExtensionHandlerInstanceView_STATUS) PopulateFromARM(o
 		view.Status = &status
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		view.Type = &typeVar
 	}
 
-	// Set property ‘TypeHandlerVersion’:
+	// Set property "TypeHandlerVersion":
 	if typedInput.TypeHandlerVersion != nil {
 		typeHandlerVersion := *typedInput.TypeHandlerVersion
 		view.TypeHandlerVersion = &typeHandlerVersion
@@ -17028,7 +17028,7 @@ func (configuration *VirtualMachineNetworkInterfaceDnsSettingsConfiguration) Con
 	}
 	result := &VirtualMachineNetworkInterfaceDnsSettingsConfiguration_ARM{}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range configuration.DnsServers {
 		result.DnsServers = append(result.DnsServers, item)
 	}
@@ -17047,7 +17047,7 @@ func (configuration *VirtualMachineNetworkInterfaceDnsSettingsConfiguration) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineNetworkInterfaceDnsSettingsConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		configuration.DnsServers = append(configuration.DnsServers, item)
 	}
@@ -17104,7 +17104,7 @@ func (configuration *VirtualMachineNetworkInterfaceDnsSettingsConfiguration_STAT
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineNetworkInterfaceDnsSettingsConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		configuration.DnsServers = append(configuration.DnsServers, item)
 	}
@@ -17165,13 +17165,13 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) ConvertToARM
 	}
 	result := &VirtualMachineNetworkInterfaceIPConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.ApplicationGatewayBackendAddressPools != nil ||
 		configuration.ApplicationSecurityGroups != nil ||
 		configuration.LoadBalancerBackendAddressPools != nil ||
@@ -17241,7 +17241,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineNetworkInterfaceIPConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -17254,7 +17254,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -17267,7 +17267,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		}
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -17280,13 +17280,13 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -17295,7 +17295,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -17304,7 +17304,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		}
 	}
 
-	// Set property ‘PublicIPAddressConfiguration’:
+	// Set property "PublicIPAddressConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressConfiguration != nil {
@@ -17318,7 +17318,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration) PopulateFrom
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -17579,7 +17579,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineNetworkInterfaceIPConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -17592,7 +17592,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -17605,7 +17605,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		}
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -17618,13 +17618,13 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -17633,7 +17633,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -17642,7 +17642,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		}
 	}
 
-	// Set property ‘PublicIPAddressConfiguration’:
+	// Set property "PublicIPAddressConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressConfiguration != nil {
@@ -17656,7 +17656,7 @@ func (configuration *VirtualMachineNetworkInterfaceIPConfiguration_STATUS) Popul
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -17905,7 +17905,7 @@ func (configuration *WinRMConfiguration) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &WinRMConfiguration_ARM{}
 
-	// Set property ‘Listeners’:
+	// Set property "Listeners":
 	for _, item := range configuration.Listeners {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -17928,7 +17928,7 @@ func (configuration *WinRMConfiguration) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Listeners’:
+	// Set property "Listeners":
 	for _, item := range typedInput.Listeners {
 		var item1 WinRMListener
 		err := item1.PopulateFromARM(owner, item)
@@ -18020,7 +18020,7 @@ func (configuration *WinRMConfiguration_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Listeners’:
+	// Set property "Listeners":
 	for _, item := range typedInput.Listeners {
 		var item1 WinRMListener_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -18160,13 +18160,13 @@ func (error *ApiError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		error.Code = &code
 	}
 
-	// Set property ‘Details’:
+	// Set property "Details":
 	for _, item := range typedInput.Details {
 		var item1 ApiErrorBase_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -18176,7 +18176,7 @@ func (error *ApiError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		error.Details = append(error.Details, item1)
 	}
 
-	// Set property ‘Innererror’:
+	// Set property "Innererror":
 	if typedInput.Innererror != nil {
 		var innererror1 InnerError_STATUS
 		err := innererror1.PopulateFromARM(owner, *typedInput.Innererror)
@@ -18187,13 +18187,13 @@ func (error *ApiError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		error.Innererror = &innererror
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		error.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		error.Target = &target
@@ -18361,13 +18361,13 @@ func (reference *KeyVaultKeyReference) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &KeyVaultKeyReference_ARM{}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if reference.KeyUrl != nil {
 		keyUrl := *reference.KeyUrl
 		result.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if reference.SourceVault != nil {
 		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -18391,13 +18391,13 @@ func (reference *KeyVaultKeyReference) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultKeyReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if typedInput.KeyUrl != nil {
 		keyUrl := *typedInput.KeyUrl
 		reference.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -18485,13 +18485,13 @@ func (reference *KeyVaultKeyReference_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultKeyReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyUrl’:
+	// Set property "KeyUrl":
 	if typedInput.KeyUrl != nil {
 		keyUrl := *typedInput.KeyUrl
 		reference.KeyUrl = &keyUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource_STATUS
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -18577,13 +18577,13 @@ func (reference *KeyVaultSecretReference) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &KeyVaultSecretReference_ARM{}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if reference.SecretUrl != nil {
 		secretUrl := *reference.SecretUrl
 		result.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if reference.SourceVault != nil {
 		sourceVault_ARM, err := (*reference.SourceVault).ConvertToARM(resolved)
 		if err != nil {
@@ -18607,13 +18607,13 @@ func (reference *KeyVaultSecretReference) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultSecretReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SecretUrl’:
+	// Set property "SecretUrl":
 	if typedInput.SecretUrl != nil {
 		secretUrl := *typedInput.SecretUrl
 		reference.SecretUrl = &secretUrl
 	}
 
-	// Set property ‘SourceVault’:
+	// Set property "SourceVault":
 	if typedInput.SourceVault != nil {
 		var sourceVault1 SubResource
 		err := sourceVault1.PopulateFromARM(owner, *typedInput.SourceVault)
@@ -18742,7 +18742,7 @@ func (settings *LinuxVMGuestPatchAutomaticByPlatformSettings) ConvertToARM(resol
 	}
 	result := &LinuxVMGuestPatchAutomaticByPlatformSettings_ARM{}
 
-	// Set property ‘RebootSetting’:
+	// Set property "RebootSetting":
 	if settings.RebootSetting != nil {
 		rebootSetting := *settings.RebootSetting
 		result.RebootSetting = &rebootSetting
@@ -18762,7 +18762,7 @@ func (settings *LinuxVMGuestPatchAutomaticByPlatformSettings) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxVMGuestPatchAutomaticByPlatformSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RebootSetting’:
+	// Set property "RebootSetting":
 	if typedInput.RebootSetting != nil {
 		rebootSetting := *typedInput.RebootSetting
 		settings.RebootSetting = &rebootSetting
@@ -18830,7 +18830,7 @@ func (settings *LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxVMGuestPatchAutomaticByPlatformSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RebootSetting’:
+	// Set property "RebootSetting":
 	if typedInput.RebootSetting != nil {
 		rebootSetting := *typedInput.RebootSetting
 		settings.RebootSetting = &rebootSetting
@@ -18935,13 +18935,13 @@ func (publicKey *SshPublicKey_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshPublicKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		publicKey.Path = &path
@@ -19001,13 +19001,13 @@ func (publicKey *SshPublicKeySpec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &SshPublicKeySpec_ARM{}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if publicKey.KeyData != nil {
 		keyData := *publicKey.KeyData
 		result.KeyData = &keyData
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if publicKey.Path != nil {
 		path := *publicKey.Path
 		result.Path = &path
@@ -19027,13 +19027,13 @@ func (publicKey *SshPublicKeySpec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SshPublicKeySpec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		publicKey.Path = &path
@@ -19121,13 +19121,13 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) ConvertToARM(re
 	}
 	result := &VirtualMachinePublicIPAddressConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.DeleteOption != nil ||
 		configuration.DnsSettings != nil ||
 		configuration.IdleTimeoutInMinutes != nil ||
@@ -19177,7 +19177,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) ConvertToARM(re
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if configuration.Sku != nil {
 		sku_ARM, err := (*configuration.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -19201,7 +19201,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachinePublicIPAddressConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -19210,7 +19210,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -19224,7 +19224,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -19233,7 +19233,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -19246,13 +19246,13 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -19261,7 +19261,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘PublicIPAllocationMethod’:
+	// Set property "PublicIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAllocationMethod != nil {
@@ -19270,7 +19270,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -19284,7 +19284,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPAddressSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -19517,7 +19517,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachinePublicIPAddressConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteOption’:
+	// Set property "DeleteOption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteOption != nil {
@@ -19526,7 +19526,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -19540,7 +19540,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -19549,7 +19549,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -19562,13 +19562,13 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -19577,7 +19577,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘PublicIPAllocationMethod’:
+	// Set property "PublicIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAllocationMethod != nil {
@@ -19586,7 +19586,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -19600,7 +19600,7 @@ func (configuration *VirtualMachinePublicIPAddressConfiguration_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPAddressSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -19821,7 +19821,7 @@ func (profile *VMDiskSecurityProfile) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &VMDiskSecurityProfile_ARM{}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if profile.DiskEncryptionSet != nil {
 		diskEncryptionSet_ARM, err := (*profile.DiskEncryptionSet).ConvertToARM(resolved)
 		if err != nil {
@@ -19831,7 +19831,7 @@ func (profile *VMDiskSecurityProfile) ConvertToARM(resolved genruntime.ConvertTo
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘SecurityEncryptionType’:
+	// Set property "SecurityEncryptionType":
 	if profile.SecurityEncryptionType != nil {
 		securityEncryptionType := *profile.SecurityEncryptionType
 		result.SecurityEncryptionType = &securityEncryptionType
@@ -19851,7 +19851,7 @@ func (profile *VMDiskSecurityProfile) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VMDiskSecurityProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -19862,7 +19862,7 @@ func (profile *VMDiskSecurityProfile) PopulateFromARM(owner genruntime.Arbitrary
 		profile.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘SecurityEncryptionType’:
+	// Set property "SecurityEncryptionType":
 	if typedInput.SecurityEncryptionType != nil {
 		securityEncryptionType := *typedInput.SecurityEncryptionType
 		profile.SecurityEncryptionType = &securityEncryptionType
@@ -19955,7 +19955,7 @@ func (profile *VMDiskSecurityProfile_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VMDiskSecurityProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiskEncryptionSet’:
+	// Set property "DiskEncryptionSet":
 	if typedInput.DiskEncryptionSet != nil {
 		var diskEncryptionSet1 SubResource_STATUS
 		err := diskEncryptionSet1.PopulateFromARM(owner, *typedInput.DiskEncryptionSet)
@@ -19966,7 +19966,7 @@ func (profile *VMDiskSecurityProfile_STATUS) PopulateFromARM(owner genruntime.Ar
 		profile.DiskEncryptionSet = &diskEncryptionSet
 	}
 
-	// Set property ‘SecurityEncryptionType’:
+	// Set property "SecurityEncryptionType":
 	if typedInput.SecurityEncryptionType != nil {
 		securityEncryptionType := *typedInput.SecurityEncryptionType
 		profile.SecurityEncryptionType = &securityEncryptionType
@@ -20053,7 +20053,7 @@ func (settings *WindowsVMGuestPatchAutomaticByPlatformSettings) ConvertToARM(res
 	}
 	result := &WindowsVMGuestPatchAutomaticByPlatformSettings_ARM{}
 
-	// Set property ‘RebootSetting’:
+	// Set property "RebootSetting":
 	if settings.RebootSetting != nil {
 		rebootSetting := *settings.RebootSetting
 		result.RebootSetting = &rebootSetting
@@ -20073,7 +20073,7 @@ func (settings *WindowsVMGuestPatchAutomaticByPlatformSettings) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsVMGuestPatchAutomaticByPlatformSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RebootSetting’:
+	// Set property "RebootSetting":
 	if typedInput.RebootSetting != nil {
 		rebootSetting := *typedInput.RebootSetting
 		settings.RebootSetting = &rebootSetting
@@ -20141,7 +20141,7 @@ func (settings *WindowsVMGuestPatchAutomaticByPlatformSettings_STATUS) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsVMGuestPatchAutomaticByPlatformSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RebootSetting’:
+	// Set property "RebootSetting":
 	if typedInput.RebootSetting != nil {
 		rebootSetting := *typedInput.RebootSetting
 		settings.RebootSetting = &rebootSetting
@@ -20205,13 +20205,13 @@ func (listener *WinRMListener) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &WinRMListener_ARM{}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if listener.CertificateUrl != nil {
 		certificateUrl := *listener.CertificateUrl
 		result.CertificateUrl = &certificateUrl
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if listener.Protocol != nil {
 		protocol := *listener.Protocol
 		result.Protocol = &protocol
@@ -20231,13 +20231,13 @@ func (listener *WinRMListener) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMListener_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		listener.CertificateUrl = &certificateUrl
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		listener.Protocol = &protocol
@@ -20312,13 +20312,13 @@ func (listener *WinRMListener_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WinRMListener_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CertificateUrl’:
+	// Set property "CertificateUrl":
 	if typedInput.CertificateUrl != nil {
 		certificateUrl := *typedInput.CertificateUrl
 		listener.CertificateUrl = &certificateUrl
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		listener.Protocol = &protocol
@@ -20394,19 +20394,19 @@ func (base *ApiErrorBase_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiErrorBase_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		base.Code = &code
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		base.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		base.Target = &target
@@ -20477,13 +20477,13 @@ func (error *InnerError_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InnerError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Errordetail’:
+	// Set property "Errordetail":
 	if typedInput.Errordetail != nil {
 		errordetail := *typedInput.Errordetail
 		error.Errordetail = &errordetail
 	}
 
-	// Set property ‘Exceptiontype’:
+	// Set property "Exceptiontype":
 	if typedInput.Exceptiontype != nil {
 		exceptiontype := *typedInput.Exceptiontype
 		error.Exceptiontype = &exceptiontype
@@ -20566,13 +20566,13 @@ func (addressSku *PublicIPAddressSku) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &PublicIPAddressSku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if addressSku.Name != nil {
 		name := *addressSku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if addressSku.Tier != nil {
 		tier := *addressSku.Tier
 		result.Tier = &tier
@@ -20592,13 +20592,13 @@ func (addressSku *PublicIPAddressSku) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		addressSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		addressSku.Tier = &tier
@@ -20683,13 +20683,13 @@ func (addressSku *PublicIPAddressSku_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		addressSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		addressSku.Tier = &tier
@@ -20769,13 +20769,13 @@ func (ipTag *VirtualMachineIpTag) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &VirtualMachineIpTag_ARM{}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if ipTag.IpTagType != nil {
 		ipTagType := *ipTag.IpTagType
 		result.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if ipTag.Tag != nil {
 		tag := *ipTag.Tag
 		result.Tag = &tag
@@ -20795,13 +20795,13 @@ func (ipTag *VirtualMachineIpTag) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIpTag_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -20866,13 +20866,13 @@ func (ipTag *VirtualMachineIpTag_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineIpTag_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -20989,7 +20989,7 @@ func (configuration *VirtualMachinePublicIPAddressDnsSettingsConfiguration) Conv
 	}
 	result := &VirtualMachinePublicIPAddressDnsSettingsConfiguration_ARM{}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if configuration.DomainNameLabel != nil {
 		domainNameLabel := *configuration.DomainNameLabel
 		result.DomainNameLabel = &domainNameLabel
@@ -21009,7 +21009,7 @@ func (configuration *VirtualMachinePublicIPAddressDnsSettingsConfiguration) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachinePublicIPAddressDnsSettingsConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		configuration.DomainNameLabel = &domainNameLabel
@@ -21067,7 +21067,7 @@ func (configuration *VirtualMachinePublicIPAddressDnsSettingsConfiguration_STATU
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachinePublicIPAddressDnsSettingsConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		configuration.DomainNameLabel = &domainNameLabel

--- a/v2/api/containerinstance/v1api20211001/container_group_types_gen.go
+++ b/v2/api/containerinstance/v1api20211001/container_group_types_gen.go
@@ -390,7 +390,7 @@ func (group *ContainerGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ContainerGroup_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if group.Identity != nil {
 		identity_ARM, err := (*group.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -400,16 +400,16 @@ func (group *ContainerGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if group.Location != nil {
 		location := *group.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if group.Containers != nil ||
 		group.Diagnostics != nil ||
 		group.DnsConfig != nil ||
@@ -504,7 +504,7 @@ func (group *ContainerGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.Volumes = append(result.Properties.Volumes, *item_ARM.(*Volume_ARM))
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if group.Tags != nil {
 		result.Tags = make(map[string]string, len(group.Tags))
 		for key, value := range group.Tags {
@@ -512,7 +512,7 @@ func (group *ContainerGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range group.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -531,10 +531,10 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroup_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	group.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Containers’:
+	// Set property "Containers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Containers {
@@ -547,7 +547,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Diagnostics’:
+	// Set property "Diagnostics":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Diagnostics != nil {
@@ -561,7 +561,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘DnsConfig’:
+	// Set property "DnsConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsConfig != nil {
@@ -575,7 +575,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘EncryptionProperties’:
+	// Set property "EncryptionProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionProperties != nil {
@@ -589,7 +589,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ContainerGroupIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -600,7 +600,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		group.Identity = &identity
 	}
 
-	// Set property ‘ImageRegistryCredentials’:
+	// Set property "ImageRegistryCredentials":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ImageRegistryCredentials {
@@ -613,7 +613,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘InitContainers’:
+	// Set property "InitContainers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InitContainers {
@@ -626,7 +626,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpAddress != nil {
@@ -640,13 +640,13 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		group.Location = &location
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -655,10 +655,10 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	group.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RestartPolicy’:
+	// Set property "RestartPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestartPolicy != nil {
@@ -667,7 +667,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -676,7 +676,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘SubnetIds’:
+	// Set property "SubnetIds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SubnetIds {
@@ -689,7 +689,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		group.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -697,7 +697,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Volumes’:
+	// Set property "Volumes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Volumes {
@@ -710,7 +710,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		group.Zones = append(group.Zones, item)
 	}
@@ -1517,9 +1517,9 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Containers’:
+	// Set property "Containers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Containers {
@@ -1532,7 +1532,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Diagnostics’:
+	// Set property "Diagnostics":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Diagnostics != nil {
@@ -1546,7 +1546,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DnsConfig’:
+	// Set property "DnsConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsConfig != nil {
@@ -1560,7 +1560,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EncryptionProperties’:
+	// Set property "EncryptionProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionProperties != nil {
@@ -1574,13 +1574,13 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		group.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ContainerGroupIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1591,7 +1591,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		group.Identity = &identity
 	}
 
-	// Set property ‘ImageRegistryCredentials’:
+	// Set property "ImageRegistryCredentials":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ImageRegistryCredentials {
@@ -1604,7 +1604,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘InitContainers’:
+	// Set property "InitContainers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InitContainers {
@@ -1617,7 +1617,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -1631,7 +1631,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpAddress != nil {
@@ -1645,19 +1645,19 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		group.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		group.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -1666,7 +1666,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1675,7 +1675,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘RestartPolicy’:
+	// Set property "RestartPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestartPolicy != nil {
@@ -1684,7 +1684,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -1693,7 +1693,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SubnetIds’:
+	// Set property "SubnetIds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SubnetIds {
@@ -1706,7 +1706,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		group.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1714,13 +1714,13 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		group.Type = &typeVar
 	}
 
-	// Set property ‘Volumes’:
+	// Set property "Volumes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Volumes {
@@ -1733,7 +1733,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		group.Zones = append(group.Zones, item)
 	}
@@ -2227,13 +2227,13 @@ func (container *Container) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &Container_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if container.Name != nil {
 		name := *container.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if container.Command != nil ||
 		container.EnvironmentVariables != nil ||
 		container.Image != nil ||
@@ -2311,7 +2311,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Container_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Command {
@@ -2319,7 +2319,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘EnvironmentVariables’:
+	// Set property "EnvironmentVariables":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EnvironmentVariables {
@@ -2332,7 +2332,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Image != nil {
@@ -2341,7 +2341,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘LivenessProbe’:
+	// Set property "LivenessProbe":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LivenessProbe != nil {
@@ -2355,13 +2355,13 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		container.Name = &name
 	}
 
-	// Set property ‘Ports’:
+	// Set property "Ports":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Ports {
@@ -2374,7 +2374,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘ReadinessProbe’:
+	// Set property "ReadinessProbe":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReadinessProbe != nil {
@@ -2388,7 +2388,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resources != nil {
@@ -2402,7 +2402,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘VolumeMounts’:
+	// Set property "VolumeMounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VolumeMounts {
@@ -2793,7 +2793,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Container_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Command {
@@ -2801,7 +2801,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘EnvironmentVariables’:
+	// Set property "EnvironmentVariables":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EnvironmentVariables {
@@ -2814,7 +2814,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Image != nil {
@@ -2823,7 +2823,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -2837,7 +2837,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘LivenessProbe’:
+	// Set property "LivenessProbe":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LivenessProbe != nil {
@@ -2851,13 +2851,13 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		container.Name = &name
 	}
 
-	// Set property ‘Ports’:
+	// Set property "Ports":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Ports {
@@ -2870,7 +2870,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ReadinessProbe’:
+	// Set property "ReadinessProbe":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReadinessProbe != nil {
@@ -2884,7 +2884,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resources != nil {
@@ -2898,7 +2898,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘VolumeMounts’:
+	// Set property "VolumeMounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VolumeMounts {
@@ -3182,7 +3182,7 @@ func (view *ContainerGroup_Properties_InstanceView_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroup_Properties_InstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Events’:
+	// Set property "Events":
 	for _, item := range typedInput.Events {
 		var item1 Event_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3192,7 +3192,7 @@ func (view *ContainerGroup_Properties_InstanceView_STATUS) PopulateFromARM(owner
 		view.Events = append(view.Events, item1)
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		view.State = &state
@@ -3314,7 +3314,7 @@ func (diagnostics *ContainerGroupDiagnostics) ConvertToARM(resolved genruntime.C
 	}
 	result := &ContainerGroupDiagnostics_ARM{}
 
-	// Set property ‘LogAnalytics’:
+	// Set property "LogAnalytics":
 	if diagnostics.LogAnalytics != nil {
 		logAnalytics_ARM, err := (*diagnostics.LogAnalytics).ConvertToARM(resolved)
 		if err != nil {
@@ -3338,7 +3338,7 @@ func (diagnostics *ContainerGroupDiagnostics) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroupDiagnostics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LogAnalytics’:
+	// Set property "LogAnalytics":
 	if typedInput.LogAnalytics != nil {
 		var logAnalytics1 LogAnalytics
 		err := logAnalytics1.PopulateFromARM(owner, *typedInput.LogAnalytics)
@@ -3439,7 +3439,7 @@ func (diagnostics *ContainerGroupDiagnostics_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroupDiagnostics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LogAnalytics’:
+	// Set property "LogAnalytics":
 	if typedInput.LogAnalytics != nil {
 		var logAnalytics1 LogAnalytics_STATUS
 		err := logAnalytics1.PopulateFromARM(owner, *typedInput.LogAnalytics)
@@ -3521,13 +3521,13 @@ func (identity *ContainerGroupIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ContainerGroupIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -3552,13 +3552,13 @@ func (identity *ContainerGroupIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroupIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -3699,25 +3699,25 @@ func (identity *ContainerGroupIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroupIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -3857,7 +3857,7 @@ func (subnetId *ContainerGroupSubnetId) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ContainerGroupSubnetId_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if subnetId.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*subnetId.Reference)
 		if err != nil {
@@ -3867,7 +3867,7 @@ func (subnetId *ContainerGroupSubnetId) ConvertToARM(resolved genruntime.Convert
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if subnetId.Name != nil {
 		name := *subnetId.Name
 		result.Name = &name
@@ -3887,13 +3887,13 @@ func (subnetId *ContainerGroupSubnetId) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroupSubnetId_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		subnetId.Name = &name
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3985,13 +3985,13 @@ func (subnetId *ContainerGroupSubnetId_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroupSubnetId_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		subnetId.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		subnetId.Name = &name
@@ -4058,18 +4058,18 @@ func (configuration *DnsConfiguration) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &DnsConfiguration_ARM{}
 
-	// Set property ‘NameServers’:
+	// Set property "NameServers":
 	for _, item := range configuration.NameServers {
 		result.NameServers = append(result.NameServers, item)
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	if configuration.Options != nil {
 		options := *configuration.Options
 		result.Options = &options
 	}
 
-	// Set property ‘SearchDomains’:
+	// Set property "SearchDomains":
 	if configuration.SearchDomains != nil {
 		searchDomains := *configuration.SearchDomains
 		result.SearchDomains = &searchDomains
@@ -4089,18 +4089,18 @@ func (configuration *DnsConfiguration) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NameServers’:
+	// Set property "NameServers":
 	for _, item := range typedInput.NameServers {
 		configuration.NameServers = append(configuration.NameServers, item)
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	if typedInput.Options != nil {
 		options := *typedInput.Options
 		configuration.Options = &options
 	}
 
-	// Set property ‘SearchDomains’:
+	// Set property "SearchDomains":
 	if typedInput.SearchDomains != nil {
 		searchDomains := *typedInput.SearchDomains
 		configuration.SearchDomains = &searchDomains
@@ -4193,18 +4193,18 @@ func (configuration *DnsConfiguration_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NameServers’:
+	// Set property "NameServers":
 	for _, item := range typedInput.NameServers {
 		configuration.NameServers = append(configuration.NameServers, item)
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	if typedInput.Options != nil {
 		options := *typedInput.Options
 		configuration.Options = &options
 	}
 
-	// Set property ‘SearchDomains’:
+	// Set property "SearchDomains":
 	if typedInput.SearchDomains != nil {
 		searchDomains := *typedInput.SearchDomains
 		configuration.SearchDomains = &searchDomains
@@ -4279,19 +4279,19 @@ func (properties *EncryptionProperties) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &EncryptionProperties_ARM{}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if properties.KeyName != nil {
 		keyName := *properties.KeyName
 		result.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if properties.KeyVersion != nil {
 		keyVersion := *properties.KeyVersion
 		result.KeyVersion = &keyVersion
 	}
 
-	// Set property ‘VaultBaseUrl’:
+	// Set property "VaultBaseUrl":
 	if properties.VaultBaseUrl != nil {
 		vaultBaseUrl := *properties.VaultBaseUrl
 		result.VaultBaseUrl = &vaultBaseUrl
@@ -4311,19 +4311,19 @@ func (properties *EncryptionProperties) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		properties.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		properties.KeyVersion = &keyVersion
 	}
 
-	// Set property ‘VaultBaseUrl’:
+	// Set property "VaultBaseUrl":
 	if typedInput.VaultBaseUrl != nil {
 		vaultBaseUrl := *typedInput.VaultBaseUrl
 		properties.VaultBaseUrl = &vaultBaseUrl
@@ -4416,19 +4416,19 @@ func (properties *EncryptionProperties_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		properties.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		properties.KeyVersion = &keyVersion
 	}
 
-	// Set property ‘VaultBaseUrl’:
+	// Set property "VaultBaseUrl":
 	if typedInput.VaultBaseUrl != nil {
 		vaultBaseUrl := *typedInput.VaultBaseUrl
 		properties.VaultBaseUrl = &vaultBaseUrl
@@ -4507,19 +4507,19 @@ func (credential *ImageRegistryCredential) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ImageRegistryCredential_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if credential.Identity != nil {
 		identity := *credential.Identity
 		result.Identity = &identity
 	}
 
-	// Set property ‘IdentityUrl’:
+	// Set property "IdentityUrl":
 	if credential.IdentityUrl != nil {
 		identityUrl := *credential.IdentityUrl
 		result.IdentityUrl = &identityUrl
 	}
 
-	// Set property ‘Password’:
+	// Set property "Password":
 	if credential.Password != nil {
 		passwordSecret, err := resolved.ResolvedSecrets.Lookup(*credential.Password)
 		if err != nil {
@@ -4529,13 +4529,13 @@ func (credential *ImageRegistryCredential) ConvertToARM(resolved genruntime.Conv
 		result.Password = &password
 	}
 
-	// Set property ‘Server’:
+	// Set property "Server":
 	if credential.Server != nil {
 		server := *credential.Server
 		result.Server = &server
 	}
 
-	// Set property ‘Username’:
+	// Set property "Username":
 	if credential.Username != nil {
 		username := *credential.Username
 		result.Username = &username
@@ -4555,27 +4555,27 @@ func (credential *ImageRegistryCredential) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageRegistryCredential_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		identity := *typedInput.Identity
 		credential.Identity = &identity
 	}
 
-	// Set property ‘IdentityUrl’:
+	// Set property "IdentityUrl":
 	if typedInput.IdentityUrl != nil {
 		identityUrl := *typedInput.IdentityUrl
 		credential.IdentityUrl = &identityUrl
 	}
 
-	// no assignment for property ‘Password’
+	// no assignment for property "Password"
 
-	// Set property ‘Server’:
+	// Set property "Server":
 	if typedInput.Server != nil {
 		server := *typedInput.Server
 		credential.Server = &server
 	}
 
-	// Set property ‘Username’:
+	// Set property "Username":
 	if typedInput.Username != nil {
 		username := *typedInput.Username
 		credential.Username = &username
@@ -4696,25 +4696,25 @@ func (credential *ImageRegistryCredential_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageRegistryCredential_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		identity := *typedInput.Identity
 		credential.Identity = &identity
 	}
 
-	// Set property ‘IdentityUrl’:
+	// Set property "IdentityUrl":
 	if typedInput.IdentityUrl != nil {
 		identityUrl := *typedInput.IdentityUrl
 		credential.IdentityUrl = &identityUrl
 	}
 
-	// Set property ‘Server’:
+	// Set property "Server":
 	if typedInput.Server != nil {
 		server := *typedInput.Server
 		credential.Server = &server
 	}
 
-	// Set property ‘Username’:
+	// Set property "Username":
 	if typedInput.Username != nil {
 		username := *typedInput.Username
 		credential.Username = &username
@@ -4799,13 +4799,13 @@ func (definition *InitContainerDefinition) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &InitContainerDefinition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if definition.Name != nil {
 		name := *definition.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if definition.Command != nil ||
 		definition.EnvironmentVariables != nil ||
 		definition.Image != nil ||
@@ -4848,7 +4848,7 @@ func (definition *InitContainerDefinition) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InitContainerDefinition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Command {
@@ -4856,7 +4856,7 @@ func (definition *InitContainerDefinition) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘EnvironmentVariables’:
+	// Set property "EnvironmentVariables":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EnvironmentVariables {
@@ -4869,7 +4869,7 @@ func (definition *InitContainerDefinition) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Image != nil {
@@ -4878,13 +4878,13 @@ func (definition *InitContainerDefinition) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		definition.Name = &name
 	}
 
-	// Set property ‘VolumeMounts’:
+	// Set property "VolumeMounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VolumeMounts {
@@ -5101,7 +5101,7 @@ func (definition *InitContainerDefinition_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InitContainerDefinition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Command {
@@ -5109,7 +5109,7 @@ func (definition *InitContainerDefinition_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘EnvironmentVariables’:
+	// Set property "EnvironmentVariables":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EnvironmentVariables {
@@ -5122,7 +5122,7 @@ func (definition *InitContainerDefinition_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Image != nil {
@@ -5131,7 +5131,7 @@ func (definition *InitContainerDefinition_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -5145,13 +5145,13 @@ func (definition *InitContainerDefinition_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		definition.Name = &name
 	}
 
-	// Set property ‘VolumeMounts’:
+	// Set property "VolumeMounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VolumeMounts {
@@ -5340,25 +5340,25 @@ func (address *IpAddress) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &IpAddress_ARM{}
 
-	// Set property ‘AutoGeneratedDomainNameLabelScope’:
+	// Set property "AutoGeneratedDomainNameLabelScope":
 	if address.AutoGeneratedDomainNameLabelScope != nil {
 		autoGeneratedDomainNameLabelScope := *address.AutoGeneratedDomainNameLabelScope
 		result.AutoGeneratedDomainNameLabelScope = &autoGeneratedDomainNameLabelScope
 	}
 
-	// Set property ‘DnsNameLabel’:
+	// Set property "DnsNameLabel":
 	if address.DnsNameLabel != nil {
 		dnsNameLabel := *address.DnsNameLabel
 		result.DnsNameLabel = &dnsNameLabel
 	}
 
-	// Set property ‘Ip’:
+	// Set property "Ip":
 	if address.Ip != nil {
 		ip := *address.Ip
 		result.Ip = &ip
 	}
 
-	// Set property ‘Ports’:
+	// Set property "Ports":
 	for _, item := range address.Ports {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5367,7 +5367,7 @@ func (address *IpAddress) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Ports = append(result.Ports, *item_ARM.(*Port_ARM))
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if address.Type != nil {
 		typeVar := *address.Type
 		result.Type = &typeVar
@@ -5387,25 +5387,25 @@ func (address *IpAddress) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpAddress_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoGeneratedDomainNameLabelScope’:
+	// Set property "AutoGeneratedDomainNameLabelScope":
 	if typedInput.AutoGeneratedDomainNameLabelScope != nil {
 		autoGeneratedDomainNameLabelScope := *typedInput.AutoGeneratedDomainNameLabelScope
 		address.AutoGeneratedDomainNameLabelScope = &autoGeneratedDomainNameLabelScope
 	}
 
-	// Set property ‘DnsNameLabel’:
+	// Set property "DnsNameLabel":
 	if typedInput.DnsNameLabel != nil {
 		dnsNameLabel := *typedInput.DnsNameLabel
 		address.DnsNameLabel = &dnsNameLabel
 	}
 
-	// Set property ‘Ip’:
+	// Set property "Ip":
 	if typedInput.Ip != nil {
 		ip := *typedInput.Ip
 		address.Ip = &ip
 	}
 
-	// Set property ‘Ports’:
+	// Set property "Ports":
 	for _, item := range typedInput.Ports {
 		var item1 Port
 		err := item1.PopulateFromARM(owner, item)
@@ -5415,7 +5415,7 @@ func (address *IpAddress) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		address.Ports = append(address.Ports, item1)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		address.Type = &typeVar
@@ -5616,31 +5616,31 @@ func (address *IpAddress_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpAddress_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoGeneratedDomainNameLabelScope’:
+	// Set property "AutoGeneratedDomainNameLabelScope":
 	if typedInput.AutoGeneratedDomainNameLabelScope != nil {
 		autoGeneratedDomainNameLabelScope := *typedInput.AutoGeneratedDomainNameLabelScope
 		address.AutoGeneratedDomainNameLabelScope = &autoGeneratedDomainNameLabelScope
 	}
 
-	// Set property ‘DnsNameLabel’:
+	// Set property "DnsNameLabel":
 	if typedInput.DnsNameLabel != nil {
 		dnsNameLabel := *typedInput.DnsNameLabel
 		address.DnsNameLabel = &dnsNameLabel
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	if typedInput.Fqdn != nil {
 		fqdn := *typedInput.Fqdn
 		address.Fqdn = &fqdn
 	}
 
-	// Set property ‘Ip’:
+	// Set property "Ip":
 	if typedInput.Ip != nil {
 		ip := *typedInput.Ip
 		address.Ip = &ip
 	}
 
-	// Set property ‘Ports’:
+	// Set property "Ports":
 	for _, item := range typedInput.Ports {
 		var item1 Port_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5650,7 +5650,7 @@ func (address *IpAddress_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		address.Ports = append(address.Ports, item1)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		address.Type = &typeVar
@@ -5797,7 +5797,7 @@ func (volume *Volume) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &Volume_ARM{}
 
-	// Set property ‘AzureFile’:
+	// Set property "AzureFile":
 	if volume.AzureFile != nil {
 		azureFile_ARM, err := (*volume.AzureFile).ConvertToARM(resolved)
 		if err != nil {
@@ -5807,7 +5807,7 @@ func (volume *Volume) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.AzureFile = &azureFile
 	}
 
-	// Set property ‘EmptyDir’:
+	// Set property "EmptyDir":
 	if volume.EmptyDir != nil {
 		result.EmptyDir = make(map[string]v1.JSON, len(volume.EmptyDir))
 		for key, value := range volume.EmptyDir {
@@ -5815,7 +5815,7 @@ func (volume *Volume) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		}
 	}
 
-	// Set property ‘GitRepo’:
+	// Set property "GitRepo":
 	if volume.GitRepo != nil {
 		gitRepo_ARM, err := (*volume.GitRepo).ConvertToARM(resolved)
 		if err != nil {
@@ -5825,13 +5825,13 @@ func (volume *Volume) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.GitRepo = &gitRepo
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if volume.Name != nil {
 		name := *volume.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Secret’:
+	// Set property "Secret":
 	if volume.Secret != nil {
 		result.Secret = make(map[string]string, len(volume.Secret))
 		for key, value := range volume.Secret {
@@ -5853,7 +5853,7 @@ func (volume *Volume) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Volume_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureFile’:
+	// Set property "AzureFile":
 	if typedInput.AzureFile != nil {
 		var azureFile1 AzureFileVolume
 		err := azureFile1.PopulateFromARM(owner, *typedInput.AzureFile)
@@ -5864,7 +5864,7 @@ func (volume *Volume) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		volume.AzureFile = &azureFile
 	}
 
-	// Set property ‘EmptyDir’:
+	// Set property "EmptyDir":
 	if typedInput.EmptyDir != nil {
 		volume.EmptyDir = make(map[string]v1.JSON, len(typedInput.EmptyDir))
 		for key, value := range typedInput.EmptyDir {
@@ -5872,7 +5872,7 @@ func (volume *Volume) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		}
 	}
 
-	// Set property ‘GitRepo’:
+	// Set property "GitRepo":
 	if typedInput.GitRepo != nil {
 		var gitRepo1 GitRepoVolume
 		err := gitRepo1.PopulateFromARM(owner, *typedInput.GitRepo)
@@ -5883,13 +5883,13 @@ func (volume *Volume) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		volume.GitRepo = &gitRepo
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		volume.Name = &name
 	}
 
-	// Set property ‘Secret’:
+	// Set property "Secret":
 	if typedInput.Secret != nil {
 		volume.Secret = make(map[string]string, len(typedInput.Secret))
 		for key, value := range typedInput.Secret {
@@ -6092,7 +6092,7 @@ func (volume *Volume_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Volume_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureFile’:
+	// Set property "AzureFile":
 	if typedInput.AzureFile != nil {
 		var azureFile1 AzureFileVolume_STATUS
 		err := azureFile1.PopulateFromARM(owner, *typedInput.AzureFile)
@@ -6103,7 +6103,7 @@ func (volume *Volume_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		volume.AzureFile = &azureFile
 	}
 
-	// Set property ‘EmptyDir’:
+	// Set property "EmptyDir":
 	if typedInput.EmptyDir != nil {
 		volume.EmptyDir = make(map[string]v1.JSON, len(typedInput.EmptyDir))
 		for key, value := range typedInput.EmptyDir {
@@ -6111,7 +6111,7 @@ func (volume *Volume_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘GitRepo’:
+	// Set property "GitRepo":
 	if typedInput.GitRepo != nil {
 		var gitRepo1 GitRepoVolume_STATUS
 		err := gitRepo1.PopulateFromARM(owner, *typedInput.GitRepo)
@@ -6122,13 +6122,13 @@ func (volume *Volume_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		volume.GitRepo = &gitRepo
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		volume.Name = &name
 	}
 
-	// Set property ‘Secret’:
+	// Set property "Secret":
 	if typedInput.Secret != nil {
 		volume.Secret = make(map[string]string, len(typedInput.Secret))
 		for key, value := range typedInput.Secret {
@@ -6275,25 +6275,25 @@ func (volume *AzureFileVolume) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &AzureFileVolume_ARM{}
 
-	// Set property ‘ReadOnly’:
+	// Set property "ReadOnly":
 	if volume.ReadOnly != nil {
 		readOnly := *volume.ReadOnly
 		result.ReadOnly = &readOnly
 	}
 
-	// Set property ‘ShareName’:
+	// Set property "ShareName":
 	if volume.ShareName != nil {
 		shareName := *volume.ShareName
 		result.ShareName = &shareName
 	}
 
-	// Set property ‘StorageAccountKey’:
+	// Set property "StorageAccountKey":
 	if volume.StorageAccountKey != nil {
 		storageAccountKey := *volume.StorageAccountKey
 		result.StorageAccountKey = &storageAccountKey
 	}
 
-	// Set property ‘StorageAccountName’:
+	// Set property "StorageAccountName":
 	if volume.StorageAccountName != nil {
 		storageAccountName := *volume.StorageAccountName
 		result.StorageAccountName = &storageAccountName
@@ -6313,25 +6313,25 @@ func (volume *AzureFileVolume) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFileVolume_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ReadOnly’:
+	// Set property "ReadOnly":
 	if typedInput.ReadOnly != nil {
 		readOnly := *typedInput.ReadOnly
 		volume.ReadOnly = &readOnly
 	}
 
-	// Set property ‘ShareName’:
+	// Set property "ShareName":
 	if typedInput.ShareName != nil {
 		shareName := *typedInput.ShareName
 		volume.ShareName = &shareName
 	}
 
-	// Set property ‘StorageAccountKey’:
+	// Set property "StorageAccountKey":
 	if typedInput.StorageAccountKey != nil {
 		storageAccountKey := *typedInput.StorageAccountKey
 		volume.StorageAccountKey = &storageAccountKey
 	}
 
-	// Set property ‘StorageAccountName’:
+	// Set property "StorageAccountName":
 	if typedInput.StorageAccountName != nil {
 		storageAccountName := *typedInput.StorageAccountName
 		volume.StorageAccountName = &storageAccountName
@@ -6451,25 +6451,25 @@ func (volume *AzureFileVolume_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFileVolume_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ReadOnly’:
+	// Set property "ReadOnly":
 	if typedInput.ReadOnly != nil {
 		readOnly := *typedInput.ReadOnly
 		volume.ReadOnly = &readOnly
 	}
 
-	// Set property ‘ShareName’:
+	// Set property "ShareName":
 	if typedInput.ShareName != nil {
 		shareName := *typedInput.ShareName
 		volume.ShareName = &shareName
 	}
 
-	// Set property ‘StorageAccountKey’:
+	// Set property "StorageAccountKey":
 	if typedInput.StorageAccountKey != nil {
 		storageAccountKey := *typedInput.StorageAccountKey
 		volume.StorageAccountKey = &storageAccountKey
 	}
 
-	// Set property ‘StorageAccountName’:
+	// Set property "StorageAccountName":
 	if typedInput.StorageAccountName != nil {
 		storageAccountName := *typedInput.StorageAccountName
 		volume.StorageAccountName = &storageAccountName
@@ -6555,13 +6555,13 @@ func (port *ContainerPort) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &ContainerPort_ARM{}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if port.Port != nil {
 		port1 := *port.Port
 		result.Port = &port1
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if port.Protocol != nil {
 		protocol := *port.Protocol
 		result.Protocol = &protocol
@@ -6581,13 +6581,13 @@ func (port *ContainerPort) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerPort_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port1 := *typedInput.Port
 		port.Port = &port1
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		port.Protocol = &protocol
@@ -6683,13 +6683,13 @@ func (port *ContainerPort_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerPort_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port1 := *typedInput.Port
 		port.Port = &port1
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		port.Protocol = &protocol
@@ -6777,7 +6777,7 @@ func (probe *ContainerProbe) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &ContainerProbe_ARM{}
 
-	// Set property ‘Exec’:
+	// Set property "Exec":
 	if probe.Exec != nil {
 		exec_ARM, err := (*probe.Exec).ConvertToARM(resolved)
 		if err != nil {
@@ -6787,13 +6787,13 @@ func (probe *ContainerProbe) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Exec = &exec
 	}
 
-	// Set property ‘FailureThreshold’:
+	// Set property "FailureThreshold":
 	if probe.FailureThreshold != nil {
 		failureThreshold := *probe.FailureThreshold
 		result.FailureThreshold = &failureThreshold
 	}
 
-	// Set property ‘HttpGet’:
+	// Set property "HttpGet":
 	if probe.HttpGet != nil {
 		httpGet_ARM, err := (*probe.HttpGet).ConvertToARM(resolved)
 		if err != nil {
@@ -6803,25 +6803,25 @@ func (probe *ContainerProbe) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.HttpGet = &httpGet
 	}
 
-	// Set property ‘InitialDelaySeconds’:
+	// Set property "InitialDelaySeconds":
 	if probe.InitialDelaySeconds != nil {
 		initialDelaySeconds := *probe.InitialDelaySeconds
 		result.InitialDelaySeconds = &initialDelaySeconds
 	}
 
-	// Set property ‘PeriodSeconds’:
+	// Set property "PeriodSeconds":
 	if probe.PeriodSeconds != nil {
 		periodSeconds := *probe.PeriodSeconds
 		result.PeriodSeconds = &periodSeconds
 	}
 
-	// Set property ‘SuccessThreshold’:
+	// Set property "SuccessThreshold":
 	if probe.SuccessThreshold != nil {
 		successThreshold := *probe.SuccessThreshold
 		result.SuccessThreshold = &successThreshold
 	}
 
-	// Set property ‘TimeoutSeconds’:
+	// Set property "TimeoutSeconds":
 	if probe.TimeoutSeconds != nil {
 		timeoutSeconds := *probe.TimeoutSeconds
 		result.TimeoutSeconds = &timeoutSeconds
@@ -6841,7 +6841,7 @@ func (probe *ContainerProbe) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerProbe_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Exec’:
+	// Set property "Exec":
 	if typedInput.Exec != nil {
 		var exec1 ContainerExec
 		err := exec1.PopulateFromARM(owner, *typedInput.Exec)
@@ -6852,13 +6852,13 @@ func (probe *ContainerProbe) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		probe.Exec = &exec
 	}
 
-	// Set property ‘FailureThreshold’:
+	// Set property "FailureThreshold":
 	if typedInput.FailureThreshold != nil {
 		failureThreshold := *typedInput.FailureThreshold
 		probe.FailureThreshold = &failureThreshold
 	}
 
-	// Set property ‘HttpGet’:
+	// Set property "HttpGet":
 	if typedInput.HttpGet != nil {
 		var httpGet1 ContainerHttpGet
 		err := httpGet1.PopulateFromARM(owner, *typedInput.HttpGet)
@@ -6869,25 +6869,25 @@ func (probe *ContainerProbe) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		probe.HttpGet = &httpGet
 	}
 
-	// Set property ‘InitialDelaySeconds’:
+	// Set property "InitialDelaySeconds":
 	if typedInput.InitialDelaySeconds != nil {
 		initialDelaySeconds := *typedInput.InitialDelaySeconds
 		probe.InitialDelaySeconds = &initialDelaySeconds
 	}
 
-	// Set property ‘PeriodSeconds’:
+	// Set property "PeriodSeconds":
 	if typedInput.PeriodSeconds != nil {
 		periodSeconds := *typedInput.PeriodSeconds
 		probe.PeriodSeconds = &periodSeconds
 	}
 
-	// Set property ‘SuccessThreshold’:
+	// Set property "SuccessThreshold":
 	if typedInput.SuccessThreshold != nil {
 		successThreshold := *typedInput.SuccessThreshold
 		probe.SuccessThreshold = &successThreshold
 	}
 
-	// Set property ‘TimeoutSeconds’:
+	// Set property "TimeoutSeconds":
 	if typedInput.TimeoutSeconds != nil {
 		timeoutSeconds := *typedInput.TimeoutSeconds
 		probe.TimeoutSeconds = &timeoutSeconds
@@ -7082,7 +7082,7 @@ func (probe *ContainerProbe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerProbe_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Exec’:
+	// Set property "Exec":
 	if typedInput.Exec != nil {
 		var exec1 ContainerExec_STATUS
 		err := exec1.PopulateFromARM(owner, *typedInput.Exec)
@@ -7093,13 +7093,13 @@ func (probe *ContainerProbe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		probe.Exec = &exec
 	}
 
-	// Set property ‘FailureThreshold’:
+	// Set property "FailureThreshold":
 	if typedInput.FailureThreshold != nil {
 		failureThreshold := *typedInput.FailureThreshold
 		probe.FailureThreshold = &failureThreshold
 	}
 
-	// Set property ‘HttpGet’:
+	// Set property "HttpGet":
 	if typedInput.HttpGet != nil {
 		var httpGet1 ContainerHttpGet_STATUS
 		err := httpGet1.PopulateFromARM(owner, *typedInput.HttpGet)
@@ -7110,25 +7110,25 @@ func (probe *ContainerProbe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		probe.HttpGet = &httpGet
 	}
 
-	// Set property ‘InitialDelaySeconds’:
+	// Set property "InitialDelaySeconds":
 	if typedInput.InitialDelaySeconds != nil {
 		initialDelaySeconds := *typedInput.InitialDelaySeconds
 		probe.InitialDelaySeconds = &initialDelaySeconds
 	}
 
-	// Set property ‘PeriodSeconds’:
+	// Set property "PeriodSeconds":
 	if typedInput.PeriodSeconds != nil {
 		periodSeconds := *typedInput.PeriodSeconds
 		probe.PeriodSeconds = &periodSeconds
 	}
 
-	// Set property ‘SuccessThreshold’:
+	// Set property "SuccessThreshold":
 	if typedInput.SuccessThreshold != nil {
 		successThreshold := *typedInput.SuccessThreshold
 		probe.SuccessThreshold = &successThreshold
 	}
 
-	// Set property ‘TimeoutSeconds’:
+	// Set property "TimeoutSeconds":
 	if typedInput.TimeoutSeconds != nil {
 		timeoutSeconds := *typedInput.TimeoutSeconds
 		probe.TimeoutSeconds = &timeoutSeconds
@@ -7267,7 +7267,7 @@ func (view *ContainerProperties_InstanceView_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerProperties_InstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CurrentState’:
+	// Set property "CurrentState":
 	if typedInput.CurrentState != nil {
 		var currentState1 ContainerState_STATUS
 		err := currentState1.PopulateFromARM(owner, *typedInput.CurrentState)
@@ -7278,7 +7278,7 @@ func (view *ContainerProperties_InstanceView_STATUS) PopulateFromARM(owner genru
 		view.CurrentState = &currentState
 	}
 
-	// Set property ‘Events’:
+	// Set property "Events":
 	for _, item := range typedInput.Events {
 		var item1 Event_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7288,7 +7288,7 @@ func (view *ContainerProperties_InstanceView_STATUS) PopulateFromARM(owner genru
 		view.Events = append(view.Events, item1)
 	}
 
-	// Set property ‘PreviousState’:
+	// Set property "PreviousState":
 	if typedInput.PreviousState != nil {
 		var previousState1 ContainerState_STATUS
 		err := previousState1.PopulateFromARM(owner, *typedInput.PreviousState)
@@ -7299,7 +7299,7 @@ func (view *ContainerProperties_InstanceView_STATUS) PopulateFromARM(owner genru
 		view.PreviousState = &previousState
 	}
 
-	// Set property ‘RestartCount’:
+	// Set property "RestartCount":
 	if typedInput.RestartCount != nil {
 		restartCount := *typedInput.RestartCount
 		view.RestartCount = &restartCount
@@ -7444,13 +7444,13 @@ func (variable *EnvironmentVariable) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &EnvironmentVariable_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if variable.Name != nil {
 		name := *variable.Name
 		result.Name = &name
 	}
 
-	// Set property ‘SecureValue’:
+	// Set property "SecureValue":
 	if variable.SecureValue != nil {
 		secureValueSecret, err := resolved.ResolvedSecrets.Lookup(*variable.SecureValue)
 		if err != nil {
@@ -7460,7 +7460,7 @@ func (variable *EnvironmentVariable) ConvertToARM(resolved genruntime.ConvertToA
 		result.SecureValue = &secureValue
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if variable.Value != nil {
 		value := *variable.Value
 		result.Value = &value
@@ -7480,15 +7480,15 @@ func (variable *EnvironmentVariable) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EnvironmentVariable_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		variable.Name = &name
 	}
 
-	// no assignment for property ‘SecureValue’
+	// no assignment for property "SecureValue"
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		variable.Value = &value
@@ -7585,13 +7585,13 @@ func (variable *EnvironmentVariable_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EnvironmentVariable_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		variable.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		variable.Value = &value
@@ -7671,37 +7671,37 @@ func (event *Event_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Event_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		event.Count = &count
 	}
 
-	// Set property ‘FirstTimestamp’:
+	// Set property "FirstTimestamp":
 	if typedInput.FirstTimestamp != nil {
 		firstTimestamp := *typedInput.FirstTimestamp
 		event.FirstTimestamp = &firstTimestamp
 	}
 
-	// Set property ‘LastTimestamp’:
+	// Set property "LastTimestamp":
 	if typedInput.LastTimestamp != nil {
 		lastTimestamp := *typedInput.LastTimestamp
 		event.LastTimestamp = &lastTimestamp
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		event.Message = &message
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		event.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		event.Type = &typeVar
@@ -7794,19 +7794,19 @@ func (volume *GitRepoVolume) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &GitRepoVolume_ARM{}
 
-	// Set property ‘Directory’:
+	// Set property "Directory":
 	if volume.Directory != nil {
 		directory := *volume.Directory
 		result.Directory = &directory
 	}
 
-	// Set property ‘Repository’:
+	// Set property "Repository":
 	if volume.Repository != nil {
 		repository := *volume.Repository
 		result.Repository = &repository
 	}
 
-	// Set property ‘Revision’:
+	// Set property "Revision":
 	if volume.Revision != nil {
 		revision := *volume.Revision
 		result.Revision = &revision
@@ -7826,19 +7826,19 @@ func (volume *GitRepoVolume) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GitRepoVolume_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Directory’:
+	// Set property "Directory":
 	if typedInput.Directory != nil {
 		directory := *typedInput.Directory
 		volume.Directory = &directory
 	}
 
-	// Set property ‘Repository’:
+	// Set property "Repository":
 	if typedInput.Repository != nil {
 		repository := *typedInput.Repository
 		volume.Repository = &repository
 	}
 
-	// Set property ‘Revision’:
+	// Set property "Revision":
 	if typedInput.Revision != nil {
 		revision := *typedInput.Revision
 		volume.Revision = &revision
@@ -7933,19 +7933,19 @@ func (volume *GitRepoVolume_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GitRepoVolume_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Directory’:
+	// Set property "Directory":
 	if typedInput.Directory != nil {
 		directory := *typedInput.Directory
 		volume.Directory = &directory
 	}
 
-	// Set property ‘Repository’:
+	// Set property "Repository":
 	if typedInput.Repository != nil {
 		repository := *typedInput.Repository
 		volume.Repository = &repository
 	}
 
-	// Set property ‘Revision’:
+	// Set property "Revision":
 	if typedInput.Revision != nil {
 		revision := *typedInput.Revision
 		volume.Revision = &revision
@@ -8024,7 +8024,7 @@ func (view *InitContainerPropertiesDefinition_InstanceView_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InitContainerPropertiesDefinition_InstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CurrentState’:
+	// Set property "CurrentState":
 	if typedInput.CurrentState != nil {
 		var currentState1 ContainerState_STATUS
 		err := currentState1.PopulateFromARM(owner, *typedInput.CurrentState)
@@ -8035,7 +8035,7 @@ func (view *InitContainerPropertiesDefinition_InstanceView_STATUS) PopulateFromA
 		view.CurrentState = &currentState
 	}
 
-	// Set property ‘Events’:
+	// Set property "Events":
 	for _, item := range typedInput.Events {
 		var item1 Event_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8045,7 +8045,7 @@ func (view *InitContainerPropertiesDefinition_InstanceView_STATUS) PopulateFromA
 		view.Events = append(view.Events, item1)
 	}
 
-	// Set property ‘PreviousState’:
+	// Set property "PreviousState":
 	if typedInput.PreviousState != nil {
 		var previousState1 ContainerState_STATUS
 		err := previousState1.PopulateFromARM(owner, *typedInput.PreviousState)
@@ -8056,7 +8056,7 @@ func (view *InitContainerPropertiesDefinition_InstanceView_STATUS) PopulateFromA
 		view.PreviousState = &previousState
 	}
 
-	// Set property ‘RestartCount’:
+	// Set property "RestartCount":
 	if typedInput.RestartCount != nil {
 		restartCount := *typedInput.RestartCount
 		view.RestartCount = &restartCount
@@ -8244,13 +8244,13 @@ func (analytics *LogAnalytics) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &LogAnalytics_ARM{}
 
-	// Set property ‘LogType’:
+	// Set property "LogType":
 	if analytics.LogType != nil {
 		logType := *analytics.LogType
 		result.LogType = &logType
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	if analytics.Metadata != nil {
 		result.Metadata = make(map[string]string, len(analytics.Metadata))
 		for key, value := range analytics.Metadata {
@@ -8258,20 +8258,20 @@ func (analytics *LogAnalytics) ConvertToARM(resolved genruntime.ConvertToARMReso
 		}
 	}
 
-	// Set property ‘WorkspaceId’:
+	// Set property "WorkspaceId":
 	if analytics.WorkspaceId != nil {
 		workspaceId := *analytics.WorkspaceId
 		result.WorkspaceId = &workspaceId
 	}
 
-	// Set property ‘WorkspaceKey’:
+	// Set property "WorkspaceKey":
 	workspaceKeySecret, err := resolved.ResolvedSecrets.Lookup(analytics.WorkspaceKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "looking up secret for property WorkspaceKey")
 	}
 	result.WorkspaceKey = workspaceKeySecret
 
-	// Set property ‘WorkspaceResourceId’:
+	// Set property "WorkspaceResourceId":
 	if analytics.WorkspaceResourceReference != nil {
 		workspaceResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*analytics.WorkspaceResourceReference)
 		if err != nil {
@@ -8295,13 +8295,13 @@ func (analytics *LogAnalytics) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LogAnalytics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LogType’:
+	// Set property "LogType":
 	if typedInput.LogType != nil {
 		logType := *typedInput.LogType
 		analytics.LogType = &logType
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	if typedInput.Metadata != nil {
 		analytics.Metadata = make(map[string]string, len(typedInput.Metadata))
 		for key, value := range typedInput.Metadata {
@@ -8309,15 +8309,15 @@ func (analytics *LogAnalytics) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘WorkspaceId’:
+	// Set property "WorkspaceId":
 	if typedInput.WorkspaceId != nil {
 		workspaceId := *typedInput.WorkspaceId
 		analytics.WorkspaceId = &workspaceId
 	}
 
-	// no assignment for property ‘WorkspaceKey’
+	// no assignment for property "WorkspaceKey"
 
-	// no assignment for property ‘WorkspaceResourceReference’
+	// no assignment for property "WorkspaceResourceReference"
 
 	// No error
 	return nil
@@ -8448,13 +8448,13 @@ func (analytics *LogAnalytics_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LogAnalytics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LogType’:
+	// Set property "LogType":
 	if typedInput.LogType != nil {
 		logType := *typedInput.LogType
 		analytics.LogType = &logType
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	if typedInput.Metadata != nil {
 		analytics.Metadata = make(map[string]string, len(typedInput.Metadata))
 		for key, value := range typedInput.Metadata {
@@ -8462,7 +8462,7 @@ func (analytics *LogAnalytics_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘WorkspaceId’:
+	// Set property "WorkspaceId":
 	if typedInput.WorkspaceId != nil {
 		workspaceId := *typedInput.WorkspaceId
 		analytics.WorkspaceId = &workspaceId
@@ -8542,13 +8542,13 @@ func (port *Port) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) 
 	}
 	result := &Port_ARM{}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if port.Port != nil {
 		port1 := *port.Port
 		result.Port = &port1
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if port.Protocol != nil {
 		protocol := *port.Protocol
 		result.Protocol = &protocol
@@ -8568,13 +8568,13 @@ func (port *Port) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armI
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Port_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port1 := *typedInput.Port
 		port.Port = &port1
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		port.Protocol = &protocol
@@ -8670,13 +8670,13 @@ func (port *Port_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Port_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port1 := *typedInput.Port
 		port.Port = &port1
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		port.Protocol = &protocol
@@ -8750,7 +8750,7 @@ func (requirements *ResourceRequirements) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &ResourceRequirements_ARM{}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if requirements.Limits != nil {
 		limits_ARM, err := (*requirements.Limits).ConvertToARM(resolved)
 		if err != nil {
@@ -8760,7 +8760,7 @@ func (requirements *ResourceRequirements) ConvertToARM(resolved genruntime.Conve
 		result.Limits = &limits
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if requirements.Requests != nil {
 		requests_ARM, err := (*requirements.Requests).ConvertToARM(resolved)
 		if err != nil {
@@ -8784,7 +8784,7 @@ func (requirements *ResourceRequirements) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceRequirements_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if typedInput.Limits != nil {
 		var limits1 ResourceLimits
 		err := limits1.PopulateFromARM(owner, *typedInput.Limits)
@@ -8795,7 +8795,7 @@ func (requirements *ResourceRequirements) PopulateFromARM(owner genruntime.Arbit
 		requirements.Limits = &limits
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if typedInput.Requests != nil {
 		var requests1 ResourceRequests
 		err := requests1.PopulateFromARM(owner, *typedInput.Requests)
@@ -8935,7 +8935,7 @@ func (requirements *ResourceRequirements_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceRequirements_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if typedInput.Limits != nil {
 		var limits1 ResourceLimits_STATUS
 		err := limits1.PopulateFromARM(owner, *typedInput.Limits)
@@ -8946,7 +8946,7 @@ func (requirements *ResourceRequirements_STATUS) PopulateFromARM(owner genruntim
 		requirements.Limits = &limits
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if typedInput.Requests != nil {
 		var requests1 ResourceRequests_STATUS
 		err := requests1.PopulateFromARM(owner, *typedInput.Requests)
@@ -9057,13 +9057,13 @@ func (identities *UserAssignedIdentities_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -9165,19 +9165,19 @@ func (mount *VolumeMount) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &VolumeMount_ARM{}
 
-	// Set property ‘MountPath’:
+	// Set property "MountPath":
 	if mount.MountPath != nil {
 		mountPath := *mount.MountPath
 		result.MountPath = &mountPath
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if mount.Name != nil {
 		name := *mount.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ReadOnly’:
+	// Set property "ReadOnly":
 	if mount.ReadOnly != nil {
 		readOnly := *mount.ReadOnly
 		result.ReadOnly = &readOnly
@@ -9197,19 +9197,19 @@ func (mount *VolumeMount) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VolumeMount_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MountPath’:
+	// Set property "MountPath":
 	if typedInput.MountPath != nil {
 		mountPath := *typedInput.MountPath
 		mount.MountPath = &mountPath
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		mount.Name = &name
 	}
 
-	// Set property ‘ReadOnly’:
+	// Set property "ReadOnly":
 	if typedInput.ReadOnly != nil {
 		readOnly := *typedInput.ReadOnly
 		mount.ReadOnly = &readOnly
@@ -9317,19 +9317,19 @@ func (mount *VolumeMount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VolumeMount_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MountPath’:
+	// Set property "MountPath":
 	if typedInput.MountPath != nil {
 		mountPath := *typedInput.MountPath
 		mount.MountPath = &mountPath
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		mount.Name = &name
 	}
 
-	// Set property ‘ReadOnly’:
+	// Set property "ReadOnly":
 	if typedInput.ReadOnly != nil {
 		readOnly := *typedInput.ReadOnly
 		mount.ReadOnly = &readOnly
@@ -9405,7 +9405,7 @@ func (exec *ContainerExec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &ContainerExec_ARM{}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	for _, item := range exec.Command {
 		result.Command = append(result.Command, item)
 	}
@@ -9424,7 +9424,7 @@ func (exec *ContainerExec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerExec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	for _, item := range typedInput.Command {
 		exec.Command = append(exec.Command, item)
 	}
@@ -9492,7 +9492,7 @@ func (exec *ContainerExec_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerExec_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	for _, item := range typedInput.Command {
 		exec.Command = append(exec.Command, item)
 	}
@@ -9555,7 +9555,7 @@ func (httpGet *ContainerHttpGet) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ContainerHttpGet_ARM{}
 
-	// Set property ‘HttpHeaders’:
+	// Set property "HttpHeaders":
 	for _, item := range httpGet.HttpHeaders {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -9564,19 +9564,19 @@ func (httpGet *ContainerHttpGet) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.HttpHeaders = append(result.HttpHeaders, *item_ARM.(*HttpHeader_ARM))
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if httpGet.Path != nil {
 		path := *httpGet.Path
 		result.Path = &path
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if httpGet.Port != nil {
 		port := *httpGet.Port
 		result.Port = &port
 	}
 
-	// Set property ‘Scheme’:
+	// Set property "Scheme":
 	if httpGet.Scheme != nil {
 		scheme := *httpGet.Scheme
 		result.Scheme = &scheme
@@ -9596,7 +9596,7 @@ func (httpGet *ContainerHttpGet) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerHttpGet_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpHeaders’:
+	// Set property "HttpHeaders":
 	for _, item := range typedInput.HttpHeaders {
 		var item1 HttpHeader
 		err := item1.PopulateFromARM(owner, item)
@@ -9606,19 +9606,19 @@ func (httpGet *ContainerHttpGet) PopulateFromARM(owner genruntime.ArbitraryOwner
 		httpGet.HttpHeaders = append(httpGet.HttpHeaders, item1)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		httpGet.Path = &path
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port := *typedInput.Port
 		httpGet.Port = &port
 	}
 
-	// Set property ‘Scheme’:
+	// Set property "Scheme":
 	if typedInput.Scheme != nil {
 		scheme := *typedInput.Scheme
 		httpGet.Scheme = &scheme
@@ -9783,7 +9783,7 @@ func (httpGet *ContainerHttpGet_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerHttpGet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpHeaders’:
+	// Set property "HttpHeaders":
 	for _, item := range typedInput.HttpHeaders {
 		var item1 HttpHeader_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -9793,19 +9793,19 @@ func (httpGet *ContainerHttpGet_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		httpGet.HttpHeaders = append(httpGet.HttpHeaders, item1)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		httpGet.Path = &path
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port := *typedInput.Port
 		httpGet.Port = &port
 	}
 
-	// Set property ‘Scheme’:
+	// Set property "Scheme":
 	if typedInput.Scheme != nil {
 		scheme := *typedInput.Scheme
 		httpGet.Scheme = &scheme
@@ -9949,31 +9949,31 @@ func (state *ContainerState_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerState_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DetailStatus’:
+	// Set property "DetailStatus":
 	if typedInput.DetailStatus != nil {
 		detailStatus := *typedInput.DetailStatus
 		state.DetailStatus = &detailStatus
 	}
 
-	// Set property ‘ExitCode’:
+	// Set property "ExitCode":
 	if typedInput.ExitCode != nil {
 		exitCode := *typedInput.ExitCode
 		state.ExitCode = &exitCode
 	}
 
-	// Set property ‘FinishTime’:
+	// Set property "FinishTime":
 	if typedInput.FinishTime != nil {
 		finishTime := *typedInput.FinishTime
 		state.FinishTime = &finishTime
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		state.StartTime = &startTime
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state1 := *typedInput.State
 		state.State = &state1
@@ -10087,13 +10087,13 @@ func (limits *ResourceLimits) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &ResourceLimits_ARM{}
 
-	// Set property ‘Cpu’:
+	// Set property "Cpu":
 	if limits.Cpu != nil {
 		cpu := *limits.Cpu
 		result.Cpu = &cpu
 	}
 
-	// Set property ‘Gpu’:
+	// Set property "Gpu":
 	if limits.Gpu != nil {
 		gpu_ARM, err := (*limits.Gpu).ConvertToARM(resolved)
 		if err != nil {
@@ -10103,7 +10103,7 @@ func (limits *ResourceLimits) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Gpu = &gpu
 	}
 
-	// Set property ‘MemoryInGB’:
+	// Set property "MemoryInGB":
 	if limits.MemoryInGB != nil {
 		memoryInGB := *limits.MemoryInGB
 		result.MemoryInGB = &memoryInGB
@@ -10123,13 +10123,13 @@ func (limits *ResourceLimits) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceLimits_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cpu’:
+	// Set property "Cpu":
 	if typedInput.Cpu != nil {
 		cpu := *typedInput.Cpu
 		limits.Cpu = &cpu
 	}
 
-	// Set property ‘Gpu’:
+	// Set property "Gpu":
 	if typedInput.Gpu != nil {
 		var gpu1 GpuResource
 		err := gpu1.PopulateFromARM(owner, *typedInput.Gpu)
@@ -10140,7 +10140,7 @@ func (limits *ResourceLimits) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		limits.Gpu = &gpu
 	}
 
-	// Set property ‘MemoryInGB’:
+	// Set property "MemoryInGB":
 	if typedInput.MemoryInGB != nil {
 		memoryInGB := *typedInput.MemoryInGB
 		limits.MemoryInGB = &memoryInGB
@@ -10290,13 +10290,13 @@ func (limits *ResourceLimits_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceLimits_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cpu’:
+	// Set property "Cpu":
 	if typedInput.Cpu != nil {
 		cpu := *typedInput.Cpu
 		limits.Cpu = &cpu
 	}
 
-	// Set property ‘Gpu’:
+	// Set property "Gpu":
 	if typedInput.Gpu != nil {
 		var gpu1 GpuResource_STATUS
 		err := gpu1.PopulateFromARM(owner, *typedInput.Gpu)
@@ -10307,7 +10307,7 @@ func (limits *ResourceLimits_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		limits.Gpu = &gpu
 	}
 
-	// Set property ‘MemoryInGB’:
+	// Set property "MemoryInGB":
 	if typedInput.MemoryInGB != nil {
 		memoryInGB := *typedInput.MemoryInGB
 		limits.MemoryInGB = &memoryInGB
@@ -10419,13 +10419,13 @@ func (requests *ResourceRequests) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ResourceRequests_ARM{}
 
-	// Set property ‘Cpu’:
+	// Set property "Cpu":
 	if requests.Cpu != nil {
 		cpu := *requests.Cpu
 		result.Cpu = &cpu
 	}
 
-	// Set property ‘Gpu’:
+	// Set property "Gpu":
 	if requests.Gpu != nil {
 		gpu_ARM, err := (*requests.Gpu).ConvertToARM(resolved)
 		if err != nil {
@@ -10435,7 +10435,7 @@ func (requests *ResourceRequests) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Gpu = &gpu
 	}
 
-	// Set property ‘MemoryInGB’:
+	// Set property "MemoryInGB":
 	if requests.MemoryInGB != nil {
 		memoryInGB := *requests.MemoryInGB
 		result.MemoryInGB = &memoryInGB
@@ -10455,13 +10455,13 @@ func (requests *ResourceRequests) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceRequests_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cpu’:
+	// Set property "Cpu":
 	if typedInput.Cpu != nil {
 		cpu := *typedInput.Cpu
 		requests.Cpu = &cpu
 	}
 
-	// Set property ‘Gpu’:
+	// Set property "Gpu":
 	if typedInput.Gpu != nil {
 		var gpu1 GpuResource
 		err := gpu1.PopulateFromARM(owner, *typedInput.Gpu)
@@ -10472,7 +10472,7 @@ func (requests *ResourceRequests) PopulateFromARM(owner genruntime.ArbitraryOwne
 		requests.Gpu = &gpu
 	}
 
-	// Set property ‘MemoryInGB’:
+	// Set property "MemoryInGB":
 	if typedInput.MemoryInGB != nil {
 		memoryInGB := *typedInput.MemoryInGB
 		requests.MemoryInGB = &memoryInGB
@@ -10622,13 +10622,13 @@ func (requests *ResourceRequests_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceRequests_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cpu’:
+	// Set property "Cpu":
 	if typedInput.Cpu != nil {
 		cpu := *typedInput.Cpu
 		requests.Cpu = &cpu
 	}
 
-	// Set property ‘Gpu’:
+	// Set property "Gpu":
 	if typedInput.Gpu != nil {
 		var gpu1 GpuResource_STATUS
 		err := gpu1.PopulateFromARM(owner, *typedInput.Gpu)
@@ -10639,7 +10639,7 @@ func (requests *ResourceRequests_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		requests.Gpu = &gpu
 	}
 
-	// Set property ‘MemoryInGB’:
+	// Set property "MemoryInGB":
 	if typedInput.MemoryInGB != nil {
 		memoryInGB := *typedInput.MemoryInGB
 		requests.MemoryInGB = &memoryInGB
@@ -10763,13 +10763,13 @@ func (resource *GpuResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &GpuResource_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if resource.Count != nil {
 		count := *resource.Count
 		result.Count = &count
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if resource.Sku != nil {
 		sku := *resource.Sku
 		result.Sku = &sku
@@ -10789,13 +10789,13 @@ func (resource *GpuResource) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GpuResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		resource.Count = &count
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		sku := *typedInput.Sku
 		resource.Sku = &sku
@@ -10891,13 +10891,13 @@ func (resource *GpuResource_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GpuResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		resource.Count = &count
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		sku := *typedInput.Sku
 		resource.Sku = &sku
@@ -10970,13 +10970,13 @@ func (header *HttpHeader) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &HttpHeader_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if header.Name != nil {
 		name := *header.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if header.Value != nil {
 		value := *header.Value
 		result.Value = &value
@@ -10996,13 +10996,13 @@ func (header *HttpHeader) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HttpHeader_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		header.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		header.Value = &value
@@ -11083,13 +11083,13 @@ func (header *HttpHeader_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HttpHeader_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		header.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		header.Value = &value

--- a/v2/api/containerinstance/v1beta20211001/container_group_types_gen.go
+++ b/v2/api/containerinstance/v1beta20211001/container_group_types_gen.go
@@ -357,7 +357,7 @@ func (group *ContainerGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ContainerGroup_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if group.Identity != nil {
 		identity_ARM, err := (*group.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -367,16 +367,16 @@ func (group *ContainerGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if group.Location != nil {
 		location := *group.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if group.Containers != nil ||
 		group.Diagnostics != nil ||
 		group.DnsConfig != nil ||
@@ -471,7 +471,7 @@ func (group *ContainerGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.Volumes = append(result.Properties.Volumes, *item_ARM.(*Volume_ARM))
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if group.Tags != nil {
 		result.Tags = make(map[string]string, len(group.Tags))
 		for key, value := range group.Tags {
@@ -479,7 +479,7 @@ func (group *ContainerGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range group.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -498,10 +498,10 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroup_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	group.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Containers’:
+	// Set property "Containers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Containers {
@@ -514,7 +514,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Diagnostics’:
+	// Set property "Diagnostics":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Diagnostics != nil {
@@ -528,7 +528,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘DnsConfig’:
+	// Set property "DnsConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsConfig != nil {
@@ -542,7 +542,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘EncryptionProperties’:
+	// Set property "EncryptionProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionProperties != nil {
@@ -556,7 +556,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ContainerGroupIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -567,7 +567,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		group.Identity = &identity
 	}
 
-	// Set property ‘ImageRegistryCredentials’:
+	// Set property "ImageRegistryCredentials":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ImageRegistryCredentials {
@@ -580,7 +580,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘InitContainers’:
+	// Set property "InitContainers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InitContainers {
@@ -593,7 +593,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpAddress != nil {
@@ -607,13 +607,13 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		group.Location = &location
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -622,10 +622,10 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	group.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RestartPolicy’:
+	// Set property "RestartPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestartPolicy != nil {
@@ -634,7 +634,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -643,7 +643,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘SubnetIds’:
+	// Set property "SubnetIds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SubnetIds {
@@ -656,7 +656,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		group.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -664,7 +664,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Volumes’:
+	// Set property "Volumes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Volumes {
@@ -677,7 +677,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		group.Zones = append(group.Zones, item)
 	}
@@ -1249,9 +1249,9 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Containers’:
+	// Set property "Containers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Containers {
@@ -1264,7 +1264,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Diagnostics’:
+	// Set property "Diagnostics":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Diagnostics != nil {
@@ -1278,7 +1278,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DnsConfig’:
+	// Set property "DnsConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsConfig != nil {
@@ -1292,7 +1292,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EncryptionProperties’:
+	// Set property "EncryptionProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionProperties != nil {
@@ -1306,13 +1306,13 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		group.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ContainerGroupIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1323,7 +1323,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		group.Identity = &identity
 	}
 
-	// Set property ‘ImageRegistryCredentials’:
+	// Set property "ImageRegistryCredentials":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ImageRegistryCredentials {
@@ -1336,7 +1336,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘InitContainers’:
+	// Set property "InitContainers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InitContainers {
@@ -1349,7 +1349,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -1363,7 +1363,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpAddress != nil {
@@ -1377,19 +1377,19 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		group.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		group.Name = &name
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -1398,7 +1398,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1407,7 +1407,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘RestartPolicy’:
+	// Set property "RestartPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestartPolicy != nil {
@@ -1416,7 +1416,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -1425,7 +1425,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SubnetIds’:
+	// Set property "SubnetIds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SubnetIds {
@@ -1438,7 +1438,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		group.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1446,13 +1446,13 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		group.Type = &typeVar
 	}
 
-	// Set property ‘Volumes’:
+	// Set property "Volumes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Volumes {
@@ -1465,7 +1465,7 @@ func (group *ContainerGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		group.Zones = append(group.Zones, item)
 	}
@@ -1945,13 +1945,13 @@ func (container *Container) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &Container_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if container.Name != nil {
 		name := *container.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if container.Command != nil ||
 		container.EnvironmentVariables != nil ||
 		container.Image != nil ||
@@ -2029,7 +2029,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Container_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Command {
@@ -2037,7 +2037,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘EnvironmentVariables’:
+	// Set property "EnvironmentVariables":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EnvironmentVariables {
@@ -2050,7 +2050,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Image != nil {
@@ -2059,7 +2059,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘LivenessProbe’:
+	// Set property "LivenessProbe":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LivenessProbe != nil {
@@ -2073,13 +2073,13 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		container.Name = &name
 	}
 
-	// Set property ‘Ports’:
+	// Set property "Ports":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Ports {
@@ -2092,7 +2092,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘ReadinessProbe’:
+	// Set property "ReadinessProbe":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReadinessProbe != nil {
@@ -2106,7 +2106,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resources != nil {
@@ -2120,7 +2120,7 @@ func (container *Container) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘VolumeMounts’:
+	// Set property "VolumeMounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VolumeMounts {
@@ -2386,7 +2386,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Container_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Command {
@@ -2394,7 +2394,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘EnvironmentVariables’:
+	// Set property "EnvironmentVariables":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EnvironmentVariables {
@@ -2407,7 +2407,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Image != nil {
@@ -2416,7 +2416,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -2430,7 +2430,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘LivenessProbe’:
+	// Set property "LivenessProbe":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LivenessProbe != nil {
@@ -2444,13 +2444,13 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		container.Name = &name
 	}
 
-	// Set property ‘Ports’:
+	// Set property "Ports":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Ports {
@@ -2463,7 +2463,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ReadinessProbe’:
+	// Set property "ReadinessProbe":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReadinessProbe != nil {
@@ -2477,7 +2477,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resources != nil {
@@ -2491,7 +2491,7 @@ func (container *Container_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘VolumeMounts’:
+	// Set property "VolumeMounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VolumeMounts {
@@ -2773,7 +2773,7 @@ func (view *ContainerGroup_Properties_InstanceView_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroup_Properties_InstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Events’:
+	// Set property "Events":
 	for _, item := range typedInput.Events {
 		var item1 Event_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2783,7 +2783,7 @@ func (view *ContainerGroup_Properties_InstanceView_STATUS) PopulateFromARM(owner
 		view.Events = append(view.Events, item1)
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		view.State = &state
@@ -2912,7 +2912,7 @@ func (diagnostics *ContainerGroupDiagnostics) ConvertToARM(resolved genruntime.C
 	}
 	result := &ContainerGroupDiagnostics_ARM{}
 
-	// Set property ‘LogAnalytics’:
+	// Set property "LogAnalytics":
 	if diagnostics.LogAnalytics != nil {
 		logAnalytics_ARM, err := (*diagnostics.LogAnalytics).ConvertToARM(resolved)
 		if err != nil {
@@ -2936,7 +2936,7 @@ func (diagnostics *ContainerGroupDiagnostics) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroupDiagnostics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LogAnalytics’:
+	// Set property "LogAnalytics":
 	if typedInput.LogAnalytics != nil {
 		var logAnalytics1 LogAnalytics
 		err := logAnalytics1.PopulateFromARM(owner, *typedInput.LogAnalytics)
@@ -3017,7 +3017,7 @@ func (diagnostics *ContainerGroupDiagnostics_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroupDiagnostics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LogAnalytics’:
+	// Set property "LogAnalytics":
 	if typedInput.LogAnalytics != nil {
 		var logAnalytics1 LogAnalytics_STATUS
 		err := logAnalytics1.PopulateFromARM(owner, *typedInput.LogAnalytics)
@@ -3094,13 +3094,13 @@ func (identity *ContainerGroupIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ContainerGroupIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -3125,13 +3125,13 @@ func (identity *ContainerGroupIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroupIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -3234,25 +3234,25 @@ func (identity *ContainerGroupIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroupIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -3390,7 +3390,7 @@ func (subnetId *ContainerGroupSubnetId) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ContainerGroupSubnetId_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if subnetId.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*subnetId.Reference)
 		if err != nil {
@@ -3400,7 +3400,7 @@ func (subnetId *ContainerGroupSubnetId) ConvertToARM(resolved genruntime.Convert
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if subnetId.Name != nil {
 		name := *subnetId.Name
 		result.Name = &name
@@ -3420,13 +3420,13 @@ func (subnetId *ContainerGroupSubnetId) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroupSubnetId_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		subnetId.Name = &name
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3497,13 +3497,13 @@ func (subnetId *ContainerGroupSubnetId_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerGroupSubnetId_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		subnetId.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		subnetId.Name = &name
@@ -3565,18 +3565,18 @@ func (configuration *DnsConfiguration) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &DnsConfiguration_ARM{}
 
-	// Set property ‘NameServers’:
+	// Set property "NameServers":
 	for _, item := range configuration.NameServers {
 		result.NameServers = append(result.NameServers, item)
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	if configuration.Options != nil {
 		options := *configuration.Options
 		result.Options = &options
 	}
 
-	// Set property ‘SearchDomains’:
+	// Set property "SearchDomains":
 	if configuration.SearchDomains != nil {
 		searchDomains := *configuration.SearchDomains
 		result.SearchDomains = &searchDomains
@@ -3596,18 +3596,18 @@ func (configuration *DnsConfiguration) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NameServers’:
+	// Set property "NameServers":
 	for _, item := range typedInput.NameServers {
 		configuration.NameServers = append(configuration.NameServers, item)
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	if typedInput.Options != nil {
 		options := *typedInput.Options
 		configuration.Options = &options
 	}
 
-	// Set property ‘SearchDomains’:
+	// Set property "SearchDomains":
 	if typedInput.SearchDomains != nil {
 		searchDomains := *typedInput.SearchDomains
 		configuration.SearchDomains = &searchDomains
@@ -3679,18 +3679,18 @@ func (configuration *DnsConfiguration_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NameServers’:
+	// Set property "NameServers":
 	for _, item := range typedInput.NameServers {
 		configuration.NameServers = append(configuration.NameServers, item)
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	if typedInput.Options != nil {
 		options := *typedInput.Options
 		configuration.Options = &options
 	}
 
-	// Set property ‘SearchDomains’:
+	// Set property "SearchDomains":
 	if typedInput.SearchDomains != nil {
 		searchDomains := *typedInput.SearchDomains
 		configuration.SearchDomains = &searchDomains
@@ -3762,19 +3762,19 @@ func (properties *EncryptionProperties) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &EncryptionProperties_ARM{}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if properties.KeyName != nil {
 		keyName := *properties.KeyName
 		result.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if properties.KeyVersion != nil {
 		keyVersion := *properties.KeyVersion
 		result.KeyVersion = &keyVersion
 	}
 
-	// Set property ‘VaultBaseUrl’:
+	// Set property "VaultBaseUrl":
 	if properties.VaultBaseUrl != nil {
 		vaultBaseUrl := *properties.VaultBaseUrl
 		result.VaultBaseUrl = &vaultBaseUrl
@@ -3794,19 +3794,19 @@ func (properties *EncryptionProperties) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		properties.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		properties.KeyVersion = &keyVersion
 	}
 
-	// Set property ‘VaultBaseUrl’:
+	// Set property "VaultBaseUrl":
 	if typedInput.VaultBaseUrl != nil {
 		vaultBaseUrl := *typedInput.VaultBaseUrl
 		properties.VaultBaseUrl = &vaultBaseUrl
@@ -3878,19 +3878,19 @@ func (properties *EncryptionProperties_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		properties.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		properties.KeyVersion = &keyVersion
 	}
 
-	// Set property ‘VaultBaseUrl’:
+	// Set property "VaultBaseUrl":
 	if typedInput.VaultBaseUrl != nil {
 		vaultBaseUrl := *typedInput.VaultBaseUrl
 		properties.VaultBaseUrl = &vaultBaseUrl
@@ -3961,19 +3961,19 @@ func (credential *ImageRegistryCredential) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ImageRegistryCredential_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if credential.Identity != nil {
 		identity := *credential.Identity
 		result.Identity = &identity
 	}
 
-	// Set property ‘IdentityUrl’:
+	// Set property "IdentityUrl":
 	if credential.IdentityUrl != nil {
 		identityUrl := *credential.IdentityUrl
 		result.IdentityUrl = &identityUrl
 	}
 
-	// Set property ‘Password’:
+	// Set property "Password":
 	if credential.Password != nil {
 		passwordSecret, err := resolved.ResolvedSecrets.Lookup(*credential.Password)
 		if err != nil {
@@ -3983,13 +3983,13 @@ func (credential *ImageRegistryCredential) ConvertToARM(resolved genruntime.Conv
 		result.Password = &password
 	}
 
-	// Set property ‘Server’:
+	// Set property "Server":
 	if credential.Server != nil {
 		server := *credential.Server
 		result.Server = &server
 	}
 
-	// Set property ‘Username’:
+	// Set property "Username":
 	if credential.Username != nil {
 		username := *credential.Username
 		result.Username = &username
@@ -4009,27 +4009,27 @@ func (credential *ImageRegistryCredential) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageRegistryCredential_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		identity := *typedInput.Identity
 		credential.Identity = &identity
 	}
 
-	// Set property ‘IdentityUrl’:
+	// Set property "IdentityUrl":
 	if typedInput.IdentityUrl != nil {
 		identityUrl := *typedInput.IdentityUrl
 		credential.IdentityUrl = &identityUrl
 	}
 
-	// no assignment for property ‘Password’
+	// no assignment for property "Password"
 
-	// Set property ‘Server’:
+	// Set property "Server":
 	if typedInput.Server != nil {
 		server := *typedInput.Server
 		credential.Server = &server
 	}
 
-	// Set property ‘Username’:
+	// Set property "Username":
 	if typedInput.Username != nil {
 		username := *typedInput.Username
 		credential.Username = &username
@@ -4124,25 +4124,25 @@ func (credential *ImageRegistryCredential_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImageRegistryCredential_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		identity := *typedInput.Identity
 		credential.Identity = &identity
 	}
 
-	// Set property ‘IdentityUrl’:
+	// Set property "IdentityUrl":
 	if typedInput.IdentityUrl != nil {
 		identityUrl := *typedInput.IdentityUrl
 		credential.IdentityUrl = &identityUrl
 	}
 
-	// Set property ‘Server’:
+	// Set property "Server":
 	if typedInput.Server != nil {
 		server := *typedInput.Server
 		credential.Server = &server
 	}
 
-	// Set property ‘Username’:
+	// Set property "Username":
 	if typedInput.Username != nil {
 		username := *typedInput.Username
 		credential.Username = &username
@@ -4219,13 +4219,13 @@ func (definition *InitContainerDefinition) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &InitContainerDefinition_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if definition.Name != nil {
 		name := *definition.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if definition.Command != nil ||
 		definition.EnvironmentVariables != nil ||
 		definition.Image != nil ||
@@ -4268,7 +4268,7 @@ func (definition *InitContainerDefinition) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InitContainerDefinition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Command {
@@ -4276,7 +4276,7 @@ func (definition *InitContainerDefinition) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘EnvironmentVariables’:
+	// Set property "EnvironmentVariables":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EnvironmentVariables {
@@ -4289,7 +4289,7 @@ func (definition *InitContainerDefinition) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Image != nil {
@@ -4298,13 +4298,13 @@ func (definition *InitContainerDefinition) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		definition.Name = &name
 	}
 
-	// Set property ‘VolumeMounts’:
+	// Set property "VolumeMounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VolumeMounts {
@@ -4458,7 +4458,7 @@ func (definition *InitContainerDefinition_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InitContainerDefinition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Command {
@@ -4466,7 +4466,7 @@ func (definition *InitContainerDefinition_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘EnvironmentVariables’:
+	// Set property "EnvironmentVariables":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EnvironmentVariables {
@@ -4479,7 +4479,7 @@ func (definition *InitContainerDefinition_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Image’:
+	// Set property "Image":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Image != nil {
@@ -4488,7 +4488,7 @@ func (definition *InitContainerDefinition_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘InstanceView’:
+	// Set property "InstanceView":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstanceView != nil {
@@ -4502,13 +4502,13 @@ func (definition *InitContainerDefinition_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		definition.Name = &name
 	}
 
-	// Set property ‘VolumeMounts’:
+	// Set property "VolumeMounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VolumeMounts {
@@ -4684,25 +4684,25 @@ func (address *IpAddress) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &IpAddress_ARM{}
 
-	// Set property ‘AutoGeneratedDomainNameLabelScope’:
+	// Set property "AutoGeneratedDomainNameLabelScope":
 	if address.AutoGeneratedDomainNameLabelScope != nil {
 		autoGeneratedDomainNameLabelScope := *address.AutoGeneratedDomainNameLabelScope
 		result.AutoGeneratedDomainNameLabelScope = &autoGeneratedDomainNameLabelScope
 	}
 
-	// Set property ‘DnsNameLabel’:
+	// Set property "DnsNameLabel":
 	if address.DnsNameLabel != nil {
 		dnsNameLabel := *address.DnsNameLabel
 		result.DnsNameLabel = &dnsNameLabel
 	}
 
-	// Set property ‘Ip’:
+	// Set property "Ip":
 	if address.Ip != nil {
 		ip := *address.Ip
 		result.Ip = &ip
 	}
 
-	// Set property ‘Ports’:
+	// Set property "Ports":
 	for _, item := range address.Ports {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4711,7 +4711,7 @@ func (address *IpAddress) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Ports = append(result.Ports, *item_ARM.(*Port_ARM))
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if address.Type != nil {
 		typeVar := *address.Type
 		result.Type = &typeVar
@@ -4731,25 +4731,25 @@ func (address *IpAddress) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpAddress_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoGeneratedDomainNameLabelScope’:
+	// Set property "AutoGeneratedDomainNameLabelScope":
 	if typedInput.AutoGeneratedDomainNameLabelScope != nil {
 		autoGeneratedDomainNameLabelScope := *typedInput.AutoGeneratedDomainNameLabelScope
 		address.AutoGeneratedDomainNameLabelScope = &autoGeneratedDomainNameLabelScope
 	}
 
-	// Set property ‘DnsNameLabel’:
+	// Set property "DnsNameLabel":
 	if typedInput.DnsNameLabel != nil {
 		dnsNameLabel := *typedInput.DnsNameLabel
 		address.DnsNameLabel = &dnsNameLabel
 	}
 
-	// Set property ‘Ip’:
+	// Set property "Ip":
 	if typedInput.Ip != nil {
 		ip := *typedInput.Ip
 		address.Ip = &ip
 	}
 
-	// Set property ‘Ports’:
+	// Set property "Ports":
 	for _, item := range typedInput.Ports {
 		var item1 Port
 		err := item1.PopulateFromARM(owner, item)
@@ -4759,7 +4759,7 @@ func (address *IpAddress) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		address.Ports = append(address.Ports, item1)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		address.Type = &typeVar
@@ -4896,31 +4896,31 @@ func (address *IpAddress_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpAddress_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoGeneratedDomainNameLabelScope’:
+	// Set property "AutoGeneratedDomainNameLabelScope":
 	if typedInput.AutoGeneratedDomainNameLabelScope != nil {
 		autoGeneratedDomainNameLabelScope := *typedInput.AutoGeneratedDomainNameLabelScope
 		address.AutoGeneratedDomainNameLabelScope = &autoGeneratedDomainNameLabelScope
 	}
 
-	// Set property ‘DnsNameLabel’:
+	// Set property "DnsNameLabel":
 	if typedInput.DnsNameLabel != nil {
 		dnsNameLabel := *typedInput.DnsNameLabel
 		address.DnsNameLabel = &dnsNameLabel
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	if typedInput.Fqdn != nil {
 		fqdn := *typedInput.Fqdn
 		address.Fqdn = &fqdn
 	}
 
-	// Set property ‘Ip’:
+	// Set property "Ip":
 	if typedInput.Ip != nil {
 		ip := *typedInput.Ip
 		address.Ip = &ip
 	}
 
-	// Set property ‘Ports’:
+	// Set property "Ports":
 	for _, item := range typedInput.Ports {
 		var item1 Port_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4930,7 +4930,7 @@ func (address *IpAddress_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		address.Ports = append(address.Ports, item1)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		address.Type = &typeVar
@@ -5069,7 +5069,7 @@ func (volume *Volume) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &Volume_ARM{}
 
-	// Set property ‘AzureFile’:
+	// Set property "AzureFile":
 	if volume.AzureFile != nil {
 		azureFile_ARM, err := (*volume.AzureFile).ConvertToARM(resolved)
 		if err != nil {
@@ -5079,7 +5079,7 @@ func (volume *Volume) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.AzureFile = &azureFile
 	}
 
-	// Set property ‘EmptyDir’:
+	// Set property "EmptyDir":
 	if volume.EmptyDir != nil {
 		result.EmptyDir = make(map[string]v1.JSON, len(volume.EmptyDir))
 		for key, value := range volume.EmptyDir {
@@ -5087,7 +5087,7 @@ func (volume *Volume) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		}
 	}
 
-	// Set property ‘GitRepo’:
+	// Set property "GitRepo":
 	if volume.GitRepo != nil {
 		gitRepo_ARM, err := (*volume.GitRepo).ConvertToARM(resolved)
 		if err != nil {
@@ -5097,13 +5097,13 @@ func (volume *Volume) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		result.GitRepo = &gitRepo
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if volume.Name != nil {
 		name := *volume.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Secret’:
+	// Set property "Secret":
 	if volume.Secret != nil {
 		result.Secret = make(map[string]string, len(volume.Secret))
 		for key, value := range volume.Secret {
@@ -5125,7 +5125,7 @@ func (volume *Volume) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Volume_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureFile’:
+	// Set property "AzureFile":
 	if typedInput.AzureFile != nil {
 		var azureFile1 AzureFileVolume
 		err := azureFile1.PopulateFromARM(owner, *typedInput.AzureFile)
@@ -5136,7 +5136,7 @@ func (volume *Volume) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		volume.AzureFile = &azureFile
 	}
 
-	// Set property ‘EmptyDir’:
+	// Set property "EmptyDir":
 	if typedInput.EmptyDir != nil {
 		volume.EmptyDir = make(map[string]v1.JSON, len(typedInput.EmptyDir))
 		for key, value := range typedInput.EmptyDir {
@@ -5144,7 +5144,7 @@ func (volume *Volume) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		}
 	}
 
-	// Set property ‘GitRepo’:
+	// Set property "GitRepo":
 	if typedInput.GitRepo != nil {
 		var gitRepo1 GitRepoVolume
 		err := gitRepo1.PopulateFromARM(owner, *typedInput.GitRepo)
@@ -5155,13 +5155,13 @@ func (volume *Volume) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		volume.GitRepo = &gitRepo
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		volume.Name = &name
 	}
 
-	// Set property ‘Secret’:
+	// Set property "Secret":
 	if typedInput.Secret != nil {
 		volume.Secret = make(map[string]string, len(typedInput.Secret))
 		for key, value := range typedInput.Secret {
@@ -5305,7 +5305,7 @@ func (volume *Volume_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Volume_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureFile’:
+	// Set property "AzureFile":
 	if typedInput.AzureFile != nil {
 		var azureFile1 AzureFileVolume_STATUS
 		err := azureFile1.PopulateFromARM(owner, *typedInput.AzureFile)
@@ -5316,7 +5316,7 @@ func (volume *Volume_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		volume.AzureFile = &azureFile
 	}
 
-	// Set property ‘EmptyDir’:
+	// Set property "EmptyDir":
 	if typedInput.EmptyDir != nil {
 		volume.EmptyDir = make(map[string]v1.JSON, len(typedInput.EmptyDir))
 		for key, value := range typedInput.EmptyDir {
@@ -5324,7 +5324,7 @@ func (volume *Volume_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘GitRepo’:
+	// Set property "GitRepo":
 	if typedInput.GitRepo != nil {
 		var gitRepo1 GitRepoVolume_STATUS
 		err := gitRepo1.PopulateFromARM(owner, *typedInput.GitRepo)
@@ -5335,13 +5335,13 @@ func (volume *Volume_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		volume.GitRepo = &gitRepo
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		volume.Name = &name
 	}
 
-	// Set property ‘Secret’:
+	// Set property "Secret":
 	if typedInput.Secret != nil {
 		volume.Secret = make(map[string]string, len(typedInput.Secret))
 		for key, value := range typedInput.Secret {
@@ -5483,25 +5483,25 @@ func (volume *AzureFileVolume) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &AzureFileVolume_ARM{}
 
-	// Set property ‘ReadOnly’:
+	// Set property "ReadOnly":
 	if volume.ReadOnly != nil {
 		readOnly := *volume.ReadOnly
 		result.ReadOnly = &readOnly
 	}
 
-	// Set property ‘ShareName’:
+	// Set property "ShareName":
 	if volume.ShareName != nil {
 		shareName := *volume.ShareName
 		result.ShareName = &shareName
 	}
 
-	// Set property ‘StorageAccountKey’:
+	// Set property "StorageAccountKey":
 	if volume.StorageAccountKey != nil {
 		storageAccountKey := *volume.StorageAccountKey
 		result.StorageAccountKey = &storageAccountKey
 	}
 
-	// Set property ‘StorageAccountName’:
+	// Set property "StorageAccountName":
 	if volume.StorageAccountName != nil {
 		storageAccountName := *volume.StorageAccountName
 		result.StorageAccountName = &storageAccountName
@@ -5521,25 +5521,25 @@ func (volume *AzureFileVolume) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFileVolume_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ReadOnly’:
+	// Set property "ReadOnly":
 	if typedInput.ReadOnly != nil {
 		readOnly := *typedInput.ReadOnly
 		volume.ReadOnly = &readOnly
 	}
 
-	// Set property ‘ShareName’:
+	// Set property "ShareName":
 	if typedInput.ShareName != nil {
 		shareName := *typedInput.ShareName
 		volume.ShareName = &shareName
 	}
 
-	// Set property ‘StorageAccountKey’:
+	// Set property "StorageAccountKey":
 	if typedInput.StorageAccountKey != nil {
 		storageAccountKey := *typedInput.StorageAccountKey
 		volume.StorageAccountKey = &storageAccountKey
 	}
 
-	// Set property ‘StorageAccountName’:
+	// Set property "StorageAccountName":
 	if typedInput.StorageAccountName != nil {
 		storageAccountName := *typedInput.StorageAccountName
 		volume.StorageAccountName = &storageAccountName
@@ -5628,25 +5628,25 @@ func (volume *AzureFileVolume_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFileVolume_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ReadOnly’:
+	// Set property "ReadOnly":
 	if typedInput.ReadOnly != nil {
 		readOnly := *typedInput.ReadOnly
 		volume.ReadOnly = &readOnly
 	}
 
-	// Set property ‘ShareName’:
+	// Set property "ShareName":
 	if typedInput.ShareName != nil {
 		shareName := *typedInput.ShareName
 		volume.ShareName = &shareName
 	}
 
-	// Set property ‘StorageAccountKey’:
+	// Set property "StorageAccountKey":
 	if typedInput.StorageAccountKey != nil {
 		storageAccountKey := *typedInput.StorageAccountKey
 		volume.StorageAccountKey = &storageAccountKey
 	}
 
-	// Set property ‘StorageAccountName’:
+	// Set property "StorageAccountName":
 	if typedInput.StorageAccountName != nil {
 		storageAccountName := *typedInput.StorageAccountName
 		volume.StorageAccountName = &storageAccountName
@@ -5729,13 +5729,13 @@ func (port *ContainerPort) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &ContainerPort_ARM{}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if port.Port != nil {
 		port1 := *port.Port
 		result.Port = &port1
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if port.Protocol != nil {
 		protocol := *port.Protocol
 		result.Protocol = &protocol
@@ -5755,13 +5755,13 @@ func (port *ContainerPort) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerPort_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port1 := *typedInput.Port
 		port.Port = &port1
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		port.Protocol = &protocol
@@ -5836,13 +5836,13 @@ func (port *ContainerPort_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerPort_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port1 := *typedInput.Port
 		port.Port = &port1
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		port.Protocol = &protocol
@@ -5917,7 +5917,7 @@ func (probe *ContainerProbe) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &ContainerProbe_ARM{}
 
-	// Set property ‘Exec’:
+	// Set property "Exec":
 	if probe.Exec != nil {
 		exec_ARM, err := (*probe.Exec).ConvertToARM(resolved)
 		if err != nil {
@@ -5927,13 +5927,13 @@ func (probe *ContainerProbe) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Exec = &exec
 	}
 
-	// Set property ‘FailureThreshold’:
+	// Set property "FailureThreshold":
 	if probe.FailureThreshold != nil {
 		failureThreshold := *probe.FailureThreshold
 		result.FailureThreshold = &failureThreshold
 	}
 
-	// Set property ‘HttpGet’:
+	// Set property "HttpGet":
 	if probe.HttpGet != nil {
 		httpGet_ARM, err := (*probe.HttpGet).ConvertToARM(resolved)
 		if err != nil {
@@ -5943,25 +5943,25 @@ func (probe *ContainerProbe) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.HttpGet = &httpGet
 	}
 
-	// Set property ‘InitialDelaySeconds’:
+	// Set property "InitialDelaySeconds":
 	if probe.InitialDelaySeconds != nil {
 		initialDelaySeconds := *probe.InitialDelaySeconds
 		result.InitialDelaySeconds = &initialDelaySeconds
 	}
 
-	// Set property ‘PeriodSeconds’:
+	// Set property "PeriodSeconds":
 	if probe.PeriodSeconds != nil {
 		periodSeconds := *probe.PeriodSeconds
 		result.PeriodSeconds = &periodSeconds
 	}
 
-	// Set property ‘SuccessThreshold’:
+	// Set property "SuccessThreshold":
 	if probe.SuccessThreshold != nil {
 		successThreshold := *probe.SuccessThreshold
 		result.SuccessThreshold = &successThreshold
 	}
 
-	// Set property ‘TimeoutSeconds’:
+	// Set property "TimeoutSeconds":
 	if probe.TimeoutSeconds != nil {
 		timeoutSeconds := *probe.TimeoutSeconds
 		result.TimeoutSeconds = &timeoutSeconds
@@ -5981,7 +5981,7 @@ func (probe *ContainerProbe) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerProbe_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Exec’:
+	// Set property "Exec":
 	if typedInput.Exec != nil {
 		var exec1 ContainerExec
 		err := exec1.PopulateFromARM(owner, *typedInput.Exec)
@@ -5992,13 +5992,13 @@ func (probe *ContainerProbe) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		probe.Exec = &exec
 	}
 
-	// Set property ‘FailureThreshold’:
+	// Set property "FailureThreshold":
 	if typedInput.FailureThreshold != nil {
 		failureThreshold := *typedInput.FailureThreshold
 		probe.FailureThreshold = &failureThreshold
 	}
 
-	// Set property ‘HttpGet’:
+	// Set property "HttpGet":
 	if typedInput.HttpGet != nil {
 		var httpGet1 ContainerHttpGet
 		err := httpGet1.PopulateFromARM(owner, *typedInput.HttpGet)
@@ -6009,25 +6009,25 @@ func (probe *ContainerProbe) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		probe.HttpGet = &httpGet
 	}
 
-	// Set property ‘InitialDelaySeconds’:
+	// Set property "InitialDelaySeconds":
 	if typedInput.InitialDelaySeconds != nil {
 		initialDelaySeconds := *typedInput.InitialDelaySeconds
 		probe.InitialDelaySeconds = &initialDelaySeconds
 	}
 
-	// Set property ‘PeriodSeconds’:
+	// Set property "PeriodSeconds":
 	if typedInput.PeriodSeconds != nil {
 		periodSeconds := *typedInput.PeriodSeconds
 		probe.PeriodSeconds = &periodSeconds
 	}
 
-	// Set property ‘SuccessThreshold’:
+	// Set property "SuccessThreshold":
 	if typedInput.SuccessThreshold != nil {
 		successThreshold := *typedInput.SuccessThreshold
 		probe.SuccessThreshold = &successThreshold
 	}
 
-	// Set property ‘TimeoutSeconds’:
+	// Set property "TimeoutSeconds":
 	if typedInput.TimeoutSeconds != nil {
 		timeoutSeconds := *typedInput.TimeoutSeconds
 		probe.TimeoutSeconds = &timeoutSeconds
@@ -6163,7 +6163,7 @@ func (probe *ContainerProbe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerProbe_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Exec’:
+	// Set property "Exec":
 	if typedInput.Exec != nil {
 		var exec1 ContainerExec_STATUS
 		err := exec1.PopulateFromARM(owner, *typedInput.Exec)
@@ -6174,13 +6174,13 @@ func (probe *ContainerProbe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		probe.Exec = &exec
 	}
 
-	// Set property ‘FailureThreshold’:
+	// Set property "FailureThreshold":
 	if typedInput.FailureThreshold != nil {
 		failureThreshold := *typedInput.FailureThreshold
 		probe.FailureThreshold = &failureThreshold
 	}
 
-	// Set property ‘HttpGet’:
+	// Set property "HttpGet":
 	if typedInput.HttpGet != nil {
 		var httpGet1 ContainerHttpGet_STATUS
 		err := httpGet1.PopulateFromARM(owner, *typedInput.HttpGet)
@@ -6191,25 +6191,25 @@ func (probe *ContainerProbe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		probe.HttpGet = &httpGet
 	}
 
-	// Set property ‘InitialDelaySeconds’:
+	// Set property "InitialDelaySeconds":
 	if typedInput.InitialDelaySeconds != nil {
 		initialDelaySeconds := *typedInput.InitialDelaySeconds
 		probe.InitialDelaySeconds = &initialDelaySeconds
 	}
 
-	// Set property ‘PeriodSeconds’:
+	// Set property "PeriodSeconds":
 	if typedInput.PeriodSeconds != nil {
 		periodSeconds := *typedInput.PeriodSeconds
 		probe.PeriodSeconds = &periodSeconds
 	}
 
-	// Set property ‘SuccessThreshold’:
+	// Set property "SuccessThreshold":
 	if typedInput.SuccessThreshold != nil {
 		successThreshold := *typedInput.SuccessThreshold
 		probe.SuccessThreshold = &successThreshold
 	}
 
-	// Set property ‘TimeoutSeconds’:
+	// Set property "TimeoutSeconds":
 	if typedInput.TimeoutSeconds != nil {
 		timeoutSeconds := *typedInput.TimeoutSeconds
 		probe.TimeoutSeconds = &timeoutSeconds
@@ -6342,7 +6342,7 @@ func (view *ContainerProperties_InstanceView_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerProperties_InstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CurrentState’:
+	// Set property "CurrentState":
 	if typedInput.CurrentState != nil {
 		var currentState1 ContainerState_STATUS
 		err := currentState1.PopulateFromARM(owner, *typedInput.CurrentState)
@@ -6353,7 +6353,7 @@ func (view *ContainerProperties_InstanceView_STATUS) PopulateFromARM(owner genru
 		view.CurrentState = &currentState
 	}
 
-	// Set property ‘Events’:
+	// Set property "Events":
 	for _, item := range typedInput.Events {
 		var item1 Event_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6363,7 +6363,7 @@ func (view *ContainerProperties_InstanceView_STATUS) PopulateFromARM(owner genru
 		view.Events = append(view.Events, item1)
 	}
 
-	// Set property ‘PreviousState’:
+	// Set property "PreviousState":
 	if typedInput.PreviousState != nil {
 		var previousState1 ContainerState_STATUS
 		err := previousState1.PopulateFromARM(owner, *typedInput.PreviousState)
@@ -6374,7 +6374,7 @@ func (view *ContainerProperties_InstanceView_STATUS) PopulateFromARM(owner genru
 		view.PreviousState = &previousState
 	}
 
-	// Set property ‘RestartCount’:
+	// Set property "RestartCount":
 	if typedInput.RestartCount != nil {
 		restartCount := *typedInput.RestartCount
 		view.RestartCount = &restartCount
@@ -6514,13 +6514,13 @@ func (variable *EnvironmentVariable) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &EnvironmentVariable_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if variable.Name != nil {
 		name := *variable.Name
 		result.Name = &name
 	}
 
-	// Set property ‘SecureValue’:
+	// Set property "SecureValue":
 	if variable.SecureValue != nil {
 		secureValueSecret, err := resolved.ResolvedSecrets.Lookup(*variable.SecureValue)
 		if err != nil {
@@ -6530,7 +6530,7 @@ func (variable *EnvironmentVariable) ConvertToARM(resolved genruntime.ConvertToA
 		result.SecureValue = &secureValue
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if variable.Value != nil {
 		value := *variable.Value
 		result.Value = &value
@@ -6550,15 +6550,15 @@ func (variable *EnvironmentVariable) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EnvironmentVariable_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		variable.Name = &name
 	}
 
-	// no assignment for property ‘SecureValue’
+	// no assignment for property "SecureValue"
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		variable.Value = &value
@@ -6639,13 +6639,13 @@ func (variable *EnvironmentVariable_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EnvironmentVariable_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		variable.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		variable.Value = &value
@@ -6714,37 +6714,37 @@ func (event *Event_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Event_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		event.Count = &count
 	}
 
-	// Set property ‘FirstTimestamp’:
+	// Set property "FirstTimestamp":
 	if typedInput.FirstTimestamp != nil {
 		firstTimestamp := *typedInput.FirstTimestamp
 		event.FirstTimestamp = &firstTimestamp
 	}
 
-	// Set property ‘LastTimestamp’:
+	// Set property "LastTimestamp":
 	if typedInput.LastTimestamp != nil {
 		lastTimestamp := *typedInput.LastTimestamp
 		event.LastTimestamp = &lastTimestamp
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		event.Message = &message
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		event.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		event.Type = &typeVar
@@ -6831,19 +6831,19 @@ func (volume *GitRepoVolume) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &GitRepoVolume_ARM{}
 
-	// Set property ‘Directory’:
+	// Set property "Directory":
 	if volume.Directory != nil {
 		directory := *volume.Directory
 		result.Directory = &directory
 	}
 
-	// Set property ‘Repository’:
+	// Set property "Repository":
 	if volume.Repository != nil {
 		repository := *volume.Repository
 		result.Repository = &repository
 	}
 
-	// Set property ‘Revision’:
+	// Set property "Revision":
 	if volume.Revision != nil {
 		revision := *volume.Revision
 		result.Revision = &revision
@@ -6863,19 +6863,19 @@ func (volume *GitRepoVolume) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GitRepoVolume_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Directory’:
+	// Set property "Directory":
 	if typedInput.Directory != nil {
 		directory := *typedInput.Directory
 		volume.Directory = &directory
 	}
 
-	// Set property ‘Repository’:
+	// Set property "Repository":
 	if typedInput.Repository != nil {
 		repository := *typedInput.Repository
 		volume.Repository = &repository
 	}
 
-	// Set property ‘Revision’:
+	// Set property "Revision":
 	if typedInput.Revision != nil {
 		revision := *typedInput.Revision
 		volume.Revision = &revision
@@ -6947,19 +6947,19 @@ func (volume *GitRepoVolume_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GitRepoVolume_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Directory’:
+	// Set property "Directory":
 	if typedInput.Directory != nil {
 		directory := *typedInput.Directory
 		volume.Directory = &directory
 	}
 
-	// Set property ‘Repository’:
+	// Set property "Repository":
 	if typedInput.Repository != nil {
 		repository := *typedInput.Repository
 		volume.Repository = &repository
 	}
 
-	// Set property ‘Revision’:
+	// Set property "Revision":
 	if typedInput.Revision != nil {
 		revision := *typedInput.Revision
 		volume.Revision = &revision
@@ -7032,7 +7032,7 @@ func (view *InitContainerPropertiesDefinition_InstanceView_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InitContainerPropertiesDefinition_InstanceView_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CurrentState’:
+	// Set property "CurrentState":
 	if typedInput.CurrentState != nil {
 		var currentState1 ContainerState_STATUS
 		err := currentState1.PopulateFromARM(owner, *typedInput.CurrentState)
@@ -7043,7 +7043,7 @@ func (view *InitContainerPropertiesDefinition_InstanceView_STATUS) PopulateFromA
 		view.CurrentState = &currentState
 	}
 
-	// Set property ‘Events’:
+	// Set property "Events":
 	for _, item := range typedInput.Events {
 		var item1 Event_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7053,7 +7053,7 @@ func (view *InitContainerPropertiesDefinition_InstanceView_STATUS) PopulateFromA
 		view.Events = append(view.Events, item1)
 	}
 
-	// Set property ‘PreviousState’:
+	// Set property "PreviousState":
 	if typedInput.PreviousState != nil {
 		var previousState1 ContainerState_STATUS
 		err := previousState1.PopulateFromARM(owner, *typedInput.PreviousState)
@@ -7064,7 +7064,7 @@ func (view *InitContainerPropertiesDefinition_InstanceView_STATUS) PopulateFromA
 		view.PreviousState = &previousState
 	}
 
-	// Set property ‘RestartCount’:
+	// Set property "RestartCount":
 	if typedInput.RestartCount != nil {
 		restartCount := *typedInput.RestartCount
 		view.RestartCount = &restartCount
@@ -7251,13 +7251,13 @@ func (analytics *LogAnalytics) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &LogAnalytics_ARM{}
 
-	// Set property ‘LogType’:
+	// Set property "LogType":
 	if analytics.LogType != nil {
 		logType := *analytics.LogType
 		result.LogType = &logType
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	if analytics.Metadata != nil {
 		result.Metadata = make(map[string]string, len(analytics.Metadata))
 		for key, value := range analytics.Metadata {
@@ -7265,20 +7265,20 @@ func (analytics *LogAnalytics) ConvertToARM(resolved genruntime.ConvertToARMReso
 		}
 	}
 
-	// Set property ‘WorkspaceId’:
+	// Set property "WorkspaceId":
 	if analytics.WorkspaceId != nil {
 		workspaceId := *analytics.WorkspaceId
 		result.WorkspaceId = &workspaceId
 	}
 
-	// Set property ‘WorkspaceKey’:
+	// Set property "WorkspaceKey":
 	workspaceKeySecret, err := resolved.ResolvedSecrets.Lookup(analytics.WorkspaceKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "looking up secret for property WorkspaceKey")
 	}
 	result.WorkspaceKey = workspaceKeySecret
 
-	// Set property ‘WorkspaceResourceId’:
+	// Set property "WorkspaceResourceId":
 	if analytics.WorkspaceResourceReference != nil {
 		workspaceResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*analytics.WorkspaceResourceReference)
 		if err != nil {
@@ -7302,13 +7302,13 @@ func (analytics *LogAnalytics) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LogAnalytics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LogType’:
+	// Set property "LogType":
 	if typedInput.LogType != nil {
 		logType := *typedInput.LogType
 		analytics.LogType = &logType
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	if typedInput.Metadata != nil {
 		analytics.Metadata = make(map[string]string, len(typedInput.Metadata))
 		for key, value := range typedInput.Metadata {
@@ -7316,15 +7316,15 @@ func (analytics *LogAnalytics) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘WorkspaceId’:
+	// Set property "WorkspaceId":
 	if typedInput.WorkspaceId != nil {
 		workspaceId := *typedInput.WorkspaceId
 		analytics.WorkspaceId = &workspaceId
 	}
 
-	// no assignment for property ‘WorkspaceKey’
+	// no assignment for property "WorkspaceKey"
 
-	// no assignment for property ‘WorkspaceResourceReference’
+	// no assignment for property "WorkspaceResourceReference"
 
 	// No error
 	return nil
@@ -7429,13 +7429,13 @@ func (analytics *LogAnalytics_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LogAnalytics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LogType’:
+	// Set property "LogType":
 	if typedInput.LogType != nil {
 		logType := *typedInput.LogType
 		analytics.LogType = &logType
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	if typedInput.Metadata != nil {
 		analytics.Metadata = make(map[string]string, len(typedInput.Metadata))
 		for key, value := range typedInput.Metadata {
@@ -7443,7 +7443,7 @@ func (analytics *LogAnalytics_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘WorkspaceId’:
+	// Set property "WorkspaceId":
 	if typedInput.WorkspaceId != nil {
 		workspaceId := *typedInput.WorkspaceId
 		analytics.WorkspaceId = &workspaceId
@@ -7520,13 +7520,13 @@ func (port *Port) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) 
 	}
 	result := &Port_ARM{}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if port.Port != nil {
 		port1 := *port.Port
 		result.Port = &port1
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if port.Protocol != nil {
 		protocol := *port.Protocol
 		result.Protocol = &protocol
@@ -7546,13 +7546,13 @@ func (port *Port) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armI
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Port_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port1 := *typedInput.Port
 		port.Port = &port1
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		port.Protocol = &protocol
@@ -7627,13 +7627,13 @@ func (port *Port_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Port_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port1 := *typedInput.Port
 		port.Port = &port1
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		port.Protocol = &protocol
@@ -7705,7 +7705,7 @@ func (requirements *ResourceRequirements) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &ResourceRequirements_ARM{}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if requirements.Limits != nil {
 		limits_ARM, err := (*requirements.Limits).ConvertToARM(resolved)
 		if err != nil {
@@ -7715,7 +7715,7 @@ func (requirements *ResourceRequirements) ConvertToARM(resolved genruntime.Conve
 		result.Limits = &limits
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if requirements.Requests != nil {
 		requests_ARM, err := (*requirements.Requests).ConvertToARM(resolved)
 		if err != nil {
@@ -7739,7 +7739,7 @@ func (requirements *ResourceRequirements) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceRequirements_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if typedInput.Limits != nil {
 		var limits1 ResourceLimits
 		err := limits1.PopulateFromARM(owner, *typedInput.Limits)
@@ -7750,7 +7750,7 @@ func (requirements *ResourceRequirements) PopulateFromARM(owner genruntime.Arbit
 		requirements.Limits = &limits
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if typedInput.Requests != nil {
 		var requests1 ResourceRequests
 		err := requests1.PopulateFromARM(owner, *typedInput.Requests)
@@ -7856,7 +7856,7 @@ func (requirements *ResourceRequirements_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceRequirements_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if typedInput.Limits != nil {
 		var limits1 ResourceLimits_STATUS
 		err := limits1.PopulateFromARM(owner, *typedInput.Limits)
@@ -7867,7 +7867,7 @@ func (requirements *ResourceRequirements_STATUS) PopulateFromARM(owner genruntim
 		requirements.Limits = &limits
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if typedInput.Requests != nil {
 		var requests1 ResourceRequests_STATUS
 		err := requests1.PopulateFromARM(owner, *typedInput.Requests)
@@ -7973,13 +7973,13 @@ func (identities *UserAssignedIdentities_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -8077,19 +8077,19 @@ func (mount *VolumeMount) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &VolumeMount_ARM{}
 
-	// Set property ‘MountPath’:
+	// Set property "MountPath":
 	if mount.MountPath != nil {
 		mountPath := *mount.MountPath
 		result.MountPath = &mountPath
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if mount.Name != nil {
 		name := *mount.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ReadOnly’:
+	// Set property "ReadOnly":
 	if mount.ReadOnly != nil {
 		readOnly := *mount.ReadOnly
 		result.ReadOnly = &readOnly
@@ -8109,19 +8109,19 @@ func (mount *VolumeMount) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VolumeMount_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MountPath’:
+	// Set property "MountPath":
 	if typedInput.MountPath != nil {
 		mountPath := *typedInput.MountPath
 		mount.MountPath = &mountPath
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		mount.Name = &name
 	}
 
-	// Set property ‘ReadOnly’:
+	// Set property "ReadOnly":
 	if typedInput.ReadOnly != nil {
 		readOnly := *typedInput.ReadOnly
 		mount.ReadOnly = &readOnly
@@ -8203,19 +8203,19 @@ func (mount *VolumeMount_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VolumeMount_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MountPath’:
+	// Set property "MountPath":
 	if typedInput.MountPath != nil {
 		mountPath := *typedInput.MountPath
 		mount.MountPath = &mountPath
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		mount.Name = &name
 	}
 
-	// Set property ‘ReadOnly’:
+	// Set property "ReadOnly":
 	if typedInput.ReadOnly != nil {
 		readOnly := *typedInput.ReadOnly
 		mount.ReadOnly = &readOnly
@@ -8290,7 +8290,7 @@ func (exec *ContainerExec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &ContainerExec_ARM{}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	for _, item := range exec.Command {
 		result.Command = append(result.Command, item)
 	}
@@ -8309,7 +8309,7 @@ func (exec *ContainerExec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerExec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	for _, item := range typedInput.Command {
 		exec.Command = append(exec.Command, item)
 	}
@@ -8366,7 +8366,7 @@ func (exec *ContainerExec_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerExec_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Command’:
+	// Set property "Command":
 	for _, item := range typedInput.Command {
 		exec.Command = append(exec.Command, item)
 	}
@@ -8423,7 +8423,7 @@ func (httpGet *ContainerHttpGet) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ContainerHttpGet_ARM{}
 
-	// Set property ‘HttpHeaders’:
+	// Set property "HttpHeaders":
 	for _, item := range httpGet.HttpHeaders {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -8432,19 +8432,19 @@ func (httpGet *ContainerHttpGet) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.HttpHeaders = append(result.HttpHeaders, *item_ARM.(*HttpHeader_ARM))
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if httpGet.Path != nil {
 		path := *httpGet.Path
 		result.Path = &path
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if httpGet.Port != nil {
 		port := *httpGet.Port
 		result.Port = &port
 	}
 
-	// Set property ‘Scheme’:
+	// Set property "Scheme":
 	if httpGet.Scheme != nil {
 		scheme := *httpGet.Scheme
 		result.Scheme = &scheme
@@ -8464,7 +8464,7 @@ func (httpGet *ContainerHttpGet) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerHttpGet_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpHeaders’:
+	// Set property "HttpHeaders":
 	for _, item := range typedInput.HttpHeaders {
 		var item1 HttpHeader
 		err := item1.PopulateFromARM(owner, item)
@@ -8474,19 +8474,19 @@ func (httpGet *ContainerHttpGet) PopulateFromARM(owner genruntime.ArbitraryOwner
 		httpGet.HttpHeaders = append(httpGet.HttpHeaders, item1)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		httpGet.Path = &path
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port := *typedInput.Port
 		httpGet.Port = &port
 	}
 
-	// Set property ‘Scheme’:
+	// Set property "Scheme":
 	if typedInput.Scheme != nil {
 		scheme := *typedInput.Scheme
 		httpGet.Scheme = &scheme
@@ -8605,7 +8605,7 @@ func (httpGet *ContainerHttpGet_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerHttpGet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpHeaders’:
+	// Set property "HttpHeaders":
 	for _, item := range typedInput.HttpHeaders {
 		var item1 HttpHeader_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8615,19 +8615,19 @@ func (httpGet *ContainerHttpGet_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		httpGet.HttpHeaders = append(httpGet.HttpHeaders, item1)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		httpGet.Path = &path
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port := *typedInput.Port
 		httpGet.Port = &port
 	}
 
-	// Set property ‘Scheme’:
+	// Set property "Scheme":
 	if typedInput.Scheme != nil {
 		scheme := *typedInput.Scheme
 		httpGet.Scheme = &scheme
@@ -8764,31 +8764,31 @@ func (state *ContainerState_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerState_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DetailStatus’:
+	// Set property "DetailStatus":
 	if typedInput.DetailStatus != nil {
 		detailStatus := *typedInput.DetailStatus
 		state.DetailStatus = &detailStatus
 	}
 
-	// Set property ‘ExitCode’:
+	// Set property "ExitCode":
 	if typedInput.ExitCode != nil {
 		exitCode := *typedInput.ExitCode
 		state.ExitCode = &exitCode
 	}
 
-	// Set property ‘FinishTime’:
+	// Set property "FinishTime":
 	if typedInput.FinishTime != nil {
 		finishTime := *typedInput.FinishTime
 		state.FinishTime = &finishTime
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		state.StartTime = &startTime
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state1 := *typedInput.State
 		state.State = &state1
@@ -8901,13 +8901,13 @@ func (limits *ResourceLimits) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &ResourceLimits_ARM{}
 
-	// Set property ‘Cpu’:
+	// Set property "Cpu":
 	if limits.Cpu != nil {
 		cpu := *limits.Cpu
 		result.Cpu = &cpu
 	}
 
-	// Set property ‘Gpu’:
+	// Set property "Gpu":
 	if limits.Gpu != nil {
 		gpu_ARM, err := (*limits.Gpu).ConvertToARM(resolved)
 		if err != nil {
@@ -8917,7 +8917,7 @@ func (limits *ResourceLimits) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Gpu = &gpu
 	}
 
-	// Set property ‘MemoryInGB’:
+	// Set property "MemoryInGB":
 	if limits.MemoryInGB != nil {
 		memoryInGB := *limits.MemoryInGB
 		result.MemoryInGB = &memoryInGB
@@ -8937,13 +8937,13 @@ func (limits *ResourceLimits) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceLimits_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cpu’:
+	// Set property "Cpu":
 	if typedInput.Cpu != nil {
 		cpu := *typedInput.Cpu
 		limits.Cpu = &cpu
 	}
 
-	// Set property ‘Gpu’:
+	// Set property "Gpu":
 	if typedInput.Gpu != nil {
 		var gpu1 GpuResource
 		err := gpu1.PopulateFromARM(owner, *typedInput.Gpu)
@@ -8954,7 +8954,7 @@ func (limits *ResourceLimits) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		limits.Gpu = &gpu
 	}
 
-	// Set property ‘MemoryInGB’:
+	// Set property "MemoryInGB":
 	if typedInput.MemoryInGB != nil {
 		memoryInGB := *typedInput.MemoryInGB
 		limits.MemoryInGB = &memoryInGB
@@ -9064,13 +9064,13 @@ func (limits *ResourceLimits_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceLimits_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cpu’:
+	// Set property "Cpu":
 	if typedInput.Cpu != nil {
 		cpu := *typedInput.Cpu
 		limits.Cpu = &cpu
 	}
 
-	// Set property ‘Gpu’:
+	// Set property "Gpu":
 	if typedInput.Gpu != nil {
 		var gpu1 GpuResource_STATUS
 		err := gpu1.PopulateFromARM(owner, *typedInput.Gpu)
@@ -9081,7 +9081,7 @@ func (limits *ResourceLimits_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		limits.Gpu = &gpu
 	}
 
-	// Set property ‘MemoryInGB’:
+	// Set property "MemoryInGB":
 	if typedInput.MemoryInGB != nil {
 		memoryInGB := *typedInput.MemoryInGB
 		limits.MemoryInGB = &memoryInGB
@@ -9189,13 +9189,13 @@ func (requests *ResourceRequests) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ResourceRequests_ARM{}
 
-	// Set property ‘Cpu’:
+	// Set property "Cpu":
 	if requests.Cpu != nil {
 		cpu := *requests.Cpu
 		result.Cpu = &cpu
 	}
 
-	// Set property ‘Gpu’:
+	// Set property "Gpu":
 	if requests.Gpu != nil {
 		gpu_ARM, err := (*requests.Gpu).ConvertToARM(resolved)
 		if err != nil {
@@ -9205,7 +9205,7 @@ func (requests *ResourceRequests) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Gpu = &gpu
 	}
 
-	// Set property ‘MemoryInGB’:
+	// Set property "MemoryInGB":
 	if requests.MemoryInGB != nil {
 		memoryInGB := *requests.MemoryInGB
 		result.MemoryInGB = &memoryInGB
@@ -9225,13 +9225,13 @@ func (requests *ResourceRequests) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceRequests_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cpu’:
+	// Set property "Cpu":
 	if typedInput.Cpu != nil {
 		cpu := *typedInput.Cpu
 		requests.Cpu = &cpu
 	}
 
-	// Set property ‘Gpu’:
+	// Set property "Gpu":
 	if typedInput.Gpu != nil {
 		var gpu1 GpuResource
 		err := gpu1.PopulateFromARM(owner, *typedInput.Gpu)
@@ -9242,7 +9242,7 @@ func (requests *ResourceRequests) PopulateFromARM(owner genruntime.ArbitraryOwne
 		requests.Gpu = &gpu
 	}
 
-	// Set property ‘MemoryInGB’:
+	// Set property "MemoryInGB":
 	if typedInput.MemoryInGB != nil {
 		memoryInGB := *typedInput.MemoryInGB
 		requests.MemoryInGB = &memoryInGB
@@ -9352,13 +9352,13 @@ func (requests *ResourceRequests_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceRequests_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cpu’:
+	// Set property "Cpu":
 	if typedInput.Cpu != nil {
 		cpu := *typedInput.Cpu
 		requests.Cpu = &cpu
 	}
 
-	// Set property ‘Gpu’:
+	// Set property "Gpu":
 	if typedInput.Gpu != nil {
 		var gpu1 GpuResource_STATUS
 		err := gpu1.PopulateFromARM(owner, *typedInput.Gpu)
@@ -9369,7 +9369,7 @@ func (requests *ResourceRequests_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		requests.Gpu = &gpu
 	}
 
-	// Set property ‘MemoryInGB’:
+	// Set property "MemoryInGB":
 	if typedInput.MemoryInGB != nil {
 		memoryInGB := *typedInput.MemoryInGB
 		requests.MemoryInGB = &memoryInGB
@@ -9493,13 +9493,13 @@ func (resource *GpuResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &GpuResource_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if resource.Count != nil {
 		count := *resource.Count
 		result.Count = &count
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if resource.Sku != nil {
 		sku := *resource.Sku
 		result.Sku = &sku
@@ -9519,13 +9519,13 @@ func (resource *GpuResource) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GpuResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		resource.Count = &count
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		sku := *typedInput.Sku
 		resource.Sku = &sku
@@ -9600,13 +9600,13 @@ func (resource *GpuResource_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GpuResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		resource.Count = &count
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		sku := *typedInput.Sku
 		resource.Sku = &sku
@@ -9676,13 +9676,13 @@ func (header *HttpHeader) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &HttpHeader_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if header.Name != nil {
 		name := *header.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if header.Value != nil {
 		value := *header.Value
 		result.Value = &value
@@ -9702,13 +9702,13 @@ func (header *HttpHeader) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HttpHeader_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		header.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		header.Value = &value
@@ -9773,13 +9773,13 @@ func (header *HttpHeader_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HttpHeader_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		header.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		header.Value = &value

--- a/v2/api/containerregistry/v1api20210901/registry_types_gen.go
+++ b/v2/api/containerregistry/v1api20210901/registry_types_gen.go
@@ -377,7 +377,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &Registry_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if registry.Identity != nil {
 		identity_ARM, err := (*registry.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -387,16 +387,16 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if registry.Location != nil {
 		location := *registry.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if registry.AdminUserEnabled != nil ||
 		registry.DataEndpointEnabled != nil ||
 		registry.Encryption != nil ||
@@ -452,7 +452,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.ZoneRedundancy = &zoneRedundancy
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if registry.Sku != nil {
 		sku_ARM, err := (*registry.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -462,7 +462,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if registry.Tags != nil {
 		result.Tags = make(map[string]string, len(registry.Tags))
 		for key, value := range registry.Tags {
@@ -484,7 +484,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Registry_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUserEnabled’:
+	// Set property "AdminUserEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdminUserEnabled != nil {
@@ -493,10 +493,10 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	registry.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DataEndpointEnabled’:
+	// Set property "DataEndpointEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataEndpointEnabled != nil {
@@ -505,7 +505,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -519,7 +519,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 IdentityProperties
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -530,13 +530,13 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		registry.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		registry.Location = &location
 	}
 
-	// Set property ‘NetworkRuleBypassOptions’:
+	// Set property "NetworkRuleBypassOptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkRuleBypassOptions != nil {
@@ -545,7 +545,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘NetworkRuleSet’:
+	// Set property "NetworkRuleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkRuleSet != nil {
@@ -559,10 +559,10 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	registry.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Policies’:
+	// Set property "Policies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Policies != nil {
@@ -576,7 +576,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -585,7 +585,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -596,7 +596,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		registry.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		registry.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -604,7 +604,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ZoneRedundancy’:
+	// Set property "ZoneRedundancy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundancy != nil {
@@ -1184,7 +1184,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Registry_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUserEnabled’:
+	// Set property "AdminUserEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdminUserEnabled != nil {
@@ -1193,9 +1193,9 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationDate’:
+	// Set property "CreationDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationDate != nil {
@@ -1204,7 +1204,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DataEndpointEnabled’:
+	// Set property "DataEndpointEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataEndpointEnabled != nil {
@@ -1213,7 +1213,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DataEndpointHostNames’:
+	// Set property "DataEndpointHostNames":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DataEndpointHostNames {
@@ -1221,7 +1221,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1235,13 +1235,13 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		registry.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 IdentityProperties_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1252,13 +1252,13 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		registry.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		registry.Location = &location
 	}
 
-	// Set property ‘LoginServer’:
+	// Set property "LoginServer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LoginServer != nil {
@@ -1267,13 +1267,13 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		registry.Name = &name
 	}
 
-	// Set property ‘NetworkRuleBypassOptions’:
+	// Set property "NetworkRuleBypassOptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkRuleBypassOptions != nil {
@@ -1282,7 +1282,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘NetworkRuleSet’:
+	// Set property "NetworkRuleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkRuleSet != nil {
@@ -1296,7 +1296,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Policies’:
+	// Set property "Policies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Policies != nil {
@@ -1310,7 +1310,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1323,7 +1323,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1332,7 +1332,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1341,7 +1341,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1352,7 +1352,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		registry.Sku = &sku
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -1366,7 +1366,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1377,7 +1377,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		registry.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		registry.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1385,13 +1385,13 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		registry.Type = &typeVar
 	}
 
-	// Set property ‘ZoneRedundancy’:
+	// Set property "ZoneRedundancy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundancy != nil {
@@ -1798,7 +1798,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &EncryptionProperty_ARM{}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if property.KeyVaultProperties != nil {
 		keyVaultProperties_ARM, err := (*property.KeyVaultProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -1808,7 +1808,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 		result.KeyVaultProperties = &keyVaultProperties
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if property.Status != nil {
 		status := *property.Status
 		result.Status = &status
@@ -1828,7 +1828,7 @@ func (property *EncryptionProperty) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperty_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -1839,7 +1839,7 @@ func (property *EncryptionProperty) PopulateFromARM(owner genruntime.ArbitraryOw
 		property.KeyVaultProperties = &keyVaultProperties
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		property.Status = &status
@@ -1961,7 +1961,7 @@ func (property *EncryptionProperty_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties_STATUS
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -1972,7 +1972,7 @@ func (property *EncryptionProperty_STATUS) PopulateFromARM(owner genruntime.Arbi
 		property.KeyVaultProperties = &keyVaultProperties
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		property.Status = &status
@@ -2072,25 +2072,25 @@ func (properties *IdentityProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &IdentityProperties_ARM{}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if properties.PrincipalId != nil {
 		principalId := *properties.PrincipalId
 		result.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if properties.TenantId != nil {
 		tenantId := *properties.TenantId
 		result.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if properties.Type != nil {
 		typeVar := *properties.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(properties.UserAssignedIdentities))
 	for _, ident := range properties.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -2115,25 +2115,25 @@ func (properties *IdentityProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IdentityProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		properties.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		properties.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		properties.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -2291,25 +2291,25 @@ func (properties *IdentityProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IdentityProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		properties.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		properties.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		properties.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		properties.UserAssignedIdentities = make(map[string]UserIdentityProperties_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2432,13 +2432,13 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &NetworkRuleSet_ARM{}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if ruleSet.DefaultAction != nil {
 		defaultAction := *ruleSet.DefaultAction
 		result.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range ruleSet.IpRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2461,13 +2461,13 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule
 		err := item1.PopulateFromARM(owner, item)
@@ -2612,13 +2612,13 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2731,7 +2731,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Policies_ARM{}
 
-	// Set property ‘ExportPolicy’:
+	// Set property "ExportPolicy":
 	if policies.ExportPolicy != nil {
 		exportPolicy_ARM, err := (*policies.ExportPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -2741,7 +2741,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.ExportPolicy = &exportPolicy
 	}
 
-	// Set property ‘QuarantinePolicy’:
+	// Set property "QuarantinePolicy":
 	if policies.QuarantinePolicy != nil {
 		quarantinePolicy_ARM, err := (*policies.QuarantinePolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -2751,7 +2751,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.QuarantinePolicy = &quarantinePolicy
 	}
 
-	// Set property ‘RetentionPolicy’:
+	// Set property "RetentionPolicy":
 	if policies.RetentionPolicy != nil {
 		retentionPolicy_ARM, err := (*policies.RetentionPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -2761,7 +2761,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.RetentionPolicy = &retentionPolicy
 	}
 
-	// Set property ‘TrustPolicy’:
+	// Set property "TrustPolicy":
 	if policies.TrustPolicy != nil {
 		trustPolicy_ARM, err := (*policies.TrustPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -2785,7 +2785,7 @@ func (policies *Policies) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Policies_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExportPolicy’:
+	// Set property "ExportPolicy":
 	if typedInput.ExportPolicy != nil {
 		var exportPolicy1 ExportPolicy
 		err := exportPolicy1.PopulateFromARM(owner, *typedInput.ExportPolicy)
@@ -2796,7 +2796,7 @@ func (policies *Policies) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		policies.ExportPolicy = &exportPolicy
 	}
 
-	// Set property ‘QuarantinePolicy’:
+	// Set property "QuarantinePolicy":
 	if typedInput.QuarantinePolicy != nil {
 		var quarantinePolicy1 QuarantinePolicy
 		err := quarantinePolicy1.PopulateFromARM(owner, *typedInput.QuarantinePolicy)
@@ -2807,7 +2807,7 @@ func (policies *Policies) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		policies.QuarantinePolicy = &quarantinePolicy
 	}
 
-	// Set property ‘RetentionPolicy’:
+	// Set property "RetentionPolicy":
 	if typedInput.RetentionPolicy != nil {
 		var retentionPolicy1 RetentionPolicy
 		err := retentionPolicy1.PopulateFromARM(owner, *typedInput.RetentionPolicy)
@@ -2818,7 +2818,7 @@ func (policies *Policies) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		policies.RetentionPolicy = &retentionPolicy
 	}
 
-	// Set property ‘TrustPolicy’:
+	// Set property "TrustPolicy":
 	if typedInput.TrustPolicy != nil {
 		var trustPolicy1 TrustPolicy
 		err := trustPolicy1.PopulateFromARM(owner, *typedInput.TrustPolicy)
@@ -3036,7 +3036,7 @@ func (policies *Policies_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Policies_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExportPolicy’:
+	// Set property "ExportPolicy":
 	if typedInput.ExportPolicy != nil {
 		var exportPolicy1 ExportPolicy_STATUS
 		err := exportPolicy1.PopulateFromARM(owner, *typedInput.ExportPolicy)
@@ -3047,7 +3047,7 @@ func (policies *Policies_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		policies.ExportPolicy = &exportPolicy
 	}
 
-	// Set property ‘QuarantinePolicy’:
+	// Set property "QuarantinePolicy":
 	if typedInput.QuarantinePolicy != nil {
 		var quarantinePolicy1 QuarantinePolicy_STATUS
 		err := quarantinePolicy1.PopulateFromARM(owner, *typedInput.QuarantinePolicy)
@@ -3058,7 +3058,7 @@ func (policies *Policies_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		policies.QuarantinePolicy = &quarantinePolicy
 	}
 
-	// Set property ‘RetentionPolicy’:
+	// Set property "RetentionPolicy":
 	if typedInput.RetentionPolicy != nil {
 		var retentionPolicy1 RetentionPolicy_STATUS
 		err := retentionPolicy1.PopulateFromARM(owner, *typedInput.RetentionPolicy)
@@ -3069,7 +3069,7 @@ func (policies *Policies_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		policies.RetentionPolicy = &retentionPolicy
 	}
 
-	// Set property ‘TrustPolicy’:
+	// Set property "TrustPolicy":
 	if typedInput.TrustPolicy != nil {
 		var trustPolicy1 TrustPolicy_STATUS
 		err := trustPolicy1.PopulateFromARM(owner, *typedInput.TrustPolicy)
@@ -3223,7 +3223,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -3334,7 +3334,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -3354,7 +3354,7 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -3441,13 +3441,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3538,19 +3538,19 @@ func (status *Status_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Status_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisplayStatus’:
+	// Set property "DisplayStatus":
 	if typedInput.DisplayStatus != nil {
 		displayStatus := *typedInput.DisplayStatus
 		status.DisplayStatus = &displayStatus
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		status.Message = &message
 	}
 
-	// Set property ‘Timestamp’:
+	// Set property "Timestamp":
 	if typedInput.Timestamp != nil {
 		timestamp := *typedInput.Timestamp
 		status.Timestamp = &timestamp
@@ -3636,37 +3636,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -3785,7 +3785,7 @@ func (policy *ExportPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &ExportPolicy_ARM{}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if policy.Status != nil {
 		status := *policy.Status
 		result.Status = &status
@@ -3805,7 +3805,7 @@ func (policy *ExportPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExportPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
@@ -3889,7 +3889,7 @@ func (policy *ExportPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExportPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
@@ -3957,13 +3957,13 @@ func (rule *IPRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &IPRule_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if rule.Action != nil {
 		action := *rule.Action
 		result.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if rule.Value != nil {
 		value := *rule.Value
 		result.Value = &value
@@ -3983,13 +3983,13 @@ func (rule *IPRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -4085,13 +4085,13 @@ func (rule *IPRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -4163,13 +4163,13 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if properties.Identity != nil {
 		identity := *properties.Identity
 		result.Identity = &identity
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if properties.KeyIdentifier != nil {
 		keyIdentifier := *properties.KeyIdentifier
 		result.KeyIdentifier = &keyIdentifier
@@ -4189,13 +4189,13 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		identity := *typedInput.Identity
 		properties.Identity = &identity
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
@@ -4285,31 +4285,31 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		identity := *typedInput.Identity
 		properties.Identity = &identity
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
 	}
 
-	// Set property ‘KeyRotationEnabled’:
+	// Set property "KeyRotationEnabled":
 	if typedInput.KeyRotationEnabled != nil {
 		keyRotationEnabled := *typedInput.KeyRotationEnabled
 		properties.KeyRotationEnabled = &keyRotationEnabled
 	}
 
-	// Set property ‘LastKeyRotationTimestamp’:
+	// Set property "LastKeyRotationTimestamp":
 	if typedInput.LastKeyRotationTimestamp != nil {
 		lastKeyRotationTimestamp := *typedInput.LastKeyRotationTimestamp
 		properties.LastKeyRotationTimestamp = &lastKeyRotationTimestamp
 	}
 
-	// Set property ‘VersionedKeyIdentifier’:
+	// Set property "VersionedKeyIdentifier":
 	if typedInput.VersionedKeyIdentifier != nil {
 		versionedKeyIdentifier := *typedInput.VersionedKeyIdentifier
 		properties.VersionedKeyIdentifier = &versionedKeyIdentifier
@@ -4412,7 +4412,7 @@ func (policy *QuarantinePolicy) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &QuarantinePolicy_ARM{}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if policy.Status != nil {
 		status := *policy.Status
 		result.Status = &status
@@ -4432,7 +4432,7 @@ func (policy *QuarantinePolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected QuarantinePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
@@ -4516,7 +4516,7 @@ func (policy *QuarantinePolicy_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected QuarantinePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
@@ -4583,13 +4583,13 @@ func (policy *RetentionPolicy) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &RetentionPolicy_ARM{}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if policy.Days != nil {
 		days := *policy.Days
 		result.Days = &days
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if policy.Status != nil {
 		status := *policy.Status
 		result.Status = &status
@@ -4609,13 +4609,13 @@ func (policy *RetentionPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RetentionPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		policy.Days = &days
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
@@ -4714,19 +4714,19 @@ func (policy *RetentionPolicy_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RetentionPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		policy.Days = &days
 	}
 
-	// Set property ‘LastUpdatedTime’:
+	// Set property "LastUpdatedTime":
 	if typedInput.LastUpdatedTime != nil {
 		lastUpdatedTime := *typedInput.LastUpdatedTime
 		policy.LastUpdatedTime = &lastUpdatedTime
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
@@ -4805,13 +4805,13 @@ func (policy *TrustPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &TrustPolicy_ARM{}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if policy.Status != nil {
 		status := *policy.Status
 		result.Status = &status
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if policy.Type != nil {
 		typeVar := *policy.Type
 		result.Type = &typeVar
@@ -4831,13 +4831,13 @@ func (policy *TrustPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TrustPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		policy.Type = &typeVar
@@ -4948,13 +4948,13 @@ func (policy *TrustPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TrustPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		policy.Type = &typeVar
@@ -5075,13 +5075,13 @@ func (properties *UserIdentityProperties_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserIdentityProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		properties.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		properties.PrincipalId = &principalId

--- a/v2/api/containerregistry/v1beta20210901/registry_types_gen.go
+++ b/v2/api/containerregistry/v1beta20210901/registry_types_gen.go
@@ -356,7 +356,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &Registry_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if registry.Identity != nil {
 		identity_ARM, err := (*registry.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -366,16 +366,16 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if registry.Location != nil {
 		location := *registry.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if registry.AdminUserEnabled != nil ||
 		registry.DataEndpointEnabled != nil ||
 		registry.Encryption != nil ||
@@ -431,7 +431,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties.ZoneRedundancy = &zoneRedundancy
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if registry.Sku != nil {
 		sku_ARM, err := (*registry.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -441,7 +441,7 @@ func (registry *Registry_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if registry.Tags != nil {
 		result.Tags = make(map[string]string, len(registry.Tags))
 		for key, value := range registry.Tags {
@@ -463,7 +463,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Registry_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUserEnabled’:
+	// Set property "AdminUserEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdminUserEnabled != nil {
@@ -472,10 +472,10 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	registry.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DataEndpointEnabled’:
+	// Set property "DataEndpointEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataEndpointEnabled != nil {
@@ -484,7 +484,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -498,7 +498,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 IdentityProperties
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -509,13 +509,13 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		registry.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		registry.Location = &location
 	}
 
-	// Set property ‘NetworkRuleBypassOptions’:
+	// Set property "NetworkRuleBypassOptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkRuleBypassOptions != nil {
@@ -524,7 +524,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘NetworkRuleSet’:
+	// Set property "NetworkRuleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkRuleSet != nil {
@@ -538,10 +538,10 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	registry.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Policies’:
+	// Set property "Policies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Policies != nil {
@@ -555,7 +555,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -564,7 +564,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -575,7 +575,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		registry.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		registry.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -583,7 +583,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ZoneRedundancy’:
+	// Set property "ZoneRedundancy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundancy != nil {
@@ -1007,7 +1007,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Registry_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUserEnabled’:
+	// Set property "AdminUserEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdminUserEnabled != nil {
@@ -1016,9 +1016,9 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationDate’:
+	// Set property "CreationDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationDate != nil {
@@ -1027,7 +1027,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DataEndpointEnabled’:
+	// Set property "DataEndpointEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataEndpointEnabled != nil {
@@ -1036,7 +1036,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DataEndpointHostNames’:
+	// Set property "DataEndpointHostNames":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DataEndpointHostNames {
@@ -1044,7 +1044,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1058,13 +1058,13 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		registry.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 IdentityProperties_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1075,13 +1075,13 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		registry.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		registry.Location = &location
 	}
 
-	// Set property ‘LoginServer’:
+	// Set property "LoginServer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LoginServer != nil {
@@ -1090,13 +1090,13 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		registry.Name = &name
 	}
 
-	// Set property ‘NetworkRuleBypassOptions’:
+	// Set property "NetworkRuleBypassOptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkRuleBypassOptions != nil {
@@ -1105,7 +1105,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘NetworkRuleSet’:
+	// Set property "NetworkRuleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkRuleSet != nil {
@@ -1119,7 +1119,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Policies’:
+	// Set property "Policies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Policies != nil {
@@ -1133,7 +1133,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1146,7 +1146,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1155,7 +1155,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1164,7 +1164,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1175,7 +1175,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		registry.Sku = &sku
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -1189,7 +1189,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1200,7 +1200,7 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		registry.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		registry.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1208,13 +1208,13 @@ func (registry *Registry_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		registry.Type = &typeVar
 	}
 
-	// Set property ‘ZoneRedundancy’:
+	// Set property "ZoneRedundancy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundancy != nil {
@@ -1619,7 +1619,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &EncryptionProperty_ARM{}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if property.KeyVaultProperties != nil {
 		keyVaultProperties_ARM, err := (*property.KeyVaultProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -1629,7 +1629,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 		result.KeyVaultProperties = &keyVaultProperties
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if property.Status != nil {
 		status := *property.Status
 		result.Status = &status
@@ -1649,7 +1649,7 @@ func (property *EncryptionProperty) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperty_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -1660,7 +1660,7 @@ func (property *EncryptionProperty) PopulateFromARM(owner genruntime.ArbitraryOw
 		property.KeyVaultProperties = &keyVaultProperties
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		property.Status = &status
@@ -1753,7 +1753,7 @@ func (property *EncryptionProperty_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties_STATUS
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -1764,7 +1764,7 @@ func (property *EncryptionProperty_STATUS) PopulateFromARM(owner genruntime.Arbi
 		property.KeyVaultProperties = &keyVaultProperties
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		property.Status = &status
@@ -1854,25 +1854,25 @@ func (properties *IdentityProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &IdentityProperties_ARM{}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if properties.PrincipalId != nil {
 		principalId := *properties.PrincipalId
 		result.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if properties.TenantId != nil {
 		tenantId := *properties.TenantId
 		result.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if properties.Type != nil {
 		typeVar := *properties.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(properties.UserAssignedIdentities))
 	for _, ident := range properties.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -1897,25 +1897,25 @@ func (properties *IdentityProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IdentityProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		properties.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		properties.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		properties.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -2030,25 +2030,25 @@ func (properties *IdentityProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IdentityProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		properties.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		properties.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		properties.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		properties.UserAssignedIdentities = make(map[string]UserIdentityProperties_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2168,13 +2168,13 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &NetworkRuleSet_ARM{}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if ruleSet.DefaultAction != nil {
 		defaultAction := *ruleSet.DefaultAction
 		result.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range ruleSet.IpRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2197,13 +2197,13 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule
 		err := item1.PopulateFromARM(owner, item)
@@ -2312,13 +2312,13 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2424,7 +2424,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Policies_ARM{}
 
-	// Set property ‘ExportPolicy’:
+	// Set property "ExportPolicy":
 	if policies.ExportPolicy != nil {
 		exportPolicy_ARM, err := (*policies.ExportPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -2434,7 +2434,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.ExportPolicy = &exportPolicy
 	}
 
-	// Set property ‘QuarantinePolicy’:
+	// Set property "QuarantinePolicy":
 	if policies.QuarantinePolicy != nil {
 		quarantinePolicy_ARM, err := (*policies.QuarantinePolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -2444,7 +2444,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.QuarantinePolicy = &quarantinePolicy
 	}
 
-	// Set property ‘RetentionPolicy’:
+	// Set property "RetentionPolicy":
 	if policies.RetentionPolicy != nil {
 		retentionPolicy_ARM, err := (*policies.RetentionPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -2454,7 +2454,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.RetentionPolicy = &retentionPolicy
 	}
 
-	// Set property ‘TrustPolicy’:
+	// Set property "TrustPolicy":
 	if policies.TrustPolicy != nil {
 		trustPolicy_ARM, err := (*policies.TrustPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -2478,7 +2478,7 @@ func (policies *Policies) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Policies_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExportPolicy’:
+	// Set property "ExportPolicy":
 	if typedInput.ExportPolicy != nil {
 		var exportPolicy1 ExportPolicy
 		err := exportPolicy1.PopulateFromARM(owner, *typedInput.ExportPolicy)
@@ -2489,7 +2489,7 @@ func (policies *Policies) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		policies.ExportPolicy = &exportPolicy
 	}
 
-	// Set property ‘QuarantinePolicy’:
+	// Set property "QuarantinePolicy":
 	if typedInput.QuarantinePolicy != nil {
 		var quarantinePolicy1 QuarantinePolicy
 		err := quarantinePolicy1.PopulateFromARM(owner, *typedInput.QuarantinePolicy)
@@ -2500,7 +2500,7 @@ func (policies *Policies) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		policies.QuarantinePolicy = &quarantinePolicy
 	}
 
-	// Set property ‘RetentionPolicy’:
+	// Set property "RetentionPolicy":
 	if typedInput.RetentionPolicy != nil {
 		var retentionPolicy1 RetentionPolicy
 		err := retentionPolicy1.PopulateFromARM(owner, *typedInput.RetentionPolicy)
@@ -2511,7 +2511,7 @@ func (policies *Policies) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		policies.RetentionPolicy = &retentionPolicy
 	}
 
-	// Set property ‘TrustPolicy’:
+	// Set property "TrustPolicy":
 	if typedInput.TrustPolicy != nil {
 		var trustPolicy1 TrustPolicy
 		err := trustPolicy1.PopulateFromARM(owner, *typedInput.TrustPolicy)
@@ -2667,7 +2667,7 @@ func (policies *Policies_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Policies_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExportPolicy’:
+	// Set property "ExportPolicy":
 	if typedInput.ExportPolicy != nil {
 		var exportPolicy1 ExportPolicy_STATUS
 		err := exportPolicy1.PopulateFromARM(owner, *typedInput.ExportPolicy)
@@ -2678,7 +2678,7 @@ func (policies *Policies_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		policies.ExportPolicy = &exportPolicy
 	}
 
-	// Set property ‘QuarantinePolicy’:
+	// Set property "QuarantinePolicy":
 	if typedInput.QuarantinePolicy != nil {
 		var quarantinePolicy1 QuarantinePolicy_STATUS
 		err := quarantinePolicy1.PopulateFromARM(owner, *typedInput.QuarantinePolicy)
@@ -2689,7 +2689,7 @@ func (policies *Policies_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		policies.QuarantinePolicy = &quarantinePolicy
 	}
 
-	// Set property ‘RetentionPolicy’:
+	// Set property "RetentionPolicy":
 	if typedInput.RetentionPolicy != nil {
 		var retentionPolicy1 RetentionPolicy_STATUS
 		err := retentionPolicy1.PopulateFromARM(owner, *typedInput.RetentionPolicy)
@@ -2700,7 +2700,7 @@ func (policies *Policies_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		policies.RetentionPolicy = &retentionPolicy
 	}
 
-	// Set property ‘TrustPolicy’:
+	// Set property "TrustPolicy":
 	if typedInput.TrustPolicy != nil {
 		var trustPolicy1 TrustPolicy_STATUS
 		err := trustPolicy1.PopulateFromARM(owner, *typedInput.TrustPolicy)
@@ -2853,7 +2853,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -2976,7 +2976,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -2996,7 +2996,7 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -3065,13 +3065,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3157,19 +3157,19 @@ func (status *Status_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Status_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisplayStatus’:
+	// Set property "DisplayStatus":
 	if typedInput.DisplayStatus != nil {
 		displayStatus := *typedInput.DisplayStatus
 		status.DisplayStatus = &displayStatus
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		status.Message = &message
 	}
 
-	// Set property ‘Timestamp’:
+	// Set property "Timestamp":
 	if typedInput.Timestamp != nil {
 		timestamp := *typedInput.Timestamp
 		status.Timestamp = &timestamp
@@ -3244,37 +3244,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -3394,7 +3394,7 @@ func (policy *ExportPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &ExportPolicy_ARM{}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if policy.Status != nil {
 		status := *policy.Status
 		result.Status = &status
@@ -3414,7 +3414,7 @@ func (policy *ExportPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExportPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
@@ -3482,7 +3482,7 @@ func (policy *ExportPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExportPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
@@ -3548,13 +3548,13 @@ func (rule *IPRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &IPRule_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if rule.Action != nil {
 		action := *rule.Action
 		result.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if rule.Value != nil {
 		value := *rule.Value
 		result.Value = &value
@@ -3574,13 +3574,13 @@ func (rule *IPRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -3655,13 +3655,13 @@ func (rule *IPRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -3731,13 +3731,13 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if properties.Identity != nil {
 		identity := *properties.Identity
 		result.Identity = &identity
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if properties.KeyIdentifier != nil {
 		keyIdentifier := *properties.KeyIdentifier
 		result.KeyIdentifier = &keyIdentifier
@@ -3757,13 +3757,13 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		identity := *typedInput.Identity
 		properties.Identity = &identity
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
@@ -3831,31 +3831,31 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		identity := *typedInput.Identity
 		properties.Identity = &identity
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
 	}
 
-	// Set property ‘KeyRotationEnabled’:
+	// Set property "KeyRotationEnabled":
 	if typedInput.KeyRotationEnabled != nil {
 		keyRotationEnabled := *typedInput.KeyRotationEnabled
 		properties.KeyRotationEnabled = &keyRotationEnabled
 	}
 
-	// Set property ‘LastKeyRotationTimestamp’:
+	// Set property "LastKeyRotationTimestamp":
 	if typedInput.LastKeyRotationTimestamp != nil {
 		lastKeyRotationTimestamp := *typedInput.LastKeyRotationTimestamp
 		properties.LastKeyRotationTimestamp = &lastKeyRotationTimestamp
 	}
 
-	// Set property ‘VersionedKeyIdentifier’:
+	// Set property "VersionedKeyIdentifier":
 	if typedInput.VersionedKeyIdentifier != nil {
 		versionedKeyIdentifier := *typedInput.VersionedKeyIdentifier
 		properties.VersionedKeyIdentifier = &versionedKeyIdentifier
@@ -3959,7 +3959,7 @@ func (policy *QuarantinePolicy) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &QuarantinePolicy_ARM{}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if policy.Status != nil {
 		status := *policy.Status
 		result.Status = &status
@@ -3979,7 +3979,7 @@ func (policy *QuarantinePolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected QuarantinePolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
@@ -4047,7 +4047,7 @@ func (policy *QuarantinePolicy_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected QuarantinePolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
@@ -4111,13 +4111,13 @@ func (policy *RetentionPolicy) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &RetentionPolicy_ARM{}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if policy.Days != nil {
 		days := *policy.Days
 		result.Days = &days
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if policy.Status != nil {
 		status := *policy.Status
 		result.Status = &status
@@ -4137,13 +4137,13 @@ func (policy *RetentionPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RetentionPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		policy.Days = &days
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
@@ -4219,19 +4219,19 @@ func (policy *RetentionPolicy_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RetentionPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		policy.Days = &days
 	}
 
-	// Set property ‘LastUpdatedTime’:
+	// Set property "LastUpdatedTime":
 	if typedInput.LastUpdatedTime != nil {
 		lastUpdatedTime := *typedInput.LastUpdatedTime
 		policy.LastUpdatedTime = &lastUpdatedTime
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
@@ -4307,13 +4307,13 @@ func (policy *TrustPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &TrustPolicy_ARM{}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if policy.Status != nil {
 		status := *policy.Status
 		result.Status = &status
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if policy.Type != nil {
 		typeVar := *policy.Type
 		result.Type = &typeVar
@@ -4333,13 +4333,13 @@ func (policy *TrustPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TrustPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		policy.Type = &typeVar
@@ -4424,13 +4424,13 @@ func (policy *TrustPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TrustPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		policy.Status = &status
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		policy.Type = &typeVar
@@ -4549,13 +4549,13 @@ func (properties *UserIdentityProperties_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserIdentityProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		properties.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		properties.PrincipalId = &principalId

--- a/v2/api/containerservice/v1api20210501/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20210501/managed_cluster_types_gen.go
@@ -456,7 +456,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ManagedCluster_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if cluster.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*cluster.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -466,7 +466,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if cluster.Identity != nil {
 		identity_ARM, err := (*cluster.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -476,16 +476,16 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if cluster.Location != nil {
 		location := *cluster.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if cluster.AadProfile != nil ||
 		cluster.AddonProfiles != nil ||
 		cluster.AgentPoolProfiles != nil ||
@@ -661,7 +661,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.WindowsProfile = &windowsProfile
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if cluster.Sku != nil {
 		sku_ARM, err := (*cluster.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -671,7 +671,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if cluster.Tags != nil {
 		result.Tags = make(map[string]string, len(cluster.Tags))
 		for key, value := range cluster.Tags {
@@ -693,7 +693,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedCluster_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadProfile’:
+	// Set property "AadProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AadProfile != nil {
@@ -707,7 +707,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AddonProfiles’:
+	// Set property "AddonProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddonProfiles != nil {
@@ -723,7 +723,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AgentPoolProfiles’:
+	// Set property "AgentPoolProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AgentPoolProfiles {
@@ -736,7 +736,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ApiServerAccessProfile’:
+	// Set property "ApiServerAccessProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApiServerAccessProfile != nil {
@@ -750,7 +750,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AutoScalerProfile’:
+	// Set property "AutoScalerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoScalerProfile != nil {
@@ -764,7 +764,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AutoUpgradeProfile’:
+	// Set property "AutoUpgradeProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeProfile != nil {
@@ -778,10 +778,10 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	cluster.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DisableLocalAccounts’:
+	// Set property "DisableLocalAccounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAccounts != nil {
@@ -790,9 +790,9 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘DiskEncryptionSetIDReference’
+	// no assignment for property "DiskEncryptionSetIDReference"
 
-	// Set property ‘DnsPrefix’:
+	// Set property "DnsPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsPrefix != nil {
@@ -801,7 +801,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnablePodSecurityPolicy’:
+	// Set property "EnablePodSecurityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePodSecurityPolicy != nil {
@@ -810,7 +810,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableRBAC’:
+	// Set property "EnableRBAC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableRBAC != nil {
@@ -819,7 +819,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -830,7 +830,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		cluster.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FqdnSubdomain’:
+	// Set property "FqdnSubdomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FqdnSubdomain != nil {
@@ -839,7 +839,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘HttpProxyConfig’:
+	// Set property "HttpProxyConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpProxyConfig != nil {
@@ -853,7 +853,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedClusterIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -864,7 +864,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		cluster.Identity = &identity
 	}
 
-	// Set property ‘IdentityProfile’:
+	// Set property "IdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdentityProfile != nil {
@@ -880,7 +880,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘KubernetesVersion’:
+	// Set property "KubernetesVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubernetesVersion != nil {
@@ -889,7 +889,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘LinuxProfile’:
+	// Set property "LinuxProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxProfile != nil {
@@ -903,13 +903,13 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		cluster.Location = &location
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -923,7 +923,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘NodeResourceGroup’:
+	// Set property "NodeResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeResourceGroup != nil {
@@ -932,12 +932,12 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	cluster.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PodIdentityProfile’:
+	// Set property "PodIdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PodIdentityProfile != nil {
@@ -951,7 +951,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘PrivateLinkResources’:
+	// Set property "PrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkResources {
@@ -964,7 +964,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ServicePrincipalProfile’:
+	// Set property "ServicePrincipalProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServicePrincipalProfile != nil {
@@ -978,7 +978,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 ManagedClusterSKU
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -989,7 +989,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		cluster.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		cluster.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -997,7 +997,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘WindowsProfile’:
+	// Set property "WindowsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WindowsProfile != nil {
@@ -1890,7 +1890,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedCluster_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadProfile’:
+	// Set property "AadProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AadProfile != nil {
@@ -1904,7 +1904,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AddonProfiles’:
+	// Set property "AddonProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddonProfiles != nil {
@@ -1920,7 +1920,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AgentPoolProfiles’:
+	// Set property "AgentPoolProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AgentPoolProfiles {
@@ -1933,7 +1933,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ApiServerAccessProfile’:
+	// Set property "ApiServerAccessProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApiServerAccessProfile != nil {
@@ -1947,7 +1947,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AutoScalerProfile’:
+	// Set property "AutoScalerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoScalerProfile != nil {
@@ -1961,7 +1961,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AutoUpgradeProfile’:
+	// Set property "AutoUpgradeProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeProfile != nil {
@@ -1975,7 +1975,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AzurePortalFQDN’:
+	// Set property "AzurePortalFQDN":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzurePortalFQDN != nil {
@@ -1984,9 +1984,9 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DisableLocalAccounts’:
+	// Set property "DisableLocalAccounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAccounts != nil {
@@ -1995,7 +1995,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DiskEncryptionSetID’:
+	// Set property "DiskEncryptionSetID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskEncryptionSetID != nil {
@@ -2004,7 +2004,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DnsPrefix’:
+	// Set property "DnsPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsPrefix != nil {
@@ -2013,7 +2013,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnablePodSecurityPolicy’:
+	// Set property "EnablePodSecurityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePodSecurityPolicy != nil {
@@ -2022,7 +2022,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableRBAC’:
+	// Set property "EnableRBAC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableRBAC != nil {
@@ -2031,7 +2031,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -2042,7 +2042,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -2051,7 +2051,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘FqdnSubdomain’:
+	// Set property "FqdnSubdomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FqdnSubdomain != nil {
@@ -2060,7 +2060,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘HttpProxyConfig’:
+	// Set property "HttpProxyConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpProxyConfig != nil {
@@ -2074,13 +2074,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		cluster.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedClusterIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2091,7 +2091,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.Identity = &identity
 	}
 
-	// Set property ‘IdentityProfile’:
+	// Set property "IdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdentityProfile != nil {
@@ -2107,7 +2107,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘KubernetesVersion’:
+	// Set property "KubernetesVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubernetesVersion != nil {
@@ -2116,7 +2116,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LinuxProfile’:
+	// Set property "LinuxProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxProfile != nil {
@@ -2130,13 +2130,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		cluster.Location = &location
 	}
 
-	// Set property ‘MaxAgentPools’:
+	// Set property "MaxAgentPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxAgentPools != nil {
@@ -2145,13 +2145,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		cluster.Name = &name
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -2165,7 +2165,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘NodeResourceGroup’:
+	// Set property "NodeResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeResourceGroup != nil {
@@ -2174,7 +2174,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PodIdentityProfile’:
+	// Set property "PodIdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PodIdentityProfile != nil {
@@ -2188,7 +2188,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PowerState != nil {
@@ -2202,7 +2202,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrivateFQDN’:
+	// Set property "PrivateFQDN":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateFQDN != nil {
@@ -2211,7 +2211,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrivateLinkResources’:
+	// Set property "PrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkResources {
@@ -2224,7 +2224,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2233,7 +2233,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ServicePrincipalProfile’:
+	// Set property "ServicePrincipalProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServicePrincipalProfile != nil {
@@ -2247,7 +2247,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 ManagedClusterSKU_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -2258,7 +2258,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		cluster.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -2266,13 +2266,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		cluster.Type = &typeVar
 	}
 
-	// Set property ‘WindowsProfile’:
+	// Set property "WindowsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WindowsProfile != nil {
@@ -2958,13 +2958,13 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ContainerServiceLinuxProfile_ARM{}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if profile.Ssh != nil {
 		ssh_ARM, err := (*profile.Ssh).ConvertToARM(resolved)
 		if err != nil {
@@ -2988,13 +2988,13 @@ func (profile *ContainerServiceLinuxProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceLinuxProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 ContainerServiceSshConfiguration
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -3095,13 +3095,13 @@ func (profile *ContainerServiceLinuxProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceLinuxProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 ContainerServiceSshConfiguration_STATUS
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -3221,19 +3221,19 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 	}
 	result := &ContainerServiceNetworkProfile_ARM{}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if profile.DnsServiceIP != nil {
 		dnsServiceIP := *profile.DnsServiceIP
 		result.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if profile.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *profile.DockerBridgeCidr
 		result.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘LoadBalancerProfile’:
+	// Set property "LoadBalancerProfile":
 	if profile.LoadBalancerProfile != nil {
 		loadBalancerProfile_ARM, err := (*profile.LoadBalancerProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3243,43 +3243,43 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 		result.LoadBalancerProfile = &loadBalancerProfile
 	}
 
-	// Set property ‘LoadBalancerSku’:
+	// Set property "LoadBalancerSku":
 	if profile.LoadBalancerSku != nil {
 		loadBalancerSku := *profile.LoadBalancerSku
 		result.LoadBalancerSku = &loadBalancerSku
 	}
 
-	// Set property ‘NetworkMode’:
+	// Set property "NetworkMode":
 	if profile.NetworkMode != nil {
 		networkMode := *profile.NetworkMode
 		result.NetworkMode = &networkMode
 	}
 
-	// Set property ‘NetworkPlugin’:
+	// Set property "NetworkPlugin":
 	if profile.NetworkPlugin != nil {
 		networkPlugin := *profile.NetworkPlugin
 		result.NetworkPlugin = &networkPlugin
 	}
 
-	// Set property ‘NetworkPolicy’:
+	// Set property "NetworkPolicy":
 	if profile.NetworkPolicy != nil {
 		networkPolicy := *profile.NetworkPolicy
 		result.NetworkPolicy = &networkPolicy
 	}
 
-	// Set property ‘OutboundType’:
+	// Set property "OutboundType":
 	if profile.OutboundType != nil {
 		outboundType := *profile.OutboundType
 		result.OutboundType = &outboundType
 	}
 
-	// Set property ‘PodCidr’:
+	// Set property "PodCidr":
 	if profile.PodCidr != nil {
 		podCidr := *profile.PodCidr
 		result.PodCidr = &podCidr
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if profile.ServiceCidr != nil {
 		serviceCidr := *profile.ServiceCidr
 		result.ServiceCidr = &serviceCidr
@@ -3299,19 +3299,19 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceNetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if typedInput.DnsServiceIP != nil {
 		dnsServiceIP := *typedInput.DnsServiceIP
 		profile.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if typedInput.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *typedInput.DockerBridgeCidr
 		profile.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘LoadBalancerProfile’:
+	// Set property "LoadBalancerProfile":
 	if typedInput.LoadBalancerProfile != nil {
 		var loadBalancerProfile1 ManagedClusterLoadBalancerProfile
 		err := loadBalancerProfile1.PopulateFromARM(owner, *typedInput.LoadBalancerProfile)
@@ -3322,43 +3322,43 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 		profile.LoadBalancerProfile = &loadBalancerProfile
 	}
 
-	// Set property ‘LoadBalancerSku’:
+	// Set property "LoadBalancerSku":
 	if typedInput.LoadBalancerSku != nil {
 		loadBalancerSku := *typedInput.LoadBalancerSku
 		profile.LoadBalancerSku = &loadBalancerSku
 	}
 
-	// Set property ‘NetworkMode’:
+	// Set property "NetworkMode":
 	if typedInput.NetworkMode != nil {
 		networkMode := *typedInput.NetworkMode
 		profile.NetworkMode = &networkMode
 	}
 
-	// Set property ‘NetworkPlugin’:
+	// Set property "NetworkPlugin":
 	if typedInput.NetworkPlugin != nil {
 		networkPlugin := *typedInput.NetworkPlugin
 		profile.NetworkPlugin = &networkPlugin
 	}
 
-	// Set property ‘NetworkPolicy’:
+	// Set property "NetworkPolicy":
 	if typedInput.NetworkPolicy != nil {
 		networkPolicy := *typedInput.NetworkPolicy
 		profile.NetworkPolicy = &networkPolicy
 	}
 
-	// Set property ‘OutboundType’:
+	// Set property "OutboundType":
 	if typedInput.OutboundType != nil {
 		outboundType := *typedInput.OutboundType
 		profile.OutboundType = &outboundType
 	}
 
-	// Set property ‘PodCidr’:
+	// Set property "PodCidr":
 	if typedInput.PodCidr != nil {
 		podCidr := *typedInput.PodCidr
 		profile.PodCidr = &podCidr
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if typedInput.ServiceCidr != nil {
 		serviceCidr := *typedInput.ServiceCidr
 		profile.ServiceCidr = &serviceCidr
@@ -3612,19 +3612,19 @@ func (profile *ContainerServiceNetworkProfile_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceNetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if typedInput.DnsServiceIP != nil {
 		dnsServiceIP := *typedInput.DnsServiceIP
 		profile.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if typedInput.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *typedInput.DockerBridgeCidr
 		profile.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘LoadBalancerProfile’:
+	// Set property "LoadBalancerProfile":
 	if typedInput.LoadBalancerProfile != nil {
 		var loadBalancerProfile1 ManagedClusterLoadBalancerProfile_STATUS
 		err := loadBalancerProfile1.PopulateFromARM(owner, *typedInput.LoadBalancerProfile)
@@ -3635,43 +3635,43 @@ func (profile *ContainerServiceNetworkProfile_STATUS) PopulateFromARM(owner genr
 		profile.LoadBalancerProfile = &loadBalancerProfile
 	}
 
-	// Set property ‘LoadBalancerSku’:
+	// Set property "LoadBalancerSku":
 	if typedInput.LoadBalancerSku != nil {
 		loadBalancerSku := *typedInput.LoadBalancerSku
 		profile.LoadBalancerSku = &loadBalancerSku
 	}
 
-	// Set property ‘NetworkMode’:
+	// Set property "NetworkMode":
 	if typedInput.NetworkMode != nil {
 		networkMode := *typedInput.NetworkMode
 		profile.NetworkMode = &networkMode
 	}
 
-	// Set property ‘NetworkPlugin’:
+	// Set property "NetworkPlugin":
 	if typedInput.NetworkPlugin != nil {
 		networkPlugin := *typedInput.NetworkPlugin
 		profile.NetworkPlugin = &networkPlugin
 	}
 
-	// Set property ‘NetworkPolicy’:
+	// Set property "NetworkPolicy":
 	if typedInput.NetworkPolicy != nil {
 		networkPolicy := *typedInput.NetworkPolicy
 		profile.NetworkPolicy = &networkPolicy
 	}
 
-	// Set property ‘OutboundType’:
+	// Set property "OutboundType":
 	if typedInput.OutboundType != nil {
 		outboundType := *typedInput.OutboundType
 		profile.OutboundType = &outboundType
 	}
 
-	// Set property ‘PodCidr’:
+	// Set property "PodCidr":
 	if typedInput.PodCidr != nil {
 		podCidr := *typedInput.PodCidr
 		profile.PodCidr = &podCidr
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if typedInput.ServiceCidr != nil {
 		serviceCidr := *typedInput.ServiceCidr
 		profile.ServiceCidr = &serviceCidr
@@ -3850,13 +3850,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -3876,13 +3876,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -3960,13 +3960,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -4055,42 +4055,42 @@ func (profile *ManagedClusterAADProfile) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &ManagedClusterAADProfile_ARM{}
 
-	// Set property ‘AdminGroupObjectIDs’:
+	// Set property "AdminGroupObjectIDs":
 	for _, item := range profile.AdminGroupObjectIDs {
 		result.AdminGroupObjectIDs = append(result.AdminGroupObjectIDs, item)
 	}
 
-	// Set property ‘ClientAppID’:
+	// Set property "ClientAppID":
 	if profile.ClientAppID != nil {
 		clientAppID := *profile.ClientAppID
 		result.ClientAppID = &clientAppID
 	}
 
-	// Set property ‘EnableAzureRBAC’:
+	// Set property "EnableAzureRBAC":
 	if profile.EnableAzureRBAC != nil {
 		enableAzureRBAC := *profile.EnableAzureRBAC
 		result.EnableAzureRBAC = &enableAzureRBAC
 	}
 
-	// Set property ‘Managed’:
+	// Set property "Managed":
 	if profile.Managed != nil {
 		managed := *profile.Managed
 		result.Managed = &managed
 	}
 
-	// Set property ‘ServerAppID’:
+	// Set property "ServerAppID":
 	if profile.ServerAppID != nil {
 		serverAppID := *profile.ServerAppID
 		result.ServerAppID = &serverAppID
 	}
 
-	// Set property ‘ServerAppSecret’:
+	// Set property "ServerAppSecret":
 	if profile.ServerAppSecret != nil {
 		serverAppSecret := *profile.ServerAppSecret
 		result.ServerAppSecret = &serverAppSecret
 	}
 
-	// Set property ‘TenantID’:
+	// Set property "TenantID":
 	if profile.TenantID != nil {
 		tenantID := *profile.TenantID
 		result.TenantID = &tenantID
@@ -4110,42 +4110,42 @@ func (profile *ManagedClusterAADProfile) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAADProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminGroupObjectIDs’:
+	// Set property "AdminGroupObjectIDs":
 	for _, item := range typedInput.AdminGroupObjectIDs {
 		profile.AdminGroupObjectIDs = append(profile.AdminGroupObjectIDs, item)
 	}
 
-	// Set property ‘ClientAppID’:
+	// Set property "ClientAppID":
 	if typedInput.ClientAppID != nil {
 		clientAppID := *typedInput.ClientAppID
 		profile.ClientAppID = &clientAppID
 	}
 
-	// Set property ‘EnableAzureRBAC’:
+	// Set property "EnableAzureRBAC":
 	if typedInput.EnableAzureRBAC != nil {
 		enableAzureRBAC := *typedInput.EnableAzureRBAC
 		profile.EnableAzureRBAC = &enableAzureRBAC
 	}
 
-	// Set property ‘Managed’:
+	// Set property "Managed":
 	if typedInput.Managed != nil {
 		managed := *typedInput.Managed
 		profile.Managed = &managed
 	}
 
-	// Set property ‘ServerAppID’:
+	// Set property "ServerAppID":
 	if typedInput.ServerAppID != nil {
 		serverAppID := *typedInput.ServerAppID
 		profile.ServerAppID = &serverAppID
 	}
 
-	// Set property ‘ServerAppSecret’:
+	// Set property "ServerAppSecret":
 	if typedInput.ServerAppSecret != nil {
 		serverAppSecret := *typedInput.ServerAppSecret
 		profile.ServerAppSecret = &serverAppSecret
 	}
 
-	// Set property ‘TenantID’:
+	// Set property "TenantID":
 	if typedInput.TenantID != nil {
 		tenantID := *typedInput.TenantID
 		profile.TenantID = &tenantID
@@ -4279,42 +4279,42 @@ func (profile *ManagedClusterAADProfile_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAADProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminGroupObjectIDs’:
+	// Set property "AdminGroupObjectIDs":
 	for _, item := range typedInput.AdminGroupObjectIDs {
 		profile.AdminGroupObjectIDs = append(profile.AdminGroupObjectIDs, item)
 	}
 
-	// Set property ‘ClientAppID’:
+	// Set property "ClientAppID":
 	if typedInput.ClientAppID != nil {
 		clientAppID := *typedInput.ClientAppID
 		profile.ClientAppID = &clientAppID
 	}
 
-	// Set property ‘EnableAzureRBAC’:
+	// Set property "EnableAzureRBAC":
 	if typedInput.EnableAzureRBAC != nil {
 		enableAzureRBAC := *typedInput.EnableAzureRBAC
 		profile.EnableAzureRBAC = &enableAzureRBAC
 	}
 
-	// Set property ‘Managed’:
+	// Set property "Managed":
 	if typedInput.Managed != nil {
 		managed := *typedInput.Managed
 		profile.Managed = &managed
 	}
 
-	// Set property ‘ServerAppID’:
+	// Set property "ServerAppID":
 	if typedInput.ServerAppID != nil {
 		serverAppID := *typedInput.ServerAppID
 		profile.ServerAppID = &serverAppID
 	}
 
-	// Set property ‘ServerAppSecret’:
+	// Set property "ServerAppSecret":
 	if typedInput.ServerAppSecret != nil {
 		serverAppSecret := *typedInput.ServerAppSecret
 		profile.ServerAppSecret = &serverAppSecret
 	}
 
-	// Set property ‘TenantID’:
+	// Set property "TenantID":
 	if typedInput.TenantID != nil {
 		tenantID := *typedInput.TenantID
 		profile.TenantID = &tenantID
@@ -4428,7 +4428,7 @@ func (profile *ManagedClusterAddonProfile) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ManagedClusterAddonProfile_ARM{}
 
-	// Set property ‘Config’:
+	// Set property "Config":
 	if profile.Config != nil {
 		result.Config = make(map[string]string, len(profile.Config))
 		for key, value := range profile.Config {
@@ -4436,7 +4436,7 @@ func (profile *ManagedClusterAddonProfile) ConvertToARM(resolved genruntime.Conv
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if profile.Enabled != nil {
 		enabled := *profile.Enabled
 		result.Enabled = &enabled
@@ -4456,7 +4456,7 @@ func (profile *ManagedClusterAddonProfile) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAddonProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Config’:
+	// Set property "Config":
 	if typedInput.Config != nil {
 		profile.Config = make(map[string]string, len(typedInput.Config))
 		for key, value := range typedInput.Config {
@@ -4464,7 +4464,7 @@ func (profile *ManagedClusterAddonProfile) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
@@ -4545,7 +4545,7 @@ func (profile *ManagedClusterAddonProfile_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAddonProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Config’:
+	// Set property "Config":
 	if typedInput.Config != nil {
 		profile.Config = make(map[string]string, len(typedInput.Config))
 		for key, value := range typedInput.Config {
@@ -4553,13 +4553,13 @@ func (profile *ManagedClusterAddonProfile_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 UserAssignedIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -4783,54 +4783,54 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 	}
 	result := &ManagedClusterAgentPoolProfile_ARM{}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	for _, item := range profile.AvailabilityZones {
 		result.AvailabilityZones = append(result.AvailabilityZones, item)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if profile.Count != nil {
 		count := *profile.Count
 		result.Count = &count
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	if profile.EnableAutoScaling != nil {
 		enableAutoScaling := *profile.EnableAutoScaling
 		result.EnableAutoScaling = &enableAutoScaling
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	if profile.EnableEncryptionAtHost != nil {
 		enableEncryptionAtHost := *profile.EnableEncryptionAtHost
 		result.EnableEncryptionAtHost = &enableEncryptionAtHost
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	if profile.EnableFIPS != nil {
 		enableFIPS := *profile.EnableFIPS
 		result.EnableFIPS = &enableFIPS
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	if profile.EnableNodePublicIP != nil {
 		enableNodePublicIP := *profile.EnableNodePublicIP
 		result.EnableNodePublicIP = &enableNodePublicIP
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	if profile.EnableUltraSSD != nil {
 		enableUltraSSD := *profile.EnableUltraSSD
 		result.EnableUltraSSD = &enableUltraSSD
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	if profile.GpuInstanceProfile != nil {
 		gpuInstanceProfile := *profile.GpuInstanceProfile
 		result.GpuInstanceProfile = &gpuInstanceProfile
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	if profile.KubeletConfig != nil {
 		kubeletConfig_ARM, err := (*profile.KubeletConfig).ConvertToARM(resolved)
 		if err != nil {
@@ -4840,13 +4840,13 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.KubeletConfig = &kubeletConfig
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	if profile.KubeletDiskType != nil {
 		kubeletDiskType := *profile.KubeletDiskType
 		result.KubeletDiskType = &kubeletDiskType
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	if profile.LinuxOSConfig != nil {
 		linuxOSConfig_ARM, err := (*profile.LinuxOSConfig).ConvertToARM(resolved)
 		if err != nil {
@@ -4856,37 +4856,37 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.LinuxOSConfig = &linuxOSConfig
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	if profile.MaxCount != nil {
 		maxCount := *profile.MaxCount
 		result.MaxCount = &maxCount
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	if profile.MaxPods != nil {
 		maxPods := *profile.MaxPods
 		result.MaxPods = &maxPods
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	if profile.MinCount != nil {
 		minCount := *profile.MinCount
 		result.MinCount = &minCount
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if profile.Mode != nil {
 		mode := *profile.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if profile.Name != nil {
 		name := *profile.Name
 		result.Name = &name
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	if profile.NodeLabels != nil {
 		result.NodeLabels = make(map[string]string, len(profile.NodeLabels))
 		for key, value := range profile.NodeLabels {
@@ -4894,7 +4894,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		}
 	}
 
-	// Set property ‘NodePublicIPPrefixID’:
+	// Set property "NodePublicIPPrefixID":
 	if profile.NodePublicIPPrefixIDReference != nil {
 		nodePublicIPPrefixIDReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.NodePublicIPPrefixIDReference)
 		if err != nil {
@@ -4904,42 +4904,42 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.NodePublicIPPrefixID = &nodePublicIPPrefixIDReference
 	}
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	for _, item := range profile.NodeTaints {
 		result.NodeTaints = append(result.NodeTaints, item)
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	if profile.OrchestratorVersion != nil {
 		orchestratorVersion := *profile.OrchestratorVersion
 		result.OrchestratorVersion = &orchestratorVersion
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	if profile.OsDiskSizeGB != nil {
 		osDiskSizeGB := *profile.OsDiskSizeGB
 		result.OsDiskSizeGB = &osDiskSizeGB
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	if profile.OsDiskType != nil {
 		osDiskType := *profile.OsDiskType
 		result.OsDiskType = &osDiskType
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	if profile.OsSKU != nil {
 		osSKU := *profile.OsSKU
 		result.OsSKU = &osSKU
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if profile.OsType != nil {
 		osType := *profile.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘PodSubnetID’:
+	// Set property "PodSubnetID":
 	if profile.PodSubnetIDReference != nil {
 		podSubnetIDReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.PodSubnetIDReference)
 		if err != nil {
@@ -4949,31 +4949,31 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.PodSubnetID = &podSubnetIDReference
 	}
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	if profile.ProximityPlacementGroupID != nil {
 		proximityPlacementGroupID := *profile.ProximityPlacementGroupID
 		result.ProximityPlacementGroupID = &proximityPlacementGroupID
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	if profile.ScaleSetEvictionPolicy != nil {
 		scaleSetEvictionPolicy := *profile.ScaleSetEvictionPolicy
 		result.ScaleSetEvictionPolicy = &scaleSetEvictionPolicy
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	if profile.ScaleSetPriority != nil {
 		scaleSetPriority := *profile.ScaleSetPriority
 		result.ScaleSetPriority = &scaleSetPriority
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	if profile.SpotMaxPrice != nil {
 		spotMaxPrice := *profile.SpotMaxPrice
 		result.SpotMaxPrice = &spotMaxPrice
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if profile.Tags != nil {
 		result.Tags = make(map[string]string, len(profile.Tags))
 		for key, value := range profile.Tags {
@@ -4981,13 +4981,13 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if profile.Type != nil {
 		typeVar := *profile.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	if profile.UpgradeSettings != nil {
 		upgradeSettings_ARM, err := (*profile.UpgradeSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -4997,13 +4997,13 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.UpgradeSettings = &upgradeSettings
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if profile.VmSize != nil {
 		vmSize := *profile.VmSize
 		result.VmSize = &vmSize
 	}
 
-	// Set property ‘VnetSubnetID’:
+	// Set property "VnetSubnetID":
 	if profile.VnetSubnetIDReference != nil {
 		vnetSubnetIDReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.VnetSubnetIDReference)
 		if err != nil {
@@ -5027,54 +5027,54 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAgentPoolProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	for _, item := range typedInput.AvailabilityZones {
 		profile.AvailabilityZones = append(profile.AvailabilityZones, item)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		profile.Count = &count
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	if typedInput.EnableAutoScaling != nil {
 		enableAutoScaling := *typedInput.EnableAutoScaling
 		profile.EnableAutoScaling = &enableAutoScaling
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	if typedInput.EnableEncryptionAtHost != nil {
 		enableEncryptionAtHost := *typedInput.EnableEncryptionAtHost
 		profile.EnableEncryptionAtHost = &enableEncryptionAtHost
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	if typedInput.EnableFIPS != nil {
 		enableFIPS := *typedInput.EnableFIPS
 		profile.EnableFIPS = &enableFIPS
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	if typedInput.EnableNodePublicIP != nil {
 		enableNodePublicIP := *typedInput.EnableNodePublicIP
 		profile.EnableNodePublicIP = &enableNodePublicIP
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	if typedInput.EnableUltraSSD != nil {
 		enableUltraSSD := *typedInput.EnableUltraSSD
 		profile.EnableUltraSSD = &enableUltraSSD
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	if typedInput.GpuInstanceProfile != nil {
 		gpuInstanceProfile := *typedInput.GpuInstanceProfile
 		profile.GpuInstanceProfile = &gpuInstanceProfile
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	if typedInput.KubeletConfig != nil {
 		var kubeletConfig1 KubeletConfig
 		err := kubeletConfig1.PopulateFromARM(owner, *typedInput.KubeletConfig)
@@ -5085,13 +5085,13 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.KubeletConfig = &kubeletConfig
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	if typedInput.KubeletDiskType != nil {
 		kubeletDiskType := *typedInput.KubeletDiskType
 		profile.KubeletDiskType = &kubeletDiskType
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	if typedInput.LinuxOSConfig != nil {
 		var linuxOSConfig1 LinuxOSConfig
 		err := linuxOSConfig1.PopulateFromARM(owner, *typedInput.LinuxOSConfig)
@@ -5102,37 +5102,37 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.LinuxOSConfig = &linuxOSConfig
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	if typedInput.MaxCount != nil {
 		maxCount := *typedInput.MaxCount
 		profile.MaxCount = &maxCount
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	if typedInput.MaxPods != nil {
 		maxPods := *typedInput.MaxPods
 		profile.MaxPods = &maxPods
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	if typedInput.MinCount != nil {
 		minCount := *typedInput.MinCount
 		profile.MinCount = &minCount
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		profile.Mode = &mode
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	if typedInput.NodeLabels != nil {
 		profile.NodeLabels = make(map[string]string, len(typedInput.NodeLabels))
 		for key, value := range typedInput.NodeLabels {
@@ -5140,70 +5140,70 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// no assignment for property ‘NodePublicIPPrefixIDReference’
+	// no assignment for property "NodePublicIPPrefixIDReference"
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	for _, item := range typedInput.NodeTaints {
 		profile.NodeTaints = append(profile.NodeTaints, item)
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	if typedInput.OrchestratorVersion != nil {
 		orchestratorVersion := *typedInput.OrchestratorVersion
 		profile.OrchestratorVersion = &orchestratorVersion
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
 		osDiskSizeGB := *typedInput.OsDiskSizeGB
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	if typedInput.OsDiskType != nil {
 		osDiskType := *typedInput.OsDiskType
 		profile.OsDiskType = &osDiskType
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	if typedInput.OsSKU != nil {
 		osSKU := *typedInput.OsSKU
 		profile.OsSKU = &osSKU
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		profile.OsType = &osType
 	}
 
-	// no assignment for property ‘PodSubnetIDReference’
+	// no assignment for property "PodSubnetIDReference"
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	if typedInput.ProximityPlacementGroupID != nil {
 		proximityPlacementGroupID := *typedInput.ProximityPlacementGroupID
 		profile.ProximityPlacementGroupID = &proximityPlacementGroupID
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	if typedInput.ScaleSetEvictionPolicy != nil {
 		scaleSetEvictionPolicy := *typedInput.ScaleSetEvictionPolicy
 		profile.ScaleSetEvictionPolicy = &scaleSetEvictionPolicy
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	if typedInput.ScaleSetPriority != nil {
 		scaleSetPriority := *typedInput.ScaleSetPriority
 		profile.ScaleSetPriority = &scaleSetPriority
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	if typedInput.SpotMaxPrice != nil {
 		spotMaxPrice := *typedInput.SpotMaxPrice
 		profile.SpotMaxPrice = &spotMaxPrice
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		profile.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -5211,13 +5211,13 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	if typedInput.UpgradeSettings != nil {
 		var upgradeSettings1 AgentPoolUpgradeSettings
 		err := upgradeSettings1.PopulateFromARM(owner, *typedInput.UpgradeSettings)
@@ -5228,13 +5228,13 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.UpgradeSettings = &upgradeSettings
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
 	}
 
-	// no assignment for property ‘VnetSubnetIDReference’
+	// no assignment for property "VnetSubnetIDReference"
 
 	// No error
 	return nil
@@ -5874,54 +5874,54 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAgentPoolProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	for _, item := range typedInput.AvailabilityZones {
 		profile.AvailabilityZones = append(profile.AvailabilityZones, item)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		profile.Count = &count
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	if typedInput.EnableAutoScaling != nil {
 		enableAutoScaling := *typedInput.EnableAutoScaling
 		profile.EnableAutoScaling = &enableAutoScaling
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	if typedInput.EnableEncryptionAtHost != nil {
 		enableEncryptionAtHost := *typedInput.EnableEncryptionAtHost
 		profile.EnableEncryptionAtHost = &enableEncryptionAtHost
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	if typedInput.EnableFIPS != nil {
 		enableFIPS := *typedInput.EnableFIPS
 		profile.EnableFIPS = &enableFIPS
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	if typedInput.EnableNodePublicIP != nil {
 		enableNodePublicIP := *typedInput.EnableNodePublicIP
 		profile.EnableNodePublicIP = &enableNodePublicIP
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	if typedInput.EnableUltraSSD != nil {
 		enableUltraSSD := *typedInput.EnableUltraSSD
 		profile.EnableUltraSSD = &enableUltraSSD
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	if typedInput.GpuInstanceProfile != nil {
 		gpuInstanceProfile := *typedInput.GpuInstanceProfile
 		profile.GpuInstanceProfile = &gpuInstanceProfile
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	if typedInput.KubeletConfig != nil {
 		var kubeletConfig1 KubeletConfig_STATUS
 		err := kubeletConfig1.PopulateFromARM(owner, *typedInput.KubeletConfig)
@@ -5932,13 +5932,13 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.KubeletConfig = &kubeletConfig
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	if typedInput.KubeletDiskType != nil {
 		kubeletDiskType := *typedInput.KubeletDiskType
 		profile.KubeletDiskType = &kubeletDiskType
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	if typedInput.LinuxOSConfig != nil {
 		var linuxOSConfig1 LinuxOSConfig_STATUS
 		err := linuxOSConfig1.PopulateFromARM(owner, *typedInput.LinuxOSConfig)
@@ -5949,43 +5949,43 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.LinuxOSConfig = &linuxOSConfig
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	if typedInput.MaxCount != nil {
 		maxCount := *typedInput.MaxCount
 		profile.MaxCount = &maxCount
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	if typedInput.MaxPods != nil {
 		maxPods := *typedInput.MaxPods
 		profile.MaxPods = &maxPods
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	if typedInput.MinCount != nil {
 		minCount := *typedInput.MinCount
 		profile.MinCount = &minCount
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		profile.Mode = &mode
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘NodeImageVersion’:
+	// Set property "NodeImageVersion":
 	if typedInput.NodeImageVersion != nil {
 		nodeImageVersion := *typedInput.NodeImageVersion
 		profile.NodeImageVersion = &nodeImageVersion
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	if typedInput.NodeLabels != nil {
 		profile.NodeLabels = make(map[string]string, len(typedInput.NodeLabels))
 		for key, value := range typedInput.NodeLabels {
@@ -5993,54 +5993,54 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘NodePublicIPPrefixID’:
+	// Set property "NodePublicIPPrefixID":
 	if typedInput.NodePublicIPPrefixID != nil {
 		nodePublicIPPrefixID := *typedInput.NodePublicIPPrefixID
 		profile.NodePublicIPPrefixID = &nodePublicIPPrefixID
 	}
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	for _, item := range typedInput.NodeTaints {
 		profile.NodeTaints = append(profile.NodeTaints, item)
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	if typedInput.OrchestratorVersion != nil {
 		orchestratorVersion := *typedInput.OrchestratorVersion
 		profile.OrchestratorVersion = &orchestratorVersion
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
 		osDiskSizeGB := *typedInput.OsDiskSizeGB
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	if typedInput.OsDiskType != nil {
 		osDiskType := *typedInput.OsDiskType
 		profile.OsDiskType = &osDiskType
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	if typedInput.OsSKU != nil {
 		osSKU := *typedInput.OsSKU
 		profile.OsSKU = &osSKU
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		profile.OsType = &osType
 	}
 
-	// Set property ‘PodSubnetID’:
+	// Set property "PodSubnetID":
 	if typedInput.PodSubnetID != nil {
 		podSubnetID := *typedInput.PodSubnetID
 		profile.PodSubnetID = &podSubnetID
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	if typedInput.PowerState != nil {
 		var powerState1 PowerState_STATUS
 		err := powerState1.PopulateFromARM(owner, *typedInput.PowerState)
@@ -6051,37 +6051,37 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.PowerState = &powerState
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		profile.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	if typedInput.ProximityPlacementGroupID != nil {
 		proximityPlacementGroupID := *typedInput.ProximityPlacementGroupID
 		profile.ProximityPlacementGroupID = &proximityPlacementGroupID
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	if typedInput.ScaleSetEvictionPolicy != nil {
 		scaleSetEvictionPolicy := *typedInput.ScaleSetEvictionPolicy
 		profile.ScaleSetEvictionPolicy = &scaleSetEvictionPolicy
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	if typedInput.ScaleSetPriority != nil {
 		scaleSetPriority := *typedInput.ScaleSetPriority
 		profile.ScaleSetPriority = &scaleSetPriority
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	if typedInput.SpotMaxPrice != nil {
 		spotMaxPrice := *typedInput.SpotMaxPrice
 		profile.SpotMaxPrice = &spotMaxPrice
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		profile.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -6089,13 +6089,13 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	if typedInput.UpgradeSettings != nil {
 		var upgradeSettings1 AgentPoolUpgradeSettings_STATUS
 		err := upgradeSettings1.PopulateFromARM(owner, *typedInput.UpgradeSettings)
@@ -6106,13 +6106,13 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.UpgradeSettings = &upgradeSettings
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
 	}
 
-	// Set property ‘VnetSubnetID’:
+	// Set property "VnetSubnetID":
 	if typedInput.VnetSubnetID != nil {
 		vnetSubnetID := *typedInput.VnetSubnetID
 		profile.VnetSubnetID = &vnetSubnetID
@@ -6618,24 +6618,24 @@ func (profile *ManagedClusterAPIServerAccessProfile) ConvertToARM(resolved genru
 	}
 	result := &ManagedClusterAPIServerAccessProfile_ARM{}
 
-	// Set property ‘AuthorizedIPRanges’:
+	// Set property "AuthorizedIPRanges":
 	for _, item := range profile.AuthorizedIPRanges {
 		result.AuthorizedIPRanges = append(result.AuthorizedIPRanges, item)
 	}
 
-	// Set property ‘EnablePrivateCluster’:
+	// Set property "EnablePrivateCluster":
 	if profile.EnablePrivateCluster != nil {
 		enablePrivateCluster := *profile.EnablePrivateCluster
 		result.EnablePrivateCluster = &enablePrivateCluster
 	}
 
-	// Set property ‘EnablePrivateClusterPublicFQDN’:
+	// Set property "EnablePrivateClusterPublicFQDN":
 	if profile.EnablePrivateClusterPublicFQDN != nil {
 		enablePrivateClusterPublicFQDN := *profile.EnablePrivateClusterPublicFQDN
 		result.EnablePrivateClusterPublicFQDN = &enablePrivateClusterPublicFQDN
 	}
 
-	// Set property ‘PrivateDNSZone’:
+	// Set property "PrivateDNSZone":
 	if profile.PrivateDNSZone != nil {
 		privateDNSZone := *profile.PrivateDNSZone
 		result.PrivateDNSZone = &privateDNSZone
@@ -6655,24 +6655,24 @@ func (profile *ManagedClusterAPIServerAccessProfile) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAPIServerAccessProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthorizedIPRanges’:
+	// Set property "AuthorizedIPRanges":
 	for _, item := range typedInput.AuthorizedIPRanges {
 		profile.AuthorizedIPRanges = append(profile.AuthorizedIPRanges, item)
 	}
 
-	// Set property ‘EnablePrivateCluster’:
+	// Set property "EnablePrivateCluster":
 	if typedInput.EnablePrivateCluster != nil {
 		enablePrivateCluster := *typedInput.EnablePrivateCluster
 		profile.EnablePrivateCluster = &enablePrivateCluster
 	}
 
-	// Set property ‘EnablePrivateClusterPublicFQDN’:
+	// Set property "EnablePrivateClusterPublicFQDN":
 	if typedInput.EnablePrivateClusterPublicFQDN != nil {
 		enablePrivateClusterPublicFQDN := *typedInput.EnablePrivateClusterPublicFQDN
 		profile.EnablePrivateClusterPublicFQDN = &enablePrivateClusterPublicFQDN
 	}
 
-	// Set property ‘PrivateDNSZone’:
+	// Set property "PrivateDNSZone":
 	if typedInput.PrivateDNSZone != nil {
 		privateDNSZone := *typedInput.PrivateDNSZone
 		profile.PrivateDNSZone = &privateDNSZone
@@ -6783,24 +6783,24 @@ func (profile *ManagedClusterAPIServerAccessProfile_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAPIServerAccessProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthorizedIPRanges’:
+	// Set property "AuthorizedIPRanges":
 	for _, item := range typedInput.AuthorizedIPRanges {
 		profile.AuthorizedIPRanges = append(profile.AuthorizedIPRanges, item)
 	}
 
-	// Set property ‘EnablePrivateCluster’:
+	// Set property "EnablePrivateCluster":
 	if typedInput.EnablePrivateCluster != nil {
 		enablePrivateCluster := *typedInput.EnablePrivateCluster
 		profile.EnablePrivateCluster = &enablePrivateCluster
 	}
 
-	// Set property ‘EnablePrivateClusterPublicFQDN’:
+	// Set property "EnablePrivateClusterPublicFQDN":
 	if typedInput.EnablePrivateClusterPublicFQDN != nil {
 		enablePrivateClusterPublicFQDN := *typedInput.EnablePrivateClusterPublicFQDN
 		profile.EnablePrivateClusterPublicFQDN = &enablePrivateClusterPublicFQDN
 	}
 
-	// Set property ‘PrivateDNSZone’:
+	// Set property "PrivateDNSZone":
 	if typedInput.PrivateDNSZone != nil {
 		privateDNSZone := *typedInput.PrivateDNSZone
 		profile.PrivateDNSZone = &privateDNSZone
@@ -6893,7 +6893,7 @@ func (profile *ManagedClusterAutoUpgradeProfile) ConvertToARM(resolved genruntim
 	}
 	result := &ManagedClusterAutoUpgradeProfile_ARM{}
 
-	// Set property ‘UpgradeChannel’:
+	// Set property "UpgradeChannel":
 	if profile.UpgradeChannel != nil {
 		upgradeChannel := *profile.UpgradeChannel
 		result.UpgradeChannel = &upgradeChannel
@@ -6913,7 +6913,7 @@ func (profile *ManagedClusterAutoUpgradeProfile) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAutoUpgradeProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UpgradeChannel’:
+	// Set property "UpgradeChannel":
 	if typedInput.UpgradeChannel != nil {
 		upgradeChannel := *typedInput.UpgradeChannel
 		profile.UpgradeChannel = &upgradeChannel
@@ -6983,7 +6983,7 @@ func (profile *ManagedClusterAutoUpgradeProfile_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAutoUpgradeProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UpgradeChannel’:
+	// Set property "UpgradeChannel":
 	if typedInput.UpgradeChannel != nil {
 		upgradeChannel := *typedInput.UpgradeChannel
 		profile.UpgradeChannel = &upgradeChannel
@@ -7056,24 +7056,24 @@ func (config *ManagedClusterHTTPProxyConfig) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ManagedClusterHTTPProxyConfig_ARM{}
 
-	// Set property ‘HttpProxy’:
+	// Set property "HttpProxy":
 	if config.HttpProxy != nil {
 		httpProxy := *config.HttpProxy
 		result.HttpProxy = &httpProxy
 	}
 
-	// Set property ‘HttpsProxy’:
+	// Set property "HttpsProxy":
 	if config.HttpsProxy != nil {
 		httpsProxy := *config.HttpsProxy
 		result.HttpsProxy = &httpsProxy
 	}
 
-	// Set property ‘NoProxy’:
+	// Set property "NoProxy":
 	for _, item := range config.NoProxy {
 		result.NoProxy = append(result.NoProxy, item)
 	}
 
-	// Set property ‘TrustedCa’:
+	// Set property "TrustedCa":
 	if config.TrustedCa != nil {
 		trustedCa := *config.TrustedCa
 		result.TrustedCa = &trustedCa
@@ -7093,24 +7093,24 @@ func (config *ManagedClusterHTTPProxyConfig) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterHTTPProxyConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpProxy’:
+	// Set property "HttpProxy":
 	if typedInput.HttpProxy != nil {
 		httpProxy := *typedInput.HttpProxy
 		config.HttpProxy = &httpProxy
 	}
 
-	// Set property ‘HttpsProxy’:
+	// Set property "HttpsProxy":
 	if typedInput.HttpsProxy != nil {
 		httpsProxy := *typedInput.HttpsProxy
 		config.HttpsProxy = &httpsProxy
 	}
 
-	// Set property ‘NoProxy’:
+	// Set property "NoProxy":
 	for _, item := range typedInput.NoProxy {
 		config.NoProxy = append(config.NoProxy, item)
 	}
 
-	// Set property ‘TrustedCa’:
+	// Set property "TrustedCa":
 	if typedInput.TrustedCa != nil {
 		trustedCa := *typedInput.TrustedCa
 		config.TrustedCa = &trustedCa
@@ -7196,24 +7196,24 @@ func (config *ManagedClusterHTTPProxyConfig_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterHTTPProxyConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpProxy’:
+	// Set property "HttpProxy":
 	if typedInput.HttpProxy != nil {
 		httpProxy := *typedInput.HttpProxy
 		config.HttpProxy = &httpProxy
 	}
 
-	// Set property ‘HttpsProxy’:
+	// Set property "HttpsProxy":
 	if typedInput.HttpsProxy != nil {
 		httpsProxy := *typedInput.HttpsProxy
 		config.HttpsProxy = &httpsProxy
 	}
 
-	// Set property ‘NoProxy’:
+	// Set property "NoProxy":
 	for _, item := range typedInput.NoProxy {
 		config.NoProxy = append(config.NoProxy, item)
 	}
 
-	// Set property ‘TrustedCa’:
+	// Set property "TrustedCa":
 	if typedInput.TrustedCa != nil {
 		trustedCa := *typedInput.TrustedCa
 		config.TrustedCa = &trustedCa
@@ -7290,13 +7290,13 @@ func (identity *ManagedClusterIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ManagedClusterIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -7321,13 +7321,13 @@ func (identity *ManagedClusterIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -7439,25 +7439,25 @@ func (identity *ManagedClusterIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]ManagedClusterIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -7642,19 +7642,19 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 	}
 	result := &ManagedClusterPodIdentityProfile_ARM{}
 
-	// Set property ‘AllowNetworkPluginKubenet’:
+	// Set property "AllowNetworkPluginKubenet":
 	if profile.AllowNetworkPluginKubenet != nil {
 		allowNetworkPluginKubenet := *profile.AllowNetworkPluginKubenet
 		result.AllowNetworkPluginKubenet = &allowNetworkPluginKubenet
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if profile.Enabled != nil {
 		enabled := *profile.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	for _, item := range profile.UserAssignedIdentities {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -7663,7 +7663,7 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 		result.UserAssignedIdentities = append(result.UserAssignedIdentities, *item_ARM.(*ManagedClusterPodIdentity_ARM))
 	}
 
-	// Set property ‘UserAssignedIdentityExceptions’:
+	// Set property "UserAssignedIdentityExceptions":
 	for _, item := range profile.UserAssignedIdentityExceptions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -7686,19 +7686,19 @@ func (profile *ManagedClusterPodIdentityProfile) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowNetworkPluginKubenet’:
+	// Set property "AllowNetworkPluginKubenet":
 	if typedInput.AllowNetworkPluginKubenet != nil {
 		allowNetworkPluginKubenet := *typedInput.AllowNetworkPluginKubenet
 		profile.AllowNetworkPluginKubenet = &allowNetworkPluginKubenet
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	for _, item := range typedInput.UserAssignedIdentities {
 		var item1 ManagedClusterPodIdentity
 		err := item1.PopulateFromARM(owner, item)
@@ -7708,7 +7708,7 @@ func (profile *ManagedClusterPodIdentityProfile) PopulateFromARM(owner genruntim
 		profile.UserAssignedIdentities = append(profile.UserAssignedIdentities, item1)
 	}
 
-	// Set property ‘UserAssignedIdentityExceptions’:
+	// Set property "UserAssignedIdentityExceptions":
 	for _, item := range typedInput.UserAssignedIdentityExceptions {
 		var item1 ManagedClusterPodIdentityException
 		err := item1.PopulateFromARM(owner, item)
@@ -7882,19 +7882,19 @@ func (profile *ManagedClusterPodIdentityProfile_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowNetworkPluginKubenet’:
+	// Set property "AllowNetworkPluginKubenet":
 	if typedInput.AllowNetworkPluginKubenet != nil {
 		allowNetworkPluginKubenet := *typedInput.AllowNetworkPluginKubenet
 		profile.AllowNetworkPluginKubenet = &allowNetworkPluginKubenet
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	for _, item := range typedInput.UserAssignedIdentities {
 		var item1 ManagedClusterPodIdentity_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7904,7 +7904,7 @@ func (profile *ManagedClusterPodIdentityProfile_STATUS) PopulateFromARM(owner ge
 		profile.UserAssignedIdentities = append(profile.UserAssignedIdentities, item1)
 	}
 
-	// Set property ‘UserAssignedIdentityExceptions’:
+	// Set property "UserAssignedIdentityExceptions":
 	for _, item := range typedInput.UserAssignedIdentityExceptions {
 		var item1 ManagedClusterPodIdentityException_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8117,103 +8117,103 @@ func (profile *ManagedClusterProperties_AutoScalerProfile) ConvertToARM(resolved
 	}
 	result := &ManagedClusterProperties_AutoScalerProfile_ARM{}
 
-	// Set property ‘BalanceSimilarNodeGroups’:
+	// Set property "BalanceSimilarNodeGroups":
 	if profile.BalanceSimilarNodeGroups != nil {
 		balanceSimilarNodeGroups := *profile.BalanceSimilarNodeGroups
 		result.BalanceSimilarNodeGroups = &balanceSimilarNodeGroups
 	}
 
-	// Set property ‘Expander’:
+	// Set property "Expander":
 	if profile.Expander != nil {
 		expander := *profile.Expander
 		result.Expander = &expander
 	}
 
-	// Set property ‘MaxEmptyBulkDelete’:
+	// Set property "MaxEmptyBulkDelete":
 	if profile.MaxEmptyBulkDelete != nil {
 		maxEmptyBulkDelete := *profile.MaxEmptyBulkDelete
 		result.MaxEmptyBulkDelete = &maxEmptyBulkDelete
 	}
 
-	// Set property ‘MaxGracefulTerminationSec’:
+	// Set property "MaxGracefulTerminationSec":
 	if profile.MaxGracefulTerminationSec != nil {
 		maxGracefulTerminationSec := *profile.MaxGracefulTerminationSec
 		result.MaxGracefulTerminationSec = &maxGracefulTerminationSec
 	}
 
-	// Set property ‘MaxNodeProvisionTime’:
+	// Set property "MaxNodeProvisionTime":
 	if profile.MaxNodeProvisionTime != nil {
 		maxNodeProvisionTime := *profile.MaxNodeProvisionTime
 		result.MaxNodeProvisionTime = &maxNodeProvisionTime
 	}
 
-	// Set property ‘MaxTotalUnreadyPercentage’:
+	// Set property "MaxTotalUnreadyPercentage":
 	if profile.MaxTotalUnreadyPercentage != nil {
 		maxTotalUnreadyPercentage := *profile.MaxTotalUnreadyPercentage
 		result.MaxTotalUnreadyPercentage = &maxTotalUnreadyPercentage
 	}
 
-	// Set property ‘NewPodScaleUpDelay’:
+	// Set property "NewPodScaleUpDelay":
 	if profile.NewPodScaleUpDelay != nil {
 		newPodScaleUpDelay := *profile.NewPodScaleUpDelay
 		result.NewPodScaleUpDelay = &newPodScaleUpDelay
 	}
 
-	// Set property ‘OkTotalUnreadyCount’:
+	// Set property "OkTotalUnreadyCount":
 	if profile.OkTotalUnreadyCount != nil {
 		okTotalUnreadyCount := *profile.OkTotalUnreadyCount
 		result.OkTotalUnreadyCount = &okTotalUnreadyCount
 	}
 
-	// Set property ‘ScaleDownDelayAfterAdd’:
+	// Set property "ScaleDownDelayAfterAdd":
 	if profile.ScaleDownDelayAfterAdd != nil {
 		scaleDownDelayAfterAdd := *profile.ScaleDownDelayAfterAdd
 		result.ScaleDownDelayAfterAdd = &scaleDownDelayAfterAdd
 	}
 
-	// Set property ‘ScaleDownDelayAfterDelete’:
+	// Set property "ScaleDownDelayAfterDelete":
 	if profile.ScaleDownDelayAfterDelete != nil {
 		scaleDownDelayAfterDelete := *profile.ScaleDownDelayAfterDelete
 		result.ScaleDownDelayAfterDelete = &scaleDownDelayAfterDelete
 	}
 
-	// Set property ‘ScaleDownDelayAfterFailure’:
+	// Set property "ScaleDownDelayAfterFailure":
 	if profile.ScaleDownDelayAfterFailure != nil {
 		scaleDownDelayAfterFailure := *profile.ScaleDownDelayAfterFailure
 		result.ScaleDownDelayAfterFailure = &scaleDownDelayAfterFailure
 	}
 
-	// Set property ‘ScaleDownUnneededTime’:
+	// Set property "ScaleDownUnneededTime":
 	if profile.ScaleDownUnneededTime != nil {
 		scaleDownUnneededTime := *profile.ScaleDownUnneededTime
 		result.ScaleDownUnneededTime = &scaleDownUnneededTime
 	}
 
-	// Set property ‘ScaleDownUnreadyTime’:
+	// Set property "ScaleDownUnreadyTime":
 	if profile.ScaleDownUnreadyTime != nil {
 		scaleDownUnreadyTime := *profile.ScaleDownUnreadyTime
 		result.ScaleDownUnreadyTime = &scaleDownUnreadyTime
 	}
 
-	// Set property ‘ScaleDownUtilizationThreshold’:
+	// Set property "ScaleDownUtilizationThreshold":
 	if profile.ScaleDownUtilizationThreshold != nil {
 		scaleDownUtilizationThreshold := *profile.ScaleDownUtilizationThreshold
 		result.ScaleDownUtilizationThreshold = &scaleDownUtilizationThreshold
 	}
 
-	// Set property ‘ScanInterval’:
+	// Set property "ScanInterval":
 	if profile.ScanInterval != nil {
 		scanInterval := *profile.ScanInterval
 		result.ScanInterval = &scanInterval
 	}
 
-	// Set property ‘SkipNodesWithLocalStorage’:
+	// Set property "SkipNodesWithLocalStorage":
 	if profile.SkipNodesWithLocalStorage != nil {
 		skipNodesWithLocalStorage := *profile.SkipNodesWithLocalStorage
 		result.SkipNodesWithLocalStorage = &skipNodesWithLocalStorage
 	}
 
-	// Set property ‘SkipNodesWithSystemPods’:
+	// Set property "SkipNodesWithSystemPods":
 	if profile.SkipNodesWithSystemPods != nil {
 		skipNodesWithSystemPods := *profile.SkipNodesWithSystemPods
 		result.SkipNodesWithSystemPods = &skipNodesWithSystemPods
@@ -8233,103 +8233,103 @@ func (profile *ManagedClusterProperties_AutoScalerProfile) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterProperties_AutoScalerProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BalanceSimilarNodeGroups’:
+	// Set property "BalanceSimilarNodeGroups":
 	if typedInput.BalanceSimilarNodeGroups != nil {
 		balanceSimilarNodeGroups := *typedInput.BalanceSimilarNodeGroups
 		profile.BalanceSimilarNodeGroups = &balanceSimilarNodeGroups
 	}
 
-	// Set property ‘Expander’:
+	// Set property "Expander":
 	if typedInput.Expander != nil {
 		expander := *typedInput.Expander
 		profile.Expander = &expander
 	}
 
-	// Set property ‘MaxEmptyBulkDelete’:
+	// Set property "MaxEmptyBulkDelete":
 	if typedInput.MaxEmptyBulkDelete != nil {
 		maxEmptyBulkDelete := *typedInput.MaxEmptyBulkDelete
 		profile.MaxEmptyBulkDelete = &maxEmptyBulkDelete
 	}
 
-	// Set property ‘MaxGracefulTerminationSec’:
+	// Set property "MaxGracefulTerminationSec":
 	if typedInput.MaxGracefulTerminationSec != nil {
 		maxGracefulTerminationSec := *typedInput.MaxGracefulTerminationSec
 		profile.MaxGracefulTerminationSec = &maxGracefulTerminationSec
 	}
 
-	// Set property ‘MaxNodeProvisionTime’:
+	// Set property "MaxNodeProvisionTime":
 	if typedInput.MaxNodeProvisionTime != nil {
 		maxNodeProvisionTime := *typedInput.MaxNodeProvisionTime
 		profile.MaxNodeProvisionTime = &maxNodeProvisionTime
 	}
 
-	// Set property ‘MaxTotalUnreadyPercentage’:
+	// Set property "MaxTotalUnreadyPercentage":
 	if typedInput.MaxTotalUnreadyPercentage != nil {
 		maxTotalUnreadyPercentage := *typedInput.MaxTotalUnreadyPercentage
 		profile.MaxTotalUnreadyPercentage = &maxTotalUnreadyPercentage
 	}
 
-	// Set property ‘NewPodScaleUpDelay’:
+	// Set property "NewPodScaleUpDelay":
 	if typedInput.NewPodScaleUpDelay != nil {
 		newPodScaleUpDelay := *typedInput.NewPodScaleUpDelay
 		profile.NewPodScaleUpDelay = &newPodScaleUpDelay
 	}
 
-	// Set property ‘OkTotalUnreadyCount’:
+	// Set property "OkTotalUnreadyCount":
 	if typedInput.OkTotalUnreadyCount != nil {
 		okTotalUnreadyCount := *typedInput.OkTotalUnreadyCount
 		profile.OkTotalUnreadyCount = &okTotalUnreadyCount
 	}
 
-	// Set property ‘ScaleDownDelayAfterAdd’:
+	// Set property "ScaleDownDelayAfterAdd":
 	if typedInput.ScaleDownDelayAfterAdd != nil {
 		scaleDownDelayAfterAdd := *typedInput.ScaleDownDelayAfterAdd
 		profile.ScaleDownDelayAfterAdd = &scaleDownDelayAfterAdd
 	}
 
-	// Set property ‘ScaleDownDelayAfterDelete’:
+	// Set property "ScaleDownDelayAfterDelete":
 	if typedInput.ScaleDownDelayAfterDelete != nil {
 		scaleDownDelayAfterDelete := *typedInput.ScaleDownDelayAfterDelete
 		profile.ScaleDownDelayAfterDelete = &scaleDownDelayAfterDelete
 	}
 
-	// Set property ‘ScaleDownDelayAfterFailure’:
+	// Set property "ScaleDownDelayAfterFailure":
 	if typedInput.ScaleDownDelayAfterFailure != nil {
 		scaleDownDelayAfterFailure := *typedInput.ScaleDownDelayAfterFailure
 		profile.ScaleDownDelayAfterFailure = &scaleDownDelayAfterFailure
 	}
 
-	// Set property ‘ScaleDownUnneededTime’:
+	// Set property "ScaleDownUnneededTime":
 	if typedInput.ScaleDownUnneededTime != nil {
 		scaleDownUnneededTime := *typedInput.ScaleDownUnneededTime
 		profile.ScaleDownUnneededTime = &scaleDownUnneededTime
 	}
 
-	// Set property ‘ScaleDownUnreadyTime’:
+	// Set property "ScaleDownUnreadyTime":
 	if typedInput.ScaleDownUnreadyTime != nil {
 		scaleDownUnreadyTime := *typedInput.ScaleDownUnreadyTime
 		profile.ScaleDownUnreadyTime = &scaleDownUnreadyTime
 	}
 
-	// Set property ‘ScaleDownUtilizationThreshold’:
+	// Set property "ScaleDownUtilizationThreshold":
 	if typedInput.ScaleDownUtilizationThreshold != nil {
 		scaleDownUtilizationThreshold := *typedInput.ScaleDownUtilizationThreshold
 		profile.ScaleDownUtilizationThreshold = &scaleDownUtilizationThreshold
 	}
 
-	// Set property ‘ScanInterval’:
+	// Set property "ScanInterval":
 	if typedInput.ScanInterval != nil {
 		scanInterval := *typedInput.ScanInterval
 		profile.ScanInterval = &scanInterval
 	}
 
-	// Set property ‘SkipNodesWithLocalStorage’:
+	// Set property "SkipNodesWithLocalStorage":
 	if typedInput.SkipNodesWithLocalStorage != nil {
 		skipNodesWithLocalStorage := *typedInput.SkipNodesWithLocalStorage
 		profile.SkipNodesWithLocalStorage = &skipNodesWithLocalStorage
 	}
 
-	// Set property ‘SkipNodesWithSystemPods’:
+	// Set property "SkipNodesWithSystemPods":
 	if typedInput.SkipNodesWithSystemPods != nil {
 		skipNodesWithSystemPods := *typedInput.SkipNodesWithSystemPods
 		profile.SkipNodesWithSystemPods = &skipNodesWithSystemPods
@@ -8551,103 +8551,103 @@ func (profile *ManagedClusterProperties_AutoScalerProfile_STATUS) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterProperties_AutoScalerProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BalanceSimilarNodeGroups’:
+	// Set property "BalanceSimilarNodeGroups":
 	if typedInput.BalanceSimilarNodeGroups != nil {
 		balanceSimilarNodeGroups := *typedInput.BalanceSimilarNodeGroups
 		profile.BalanceSimilarNodeGroups = &balanceSimilarNodeGroups
 	}
 
-	// Set property ‘Expander’:
+	// Set property "Expander":
 	if typedInput.Expander != nil {
 		expander := *typedInput.Expander
 		profile.Expander = &expander
 	}
 
-	// Set property ‘MaxEmptyBulkDelete’:
+	// Set property "MaxEmptyBulkDelete":
 	if typedInput.MaxEmptyBulkDelete != nil {
 		maxEmptyBulkDelete := *typedInput.MaxEmptyBulkDelete
 		profile.MaxEmptyBulkDelete = &maxEmptyBulkDelete
 	}
 
-	// Set property ‘MaxGracefulTerminationSec’:
+	// Set property "MaxGracefulTerminationSec":
 	if typedInput.MaxGracefulTerminationSec != nil {
 		maxGracefulTerminationSec := *typedInput.MaxGracefulTerminationSec
 		profile.MaxGracefulTerminationSec = &maxGracefulTerminationSec
 	}
 
-	// Set property ‘MaxNodeProvisionTime’:
+	// Set property "MaxNodeProvisionTime":
 	if typedInput.MaxNodeProvisionTime != nil {
 		maxNodeProvisionTime := *typedInput.MaxNodeProvisionTime
 		profile.MaxNodeProvisionTime = &maxNodeProvisionTime
 	}
 
-	// Set property ‘MaxTotalUnreadyPercentage’:
+	// Set property "MaxTotalUnreadyPercentage":
 	if typedInput.MaxTotalUnreadyPercentage != nil {
 		maxTotalUnreadyPercentage := *typedInput.MaxTotalUnreadyPercentage
 		profile.MaxTotalUnreadyPercentage = &maxTotalUnreadyPercentage
 	}
 
-	// Set property ‘NewPodScaleUpDelay’:
+	// Set property "NewPodScaleUpDelay":
 	if typedInput.NewPodScaleUpDelay != nil {
 		newPodScaleUpDelay := *typedInput.NewPodScaleUpDelay
 		profile.NewPodScaleUpDelay = &newPodScaleUpDelay
 	}
 
-	// Set property ‘OkTotalUnreadyCount’:
+	// Set property "OkTotalUnreadyCount":
 	if typedInput.OkTotalUnreadyCount != nil {
 		okTotalUnreadyCount := *typedInput.OkTotalUnreadyCount
 		profile.OkTotalUnreadyCount = &okTotalUnreadyCount
 	}
 
-	// Set property ‘ScaleDownDelayAfterAdd’:
+	// Set property "ScaleDownDelayAfterAdd":
 	if typedInput.ScaleDownDelayAfterAdd != nil {
 		scaleDownDelayAfterAdd := *typedInput.ScaleDownDelayAfterAdd
 		profile.ScaleDownDelayAfterAdd = &scaleDownDelayAfterAdd
 	}
 
-	// Set property ‘ScaleDownDelayAfterDelete’:
+	// Set property "ScaleDownDelayAfterDelete":
 	if typedInput.ScaleDownDelayAfterDelete != nil {
 		scaleDownDelayAfterDelete := *typedInput.ScaleDownDelayAfterDelete
 		profile.ScaleDownDelayAfterDelete = &scaleDownDelayAfterDelete
 	}
 
-	// Set property ‘ScaleDownDelayAfterFailure’:
+	// Set property "ScaleDownDelayAfterFailure":
 	if typedInput.ScaleDownDelayAfterFailure != nil {
 		scaleDownDelayAfterFailure := *typedInput.ScaleDownDelayAfterFailure
 		profile.ScaleDownDelayAfterFailure = &scaleDownDelayAfterFailure
 	}
 
-	// Set property ‘ScaleDownUnneededTime’:
+	// Set property "ScaleDownUnneededTime":
 	if typedInput.ScaleDownUnneededTime != nil {
 		scaleDownUnneededTime := *typedInput.ScaleDownUnneededTime
 		profile.ScaleDownUnneededTime = &scaleDownUnneededTime
 	}
 
-	// Set property ‘ScaleDownUnreadyTime’:
+	// Set property "ScaleDownUnreadyTime":
 	if typedInput.ScaleDownUnreadyTime != nil {
 		scaleDownUnreadyTime := *typedInput.ScaleDownUnreadyTime
 		profile.ScaleDownUnreadyTime = &scaleDownUnreadyTime
 	}
 
-	// Set property ‘ScaleDownUtilizationThreshold’:
+	// Set property "ScaleDownUtilizationThreshold":
 	if typedInput.ScaleDownUtilizationThreshold != nil {
 		scaleDownUtilizationThreshold := *typedInput.ScaleDownUtilizationThreshold
 		profile.ScaleDownUtilizationThreshold = &scaleDownUtilizationThreshold
 	}
 
-	// Set property ‘ScanInterval’:
+	// Set property "ScanInterval":
 	if typedInput.ScanInterval != nil {
 		scanInterval := *typedInput.ScanInterval
 		profile.ScanInterval = &scanInterval
 	}
 
-	// Set property ‘SkipNodesWithLocalStorage’:
+	// Set property "SkipNodesWithLocalStorage":
 	if typedInput.SkipNodesWithLocalStorage != nil {
 		skipNodesWithLocalStorage := *typedInput.SkipNodesWithLocalStorage
 		profile.SkipNodesWithLocalStorage = &skipNodesWithLocalStorage
 	}
 
-	// Set property ‘SkipNodesWithSystemPods’:
+	// Set property "SkipNodesWithSystemPods":
 	if typedInput.SkipNodesWithSystemPods != nil {
 		skipNodesWithSystemPods := *typedInput.SkipNodesWithSystemPods
 		profile.SkipNodesWithSystemPods = &skipNodesWithSystemPods
@@ -8811,13 +8811,13 @@ func (profile *ManagedClusterServicePrincipalProfile) ConvertToARM(resolved genr
 	}
 	result := &ManagedClusterServicePrincipalProfile_ARM{}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if profile.ClientId != nil {
 		clientId := *profile.ClientId
 		result.ClientId = &clientId
 	}
 
-	// Set property ‘Secret’:
+	// Set property "Secret":
 	if profile.Secret != nil {
 		secretSecret, err := resolved.ResolvedSecrets.Lookup(*profile.Secret)
 		if err != nil {
@@ -8841,13 +8841,13 @@ func (profile *ManagedClusterServicePrincipalProfile) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterServicePrincipalProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		profile.ClientId = &clientId
 	}
 
-	// no assignment for property ‘Secret’
+	// no assignment for property "Secret"
 
 	// No error
 	return nil
@@ -8918,7 +8918,7 @@ func (profile *ManagedClusterServicePrincipalProfile_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterServicePrincipalProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		profile.ClientId = &clientId
@@ -8976,13 +8976,13 @@ func (clusterSKU *ManagedClusterSKU) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &ManagedClusterSKU_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if clusterSKU.Name != nil {
 		name := *clusterSKU.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if clusterSKU.Tier != nil {
 		tier := *clusterSKU.Tier
 		result.Tier = &tier
@@ -9002,13 +9002,13 @@ func (clusterSKU *ManagedClusterSKU) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSKU_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		clusterSKU.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		clusterSKU.Tier = &tier
@@ -9097,13 +9097,13 @@ func (clusterSKU *ManagedClusterSKU_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSKU_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		clusterSKU.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		clusterSKU.Tier = &tier
@@ -9210,25 +9210,25 @@ func (profile *ManagedClusterWindowsProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ManagedClusterWindowsProfile_ARM{}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if profile.AdminPassword != nil {
 		adminPassword := *profile.AdminPassword
 		result.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘EnableCSIProxy’:
+	// Set property "EnableCSIProxy":
 	if profile.EnableCSIProxy != nil {
 		enableCSIProxy := *profile.EnableCSIProxy
 		result.EnableCSIProxy = &enableCSIProxy
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if profile.LicenseType != nil {
 		licenseType := *profile.LicenseType
 		result.LicenseType = &licenseType
@@ -9248,25 +9248,25 @@ func (profile *ManagedClusterWindowsProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWindowsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if typedInput.AdminPassword != nil {
 		adminPassword := *typedInput.AdminPassword
 		profile.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘EnableCSIProxy’:
+	// Set property "EnableCSIProxy":
 	if typedInput.EnableCSIProxy != nil {
 		enableCSIProxy := *typedInput.EnableCSIProxy
 		profile.EnableCSIProxy = &enableCSIProxy
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
@@ -9389,25 +9389,25 @@ func (profile *ManagedClusterWindowsProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWindowsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if typedInput.AdminPassword != nil {
 		adminPassword := *typedInput.AdminPassword
 		profile.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘EnableCSIProxy’:
+	// Set property "EnableCSIProxy":
 	if typedInput.EnableCSIProxy != nil {
 		enableCSIProxy := *typedInput.EnableCSIProxy
 		profile.EnableCSIProxy = &enableCSIProxy
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
@@ -9504,7 +9504,7 @@ func (state *PowerState_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PowerState_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		state.Code = &code
@@ -9580,13 +9580,13 @@ func (resource *PrivateLinkResource) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &PrivateLinkResource_ARM{}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if resource.GroupId != nil {
 		groupId := *resource.GroupId
 		result.GroupId = &groupId
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -9596,18 +9596,18 @@ func (resource *PrivateLinkResource) ConvertToARM(resolved genruntime.ConvertToA
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if resource.Name != nil {
 		name := *resource.Name
 		result.Name = &name
 	}
 
-	// Set property ‘RequiredMembers’:
+	// Set property "RequiredMembers":
 	for _, item := range resource.RequiredMembers {
 		result.RequiredMembers = append(result.RequiredMembers, item)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if resource.Type != nil {
 		typeVar := *resource.Type
 		result.Type = &typeVar
@@ -9627,26 +9627,26 @@ func (resource *PrivateLinkResource) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if typedInput.GroupId != nil {
 		groupId := *typedInput.GroupId
 		resource.GroupId = &groupId
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resource.Name = &name
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘RequiredMembers’:
+	// Set property "RequiredMembers":
 	for _, item := range typedInput.RequiredMembers {
 		resource.RequiredMembers = append(resource.RequiredMembers, item)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		resource.Type = &typeVar
@@ -9754,36 +9754,36 @@ func (resource *PrivateLinkResource_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if typedInput.GroupId != nil {
 		groupId := *typedInput.GroupId
 		resource.GroupId = &groupId
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resource.Name = &name
 	}
 
-	// Set property ‘PrivateLinkServiceID’:
+	// Set property "PrivateLinkServiceID":
 	if typedInput.PrivateLinkServiceID != nil {
 		privateLinkServiceID := *typedInput.PrivateLinkServiceID
 		resource.PrivateLinkServiceID = &privateLinkServiceID
 	}
 
-	// Set property ‘RequiredMembers’:
+	// Set property "RequiredMembers":
 	for _, item := range typedInput.RequiredMembers {
 		resource.RequiredMembers = append(resource.RequiredMembers, item)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		resource.Type = &typeVar
@@ -9873,19 +9873,19 @@ func (identity *UserAssignedIdentity) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &UserAssignedIdentity_ARM{}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if identity.ClientId != nil {
 		clientId := *identity.ClientId
 		result.ClientId = &clientId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if identity.ObjectId != nil {
 		objectId := *identity.ObjectId
 		result.ObjectId = &objectId
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if identity.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*identity.ResourceReference)
 		if err != nil {
@@ -9909,19 +9909,19 @@ func (identity *UserAssignedIdentity) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		identity.ObjectId = &objectId
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -10004,19 +10004,19 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		identity.ObjectId = &objectId
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		identity.ResourceId = &resourceId
@@ -10158,7 +10158,7 @@ func (configuration *ContainerServiceSshConfiguration) ConvertToARM(resolved gen
 	}
 	result := &ContainerServiceSshConfiguration_ARM{}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range configuration.PublicKeys {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -10181,7 +10181,7 @@ func (configuration *ContainerServiceSshConfiguration) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 ContainerServiceSshPublicKey
 		err := item1.PopulateFromARM(owner, item)
@@ -10274,7 +10274,7 @@ func (configuration *ContainerServiceSshConfiguration_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 ContainerServiceSshPublicKey_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10390,13 +10390,13 @@ func (identities *ManagedClusterIdentity_UserAssignedIdentities_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -10477,13 +10477,13 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 	}
 	result := &ManagedClusterLoadBalancerProfile_ARM{}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	if profile.AllocatedOutboundPorts != nil {
 		allocatedOutboundPorts := *profile.AllocatedOutboundPorts
 		result.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range profile.EffectiveOutboundIPs {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -10492,13 +10492,13 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		result.EffectiveOutboundIPs = append(result.EffectiveOutboundIPs, *item_ARM.(*ResourceReference_ARM))
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if profile.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *profile.IdleTimeoutInMinutes
 		result.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPs’:
+	// Set property "ManagedOutboundIPs":
 	if profile.ManagedOutboundIPs != nil {
 		managedOutboundIPs_ARM, err := (*profile.ManagedOutboundIPs).ConvertToARM(resolved)
 		if err != nil {
@@ -10508,7 +10508,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		result.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
-	// Set property ‘OutboundIPPrefixes’:
+	// Set property "OutboundIPPrefixes":
 	if profile.OutboundIPPrefixes != nil {
 		outboundIPPrefixes_ARM, err := (*profile.OutboundIPPrefixes).ConvertToARM(resolved)
 		if err != nil {
@@ -10518,7 +10518,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		result.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
-	// Set property ‘OutboundIPs’:
+	// Set property "OutboundIPs":
 	if profile.OutboundIPs != nil {
 		outboundIPs_ARM, err := (*profile.OutboundIPs).ConvertToARM(resolved)
 		if err != nil {
@@ -10542,13 +10542,13 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	if typedInput.AllocatedOutboundPorts != nil {
 		allocatedOutboundPorts := *typedInput.AllocatedOutboundPorts
 		profile.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range typedInput.EffectiveOutboundIPs {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -10558,13 +10558,13 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		profile.EffectiveOutboundIPs = append(profile.EffectiveOutboundIPs, item1)
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if typedInput.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *typedInput.IdleTimeoutInMinutes
 		profile.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPs’:
+	// Set property "ManagedOutboundIPs":
 	if typedInput.ManagedOutboundIPs != nil {
 		var managedOutboundIPs1 ManagedClusterLoadBalancerProfile_ManagedOutboundIPs
 		err := managedOutboundIPs1.PopulateFromARM(owner, *typedInput.ManagedOutboundIPs)
@@ -10575,7 +10575,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		profile.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
-	// Set property ‘OutboundIPPrefixes’:
+	// Set property "OutboundIPPrefixes":
 	if typedInput.OutboundIPPrefixes != nil {
 		var outboundIPPrefixes1 ManagedClusterLoadBalancerProfile_OutboundIPPrefixes
 		err := outboundIPPrefixes1.PopulateFromARM(owner, *typedInput.OutboundIPPrefixes)
@@ -10586,7 +10586,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		profile.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
-	// Set property ‘OutboundIPs’:
+	// Set property "OutboundIPs":
 	if typedInput.OutboundIPs != nil {
 		var outboundIPs1 ManagedClusterLoadBalancerProfile_OutboundIPs
 		err := outboundIPs1.PopulateFromARM(owner, *typedInput.OutboundIPs)
@@ -10801,13 +10801,13 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	if typedInput.AllocatedOutboundPorts != nil {
 		allocatedOutboundPorts := *typedInput.AllocatedOutboundPorts
 		profile.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range typedInput.EffectiveOutboundIPs {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10817,13 +10817,13 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		profile.EffectiveOutboundIPs = append(profile.EffectiveOutboundIPs, item1)
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if typedInput.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *typedInput.IdleTimeoutInMinutes
 		profile.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPs’:
+	// Set property "ManagedOutboundIPs":
 	if typedInput.ManagedOutboundIPs != nil {
 		var managedOutboundIPs1 ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS
 		err := managedOutboundIPs1.PopulateFromARM(owner, *typedInput.ManagedOutboundIPs)
@@ -10834,7 +10834,7 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		profile.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
-	// Set property ‘OutboundIPPrefixes’:
+	// Set property "OutboundIPPrefixes":
 	if typedInput.OutboundIPPrefixes != nil {
 		var outboundIPPrefixes1 ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS
 		err := outboundIPPrefixes1.PopulateFromARM(owner, *typedInput.OutboundIPPrefixes)
@@ -10845,7 +10845,7 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		profile.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
-	// Set property ‘OutboundIPs’:
+	// Set property "OutboundIPs":
 	if typedInput.OutboundIPs != nil {
 		var outboundIPs1 ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS
 		err := outboundIPs1.PopulateFromARM(owner, *typedInput.OutboundIPs)
@@ -11095,13 +11095,13 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ManagedClusterPodIdentity_ARM{}
 
-	// Set property ‘BindingSelector’:
+	// Set property "BindingSelector":
 	if identity.BindingSelector != nil {
 		bindingSelector := *identity.BindingSelector
 		result.BindingSelector = &bindingSelector
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if identity.Identity != nil {
 		identity_ARM, err := (*identity.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -11111,13 +11111,13 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 		result.Identity = &identity1
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if identity.Name != nil {
 		name := *identity.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if identity.Namespace != nil {
 		namespace := *identity.Namespace
 		result.Namespace = &namespace
@@ -11137,13 +11137,13 @@ func (identity *ManagedClusterPodIdentity) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BindingSelector’:
+	// Set property "BindingSelector":
 	if typedInput.BindingSelector != nil {
 		bindingSelector := *typedInput.BindingSelector
 		identity.BindingSelector = &bindingSelector
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity2 UserAssignedIdentity
 		err := identity2.PopulateFromARM(owner, *typedInput.Identity)
@@ -11154,13 +11154,13 @@ func (identity *ManagedClusterPodIdentity) PopulateFromARM(owner genruntime.Arbi
 		identity.Identity = &identity1
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		identity.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		identity.Namespace = &namespace
@@ -11268,13 +11268,13 @@ func (identity *ManagedClusterPodIdentity_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BindingSelector’:
+	// Set property "BindingSelector":
 	if typedInput.BindingSelector != nil {
 		bindingSelector := *typedInput.BindingSelector
 		identity.BindingSelector = &bindingSelector
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity2 UserAssignedIdentity_STATUS
 		err := identity2.PopulateFromARM(owner, *typedInput.Identity)
@@ -11285,19 +11285,19 @@ func (identity *ManagedClusterPodIdentity_STATUS) PopulateFromARM(owner genrunti
 		identity.Identity = &identity1
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		identity.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		identity.Namespace = &namespace
 	}
 
-	// Set property ‘ProvisioningInfo’:
+	// Set property "ProvisioningInfo":
 	if typedInput.ProvisioningInfo != nil {
 		var provisioningInfo1 ManagedClusterPodIdentity_ProvisioningInfo_STATUS
 		err := provisioningInfo1.PopulateFromARM(owner, *typedInput.ProvisioningInfo)
@@ -11308,7 +11308,7 @@ func (identity *ManagedClusterPodIdentity_STATUS) PopulateFromARM(owner genrunti
 		identity.ProvisioningInfo = &provisioningInfo
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		identity.ProvisioningState = &provisioningState
@@ -11448,19 +11448,19 @@ func (exception *ManagedClusterPodIdentityException) ConvertToARM(resolved genru
 	}
 	result := &ManagedClusterPodIdentityException_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if exception.Name != nil {
 		name := *exception.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if exception.Namespace != nil {
 		namespace := *exception.Namespace
 		result.Namespace = &namespace
 	}
 
-	// Set property ‘PodLabels’:
+	// Set property "PodLabels":
 	if exception.PodLabels != nil {
 		result.PodLabels = make(map[string]string, len(exception.PodLabels))
 		for key, value := range exception.PodLabels {
@@ -11482,19 +11482,19 @@ func (exception *ManagedClusterPodIdentityException) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityException_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		exception.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		exception.Namespace = &namespace
 	}
 
-	// Set property ‘PodLabels’:
+	// Set property "PodLabels":
 	if typedInput.PodLabels != nil {
 		exception.PodLabels = make(map[string]string, len(typedInput.PodLabels))
 		for key, value := range typedInput.PodLabels {
@@ -11574,19 +11574,19 @@ func (exception *ManagedClusterPodIdentityException_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityException_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		exception.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		exception.Namespace = &namespace
 	}
 
-	// Set property ‘PodLabels’:
+	// Set property "PodLabels":
 	if typedInput.PodLabels != nil {
 		exception.PodLabels = make(map[string]string, len(typedInput.PodLabels))
 		for key, value := range typedInput.PodLabels {
@@ -11731,7 +11731,7 @@ func (publicKey *ContainerServiceSshPublicKey) ConvertToARM(resolved genruntime.
 	}
 	result := &ContainerServiceSshPublicKey_ARM{}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if publicKey.KeyData != nil {
 		keyData := *publicKey.KeyData
 		result.KeyData = &keyData
@@ -11751,7 +11751,7 @@ func (publicKey *ContainerServiceSshPublicKey) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshPublicKey_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
@@ -11811,7 +11811,7 @@ func (publicKey *ContainerServiceSshPublicKey_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshPublicKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
@@ -11867,7 +11867,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) ConvertToARM(re
 	}
 	result := &ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if iPs.Count != nil {
 		count := *iPs.Count
 		result.Count = &count
@@ -11887,7 +11887,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		iPs.Count = &count
@@ -11956,7 +11956,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		iPs.Count = &count
@@ -12009,7 +12009,7 @@ func (prefixes *ManagedClusterLoadBalancerProfile_OutboundIPPrefixes) ConvertToA
 	}
 	result := &ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_ARM{}
 
-	// Set property ‘PublicIPPrefixes’:
+	// Set property "PublicIPPrefixes":
 	for _, item := range prefixes.PublicIPPrefixes {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -12032,7 +12032,7 @@ func (prefixes *ManagedClusterLoadBalancerProfile_OutboundIPPrefixes) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPPrefixes’:
+	// Set property "PublicIPPrefixes":
 	for _, item := range typedInput.PublicIPPrefixes {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -12124,7 +12124,7 @@ func (prefixes *ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPPrefixes’:
+	// Set property "PublicIPPrefixes":
 	for _, item := range typedInput.PublicIPPrefixes {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -12211,7 +12211,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_OutboundIPs) ConvertToARM(resolved 
 	}
 	result := &ManagedClusterLoadBalancerProfile_OutboundIPs_ARM{}
 
-	// Set property ‘PublicIPs’:
+	// Set property "PublicIPs":
 	for _, item := range iPs.PublicIPs {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -12234,7 +12234,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_OutboundIPs) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPs_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPs’:
+	// Set property "PublicIPs":
 	for _, item := range typedInput.PublicIPs {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -12326,7 +12326,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPs’:
+	// Set property "PublicIPs":
 	for _, item := range typedInput.PublicIPs {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -12418,7 +12418,7 @@ func (info *ManagedClusterPodIdentity_ProvisioningInfo_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentity_ProvisioningInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ManagedClusterPodIdentityProvisioningError_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -12504,7 +12504,7 @@ func (reference *ResourceReference) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ResourceReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -12528,7 +12528,7 @@ func (reference *ResourceReference) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceReference_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -12593,7 +12593,7 @@ func (reference *ResourceReference_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
@@ -12652,7 +12652,7 @@ func (error *ManagedClusterPodIdentityProvisioningError_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProvisioningError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error2 ManagedClusterPodIdentityProvisioningErrorBody_STATUS
 		err := error2.PopulateFromARM(owner, *typedInput.Error)
@@ -12743,13 +12743,13 @@ func (body *ManagedClusterPodIdentityProvisioningErrorBody_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProvisioningErrorBody_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		body.Code = &code
 	}
 
-	// Set property ‘Details’:
+	// Set property "Details":
 	for _, item := range typedInput.Details {
 		var item1 ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled
 		err := item1.PopulateFromARM(owner, item)
@@ -12759,13 +12759,13 @@ func (body *ManagedClusterPodIdentityProvisioningErrorBody_STATUS) PopulateFromA
 		body.Details = append(body.Details, item1)
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		body.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		body.Target = &target
@@ -12877,19 +12877,19 @@ func (unrolled *ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		unrolled.Code = &code
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		unrolled.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		unrolled.Target = &target

--- a/v2/api/containerservice/v1api20210501/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20210501/managed_clusters_agent_pool_types_gen.go
@@ -458,10 +458,10 @@ func (pool *ManagedClusters_AgentPool_Spec) ConvertToARM(resolved genruntime.Con
 	}
 	result := &ManagedClusters_AgentPool_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if pool.AvailabilityZones != nil ||
 		pool.Count != nil ||
 		pool.EnableAutoScaling != nil ||
@@ -670,7 +670,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusters_AgentPool_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AvailabilityZones {
@@ -678,10 +678,10 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	pool.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Count != nil {
@@ -690,7 +690,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutoScaling != nil {
@@ -699,7 +699,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableEncryptionAtHost != nil {
@@ -708,7 +708,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFIPS != nil {
@@ -717,7 +717,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNodePublicIP != nil {
@@ -726,7 +726,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableUltraSSD != nil {
@@ -735,7 +735,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GpuInstanceProfile != nil {
@@ -744,7 +744,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletConfig != nil {
@@ -758,7 +758,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletDiskType != nil {
@@ -767,7 +767,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxOSConfig != nil {
@@ -781,7 +781,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxCount != nil {
@@ -790,7 +790,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxPods != nil {
@@ -799,7 +799,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinCount != nil {
@@ -808,7 +808,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Mode != nil {
@@ -817,7 +817,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeLabels != nil {
@@ -828,9 +828,9 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘NodePublicIPPrefixIDReference’
+	// no assignment for property "NodePublicIPPrefixIDReference"
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NodeTaints {
@@ -838,7 +838,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestratorVersion != nil {
@@ -847,7 +847,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
@@ -856,7 +856,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskType != nil {
@@ -865,7 +865,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsSKU != nil {
@@ -874,7 +874,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -883,12 +883,12 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	pool.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// no assignment for property ‘PodSubnetIDReference’
+	// no assignment for property "PodSubnetIDReference"
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroupID != nil {
@@ -897,7 +897,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetEvictionPolicy != nil {
@@ -906,7 +906,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetPriority != nil {
@@ -915,7 +915,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotMaxPrice != nil {
@@ -924,7 +924,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tags != nil {
@@ -935,7 +935,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -944,7 +944,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradeSettings != nil {
@@ -958,7 +958,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VmSize != nil {
@@ -967,7 +967,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘VnetSubnetIDReference’
+	// no assignment for property "VnetSubnetIDReference"
 
 	// No error
 	return nil
@@ -1734,7 +1734,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusters_AgentPool_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AvailabilityZones {
@@ -1742,9 +1742,9 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Count != nil {
@@ -1753,7 +1753,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutoScaling != nil {
@@ -1762,7 +1762,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableEncryptionAtHost != nil {
@@ -1771,7 +1771,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFIPS != nil {
@@ -1780,7 +1780,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNodePublicIP != nil {
@@ -1789,7 +1789,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableUltraSSD != nil {
@@ -1798,7 +1798,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GpuInstanceProfile != nil {
@@ -1807,13 +1807,13 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		pool.Id = &id
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletConfig != nil {
@@ -1827,7 +1827,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletDiskType != nil {
@@ -1836,7 +1836,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxOSConfig != nil {
@@ -1850,7 +1850,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxCount != nil {
@@ -1859,7 +1859,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxPods != nil {
@@ -1868,7 +1868,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinCount != nil {
@@ -1877,7 +1877,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Mode != nil {
@@ -1886,13 +1886,13 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pool.Name = &name
 	}
 
-	// Set property ‘NodeImageVersion’:
+	// Set property "NodeImageVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeImageVersion != nil {
@@ -1901,7 +1901,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeLabels != nil {
@@ -1912,7 +1912,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘NodePublicIPPrefixID’:
+	// Set property "NodePublicIPPrefixID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodePublicIPPrefixID != nil {
@@ -1921,7 +1921,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NodeTaints {
@@ -1929,7 +1929,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestratorVersion != nil {
@@ -1938,7 +1938,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
@@ -1947,7 +1947,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskType != nil {
@@ -1956,7 +1956,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsSKU != nil {
@@ -1965,7 +1965,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -1974,7 +1974,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘PodSubnetID’:
+	// Set property "PodSubnetID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PodSubnetID != nil {
@@ -1983,7 +1983,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PowerState != nil {
@@ -1997,7 +1997,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘PropertiesType’:
+	// Set property "PropertiesType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -2006,7 +2006,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2015,7 +2015,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroupID != nil {
@@ -2024,7 +2024,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetEvictionPolicy != nil {
@@ -2033,7 +2033,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetPriority != nil {
@@ -2042,7 +2042,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotMaxPrice != nil {
@@ -2051,7 +2051,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tags != nil {
@@ -2062,13 +2062,13 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		pool.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradeSettings != nil {
@@ -2082,7 +2082,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VmSize != nil {
@@ -2091,7 +2091,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘VnetSubnetID’:
+	// Set property "VnetSubnetID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetSubnetID != nil {
@@ -2643,7 +2643,7 @@ func (settings *AgentPoolUpgradeSettings) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &AgentPoolUpgradeSettings_ARM{}
 
-	// Set property ‘MaxSurge’:
+	// Set property "MaxSurge":
 	if settings.MaxSurge != nil {
 		maxSurge := *settings.MaxSurge
 		result.MaxSurge = &maxSurge
@@ -2663,7 +2663,7 @@ func (settings *AgentPoolUpgradeSettings) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AgentPoolUpgradeSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxSurge’:
+	// Set property "MaxSurge":
 	if typedInput.MaxSurge != nil {
 		maxSurge := *typedInput.MaxSurge
 		settings.MaxSurge = &maxSurge
@@ -2725,7 +2725,7 @@ func (settings *AgentPoolUpgradeSettings_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AgentPoolUpgradeSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxSurge’:
+	// Set property "MaxSurge":
 	if typedInput.MaxSurge != nil {
 		maxSurge := *typedInput.MaxSurge
 		settings.MaxSurge = &maxSurge
@@ -2843,66 +2843,66 @@ func (config *KubeletConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &KubeletConfig_ARM{}
 
-	// Set property ‘AllowedUnsafeSysctls’:
+	// Set property "AllowedUnsafeSysctls":
 	for _, item := range config.AllowedUnsafeSysctls {
 		result.AllowedUnsafeSysctls = append(result.AllowedUnsafeSysctls, item)
 	}
 
-	// Set property ‘ContainerLogMaxFiles’:
+	// Set property "ContainerLogMaxFiles":
 	if config.ContainerLogMaxFiles != nil {
 		containerLogMaxFiles := *config.ContainerLogMaxFiles
 		result.ContainerLogMaxFiles = &containerLogMaxFiles
 	}
 
-	// Set property ‘ContainerLogMaxSizeMB’:
+	// Set property "ContainerLogMaxSizeMB":
 	if config.ContainerLogMaxSizeMB != nil {
 		containerLogMaxSizeMB := *config.ContainerLogMaxSizeMB
 		result.ContainerLogMaxSizeMB = &containerLogMaxSizeMB
 	}
 
-	// Set property ‘CpuCfsQuota’:
+	// Set property "CpuCfsQuota":
 	if config.CpuCfsQuota != nil {
 		cpuCfsQuota := *config.CpuCfsQuota
 		result.CpuCfsQuota = &cpuCfsQuota
 	}
 
-	// Set property ‘CpuCfsQuotaPeriod’:
+	// Set property "CpuCfsQuotaPeriod":
 	if config.CpuCfsQuotaPeriod != nil {
 		cpuCfsQuotaPeriod := *config.CpuCfsQuotaPeriod
 		result.CpuCfsQuotaPeriod = &cpuCfsQuotaPeriod
 	}
 
-	// Set property ‘CpuManagerPolicy’:
+	// Set property "CpuManagerPolicy":
 	if config.CpuManagerPolicy != nil {
 		cpuManagerPolicy := *config.CpuManagerPolicy
 		result.CpuManagerPolicy = &cpuManagerPolicy
 	}
 
-	// Set property ‘FailSwapOn’:
+	// Set property "FailSwapOn":
 	if config.FailSwapOn != nil {
 		failSwapOn := *config.FailSwapOn
 		result.FailSwapOn = &failSwapOn
 	}
 
-	// Set property ‘ImageGcHighThreshold’:
+	// Set property "ImageGcHighThreshold":
 	if config.ImageGcHighThreshold != nil {
 		imageGcHighThreshold := *config.ImageGcHighThreshold
 		result.ImageGcHighThreshold = &imageGcHighThreshold
 	}
 
-	// Set property ‘ImageGcLowThreshold’:
+	// Set property "ImageGcLowThreshold":
 	if config.ImageGcLowThreshold != nil {
 		imageGcLowThreshold := *config.ImageGcLowThreshold
 		result.ImageGcLowThreshold = &imageGcLowThreshold
 	}
 
-	// Set property ‘PodMaxPids’:
+	// Set property "PodMaxPids":
 	if config.PodMaxPids != nil {
 		podMaxPids := *config.PodMaxPids
 		result.PodMaxPids = &podMaxPids
 	}
 
-	// Set property ‘TopologyManagerPolicy’:
+	// Set property "TopologyManagerPolicy":
 	if config.TopologyManagerPolicy != nil {
 		topologyManagerPolicy := *config.TopologyManagerPolicy
 		result.TopologyManagerPolicy = &topologyManagerPolicy
@@ -2922,66 +2922,66 @@ func (config *KubeletConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubeletConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedUnsafeSysctls’:
+	// Set property "AllowedUnsafeSysctls":
 	for _, item := range typedInput.AllowedUnsafeSysctls {
 		config.AllowedUnsafeSysctls = append(config.AllowedUnsafeSysctls, item)
 	}
 
-	// Set property ‘ContainerLogMaxFiles’:
+	// Set property "ContainerLogMaxFiles":
 	if typedInput.ContainerLogMaxFiles != nil {
 		containerLogMaxFiles := *typedInput.ContainerLogMaxFiles
 		config.ContainerLogMaxFiles = &containerLogMaxFiles
 	}
 
-	// Set property ‘ContainerLogMaxSizeMB’:
+	// Set property "ContainerLogMaxSizeMB":
 	if typedInput.ContainerLogMaxSizeMB != nil {
 		containerLogMaxSizeMB := *typedInput.ContainerLogMaxSizeMB
 		config.ContainerLogMaxSizeMB = &containerLogMaxSizeMB
 	}
 
-	// Set property ‘CpuCfsQuota’:
+	// Set property "CpuCfsQuota":
 	if typedInput.CpuCfsQuota != nil {
 		cpuCfsQuota := *typedInput.CpuCfsQuota
 		config.CpuCfsQuota = &cpuCfsQuota
 	}
 
-	// Set property ‘CpuCfsQuotaPeriod’:
+	// Set property "CpuCfsQuotaPeriod":
 	if typedInput.CpuCfsQuotaPeriod != nil {
 		cpuCfsQuotaPeriod := *typedInput.CpuCfsQuotaPeriod
 		config.CpuCfsQuotaPeriod = &cpuCfsQuotaPeriod
 	}
 
-	// Set property ‘CpuManagerPolicy’:
+	// Set property "CpuManagerPolicy":
 	if typedInput.CpuManagerPolicy != nil {
 		cpuManagerPolicy := *typedInput.CpuManagerPolicy
 		config.CpuManagerPolicy = &cpuManagerPolicy
 	}
 
-	// Set property ‘FailSwapOn’:
+	// Set property "FailSwapOn":
 	if typedInput.FailSwapOn != nil {
 		failSwapOn := *typedInput.FailSwapOn
 		config.FailSwapOn = &failSwapOn
 	}
 
-	// Set property ‘ImageGcHighThreshold’:
+	// Set property "ImageGcHighThreshold":
 	if typedInput.ImageGcHighThreshold != nil {
 		imageGcHighThreshold := *typedInput.ImageGcHighThreshold
 		config.ImageGcHighThreshold = &imageGcHighThreshold
 	}
 
-	// Set property ‘ImageGcLowThreshold’:
+	// Set property "ImageGcLowThreshold":
 	if typedInput.ImageGcLowThreshold != nil {
 		imageGcLowThreshold := *typedInput.ImageGcLowThreshold
 		config.ImageGcLowThreshold = &imageGcLowThreshold
 	}
 
-	// Set property ‘PodMaxPids’:
+	// Set property "PodMaxPids":
 	if typedInput.PodMaxPids != nil {
 		podMaxPids := *typedInput.PodMaxPids
 		config.PodMaxPids = &podMaxPids
 	}
 
-	// Set property ‘TopologyManagerPolicy’:
+	// Set property "TopologyManagerPolicy":
 	if typedInput.TopologyManagerPolicy != nil {
 		topologyManagerPolicy := *typedInput.TopologyManagerPolicy
 		config.TopologyManagerPolicy = &topologyManagerPolicy
@@ -3166,66 +3166,66 @@ func (config *KubeletConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubeletConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedUnsafeSysctls’:
+	// Set property "AllowedUnsafeSysctls":
 	for _, item := range typedInput.AllowedUnsafeSysctls {
 		config.AllowedUnsafeSysctls = append(config.AllowedUnsafeSysctls, item)
 	}
 
-	// Set property ‘ContainerLogMaxFiles’:
+	// Set property "ContainerLogMaxFiles":
 	if typedInput.ContainerLogMaxFiles != nil {
 		containerLogMaxFiles := *typedInput.ContainerLogMaxFiles
 		config.ContainerLogMaxFiles = &containerLogMaxFiles
 	}
 
-	// Set property ‘ContainerLogMaxSizeMB’:
+	// Set property "ContainerLogMaxSizeMB":
 	if typedInput.ContainerLogMaxSizeMB != nil {
 		containerLogMaxSizeMB := *typedInput.ContainerLogMaxSizeMB
 		config.ContainerLogMaxSizeMB = &containerLogMaxSizeMB
 	}
 
-	// Set property ‘CpuCfsQuota’:
+	// Set property "CpuCfsQuota":
 	if typedInput.CpuCfsQuota != nil {
 		cpuCfsQuota := *typedInput.CpuCfsQuota
 		config.CpuCfsQuota = &cpuCfsQuota
 	}
 
-	// Set property ‘CpuCfsQuotaPeriod’:
+	// Set property "CpuCfsQuotaPeriod":
 	if typedInput.CpuCfsQuotaPeriod != nil {
 		cpuCfsQuotaPeriod := *typedInput.CpuCfsQuotaPeriod
 		config.CpuCfsQuotaPeriod = &cpuCfsQuotaPeriod
 	}
 
-	// Set property ‘CpuManagerPolicy’:
+	// Set property "CpuManagerPolicy":
 	if typedInput.CpuManagerPolicy != nil {
 		cpuManagerPolicy := *typedInput.CpuManagerPolicy
 		config.CpuManagerPolicy = &cpuManagerPolicy
 	}
 
-	// Set property ‘FailSwapOn’:
+	// Set property "FailSwapOn":
 	if typedInput.FailSwapOn != nil {
 		failSwapOn := *typedInput.FailSwapOn
 		config.FailSwapOn = &failSwapOn
 	}
 
-	// Set property ‘ImageGcHighThreshold’:
+	// Set property "ImageGcHighThreshold":
 	if typedInput.ImageGcHighThreshold != nil {
 		imageGcHighThreshold := *typedInput.ImageGcHighThreshold
 		config.ImageGcHighThreshold = &imageGcHighThreshold
 	}
 
-	// Set property ‘ImageGcLowThreshold’:
+	// Set property "ImageGcLowThreshold":
 	if typedInput.ImageGcLowThreshold != nil {
 		imageGcLowThreshold := *typedInput.ImageGcLowThreshold
 		config.ImageGcLowThreshold = &imageGcLowThreshold
 	}
 
-	// Set property ‘PodMaxPids’:
+	// Set property "PodMaxPids":
 	if typedInput.PodMaxPids != nil {
 		podMaxPids := *typedInput.PodMaxPids
 		config.PodMaxPids = &podMaxPids
 	}
 
-	// Set property ‘TopologyManagerPolicy’:
+	// Set property "TopologyManagerPolicy":
 	if typedInput.TopologyManagerPolicy != nil {
 		topologyManagerPolicy := *typedInput.TopologyManagerPolicy
 		config.TopologyManagerPolicy = &topologyManagerPolicy
@@ -3389,13 +3389,13 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &LinuxOSConfig_ARM{}
 
-	// Set property ‘SwapFileSizeMB’:
+	// Set property "SwapFileSizeMB":
 	if config.SwapFileSizeMB != nil {
 		swapFileSizeMB := *config.SwapFileSizeMB
 		result.SwapFileSizeMB = &swapFileSizeMB
 	}
 
-	// Set property ‘Sysctls’:
+	// Set property "Sysctls":
 	if config.Sysctls != nil {
 		sysctls_ARM, err := (*config.Sysctls).ConvertToARM(resolved)
 		if err != nil {
@@ -3405,13 +3405,13 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Sysctls = &sysctls
 	}
 
-	// Set property ‘TransparentHugePageDefrag’:
+	// Set property "TransparentHugePageDefrag":
 	if config.TransparentHugePageDefrag != nil {
 		transparentHugePageDefrag := *config.TransparentHugePageDefrag
 		result.TransparentHugePageDefrag = &transparentHugePageDefrag
 	}
 
-	// Set property ‘TransparentHugePageEnabled’:
+	// Set property "TransparentHugePageEnabled":
 	if config.TransparentHugePageEnabled != nil {
 		transparentHugePageEnabled := *config.TransparentHugePageEnabled
 		result.TransparentHugePageEnabled = &transparentHugePageEnabled
@@ -3431,13 +3431,13 @@ func (config *LinuxOSConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxOSConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SwapFileSizeMB’:
+	// Set property "SwapFileSizeMB":
 	if typedInput.SwapFileSizeMB != nil {
 		swapFileSizeMB := *typedInput.SwapFileSizeMB
 		config.SwapFileSizeMB = &swapFileSizeMB
 	}
 
-	// Set property ‘Sysctls’:
+	// Set property "Sysctls":
 	if typedInput.Sysctls != nil {
 		var sysctls1 SysctlConfig
 		err := sysctls1.PopulateFromARM(owner, *typedInput.Sysctls)
@@ -3448,13 +3448,13 @@ func (config *LinuxOSConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		config.Sysctls = &sysctls
 	}
 
-	// Set property ‘TransparentHugePageDefrag’:
+	// Set property "TransparentHugePageDefrag":
 	if typedInput.TransparentHugePageDefrag != nil {
 		transparentHugePageDefrag := *typedInput.TransparentHugePageDefrag
 		config.TransparentHugePageDefrag = &transparentHugePageDefrag
 	}
 
-	// Set property ‘TransparentHugePageEnabled’:
+	// Set property "TransparentHugePageEnabled":
 	if typedInput.TransparentHugePageEnabled != nil {
 		transparentHugePageEnabled := *typedInput.TransparentHugePageEnabled
 		config.TransparentHugePageEnabled = &transparentHugePageEnabled
@@ -3562,13 +3562,13 @@ func (config *LinuxOSConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxOSConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SwapFileSizeMB’:
+	// Set property "SwapFileSizeMB":
 	if typedInput.SwapFileSizeMB != nil {
 		swapFileSizeMB := *typedInput.SwapFileSizeMB
 		config.SwapFileSizeMB = &swapFileSizeMB
 	}
 
-	// Set property ‘Sysctls’:
+	// Set property "Sysctls":
 	if typedInput.Sysctls != nil {
 		var sysctls1 SysctlConfig_STATUS
 		err := sysctls1.PopulateFromARM(owner, *typedInput.Sysctls)
@@ -3579,13 +3579,13 @@ func (config *LinuxOSConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		config.Sysctls = &sysctls
 	}
 
-	// Set property ‘TransparentHugePageDefrag’:
+	// Set property "TransparentHugePageDefrag":
 	if typedInput.TransparentHugePageDefrag != nil {
 		transparentHugePageDefrag := *typedInput.TransparentHugePageDefrag
 		config.TransparentHugePageDefrag = &transparentHugePageDefrag
 	}
 
-	// Set property ‘TransparentHugePageEnabled’:
+	// Set property "TransparentHugePageEnabled":
 	if typedInput.TransparentHugePageEnabled != nil {
 		transparentHugePageEnabled := *typedInput.TransparentHugePageEnabled
 		config.TransparentHugePageEnabled = &transparentHugePageEnabled
@@ -3847,169 +3847,169 @@ func (config *SysctlConfig) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &SysctlConfig_ARM{}
 
-	// Set property ‘FsAioMaxNr’:
+	// Set property "FsAioMaxNr":
 	if config.FsAioMaxNr != nil {
 		fsAioMaxNr := *config.FsAioMaxNr
 		result.FsAioMaxNr = &fsAioMaxNr
 	}
 
-	// Set property ‘FsFileMax’:
+	// Set property "FsFileMax":
 	if config.FsFileMax != nil {
 		fsFileMax := *config.FsFileMax
 		result.FsFileMax = &fsFileMax
 	}
 
-	// Set property ‘FsInotifyMaxUserWatches’:
+	// Set property "FsInotifyMaxUserWatches":
 	if config.FsInotifyMaxUserWatches != nil {
 		fsInotifyMaxUserWatches := *config.FsInotifyMaxUserWatches
 		result.FsInotifyMaxUserWatches = &fsInotifyMaxUserWatches
 	}
 
-	// Set property ‘FsNrOpen’:
+	// Set property "FsNrOpen":
 	if config.FsNrOpen != nil {
 		fsNrOpen := *config.FsNrOpen
 		result.FsNrOpen = &fsNrOpen
 	}
 
-	// Set property ‘KernelThreadsMax’:
+	// Set property "KernelThreadsMax":
 	if config.KernelThreadsMax != nil {
 		kernelThreadsMax := *config.KernelThreadsMax
 		result.KernelThreadsMax = &kernelThreadsMax
 	}
 
-	// Set property ‘NetCoreNetdevMaxBacklog’:
+	// Set property "NetCoreNetdevMaxBacklog":
 	if config.NetCoreNetdevMaxBacklog != nil {
 		netCoreNetdevMaxBacklog := *config.NetCoreNetdevMaxBacklog
 		result.NetCoreNetdevMaxBacklog = &netCoreNetdevMaxBacklog
 	}
 
-	// Set property ‘NetCoreOptmemMax’:
+	// Set property "NetCoreOptmemMax":
 	if config.NetCoreOptmemMax != nil {
 		netCoreOptmemMax := *config.NetCoreOptmemMax
 		result.NetCoreOptmemMax = &netCoreOptmemMax
 	}
 
-	// Set property ‘NetCoreRmemDefault’:
+	// Set property "NetCoreRmemDefault":
 	if config.NetCoreRmemDefault != nil {
 		netCoreRmemDefault := *config.NetCoreRmemDefault
 		result.NetCoreRmemDefault = &netCoreRmemDefault
 	}
 
-	// Set property ‘NetCoreRmemMax’:
+	// Set property "NetCoreRmemMax":
 	if config.NetCoreRmemMax != nil {
 		netCoreRmemMax := *config.NetCoreRmemMax
 		result.NetCoreRmemMax = &netCoreRmemMax
 	}
 
-	// Set property ‘NetCoreSomaxconn’:
+	// Set property "NetCoreSomaxconn":
 	if config.NetCoreSomaxconn != nil {
 		netCoreSomaxconn := *config.NetCoreSomaxconn
 		result.NetCoreSomaxconn = &netCoreSomaxconn
 	}
 
-	// Set property ‘NetCoreWmemDefault’:
+	// Set property "NetCoreWmemDefault":
 	if config.NetCoreWmemDefault != nil {
 		netCoreWmemDefault := *config.NetCoreWmemDefault
 		result.NetCoreWmemDefault = &netCoreWmemDefault
 	}
 
-	// Set property ‘NetCoreWmemMax’:
+	// Set property "NetCoreWmemMax":
 	if config.NetCoreWmemMax != nil {
 		netCoreWmemMax := *config.NetCoreWmemMax
 		result.NetCoreWmemMax = &netCoreWmemMax
 	}
 
-	// Set property ‘NetIpv4IpLocalPortRange’:
+	// Set property "NetIpv4IpLocalPortRange":
 	if config.NetIpv4IpLocalPortRange != nil {
 		netIpv4IpLocalPortRange := *config.NetIpv4IpLocalPortRange
 		result.NetIpv4IpLocalPortRange = &netIpv4IpLocalPortRange
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh1’:
+	// Set property "NetIpv4NeighDefaultGcThresh1":
 	if config.NetIpv4NeighDefaultGcThresh1 != nil {
 		netIpv4NeighDefaultGcThresh1 := *config.NetIpv4NeighDefaultGcThresh1
 		result.NetIpv4NeighDefaultGcThresh1 = &netIpv4NeighDefaultGcThresh1
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh2’:
+	// Set property "NetIpv4NeighDefaultGcThresh2":
 	if config.NetIpv4NeighDefaultGcThresh2 != nil {
 		netIpv4NeighDefaultGcThresh2 := *config.NetIpv4NeighDefaultGcThresh2
 		result.NetIpv4NeighDefaultGcThresh2 = &netIpv4NeighDefaultGcThresh2
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh3’:
+	// Set property "NetIpv4NeighDefaultGcThresh3":
 	if config.NetIpv4NeighDefaultGcThresh3 != nil {
 		netIpv4NeighDefaultGcThresh3 := *config.NetIpv4NeighDefaultGcThresh3
 		result.NetIpv4NeighDefaultGcThresh3 = &netIpv4NeighDefaultGcThresh3
 	}
 
-	// Set property ‘NetIpv4TcpFinTimeout’:
+	// Set property "NetIpv4TcpFinTimeout":
 	if config.NetIpv4TcpFinTimeout != nil {
 		netIpv4TcpFinTimeout := *config.NetIpv4TcpFinTimeout
 		result.NetIpv4TcpFinTimeout = &netIpv4TcpFinTimeout
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveProbes’:
+	// Set property "NetIpv4TcpKeepaliveProbes":
 	if config.NetIpv4TcpKeepaliveProbes != nil {
 		netIpv4TcpKeepaliveProbes := *config.NetIpv4TcpKeepaliveProbes
 		result.NetIpv4TcpKeepaliveProbes = &netIpv4TcpKeepaliveProbes
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveTime’:
+	// Set property "NetIpv4TcpKeepaliveTime":
 	if config.NetIpv4TcpKeepaliveTime != nil {
 		netIpv4TcpKeepaliveTime := *config.NetIpv4TcpKeepaliveTime
 		result.NetIpv4TcpKeepaliveTime = &netIpv4TcpKeepaliveTime
 	}
 
-	// Set property ‘NetIpv4TcpMaxSynBacklog’:
+	// Set property "NetIpv4TcpMaxSynBacklog":
 	if config.NetIpv4TcpMaxSynBacklog != nil {
 		netIpv4TcpMaxSynBacklog := *config.NetIpv4TcpMaxSynBacklog
 		result.NetIpv4TcpMaxSynBacklog = &netIpv4TcpMaxSynBacklog
 	}
 
-	// Set property ‘NetIpv4TcpMaxTwBuckets’:
+	// Set property "NetIpv4TcpMaxTwBuckets":
 	if config.NetIpv4TcpMaxTwBuckets != nil {
 		netIpv4TcpMaxTwBuckets := *config.NetIpv4TcpMaxTwBuckets
 		result.NetIpv4TcpMaxTwBuckets = &netIpv4TcpMaxTwBuckets
 	}
 
-	// Set property ‘NetIpv4TcpTwReuse’:
+	// Set property "NetIpv4TcpTwReuse":
 	if config.NetIpv4TcpTwReuse != nil {
 		netIpv4TcpTwReuse := *config.NetIpv4TcpTwReuse
 		result.NetIpv4TcpTwReuse = &netIpv4TcpTwReuse
 	}
 
-	// Set property ‘NetIpv4TcpkeepaliveIntvl’:
+	// Set property "NetIpv4TcpkeepaliveIntvl":
 	if config.NetIpv4TcpkeepaliveIntvl != nil {
 		netIpv4TcpkeepaliveIntvl := *config.NetIpv4TcpkeepaliveIntvl
 		result.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
 	}
 
-	// Set property ‘NetNetfilterNfConntrackBuckets’:
+	// Set property "NetNetfilterNfConntrackBuckets":
 	if config.NetNetfilterNfConntrackBuckets != nil {
 		netNetfilterNfConntrackBuckets := *config.NetNetfilterNfConntrackBuckets
 		result.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBuckets
 	}
 
-	// Set property ‘NetNetfilterNfConntrackMax’:
+	// Set property "NetNetfilterNfConntrackMax":
 	if config.NetNetfilterNfConntrackMax != nil {
 		netNetfilterNfConntrackMax := *config.NetNetfilterNfConntrackMax
 		result.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
 	}
 
-	// Set property ‘VmMaxMapCount’:
+	// Set property "VmMaxMapCount":
 	if config.VmMaxMapCount != nil {
 		vmMaxMapCount := *config.VmMaxMapCount
 		result.VmMaxMapCount = &vmMaxMapCount
 	}
 
-	// Set property ‘VmSwappiness’:
+	// Set property "VmSwappiness":
 	if config.VmSwappiness != nil {
 		vmSwappiness := *config.VmSwappiness
 		result.VmSwappiness = &vmSwappiness
 	}
 
-	// Set property ‘VmVfsCachePressure’:
+	// Set property "VmVfsCachePressure":
 	if config.VmVfsCachePressure != nil {
 		vmVfsCachePressure := *config.VmVfsCachePressure
 		result.VmVfsCachePressure = &vmVfsCachePressure
@@ -4029,169 +4029,169 @@ func (config *SysctlConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SysctlConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FsAioMaxNr’:
+	// Set property "FsAioMaxNr":
 	if typedInput.FsAioMaxNr != nil {
 		fsAioMaxNr := *typedInput.FsAioMaxNr
 		config.FsAioMaxNr = &fsAioMaxNr
 	}
 
-	// Set property ‘FsFileMax’:
+	// Set property "FsFileMax":
 	if typedInput.FsFileMax != nil {
 		fsFileMax := *typedInput.FsFileMax
 		config.FsFileMax = &fsFileMax
 	}
 
-	// Set property ‘FsInotifyMaxUserWatches’:
+	// Set property "FsInotifyMaxUserWatches":
 	if typedInput.FsInotifyMaxUserWatches != nil {
 		fsInotifyMaxUserWatches := *typedInput.FsInotifyMaxUserWatches
 		config.FsInotifyMaxUserWatches = &fsInotifyMaxUserWatches
 	}
 
-	// Set property ‘FsNrOpen’:
+	// Set property "FsNrOpen":
 	if typedInput.FsNrOpen != nil {
 		fsNrOpen := *typedInput.FsNrOpen
 		config.FsNrOpen = &fsNrOpen
 	}
 
-	// Set property ‘KernelThreadsMax’:
+	// Set property "KernelThreadsMax":
 	if typedInput.KernelThreadsMax != nil {
 		kernelThreadsMax := *typedInput.KernelThreadsMax
 		config.KernelThreadsMax = &kernelThreadsMax
 	}
 
-	// Set property ‘NetCoreNetdevMaxBacklog’:
+	// Set property "NetCoreNetdevMaxBacklog":
 	if typedInput.NetCoreNetdevMaxBacklog != nil {
 		netCoreNetdevMaxBacklog := *typedInput.NetCoreNetdevMaxBacklog
 		config.NetCoreNetdevMaxBacklog = &netCoreNetdevMaxBacklog
 	}
 
-	// Set property ‘NetCoreOptmemMax’:
+	// Set property "NetCoreOptmemMax":
 	if typedInput.NetCoreOptmemMax != nil {
 		netCoreOptmemMax := *typedInput.NetCoreOptmemMax
 		config.NetCoreOptmemMax = &netCoreOptmemMax
 	}
 
-	// Set property ‘NetCoreRmemDefault’:
+	// Set property "NetCoreRmemDefault":
 	if typedInput.NetCoreRmemDefault != nil {
 		netCoreRmemDefault := *typedInput.NetCoreRmemDefault
 		config.NetCoreRmemDefault = &netCoreRmemDefault
 	}
 
-	// Set property ‘NetCoreRmemMax’:
+	// Set property "NetCoreRmemMax":
 	if typedInput.NetCoreRmemMax != nil {
 		netCoreRmemMax := *typedInput.NetCoreRmemMax
 		config.NetCoreRmemMax = &netCoreRmemMax
 	}
 
-	// Set property ‘NetCoreSomaxconn’:
+	// Set property "NetCoreSomaxconn":
 	if typedInput.NetCoreSomaxconn != nil {
 		netCoreSomaxconn := *typedInput.NetCoreSomaxconn
 		config.NetCoreSomaxconn = &netCoreSomaxconn
 	}
 
-	// Set property ‘NetCoreWmemDefault’:
+	// Set property "NetCoreWmemDefault":
 	if typedInput.NetCoreWmemDefault != nil {
 		netCoreWmemDefault := *typedInput.NetCoreWmemDefault
 		config.NetCoreWmemDefault = &netCoreWmemDefault
 	}
 
-	// Set property ‘NetCoreWmemMax’:
+	// Set property "NetCoreWmemMax":
 	if typedInput.NetCoreWmemMax != nil {
 		netCoreWmemMax := *typedInput.NetCoreWmemMax
 		config.NetCoreWmemMax = &netCoreWmemMax
 	}
 
-	// Set property ‘NetIpv4IpLocalPortRange’:
+	// Set property "NetIpv4IpLocalPortRange":
 	if typedInput.NetIpv4IpLocalPortRange != nil {
 		netIpv4IpLocalPortRange := *typedInput.NetIpv4IpLocalPortRange
 		config.NetIpv4IpLocalPortRange = &netIpv4IpLocalPortRange
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh1’:
+	// Set property "NetIpv4NeighDefaultGcThresh1":
 	if typedInput.NetIpv4NeighDefaultGcThresh1 != nil {
 		netIpv4NeighDefaultGcThresh1 := *typedInput.NetIpv4NeighDefaultGcThresh1
 		config.NetIpv4NeighDefaultGcThresh1 = &netIpv4NeighDefaultGcThresh1
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh2’:
+	// Set property "NetIpv4NeighDefaultGcThresh2":
 	if typedInput.NetIpv4NeighDefaultGcThresh2 != nil {
 		netIpv4NeighDefaultGcThresh2 := *typedInput.NetIpv4NeighDefaultGcThresh2
 		config.NetIpv4NeighDefaultGcThresh2 = &netIpv4NeighDefaultGcThresh2
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh3’:
+	// Set property "NetIpv4NeighDefaultGcThresh3":
 	if typedInput.NetIpv4NeighDefaultGcThresh3 != nil {
 		netIpv4NeighDefaultGcThresh3 := *typedInput.NetIpv4NeighDefaultGcThresh3
 		config.NetIpv4NeighDefaultGcThresh3 = &netIpv4NeighDefaultGcThresh3
 	}
 
-	// Set property ‘NetIpv4TcpFinTimeout’:
+	// Set property "NetIpv4TcpFinTimeout":
 	if typedInput.NetIpv4TcpFinTimeout != nil {
 		netIpv4TcpFinTimeout := *typedInput.NetIpv4TcpFinTimeout
 		config.NetIpv4TcpFinTimeout = &netIpv4TcpFinTimeout
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveProbes’:
+	// Set property "NetIpv4TcpKeepaliveProbes":
 	if typedInput.NetIpv4TcpKeepaliveProbes != nil {
 		netIpv4TcpKeepaliveProbes := *typedInput.NetIpv4TcpKeepaliveProbes
 		config.NetIpv4TcpKeepaliveProbes = &netIpv4TcpKeepaliveProbes
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveTime’:
+	// Set property "NetIpv4TcpKeepaliveTime":
 	if typedInput.NetIpv4TcpKeepaliveTime != nil {
 		netIpv4TcpKeepaliveTime := *typedInput.NetIpv4TcpKeepaliveTime
 		config.NetIpv4TcpKeepaliveTime = &netIpv4TcpKeepaliveTime
 	}
 
-	// Set property ‘NetIpv4TcpMaxSynBacklog’:
+	// Set property "NetIpv4TcpMaxSynBacklog":
 	if typedInput.NetIpv4TcpMaxSynBacklog != nil {
 		netIpv4TcpMaxSynBacklog := *typedInput.NetIpv4TcpMaxSynBacklog
 		config.NetIpv4TcpMaxSynBacklog = &netIpv4TcpMaxSynBacklog
 	}
 
-	// Set property ‘NetIpv4TcpMaxTwBuckets’:
+	// Set property "NetIpv4TcpMaxTwBuckets":
 	if typedInput.NetIpv4TcpMaxTwBuckets != nil {
 		netIpv4TcpMaxTwBuckets := *typedInput.NetIpv4TcpMaxTwBuckets
 		config.NetIpv4TcpMaxTwBuckets = &netIpv4TcpMaxTwBuckets
 	}
 
-	// Set property ‘NetIpv4TcpTwReuse’:
+	// Set property "NetIpv4TcpTwReuse":
 	if typedInput.NetIpv4TcpTwReuse != nil {
 		netIpv4TcpTwReuse := *typedInput.NetIpv4TcpTwReuse
 		config.NetIpv4TcpTwReuse = &netIpv4TcpTwReuse
 	}
 
-	// Set property ‘NetIpv4TcpkeepaliveIntvl’:
+	// Set property "NetIpv4TcpkeepaliveIntvl":
 	if typedInput.NetIpv4TcpkeepaliveIntvl != nil {
 		netIpv4TcpkeepaliveIntvl := *typedInput.NetIpv4TcpkeepaliveIntvl
 		config.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
 	}
 
-	// Set property ‘NetNetfilterNfConntrackBuckets’:
+	// Set property "NetNetfilterNfConntrackBuckets":
 	if typedInput.NetNetfilterNfConntrackBuckets != nil {
 		netNetfilterNfConntrackBuckets := *typedInput.NetNetfilterNfConntrackBuckets
 		config.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBuckets
 	}
 
-	// Set property ‘NetNetfilterNfConntrackMax’:
+	// Set property "NetNetfilterNfConntrackMax":
 	if typedInput.NetNetfilterNfConntrackMax != nil {
 		netNetfilterNfConntrackMax := *typedInput.NetNetfilterNfConntrackMax
 		config.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
 	}
 
-	// Set property ‘VmMaxMapCount’:
+	// Set property "VmMaxMapCount":
 	if typedInput.VmMaxMapCount != nil {
 		vmMaxMapCount := *typedInput.VmMaxMapCount
 		config.VmMaxMapCount = &vmMaxMapCount
 	}
 
-	// Set property ‘VmSwappiness’:
+	// Set property "VmSwappiness":
 	if typedInput.VmSwappiness != nil {
 		vmSwappiness := *typedInput.VmSwappiness
 		config.VmSwappiness = &vmSwappiness
 	}
 
-	// Set property ‘VmVfsCachePressure’:
+	// Set property "VmVfsCachePressure":
 	if typedInput.VmVfsCachePressure != nil {
 		vmVfsCachePressure := *typedInput.VmVfsCachePressure
 		config.VmVfsCachePressure = &vmVfsCachePressure
@@ -4503,169 +4503,169 @@ func (config *SysctlConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SysctlConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FsAioMaxNr’:
+	// Set property "FsAioMaxNr":
 	if typedInput.FsAioMaxNr != nil {
 		fsAioMaxNr := *typedInput.FsAioMaxNr
 		config.FsAioMaxNr = &fsAioMaxNr
 	}
 
-	// Set property ‘FsFileMax’:
+	// Set property "FsFileMax":
 	if typedInput.FsFileMax != nil {
 		fsFileMax := *typedInput.FsFileMax
 		config.FsFileMax = &fsFileMax
 	}
 
-	// Set property ‘FsInotifyMaxUserWatches’:
+	// Set property "FsInotifyMaxUserWatches":
 	if typedInput.FsInotifyMaxUserWatches != nil {
 		fsInotifyMaxUserWatches := *typedInput.FsInotifyMaxUserWatches
 		config.FsInotifyMaxUserWatches = &fsInotifyMaxUserWatches
 	}
 
-	// Set property ‘FsNrOpen’:
+	// Set property "FsNrOpen":
 	if typedInput.FsNrOpen != nil {
 		fsNrOpen := *typedInput.FsNrOpen
 		config.FsNrOpen = &fsNrOpen
 	}
 
-	// Set property ‘KernelThreadsMax’:
+	// Set property "KernelThreadsMax":
 	if typedInput.KernelThreadsMax != nil {
 		kernelThreadsMax := *typedInput.KernelThreadsMax
 		config.KernelThreadsMax = &kernelThreadsMax
 	}
 
-	// Set property ‘NetCoreNetdevMaxBacklog’:
+	// Set property "NetCoreNetdevMaxBacklog":
 	if typedInput.NetCoreNetdevMaxBacklog != nil {
 		netCoreNetdevMaxBacklog := *typedInput.NetCoreNetdevMaxBacklog
 		config.NetCoreNetdevMaxBacklog = &netCoreNetdevMaxBacklog
 	}
 
-	// Set property ‘NetCoreOptmemMax’:
+	// Set property "NetCoreOptmemMax":
 	if typedInput.NetCoreOptmemMax != nil {
 		netCoreOptmemMax := *typedInput.NetCoreOptmemMax
 		config.NetCoreOptmemMax = &netCoreOptmemMax
 	}
 
-	// Set property ‘NetCoreRmemDefault’:
+	// Set property "NetCoreRmemDefault":
 	if typedInput.NetCoreRmemDefault != nil {
 		netCoreRmemDefault := *typedInput.NetCoreRmemDefault
 		config.NetCoreRmemDefault = &netCoreRmemDefault
 	}
 
-	// Set property ‘NetCoreRmemMax’:
+	// Set property "NetCoreRmemMax":
 	if typedInput.NetCoreRmemMax != nil {
 		netCoreRmemMax := *typedInput.NetCoreRmemMax
 		config.NetCoreRmemMax = &netCoreRmemMax
 	}
 
-	// Set property ‘NetCoreSomaxconn’:
+	// Set property "NetCoreSomaxconn":
 	if typedInput.NetCoreSomaxconn != nil {
 		netCoreSomaxconn := *typedInput.NetCoreSomaxconn
 		config.NetCoreSomaxconn = &netCoreSomaxconn
 	}
 
-	// Set property ‘NetCoreWmemDefault’:
+	// Set property "NetCoreWmemDefault":
 	if typedInput.NetCoreWmemDefault != nil {
 		netCoreWmemDefault := *typedInput.NetCoreWmemDefault
 		config.NetCoreWmemDefault = &netCoreWmemDefault
 	}
 
-	// Set property ‘NetCoreWmemMax’:
+	// Set property "NetCoreWmemMax":
 	if typedInput.NetCoreWmemMax != nil {
 		netCoreWmemMax := *typedInput.NetCoreWmemMax
 		config.NetCoreWmemMax = &netCoreWmemMax
 	}
 
-	// Set property ‘NetIpv4IpLocalPortRange’:
+	// Set property "NetIpv4IpLocalPortRange":
 	if typedInput.NetIpv4IpLocalPortRange != nil {
 		netIpv4IpLocalPortRange := *typedInput.NetIpv4IpLocalPortRange
 		config.NetIpv4IpLocalPortRange = &netIpv4IpLocalPortRange
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh1’:
+	// Set property "NetIpv4NeighDefaultGcThresh1":
 	if typedInput.NetIpv4NeighDefaultGcThresh1 != nil {
 		netIpv4NeighDefaultGcThresh1 := *typedInput.NetIpv4NeighDefaultGcThresh1
 		config.NetIpv4NeighDefaultGcThresh1 = &netIpv4NeighDefaultGcThresh1
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh2’:
+	// Set property "NetIpv4NeighDefaultGcThresh2":
 	if typedInput.NetIpv4NeighDefaultGcThresh2 != nil {
 		netIpv4NeighDefaultGcThresh2 := *typedInput.NetIpv4NeighDefaultGcThresh2
 		config.NetIpv4NeighDefaultGcThresh2 = &netIpv4NeighDefaultGcThresh2
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh3’:
+	// Set property "NetIpv4NeighDefaultGcThresh3":
 	if typedInput.NetIpv4NeighDefaultGcThresh3 != nil {
 		netIpv4NeighDefaultGcThresh3 := *typedInput.NetIpv4NeighDefaultGcThresh3
 		config.NetIpv4NeighDefaultGcThresh3 = &netIpv4NeighDefaultGcThresh3
 	}
 
-	// Set property ‘NetIpv4TcpFinTimeout’:
+	// Set property "NetIpv4TcpFinTimeout":
 	if typedInput.NetIpv4TcpFinTimeout != nil {
 		netIpv4TcpFinTimeout := *typedInput.NetIpv4TcpFinTimeout
 		config.NetIpv4TcpFinTimeout = &netIpv4TcpFinTimeout
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveProbes’:
+	// Set property "NetIpv4TcpKeepaliveProbes":
 	if typedInput.NetIpv4TcpKeepaliveProbes != nil {
 		netIpv4TcpKeepaliveProbes := *typedInput.NetIpv4TcpKeepaliveProbes
 		config.NetIpv4TcpKeepaliveProbes = &netIpv4TcpKeepaliveProbes
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveTime’:
+	// Set property "NetIpv4TcpKeepaliveTime":
 	if typedInput.NetIpv4TcpKeepaliveTime != nil {
 		netIpv4TcpKeepaliveTime := *typedInput.NetIpv4TcpKeepaliveTime
 		config.NetIpv4TcpKeepaliveTime = &netIpv4TcpKeepaliveTime
 	}
 
-	// Set property ‘NetIpv4TcpMaxSynBacklog’:
+	// Set property "NetIpv4TcpMaxSynBacklog":
 	if typedInput.NetIpv4TcpMaxSynBacklog != nil {
 		netIpv4TcpMaxSynBacklog := *typedInput.NetIpv4TcpMaxSynBacklog
 		config.NetIpv4TcpMaxSynBacklog = &netIpv4TcpMaxSynBacklog
 	}
 
-	// Set property ‘NetIpv4TcpMaxTwBuckets’:
+	// Set property "NetIpv4TcpMaxTwBuckets":
 	if typedInput.NetIpv4TcpMaxTwBuckets != nil {
 		netIpv4TcpMaxTwBuckets := *typedInput.NetIpv4TcpMaxTwBuckets
 		config.NetIpv4TcpMaxTwBuckets = &netIpv4TcpMaxTwBuckets
 	}
 
-	// Set property ‘NetIpv4TcpTwReuse’:
+	// Set property "NetIpv4TcpTwReuse":
 	if typedInput.NetIpv4TcpTwReuse != nil {
 		netIpv4TcpTwReuse := *typedInput.NetIpv4TcpTwReuse
 		config.NetIpv4TcpTwReuse = &netIpv4TcpTwReuse
 	}
 
-	// Set property ‘NetIpv4TcpkeepaliveIntvl’:
+	// Set property "NetIpv4TcpkeepaliveIntvl":
 	if typedInput.NetIpv4TcpkeepaliveIntvl != nil {
 		netIpv4TcpkeepaliveIntvl := *typedInput.NetIpv4TcpkeepaliveIntvl
 		config.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
 	}
 
-	// Set property ‘NetNetfilterNfConntrackBuckets’:
+	// Set property "NetNetfilterNfConntrackBuckets":
 	if typedInput.NetNetfilterNfConntrackBuckets != nil {
 		netNetfilterNfConntrackBuckets := *typedInput.NetNetfilterNfConntrackBuckets
 		config.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBuckets
 	}
 
-	// Set property ‘NetNetfilterNfConntrackMax’:
+	// Set property "NetNetfilterNfConntrackMax":
 	if typedInput.NetNetfilterNfConntrackMax != nil {
 		netNetfilterNfConntrackMax := *typedInput.NetNetfilterNfConntrackMax
 		config.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
 	}
 
-	// Set property ‘VmMaxMapCount’:
+	// Set property "VmMaxMapCount":
 	if typedInput.VmMaxMapCount != nil {
 		vmMaxMapCount := *typedInput.VmMaxMapCount
 		config.VmMaxMapCount = &vmMaxMapCount
 	}
 
-	// Set property ‘VmSwappiness’:
+	// Set property "VmSwappiness":
 	if typedInput.VmSwappiness != nil {
 		vmSwappiness := *typedInput.VmSwappiness
 		config.VmSwappiness = &vmSwappiness
 	}
 
-	// Set property ‘VmVfsCachePressure’:
+	// Set property "VmVfsCachePressure":
 	if typedInput.VmVfsCachePressure != nil {
 		vmVfsCachePressure := *typedInput.VmVfsCachePressure
 		config.VmVfsCachePressure = &vmVfsCachePressure

--- a/v2/api/containerservice/v1api20230201/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20230201/managed_cluster_types_gen.go
@@ -516,7 +516,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ManagedCluster_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if cluster.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*cluster.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -526,7 +526,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if cluster.Identity != nil {
 		identity_ARM, err := (*cluster.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -536,16 +536,16 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if cluster.Location != nil {
 		location := *cluster.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if cluster.AadProfile != nil ||
 		cluster.AddonProfiles != nil ||
 		cluster.AgentPoolProfiles != nil ||
@@ -771,7 +771,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.WorkloadAutoScalerProfile = &workloadAutoScalerProfile
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if cluster.Sku != nil {
 		sku_ARM, err := (*cluster.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -781,7 +781,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if cluster.Tags != nil {
 		result.Tags = make(map[string]string, len(cluster.Tags))
 		for key, value := range cluster.Tags {
@@ -803,7 +803,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedCluster_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadProfile’:
+	// Set property "AadProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AadProfile != nil {
@@ -817,7 +817,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AddonProfiles’:
+	// Set property "AddonProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddonProfiles != nil {
@@ -833,7 +833,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AgentPoolProfiles’:
+	// Set property "AgentPoolProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AgentPoolProfiles {
@@ -846,7 +846,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ApiServerAccessProfile’:
+	// Set property "ApiServerAccessProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApiServerAccessProfile != nil {
@@ -860,7 +860,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AutoScalerProfile’:
+	// Set property "AutoScalerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoScalerProfile != nil {
@@ -874,7 +874,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AutoUpgradeProfile’:
+	// Set property "AutoUpgradeProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeProfile != nil {
@@ -888,7 +888,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureMonitorProfile’:
+	// Set property "AzureMonitorProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureMonitorProfile != nil {
@@ -902,10 +902,10 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	cluster.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DisableLocalAccounts’:
+	// Set property "DisableLocalAccounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAccounts != nil {
@@ -914,9 +914,9 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘DiskEncryptionSetReference’
+	// no assignment for property "DiskEncryptionSetReference"
 
-	// Set property ‘DnsPrefix’:
+	// Set property "DnsPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsPrefix != nil {
@@ -925,7 +925,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnablePodSecurityPolicy’:
+	// Set property "EnablePodSecurityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePodSecurityPolicy != nil {
@@ -934,7 +934,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableRBAC’:
+	// Set property "EnableRBAC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableRBAC != nil {
@@ -943,7 +943,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -954,7 +954,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		cluster.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FqdnSubdomain’:
+	// Set property "FqdnSubdomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FqdnSubdomain != nil {
@@ -963,7 +963,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘HttpProxyConfig’:
+	// Set property "HttpProxyConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpProxyConfig != nil {
@@ -977,7 +977,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedClusterIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -988,7 +988,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		cluster.Identity = &identity
 	}
 
-	// Set property ‘IdentityProfile’:
+	// Set property "IdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdentityProfile != nil {
@@ -1004,7 +1004,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘KubernetesVersion’:
+	// Set property "KubernetesVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubernetesVersion != nil {
@@ -1013,7 +1013,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘LinuxProfile’:
+	// Set property "LinuxProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxProfile != nil {
@@ -1027,13 +1027,13 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		cluster.Location = &location
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -1047,7 +1047,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘NodeResourceGroup’:
+	// Set property "NodeResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeResourceGroup != nil {
@@ -1056,7 +1056,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘OidcIssuerProfile’:
+	// Set property "OidcIssuerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OidcIssuerProfile != nil {
@@ -1070,12 +1070,12 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	cluster.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PodIdentityProfile’:
+	// Set property "PodIdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PodIdentityProfile != nil {
@@ -1089,7 +1089,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘PrivateLinkResources’:
+	// Set property "PrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkResources {
@@ -1102,7 +1102,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1111,7 +1111,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecurityProfile != nil {
@@ -1125,7 +1125,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ServicePrincipalProfile’:
+	// Set property "ServicePrincipalProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServicePrincipalProfile != nil {
@@ -1139,7 +1139,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 ManagedClusterSKU
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1150,7 +1150,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		cluster.Sku = &sku
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -1164,7 +1164,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		cluster.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1172,7 +1172,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘WindowsProfile’:
+	// Set property "WindowsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WindowsProfile != nil {
@@ -1186,7 +1186,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘WorkloadAutoScalerProfile’:
+	// Set property "WorkloadAutoScalerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkloadAutoScalerProfile != nil {
@@ -2591,7 +2591,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedCluster_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadProfile’:
+	// Set property "AadProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AadProfile != nil {
@@ -2605,7 +2605,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AddonProfiles’:
+	// Set property "AddonProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddonProfiles != nil {
@@ -2621,7 +2621,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AgentPoolProfiles’:
+	// Set property "AgentPoolProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AgentPoolProfiles {
@@ -2634,7 +2634,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ApiServerAccessProfile’:
+	// Set property "ApiServerAccessProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApiServerAccessProfile != nil {
@@ -2648,7 +2648,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AutoScalerProfile’:
+	// Set property "AutoScalerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoScalerProfile != nil {
@@ -2662,7 +2662,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AutoUpgradeProfile’:
+	// Set property "AutoUpgradeProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeProfile != nil {
@@ -2676,7 +2676,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AzureMonitorProfile’:
+	// Set property "AzureMonitorProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureMonitorProfile != nil {
@@ -2690,7 +2690,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AzurePortalFQDN’:
+	// Set property "AzurePortalFQDN":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzurePortalFQDN != nil {
@@ -2699,9 +2699,9 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CurrentKubernetesVersion’:
+	// Set property "CurrentKubernetesVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CurrentKubernetesVersion != nil {
@@ -2710,7 +2710,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DisableLocalAccounts’:
+	// Set property "DisableLocalAccounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAccounts != nil {
@@ -2719,7 +2719,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DiskEncryptionSetID’:
+	// Set property "DiskEncryptionSetID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskEncryptionSetID != nil {
@@ -2728,7 +2728,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DnsPrefix’:
+	// Set property "DnsPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsPrefix != nil {
@@ -2737,7 +2737,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnablePodSecurityPolicy’:
+	// Set property "EnablePodSecurityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePodSecurityPolicy != nil {
@@ -2746,7 +2746,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableRBAC’:
+	// Set property "EnableRBAC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableRBAC != nil {
@@ -2755,7 +2755,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -2766,7 +2766,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -2775,7 +2775,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘FqdnSubdomain’:
+	// Set property "FqdnSubdomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FqdnSubdomain != nil {
@@ -2784,7 +2784,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘HttpProxyConfig’:
+	// Set property "HttpProxyConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpProxyConfig != nil {
@@ -2798,13 +2798,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		cluster.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedClusterIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2815,7 +2815,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.Identity = &identity
 	}
 
-	// Set property ‘IdentityProfile’:
+	// Set property "IdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdentityProfile != nil {
@@ -2831,7 +2831,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘KubernetesVersion’:
+	// Set property "KubernetesVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubernetesVersion != nil {
@@ -2840,7 +2840,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LinuxProfile’:
+	// Set property "LinuxProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxProfile != nil {
@@ -2854,13 +2854,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		cluster.Location = &location
 	}
 
-	// Set property ‘MaxAgentPools’:
+	// Set property "MaxAgentPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxAgentPools != nil {
@@ -2869,13 +2869,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		cluster.Name = &name
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -2889,7 +2889,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘NodeResourceGroup’:
+	// Set property "NodeResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeResourceGroup != nil {
@@ -2898,7 +2898,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘OidcIssuerProfile’:
+	// Set property "OidcIssuerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OidcIssuerProfile != nil {
@@ -2912,7 +2912,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PodIdentityProfile’:
+	// Set property "PodIdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PodIdentityProfile != nil {
@@ -2926,7 +2926,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PowerState != nil {
@@ -2940,7 +2940,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrivateFQDN’:
+	// Set property "PrivateFQDN":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateFQDN != nil {
@@ -2949,7 +2949,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrivateLinkResources’:
+	// Set property "PrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkResources {
@@ -2962,7 +2962,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2971,7 +2971,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -2980,7 +2980,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecurityProfile != nil {
@@ -2994,7 +2994,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ServicePrincipalProfile’:
+	// Set property "ServicePrincipalProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServicePrincipalProfile != nil {
@@ -3008,7 +3008,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 ManagedClusterSKU_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -3019,7 +3019,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.Sku = &sku
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -3033,7 +3033,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -3044,7 +3044,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		cluster.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -3052,13 +3052,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		cluster.Type = &typeVar
 	}
 
-	// Set property ‘WindowsProfile’:
+	// Set property "WindowsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WindowsProfile != nil {
@@ -3072,7 +3072,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘WorkloadAutoScalerProfile’:
+	// Set property "WorkloadAutoScalerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkloadAutoScalerProfile != nil {
@@ -3924,13 +3924,13 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ContainerServiceLinuxProfile_ARM{}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if profile.Ssh != nil {
 		ssh_ARM, err := (*profile.Ssh).ConvertToARM(resolved)
 		if err != nil {
@@ -3954,13 +3954,13 @@ func (profile *ContainerServiceLinuxProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceLinuxProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 ContainerServiceSshConfiguration
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -4088,13 +4088,13 @@ func (profile *ContainerServiceLinuxProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceLinuxProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 ContainerServiceSshConfiguration_STATUS
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -4235,24 +4235,24 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 	}
 	result := &ContainerServiceNetworkProfile_ARM{}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if profile.DnsServiceIP != nil {
 		dnsServiceIP := *profile.DnsServiceIP
 		result.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if profile.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *profile.DockerBridgeCidr
 		result.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘IpFamilies’:
+	// Set property "IpFamilies":
 	for _, item := range profile.IpFamilies {
 		result.IpFamilies = append(result.IpFamilies, item)
 	}
 
-	// Set property ‘LoadBalancerProfile’:
+	// Set property "LoadBalancerProfile":
 	if profile.LoadBalancerProfile != nil {
 		loadBalancerProfile_ARM, err := (*profile.LoadBalancerProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4262,13 +4262,13 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 		result.LoadBalancerProfile = &loadBalancerProfile
 	}
 
-	// Set property ‘LoadBalancerSku’:
+	// Set property "LoadBalancerSku":
 	if profile.LoadBalancerSku != nil {
 		loadBalancerSku := *profile.LoadBalancerSku
 		result.LoadBalancerSku = &loadBalancerSku
 	}
 
-	// Set property ‘NatGatewayProfile’:
+	// Set property "NatGatewayProfile":
 	if profile.NatGatewayProfile != nil {
 		natGatewayProfile_ARM, err := (*profile.NatGatewayProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4278,60 +4278,60 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 		result.NatGatewayProfile = &natGatewayProfile
 	}
 
-	// Set property ‘NetworkDataplane’:
+	// Set property "NetworkDataplane":
 	if profile.NetworkDataplane != nil {
 		networkDataplane := *profile.NetworkDataplane
 		result.NetworkDataplane = &networkDataplane
 	}
 
-	// Set property ‘NetworkMode’:
+	// Set property "NetworkMode":
 	if profile.NetworkMode != nil {
 		networkMode := *profile.NetworkMode
 		result.NetworkMode = &networkMode
 	}
 
-	// Set property ‘NetworkPlugin’:
+	// Set property "NetworkPlugin":
 	if profile.NetworkPlugin != nil {
 		networkPlugin := *profile.NetworkPlugin
 		result.NetworkPlugin = &networkPlugin
 	}
 
-	// Set property ‘NetworkPluginMode’:
+	// Set property "NetworkPluginMode":
 	if profile.NetworkPluginMode != nil {
 		networkPluginMode := *profile.NetworkPluginMode
 		result.NetworkPluginMode = &networkPluginMode
 	}
 
-	// Set property ‘NetworkPolicy’:
+	// Set property "NetworkPolicy":
 	if profile.NetworkPolicy != nil {
 		networkPolicy := *profile.NetworkPolicy
 		result.NetworkPolicy = &networkPolicy
 	}
 
-	// Set property ‘OutboundType’:
+	// Set property "OutboundType":
 	if profile.OutboundType != nil {
 		outboundType := *profile.OutboundType
 		result.OutboundType = &outboundType
 	}
 
-	// Set property ‘PodCidr’:
+	// Set property "PodCidr":
 	if profile.PodCidr != nil {
 		podCidr := *profile.PodCidr
 		result.PodCidr = &podCidr
 	}
 
-	// Set property ‘PodCidrs’:
+	// Set property "PodCidrs":
 	for _, item := range profile.PodCidrs {
 		result.PodCidrs = append(result.PodCidrs, item)
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if profile.ServiceCidr != nil {
 		serviceCidr := *profile.ServiceCidr
 		result.ServiceCidr = &serviceCidr
 	}
 
-	// Set property ‘ServiceCidrs’:
+	// Set property "ServiceCidrs":
 	for _, item := range profile.ServiceCidrs {
 		result.ServiceCidrs = append(result.ServiceCidrs, item)
 	}
@@ -4350,24 +4350,24 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceNetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if typedInput.DnsServiceIP != nil {
 		dnsServiceIP := *typedInput.DnsServiceIP
 		profile.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if typedInput.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *typedInput.DockerBridgeCidr
 		profile.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘IpFamilies’:
+	// Set property "IpFamilies":
 	for _, item := range typedInput.IpFamilies {
 		profile.IpFamilies = append(profile.IpFamilies, item)
 	}
 
-	// Set property ‘LoadBalancerProfile’:
+	// Set property "LoadBalancerProfile":
 	if typedInput.LoadBalancerProfile != nil {
 		var loadBalancerProfile1 ManagedClusterLoadBalancerProfile
 		err := loadBalancerProfile1.PopulateFromARM(owner, *typedInput.LoadBalancerProfile)
@@ -4378,13 +4378,13 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 		profile.LoadBalancerProfile = &loadBalancerProfile
 	}
 
-	// Set property ‘LoadBalancerSku’:
+	// Set property "LoadBalancerSku":
 	if typedInput.LoadBalancerSku != nil {
 		loadBalancerSku := *typedInput.LoadBalancerSku
 		profile.LoadBalancerSku = &loadBalancerSku
 	}
 
-	// Set property ‘NatGatewayProfile’:
+	// Set property "NatGatewayProfile":
 	if typedInput.NatGatewayProfile != nil {
 		var natGatewayProfile1 ManagedClusterNATGatewayProfile
 		err := natGatewayProfile1.PopulateFromARM(owner, *typedInput.NatGatewayProfile)
@@ -4395,60 +4395,60 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 		profile.NatGatewayProfile = &natGatewayProfile
 	}
 
-	// Set property ‘NetworkDataplane’:
+	// Set property "NetworkDataplane":
 	if typedInput.NetworkDataplane != nil {
 		networkDataplane := *typedInput.NetworkDataplane
 		profile.NetworkDataplane = &networkDataplane
 	}
 
-	// Set property ‘NetworkMode’:
+	// Set property "NetworkMode":
 	if typedInput.NetworkMode != nil {
 		networkMode := *typedInput.NetworkMode
 		profile.NetworkMode = &networkMode
 	}
 
-	// Set property ‘NetworkPlugin’:
+	// Set property "NetworkPlugin":
 	if typedInput.NetworkPlugin != nil {
 		networkPlugin := *typedInput.NetworkPlugin
 		profile.NetworkPlugin = &networkPlugin
 	}
 
-	// Set property ‘NetworkPluginMode’:
+	// Set property "NetworkPluginMode":
 	if typedInput.NetworkPluginMode != nil {
 		networkPluginMode := *typedInput.NetworkPluginMode
 		profile.NetworkPluginMode = &networkPluginMode
 	}
 
-	// Set property ‘NetworkPolicy’:
+	// Set property "NetworkPolicy":
 	if typedInput.NetworkPolicy != nil {
 		networkPolicy := *typedInput.NetworkPolicy
 		profile.NetworkPolicy = &networkPolicy
 	}
 
-	// Set property ‘OutboundType’:
+	// Set property "OutboundType":
 	if typedInput.OutboundType != nil {
 		outboundType := *typedInput.OutboundType
 		profile.OutboundType = &outboundType
 	}
 
-	// Set property ‘PodCidr’:
+	// Set property "PodCidr":
 	if typedInput.PodCidr != nil {
 		podCidr := *typedInput.PodCidr
 		profile.PodCidr = &podCidr
 	}
 
-	// Set property ‘PodCidrs’:
+	// Set property "PodCidrs":
 	for _, item := range typedInput.PodCidrs {
 		profile.PodCidrs = append(profile.PodCidrs, item)
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if typedInput.ServiceCidr != nil {
 		serviceCidr := *typedInput.ServiceCidr
 		profile.ServiceCidr = &serviceCidr
 	}
 
-	// Set property ‘ServiceCidrs’:
+	// Set property "ServiceCidrs":
 	for _, item := range typedInput.ServiceCidrs {
 		profile.ServiceCidrs = append(profile.ServiceCidrs, item)
 	}
@@ -4955,24 +4955,24 @@ func (profile *ContainerServiceNetworkProfile_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceNetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if typedInput.DnsServiceIP != nil {
 		dnsServiceIP := *typedInput.DnsServiceIP
 		profile.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if typedInput.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *typedInput.DockerBridgeCidr
 		profile.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘IpFamilies’:
+	// Set property "IpFamilies":
 	for _, item := range typedInput.IpFamilies {
 		profile.IpFamilies = append(profile.IpFamilies, item)
 	}
 
-	// Set property ‘LoadBalancerProfile’:
+	// Set property "LoadBalancerProfile":
 	if typedInput.LoadBalancerProfile != nil {
 		var loadBalancerProfile1 ManagedClusterLoadBalancerProfile_STATUS
 		err := loadBalancerProfile1.PopulateFromARM(owner, *typedInput.LoadBalancerProfile)
@@ -4983,13 +4983,13 @@ func (profile *ContainerServiceNetworkProfile_STATUS) PopulateFromARM(owner genr
 		profile.LoadBalancerProfile = &loadBalancerProfile
 	}
 
-	// Set property ‘LoadBalancerSku’:
+	// Set property "LoadBalancerSku":
 	if typedInput.LoadBalancerSku != nil {
 		loadBalancerSku := *typedInput.LoadBalancerSku
 		profile.LoadBalancerSku = &loadBalancerSku
 	}
 
-	// Set property ‘NatGatewayProfile’:
+	// Set property "NatGatewayProfile":
 	if typedInput.NatGatewayProfile != nil {
 		var natGatewayProfile1 ManagedClusterNATGatewayProfile_STATUS
 		err := natGatewayProfile1.PopulateFromARM(owner, *typedInput.NatGatewayProfile)
@@ -5000,60 +5000,60 @@ func (profile *ContainerServiceNetworkProfile_STATUS) PopulateFromARM(owner genr
 		profile.NatGatewayProfile = &natGatewayProfile
 	}
 
-	// Set property ‘NetworkDataplane’:
+	// Set property "NetworkDataplane":
 	if typedInput.NetworkDataplane != nil {
 		networkDataplane := *typedInput.NetworkDataplane
 		profile.NetworkDataplane = &networkDataplane
 	}
 
-	// Set property ‘NetworkMode’:
+	// Set property "NetworkMode":
 	if typedInput.NetworkMode != nil {
 		networkMode := *typedInput.NetworkMode
 		profile.NetworkMode = &networkMode
 	}
 
-	// Set property ‘NetworkPlugin’:
+	// Set property "NetworkPlugin":
 	if typedInput.NetworkPlugin != nil {
 		networkPlugin := *typedInput.NetworkPlugin
 		profile.NetworkPlugin = &networkPlugin
 	}
 
-	// Set property ‘NetworkPluginMode’:
+	// Set property "NetworkPluginMode":
 	if typedInput.NetworkPluginMode != nil {
 		networkPluginMode := *typedInput.NetworkPluginMode
 		profile.NetworkPluginMode = &networkPluginMode
 	}
 
-	// Set property ‘NetworkPolicy’:
+	// Set property "NetworkPolicy":
 	if typedInput.NetworkPolicy != nil {
 		networkPolicy := *typedInput.NetworkPolicy
 		profile.NetworkPolicy = &networkPolicy
 	}
 
-	// Set property ‘OutboundType’:
+	// Set property "OutboundType":
 	if typedInput.OutboundType != nil {
 		outboundType := *typedInput.OutboundType
 		profile.OutboundType = &outboundType
 	}
 
-	// Set property ‘PodCidr’:
+	// Set property "PodCidr":
 	if typedInput.PodCidr != nil {
 		podCidr := *typedInput.PodCidr
 		profile.PodCidr = &podCidr
 	}
 
-	// Set property ‘PodCidrs’:
+	// Set property "PodCidrs":
 	for _, item := range typedInput.PodCidrs {
 		profile.PodCidrs = append(profile.PodCidrs, item)
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if typedInput.ServiceCidr != nil {
 		serviceCidr := *typedInput.ServiceCidr
 		profile.ServiceCidr = &serviceCidr
 	}
 
-	// Set property ‘ServiceCidrs’:
+	// Set property "ServiceCidrs":
 	for _, item := range typedInput.ServiceCidrs {
 		profile.ServiceCidrs = append(profile.ServiceCidrs, item)
 	}
@@ -5325,13 +5325,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -5351,13 +5351,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -5453,13 +5453,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -5548,42 +5548,42 @@ func (profile *ManagedClusterAADProfile) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &ManagedClusterAADProfile_ARM{}
 
-	// Set property ‘AdminGroupObjectIDs’:
+	// Set property "AdminGroupObjectIDs":
 	for _, item := range profile.AdminGroupObjectIDs {
 		result.AdminGroupObjectIDs = append(result.AdminGroupObjectIDs, item)
 	}
 
-	// Set property ‘ClientAppID’:
+	// Set property "ClientAppID":
 	if profile.ClientAppID != nil {
 		clientAppID := *profile.ClientAppID
 		result.ClientAppID = &clientAppID
 	}
 
-	// Set property ‘EnableAzureRBAC’:
+	// Set property "EnableAzureRBAC":
 	if profile.EnableAzureRBAC != nil {
 		enableAzureRBAC := *profile.EnableAzureRBAC
 		result.EnableAzureRBAC = &enableAzureRBAC
 	}
 
-	// Set property ‘Managed’:
+	// Set property "Managed":
 	if profile.Managed != nil {
 		managed := *profile.Managed
 		result.Managed = &managed
 	}
 
-	// Set property ‘ServerAppID’:
+	// Set property "ServerAppID":
 	if profile.ServerAppID != nil {
 		serverAppID := *profile.ServerAppID
 		result.ServerAppID = &serverAppID
 	}
 
-	// Set property ‘ServerAppSecret’:
+	// Set property "ServerAppSecret":
 	if profile.ServerAppSecret != nil {
 		serverAppSecret := *profile.ServerAppSecret
 		result.ServerAppSecret = &serverAppSecret
 	}
 
-	// Set property ‘TenantID’:
+	// Set property "TenantID":
 	if profile.TenantID != nil {
 		tenantID := *profile.TenantID
 		result.TenantID = &tenantID
@@ -5603,42 +5603,42 @@ func (profile *ManagedClusterAADProfile) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAADProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminGroupObjectIDs’:
+	// Set property "AdminGroupObjectIDs":
 	for _, item := range typedInput.AdminGroupObjectIDs {
 		profile.AdminGroupObjectIDs = append(profile.AdminGroupObjectIDs, item)
 	}
 
-	// Set property ‘ClientAppID’:
+	// Set property "ClientAppID":
 	if typedInput.ClientAppID != nil {
 		clientAppID := *typedInput.ClientAppID
 		profile.ClientAppID = &clientAppID
 	}
 
-	// Set property ‘EnableAzureRBAC’:
+	// Set property "EnableAzureRBAC":
 	if typedInput.EnableAzureRBAC != nil {
 		enableAzureRBAC := *typedInput.EnableAzureRBAC
 		profile.EnableAzureRBAC = &enableAzureRBAC
 	}
 
-	// Set property ‘Managed’:
+	// Set property "Managed":
 	if typedInput.Managed != nil {
 		managed := *typedInput.Managed
 		profile.Managed = &managed
 	}
 
-	// Set property ‘ServerAppID’:
+	// Set property "ServerAppID":
 	if typedInput.ServerAppID != nil {
 		serverAppID := *typedInput.ServerAppID
 		profile.ServerAppID = &serverAppID
 	}
 
-	// Set property ‘ServerAppSecret’:
+	// Set property "ServerAppSecret":
 	if typedInput.ServerAppSecret != nil {
 		serverAppSecret := *typedInput.ServerAppSecret
 		profile.ServerAppSecret = &serverAppSecret
 	}
 
-	// Set property ‘TenantID’:
+	// Set property "TenantID":
 	if typedInput.TenantID != nil {
 		tenantID := *typedInput.TenantID
 		profile.TenantID = &tenantID
@@ -5810,42 +5810,42 @@ func (profile *ManagedClusterAADProfile_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAADProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminGroupObjectIDs’:
+	// Set property "AdminGroupObjectIDs":
 	for _, item := range typedInput.AdminGroupObjectIDs {
 		profile.AdminGroupObjectIDs = append(profile.AdminGroupObjectIDs, item)
 	}
 
-	// Set property ‘ClientAppID’:
+	// Set property "ClientAppID":
 	if typedInput.ClientAppID != nil {
 		clientAppID := *typedInput.ClientAppID
 		profile.ClientAppID = &clientAppID
 	}
 
-	// Set property ‘EnableAzureRBAC’:
+	// Set property "EnableAzureRBAC":
 	if typedInput.EnableAzureRBAC != nil {
 		enableAzureRBAC := *typedInput.EnableAzureRBAC
 		profile.EnableAzureRBAC = &enableAzureRBAC
 	}
 
-	// Set property ‘Managed’:
+	// Set property "Managed":
 	if typedInput.Managed != nil {
 		managed := *typedInput.Managed
 		profile.Managed = &managed
 	}
 
-	// Set property ‘ServerAppID’:
+	// Set property "ServerAppID":
 	if typedInput.ServerAppID != nil {
 		serverAppID := *typedInput.ServerAppID
 		profile.ServerAppID = &serverAppID
 	}
 
-	// Set property ‘ServerAppSecret’:
+	// Set property "ServerAppSecret":
 	if typedInput.ServerAppSecret != nil {
 		serverAppSecret := *typedInput.ServerAppSecret
 		profile.ServerAppSecret = &serverAppSecret
 	}
 
-	// Set property ‘TenantID’:
+	// Set property "TenantID":
 	if typedInput.TenantID != nil {
 		tenantID := *typedInput.TenantID
 		profile.TenantID = &tenantID
@@ -5959,7 +5959,7 @@ func (profile *ManagedClusterAddonProfile) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ManagedClusterAddonProfile_ARM{}
 
-	// Set property ‘Config’:
+	// Set property "Config":
 	if profile.Config != nil {
 		result.Config = make(map[string]string, len(profile.Config))
 		for key, value := range profile.Config {
@@ -5967,7 +5967,7 @@ func (profile *ManagedClusterAddonProfile) ConvertToARM(resolved genruntime.Conv
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if profile.Enabled != nil {
 		enabled := *profile.Enabled
 		result.Enabled = &enabled
@@ -5987,7 +5987,7 @@ func (profile *ManagedClusterAddonProfile) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAddonProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Config’:
+	// Set property "Config":
 	if typedInput.Config != nil {
 		profile.Config = make(map[string]string, len(typedInput.Config))
 		for key, value := range typedInput.Config {
@@ -5995,7 +5995,7 @@ func (profile *ManagedClusterAddonProfile) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
@@ -6094,7 +6094,7 @@ func (profile *ManagedClusterAddonProfile_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAddonProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Config’:
+	// Set property "Config":
 	if typedInput.Config != nil {
 		profile.Config = make(map[string]string, len(typedInput.Config))
 		for key, value := range typedInput.Config {
@@ -6102,13 +6102,13 @@ func (profile *ManagedClusterAddonProfile_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 UserAssignedIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -6357,18 +6357,18 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 	}
 	result := &ManagedClusterAgentPoolProfile_ARM{}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	for _, item := range profile.AvailabilityZones {
 		result.AvailabilityZones = append(result.AvailabilityZones, item)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if profile.Count != nil {
 		count := *profile.Count
 		result.Count = &count
 	}
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	if profile.CreationData != nil {
 		creationData_ARM, err := (*profile.CreationData).ConvertToARM(resolved)
 		if err != nil {
@@ -6378,43 +6378,43 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.CreationData = &creationData
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	if profile.EnableAutoScaling != nil {
 		enableAutoScaling := *profile.EnableAutoScaling
 		result.EnableAutoScaling = &enableAutoScaling
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	if profile.EnableEncryptionAtHost != nil {
 		enableEncryptionAtHost := *profile.EnableEncryptionAtHost
 		result.EnableEncryptionAtHost = &enableEncryptionAtHost
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	if profile.EnableFIPS != nil {
 		enableFIPS := *profile.EnableFIPS
 		result.EnableFIPS = &enableFIPS
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	if profile.EnableNodePublicIP != nil {
 		enableNodePublicIP := *profile.EnableNodePublicIP
 		result.EnableNodePublicIP = &enableNodePublicIP
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	if profile.EnableUltraSSD != nil {
 		enableUltraSSD := *profile.EnableUltraSSD
 		result.EnableUltraSSD = &enableUltraSSD
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	if profile.GpuInstanceProfile != nil {
 		gpuInstanceProfile := *profile.GpuInstanceProfile
 		result.GpuInstanceProfile = &gpuInstanceProfile
 	}
 
-	// Set property ‘HostGroupID’:
+	// Set property "HostGroupID":
 	if profile.HostGroupReference != nil {
 		hostGroupReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.HostGroupReference)
 		if err != nil {
@@ -6424,7 +6424,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.HostGroupID = &hostGroupReference
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	if profile.KubeletConfig != nil {
 		kubeletConfig_ARM, err := (*profile.KubeletConfig).ConvertToARM(resolved)
 		if err != nil {
@@ -6434,13 +6434,13 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.KubeletConfig = &kubeletConfig
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	if profile.KubeletDiskType != nil {
 		kubeletDiskType := *profile.KubeletDiskType
 		result.KubeletDiskType = &kubeletDiskType
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	if profile.LinuxOSConfig != nil {
 		linuxOSConfig_ARM, err := (*profile.LinuxOSConfig).ConvertToARM(resolved)
 		if err != nil {
@@ -6450,37 +6450,37 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.LinuxOSConfig = &linuxOSConfig
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	if profile.MaxCount != nil {
 		maxCount := *profile.MaxCount
 		result.MaxCount = &maxCount
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	if profile.MaxPods != nil {
 		maxPods := *profile.MaxPods
 		result.MaxPods = &maxPods
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	if profile.MinCount != nil {
 		minCount := *profile.MinCount
 		result.MinCount = &minCount
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if profile.Mode != nil {
 		mode := *profile.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if profile.Name != nil {
 		name := *profile.Name
 		result.Name = &name
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	if profile.NodeLabels != nil {
 		result.NodeLabels = make(map[string]string, len(profile.NodeLabels))
 		for key, value := range profile.NodeLabels {
@@ -6488,7 +6488,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		}
 	}
 
-	// Set property ‘NodePublicIPPrefixID’:
+	// Set property "NodePublicIPPrefixID":
 	if profile.NodePublicIPPrefixReference != nil {
 		nodePublicIPPrefixReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.NodePublicIPPrefixReference)
 		if err != nil {
@@ -6498,42 +6498,42 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.NodePublicIPPrefixID = &nodePublicIPPrefixReference
 	}
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	for _, item := range profile.NodeTaints {
 		result.NodeTaints = append(result.NodeTaints, item)
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	if profile.OrchestratorVersion != nil {
 		orchestratorVersion := *profile.OrchestratorVersion
 		result.OrchestratorVersion = &orchestratorVersion
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	if profile.OsDiskSizeGB != nil {
 		osDiskSizeGB := *profile.OsDiskSizeGB
 		result.OsDiskSizeGB = &osDiskSizeGB
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	if profile.OsDiskType != nil {
 		osDiskType := *profile.OsDiskType
 		result.OsDiskType = &osDiskType
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	if profile.OsSKU != nil {
 		osSKU := *profile.OsSKU
 		result.OsSKU = &osSKU
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if profile.OsType != nil {
 		osType := *profile.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘PodSubnetID’:
+	// Set property "PodSubnetID":
 	if profile.PodSubnetReference != nil {
 		podSubnetReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.PodSubnetReference)
 		if err != nil {
@@ -6543,7 +6543,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.PodSubnetID = &podSubnetReference
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	if profile.PowerState != nil {
 		powerState_ARM, err := (*profile.PowerState).ConvertToARM(resolved)
 		if err != nil {
@@ -6553,7 +6553,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.PowerState = &powerState
 	}
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	if profile.ProximityPlacementGroupReference != nil {
 		proximityPlacementGroupReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.ProximityPlacementGroupReference)
 		if err != nil {
@@ -6563,31 +6563,31 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.ProximityPlacementGroupID = &proximityPlacementGroupReference
 	}
 
-	// Set property ‘ScaleDownMode’:
+	// Set property "ScaleDownMode":
 	if profile.ScaleDownMode != nil {
 		scaleDownMode := *profile.ScaleDownMode
 		result.ScaleDownMode = &scaleDownMode
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	if profile.ScaleSetEvictionPolicy != nil {
 		scaleSetEvictionPolicy := *profile.ScaleSetEvictionPolicy
 		result.ScaleSetEvictionPolicy = &scaleSetEvictionPolicy
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	if profile.ScaleSetPriority != nil {
 		scaleSetPriority := *profile.ScaleSetPriority
 		result.ScaleSetPriority = &scaleSetPriority
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	if profile.SpotMaxPrice != nil {
 		spotMaxPrice := *profile.SpotMaxPrice
 		result.SpotMaxPrice = &spotMaxPrice
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if profile.Tags != nil {
 		result.Tags = make(map[string]string, len(profile.Tags))
 		for key, value := range profile.Tags {
@@ -6595,13 +6595,13 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if profile.Type != nil {
 		typeVar := *profile.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	if profile.UpgradeSettings != nil {
 		upgradeSettings_ARM, err := (*profile.UpgradeSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -6611,13 +6611,13 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.UpgradeSettings = &upgradeSettings
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if profile.VmSize != nil {
 		vmSize := *profile.VmSize
 		result.VmSize = &vmSize
 	}
 
-	// Set property ‘VnetSubnetID’:
+	// Set property "VnetSubnetID":
 	if profile.VnetSubnetReference != nil {
 		vnetSubnetReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.VnetSubnetReference)
 		if err != nil {
@@ -6627,7 +6627,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.VnetSubnetID = &vnetSubnetReference
 	}
 
-	// Set property ‘WorkloadRuntime’:
+	// Set property "WorkloadRuntime":
 	if profile.WorkloadRuntime != nil {
 		workloadRuntime := *profile.WorkloadRuntime
 		result.WorkloadRuntime = &workloadRuntime
@@ -6647,18 +6647,18 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAgentPoolProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	for _, item := range typedInput.AvailabilityZones {
 		profile.AvailabilityZones = append(profile.AvailabilityZones, item)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		profile.Count = &count
 	}
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	if typedInput.CreationData != nil {
 		var creationData1 CreationData
 		err := creationData1.PopulateFromARM(owner, *typedInput.CreationData)
@@ -6669,45 +6669,45 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.CreationData = &creationData
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	if typedInput.EnableAutoScaling != nil {
 		enableAutoScaling := *typedInput.EnableAutoScaling
 		profile.EnableAutoScaling = &enableAutoScaling
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	if typedInput.EnableEncryptionAtHost != nil {
 		enableEncryptionAtHost := *typedInput.EnableEncryptionAtHost
 		profile.EnableEncryptionAtHost = &enableEncryptionAtHost
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	if typedInput.EnableFIPS != nil {
 		enableFIPS := *typedInput.EnableFIPS
 		profile.EnableFIPS = &enableFIPS
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	if typedInput.EnableNodePublicIP != nil {
 		enableNodePublicIP := *typedInput.EnableNodePublicIP
 		profile.EnableNodePublicIP = &enableNodePublicIP
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	if typedInput.EnableUltraSSD != nil {
 		enableUltraSSD := *typedInput.EnableUltraSSD
 		profile.EnableUltraSSD = &enableUltraSSD
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	if typedInput.GpuInstanceProfile != nil {
 		gpuInstanceProfile := *typedInput.GpuInstanceProfile
 		profile.GpuInstanceProfile = &gpuInstanceProfile
 	}
 
-	// no assignment for property ‘HostGroupReference’
+	// no assignment for property "HostGroupReference"
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	if typedInput.KubeletConfig != nil {
 		var kubeletConfig1 KubeletConfig
 		err := kubeletConfig1.PopulateFromARM(owner, *typedInput.KubeletConfig)
@@ -6718,13 +6718,13 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.KubeletConfig = &kubeletConfig
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	if typedInput.KubeletDiskType != nil {
 		kubeletDiskType := *typedInput.KubeletDiskType
 		profile.KubeletDiskType = &kubeletDiskType
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	if typedInput.LinuxOSConfig != nil {
 		var linuxOSConfig1 LinuxOSConfig
 		err := linuxOSConfig1.PopulateFromARM(owner, *typedInput.LinuxOSConfig)
@@ -6735,37 +6735,37 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.LinuxOSConfig = &linuxOSConfig
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	if typedInput.MaxCount != nil {
 		maxCount := *typedInput.MaxCount
 		profile.MaxCount = &maxCount
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	if typedInput.MaxPods != nil {
 		maxPods := *typedInput.MaxPods
 		profile.MaxPods = &maxPods
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	if typedInput.MinCount != nil {
 		minCount := *typedInput.MinCount
 		profile.MinCount = &minCount
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		profile.Mode = &mode
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	if typedInput.NodeLabels != nil {
 		profile.NodeLabels = make(map[string]string, len(typedInput.NodeLabels))
 		for key, value := range typedInput.NodeLabels {
@@ -6773,46 +6773,46 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// no assignment for property ‘NodePublicIPPrefixReference’
+	// no assignment for property "NodePublicIPPrefixReference"
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	for _, item := range typedInput.NodeTaints {
 		profile.NodeTaints = append(profile.NodeTaints, item)
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	if typedInput.OrchestratorVersion != nil {
 		orchestratorVersion := *typedInput.OrchestratorVersion
 		profile.OrchestratorVersion = &orchestratorVersion
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
 		osDiskSizeGB := *typedInput.OsDiskSizeGB
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	if typedInput.OsDiskType != nil {
 		osDiskType := *typedInput.OsDiskType
 		profile.OsDiskType = &osDiskType
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	if typedInput.OsSKU != nil {
 		osSKU := *typedInput.OsSKU
 		profile.OsSKU = &osSKU
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		profile.OsType = &osType
 	}
 
-	// no assignment for property ‘PodSubnetReference’
+	// no assignment for property "PodSubnetReference"
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	if typedInput.PowerState != nil {
 		var powerState1 PowerState
 		err := powerState1.PopulateFromARM(owner, *typedInput.PowerState)
@@ -6823,33 +6823,33 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.PowerState = &powerState
 	}
 
-	// no assignment for property ‘ProximityPlacementGroupReference’
+	// no assignment for property "ProximityPlacementGroupReference"
 
-	// Set property ‘ScaleDownMode’:
+	// Set property "ScaleDownMode":
 	if typedInput.ScaleDownMode != nil {
 		scaleDownMode := *typedInput.ScaleDownMode
 		profile.ScaleDownMode = &scaleDownMode
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	if typedInput.ScaleSetEvictionPolicy != nil {
 		scaleSetEvictionPolicy := *typedInput.ScaleSetEvictionPolicy
 		profile.ScaleSetEvictionPolicy = &scaleSetEvictionPolicy
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	if typedInput.ScaleSetPriority != nil {
 		scaleSetPriority := *typedInput.ScaleSetPriority
 		profile.ScaleSetPriority = &scaleSetPriority
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	if typedInput.SpotMaxPrice != nil {
 		spotMaxPrice := *typedInput.SpotMaxPrice
 		profile.SpotMaxPrice = &spotMaxPrice
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		profile.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -6857,13 +6857,13 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	if typedInput.UpgradeSettings != nil {
 		var upgradeSettings1 AgentPoolUpgradeSettings
 		err := upgradeSettings1.PopulateFromARM(owner, *typedInput.UpgradeSettings)
@@ -6874,15 +6874,15 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.UpgradeSettings = &upgradeSettings
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
 	}
 
-	// no assignment for property ‘VnetSubnetReference’
+	// no assignment for property "VnetSubnetReference"
 
-	// Set property ‘WorkloadRuntime’:
+	// Set property "WorkloadRuntime":
 	if typedInput.WorkloadRuntime != nil {
 		workloadRuntime := *typedInput.WorkloadRuntime
 		profile.WorkloadRuntime = &workloadRuntime
@@ -7907,18 +7907,18 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAgentPoolProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	for _, item := range typedInput.AvailabilityZones {
 		profile.AvailabilityZones = append(profile.AvailabilityZones, item)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		profile.Count = &count
 	}
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	if typedInput.CreationData != nil {
 		var creationData1 CreationData_STATUS
 		err := creationData1.PopulateFromARM(owner, *typedInput.CreationData)
@@ -7929,55 +7929,55 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.CreationData = &creationData
 	}
 
-	// Set property ‘CurrentOrchestratorVersion’:
+	// Set property "CurrentOrchestratorVersion":
 	if typedInput.CurrentOrchestratorVersion != nil {
 		currentOrchestratorVersion := *typedInput.CurrentOrchestratorVersion
 		profile.CurrentOrchestratorVersion = &currentOrchestratorVersion
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	if typedInput.EnableAutoScaling != nil {
 		enableAutoScaling := *typedInput.EnableAutoScaling
 		profile.EnableAutoScaling = &enableAutoScaling
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	if typedInput.EnableEncryptionAtHost != nil {
 		enableEncryptionAtHost := *typedInput.EnableEncryptionAtHost
 		profile.EnableEncryptionAtHost = &enableEncryptionAtHost
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	if typedInput.EnableFIPS != nil {
 		enableFIPS := *typedInput.EnableFIPS
 		profile.EnableFIPS = &enableFIPS
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	if typedInput.EnableNodePublicIP != nil {
 		enableNodePublicIP := *typedInput.EnableNodePublicIP
 		profile.EnableNodePublicIP = &enableNodePublicIP
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	if typedInput.EnableUltraSSD != nil {
 		enableUltraSSD := *typedInput.EnableUltraSSD
 		profile.EnableUltraSSD = &enableUltraSSD
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	if typedInput.GpuInstanceProfile != nil {
 		gpuInstanceProfile := *typedInput.GpuInstanceProfile
 		profile.GpuInstanceProfile = &gpuInstanceProfile
 	}
 
-	// Set property ‘HostGroupID’:
+	// Set property "HostGroupID":
 	if typedInput.HostGroupID != nil {
 		hostGroupID := *typedInput.HostGroupID
 		profile.HostGroupID = &hostGroupID
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	if typedInput.KubeletConfig != nil {
 		var kubeletConfig1 KubeletConfig_STATUS
 		err := kubeletConfig1.PopulateFromARM(owner, *typedInput.KubeletConfig)
@@ -7988,13 +7988,13 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.KubeletConfig = &kubeletConfig
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	if typedInput.KubeletDiskType != nil {
 		kubeletDiskType := *typedInput.KubeletDiskType
 		profile.KubeletDiskType = &kubeletDiskType
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	if typedInput.LinuxOSConfig != nil {
 		var linuxOSConfig1 LinuxOSConfig_STATUS
 		err := linuxOSConfig1.PopulateFromARM(owner, *typedInput.LinuxOSConfig)
@@ -8005,43 +8005,43 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.LinuxOSConfig = &linuxOSConfig
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	if typedInput.MaxCount != nil {
 		maxCount := *typedInput.MaxCount
 		profile.MaxCount = &maxCount
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	if typedInput.MaxPods != nil {
 		maxPods := *typedInput.MaxPods
 		profile.MaxPods = &maxPods
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	if typedInput.MinCount != nil {
 		minCount := *typedInput.MinCount
 		profile.MinCount = &minCount
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		profile.Mode = &mode
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘NodeImageVersion’:
+	// Set property "NodeImageVersion":
 	if typedInput.NodeImageVersion != nil {
 		nodeImageVersion := *typedInput.NodeImageVersion
 		profile.NodeImageVersion = &nodeImageVersion
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	if typedInput.NodeLabels != nil {
 		profile.NodeLabels = make(map[string]string, len(typedInput.NodeLabels))
 		for key, value := range typedInput.NodeLabels {
@@ -8049,54 +8049,54 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘NodePublicIPPrefixID’:
+	// Set property "NodePublicIPPrefixID":
 	if typedInput.NodePublicIPPrefixID != nil {
 		nodePublicIPPrefixID := *typedInput.NodePublicIPPrefixID
 		profile.NodePublicIPPrefixID = &nodePublicIPPrefixID
 	}
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	for _, item := range typedInput.NodeTaints {
 		profile.NodeTaints = append(profile.NodeTaints, item)
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	if typedInput.OrchestratorVersion != nil {
 		orchestratorVersion := *typedInput.OrchestratorVersion
 		profile.OrchestratorVersion = &orchestratorVersion
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
 		osDiskSizeGB := *typedInput.OsDiskSizeGB
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	if typedInput.OsDiskType != nil {
 		osDiskType := *typedInput.OsDiskType
 		profile.OsDiskType = &osDiskType
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	if typedInput.OsSKU != nil {
 		osSKU := *typedInput.OsSKU
 		profile.OsSKU = &osSKU
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		profile.OsType = &osType
 	}
 
-	// Set property ‘PodSubnetID’:
+	// Set property "PodSubnetID":
 	if typedInput.PodSubnetID != nil {
 		podSubnetID := *typedInput.PodSubnetID
 		profile.PodSubnetID = &podSubnetID
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	if typedInput.PowerState != nil {
 		var powerState1 PowerState_STATUS
 		err := powerState1.PopulateFromARM(owner, *typedInput.PowerState)
@@ -8107,43 +8107,43 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.PowerState = &powerState
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		profile.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	if typedInput.ProximityPlacementGroupID != nil {
 		proximityPlacementGroupID := *typedInput.ProximityPlacementGroupID
 		profile.ProximityPlacementGroupID = &proximityPlacementGroupID
 	}
 
-	// Set property ‘ScaleDownMode’:
+	// Set property "ScaleDownMode":
 	if typedInput.ScaleDownMode != nil {
 		scaleDownMode := *typedInput.ScaleDownMode
 		profile.ScaleDownMode = &scaleDownMode
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	if typedInput.ScaleSetEvictionPolicy != nil {
 		scaleSetEvictionPolicy := *typedInput.ScaleSetEvictionPolicy
 		profile.ScaleSetEvictionPolicy = &scaleSetEvictionPolicy
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	if typedInput.ScaleSetPriority != nil {
 		scaleSetPriority := *typedInput.ScaleSetPriority
 		profile.ScaleSetPriority = &scaleSetPriority
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	if typedInput.SpotMaxPrice != nil {
 		spotMaxPrice := *typedInput.SpotMaxPrice
 		profile.SpotMaxPrice = &spotMaxPrice
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		profile.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -8151,13 +8151,13 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	if typedInput.UpgradeSettings != nil {
 		var upgradeSettings1 AgentPoolUpgradeSettings_STATUS
 		err := upgradeSettings1.PopulateFromARM(owner, *typedInput.UpgradeSettings)
@@ -8168,19 +8168,19 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.UpgradeSettings = &upgradeSettings
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
 	}
 
-	// Set property ‘VnetSubnetID’:
+	// Set property "VnetSubnetID":
 	if typedInput.VnetSubnetID != nil {
 		vnetSubnetID := *typedInput.VnetSubnetID
 		profile.VnetSubnetID = &vnetSubnetID
 	}
 
-	// Set property ‘WorkloadRuntime’:
+	// Set property "WorkloadRuntime":
 	if typedInput.WorkloadRuntime != nil {
 		workloadRuntime := *typedInput.WorkloadRuntime
 		profile.WorkloadRuntime = &workloadRuntime
@@ -8757,30 +8757,30 @@ func (profile *ManagedClusterAPIServerAccessProfile) ConvertToARM(resolved genru
 	}
 	result := &ManagedClusterAPIServerAccessProfile_ARM{}
 
-	// Set property ‘AuthorizedIPRanges’:
+	// Set property "AuthorizedIPRanges":
 	for _, item := range profile.AuthorizedIPRanges {
 		result.AuthorizedIPRanges = append(result.AuthorizedIPRanges, item)
 	}
 
-	// Set property ‘DisableRunCommand’:
+	// Set property "DisableRunCommand":
 	if profile.DisableRunCommand != nil {
 		disableRunCommand := *profile.DisableRunCommand
 		result.DisableRunCommand = &disableRunCommand
 	}
 
-	// Set property ‘EnablePrivateCluster’:
+	// Set property "EnablePrivateCluster":
 	if profile.EnablePrivateCluster != nil {
 		enablePrivateCluster := *profile.EnablePrivateCluster
 		result.EnablePrivateCluster = &enablePrivateCluster
 	}
 
-	// Set property ‘EnablePrivateClusterPublicFQDN’:
+	// Set property "EnablePrivateClusterPublicFQDN":
 	if profile.EnablePrivateClusterPublicFQDN != nil {
 		enablePrivateClusterPublicFQDN := *profile.EnablePrivateClusterPublicFQDN
 		result.EnablePrivateClusterPublicFQDN = &enablePrivateClusterPublicFQDN
 	}
 
-	// Set property ‘PrivateDNSZone’:
+	// Set property "PrivateDNSZone":
 	if profile.PrivateDNSZone != nil {
 		privateDNSZone := *profile.PrivateDNSZone
 		result.PrivateDNSZone = &privateDNSZone
@@ -8800,30 +8800,30 @@ func (profile *ManagedClusterAPIServerAccessProfile) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAPIServerAccessProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthorizedIPRanges’:
+	// Set property "AuthorizedIPRanges":
 	for _, item := range typedInput.AuthorizedIPRanges {
 		profile.AuthorizedIPRanges = append(profile.AuthorizedIPRanges, item)
 	}
 
-	// Set property ‘DisableRunCommand’:
+	// Set property "DisableRunCommand":
 	if typedInput.DisableRunCommand != nil {
 		disableRunCommand := *typedInput.DisableRunCommand
 		profile.DisableRunCommand = &disableRunCommand
 	}
 
-	// Set property ‘EnablePrivateCluster’:
+	// Set property "EnablePrivateCluster":
 	if typedInput.EnablePrivateCluster != nil {
 		enablePrivateCluster := *typedInput.EnablePrivateCluster
 		profile.EnablePrivateCluster = &enablePrivateCluster
 	}
 
-	// Set property ‘EnablePrivateClusterPublicFQDN’:
+	// Set property "EnablePrivateClusterPublicFQDN":
 	if typedInput.EnablePrivateClusterPublicFQDN != nil {
 		enablePrivateClusterPublicFQDN := *typedInput.EnablePrivateClusterPublicFQDN
 		profile.EnablePrivateClusterPublicFQDN = &enablePrivateClusterPublicFQDN
 	}
 
-	// Set property ‘PrivateDNSZone’:
+	// Set property "PrivateDNSZone":
 	if typedInput.PrivateDNSZone != nil {
 		privateDNSZone := *typedInput.PrivateDNSZone
 		profile.PrivateDNSZone = &privateDNSZone
@@ -8990,30 +8990,30 @@ func (profile *ManagedClusterAPIServerAccessProfile_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAPIServerAccessProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthorizedIPRanges’:
+	// Set property "AuthorizedIPRanges":
 	for _, item := range typedInput.AuthorizedIPRanges {
 		profile.AuthorizedIPRanges = append(profile.AuthorizedIPRanges, item)
 	}
 
-	// Set property ‘DisableRunCommand’:
+	// Set property "DisableRunCommand":
 	if typedInput.DisableRunCommand != nil {
 		disableRunCommand := *typedInput.DisableRunCommand
 		profile.DisableRunCommand = &disableRunCommand
 	}
 
-	// Set property ‘EnablePrivateCluster’:
+	// Set property "EnablePrivateCluster":
 	if typedInput.EnablePrivateCluster != nil {
 		enablePrivateCluster := *typedInput.EnablePrivateCluster
 		profile.EnablePrivateCluster = &enablePrivateCluster
 	}
 
-	// Set property ‘EnablePrivateClusterPublicFQDN’:
+	// Set property "EnablePrivateClusterPublicFQDN":
 	if typedInput.EnablePrivateClusterPublicFQDN != nil {
 		enablePrivateClusterPublicFQDN := *typedInput.EnablePrivateClusterPublicFQDN
 		profile.EnablePrivateClusterPublicFQDN = &enablePrivateClusterPublicFQDN
 	}
 
-	// Set property ‘PrivateDNSZone’:
+	// Set property "PrivateDNSZone":
 	if typedInput.PrivateDNSZone != nil {
 		privateDNSZone := *typedInput.PrivateDNSZone
 		profile.PrivateDNSZone = &privateDNSZone
@@ -9122,7 +9122,7 @@ func (profile *ManagedClusterAutoUpgradeProfile) ConvertToARM(resolved genruntim
 	}
 	result := &ManagedClusterAutoUpgradeProfile_ARM{}
 
-	// Set property ‘UpgradeChannel’:
+	// Set property "UpgradeChannel":
 	if profile.UpgradeChannel != nil {
 		upgradeChannel := *profile.UpgradeChannel
 		result.UpgradeChannel = &upgradeChannel
@@ -9142,7 +9142,7 @@ func (profile *ManagedClusterAutoUpgradeProfile) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAutoUpgradeProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UpgradeChannel’:
+	// Set property "UpgradeChannel":
 	if typedInput.UpgradeChannel != nil {
 		upgradeChannel := *typedInput.UpgradeChannel
 		profile.UpgradeChannel = &upgradeChannel
@@ -9227,7 +9227,7 @@ func (profile *ManagedClusterAutoUpgradeProfile_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAutoUpgradeProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UpgradeChannel’:
+	// Set property "UpgradeChannel":
 	if typedInput.UpgradeChannel != nil {
 		upgradeChannel := *typedInput.UpgradeChannel
 		profile.UpgradeChannel = &upgradeChannel
@@ -9293,7 +9293,7 @@ func (profile *ManagedClusterAzureMonitorProfile) ConvertToARM(resolved genrunti
 	}
 	result := &ManagedClusterAzureMonitorProfile_ARM{}
 
-	// Set property ‘Metrics’:
+	// Set property "Metrics":
 	if profile.Metrics != nil {
 		metrics_ARM, err := (*profile.Metrics).ConvertToARM(resolved)
 		if err != nil {
@@ -9317,7 +9317,7 @@ func (profile *ManagedClusterAzureMonitorProfile) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAzureMonitorProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Metrics’:
+	// Set property "Metrics":
 	if typedInput.Metrics != nil {
 		var metrics1 ManagedClusterAzureMonitorProfileMetrics
 		err := metrics1.PopulateFromARM(owner, *typedInput.Metrics)
@@ -9420,7 +9420,7 @@ func (profile *ManagedClusterAzureMonitorProfile_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAzureMonitorProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Metrics’:
+	// Set property "Metrics":
 	if typedInput.Metrics != nil {
 		var metrics1 ManagedClusterAzureMonitorProfileMetrics_STATUS
 		err := metrics1.PopulateFromARM(owner, *typedInput.Metrics)
@@ -9506,24 +9506,24 @@ func (config *ManagedClusterHTTPProxyConfig) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ManagedClusterHTTPProxyConfig_ARM{}
 
-	// Set property ‘HttpProxy’:
+	// Set property "HttpProxy":
 	if config.HttpProxy != nil {
 		httpProxy := *config.HttpProxy
 		result.HttpProxy = &httpProxy
 	}
 
-	// Set property ‘HttpsProxy’:
+	// Set property "HttpsProxy":
 	if config.HttpsProxy != nil {
 		httpsProxy := *config.HttpsProxy
 		result.HttpsProxy = &httpsProxy
 	}
 
-	// Set property ‘NoProxy’:
+	// Set property "NoProxy":
 	for _, item := range config.NoProxy {
 		result.NoProxy = append(result.NoProxy, item)
 	}
 
-	// Set property ‘TrustedCa’:
+	// Set property "TrustedCa":
 	if config.TrustedCa != nil {
 		trustedCa := *config.TrustedCa
 		result.TrustedCa = &trustedCa
@@ -9543,24 +9543,24 @@ func (config *ManagedClusterHTTPProxyConfig) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterHTTPProxyConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpProxy’:
+	// Set property "HttpProxy":
 	if typedInput.HttpProxy != nil {
 		httpProxy := *typedInput.HttpProxy
 		config.HttpProxy = &httpProxy
 	}
 
-	// Set property ‘HttpsProxy’:
+	// Set property "HttpsProxy":
 	if typedInput.HttpsProxy != nil {
 		httpsProxy := *typedInput.HttpsProxy
 		config.HttpsProxy = &httpsProxy
 	}
 
-	// Set property ‘NoProxy’:
+	// Set property "NoProxy":
 	for _, item := range typedInput.NoProxy {
 		config.NoProxy = append(config.NoProxy, item)
 	}
 
-	// Set property ‘TrustedCa’:
+	// Set property "TrustedCa":
 	if typedInput.TrustedCa != nil {
 		trustedCa := *typedInput.TrustedCa
 		config.TrustedCa = &trustedCa
@@ -9665,24 +9665,24 @@ func (config *ManagedClusterHTTPProxyConfig_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterHTTPProxyConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpProxy’:
+	// Set property "HttpProxy":
 	if typedInput.HttpProxy != nil {
 		httpProxy := *typedInput.HttpProxy
 		config.HttpProxy = &httpProxy
 	}
 
-	// Set property ‘HttpsProxy’:
+	// Set property "HttpsProxy":
 	if typedInput.HttpsProxy != nil {
 		httpsProxy := *typedInput.HttpsProxy
 		config.HttpsProxy = &httpsProxy
 	}
 
-	// Set property ‘NoProxy’:
+	// Set property "NoProxy":
 	for _, item := range typedInput.NoProxy {
 		config.NoProxy = append(config.NoProxy, item)
 	}
 
-	// Set property ‘TrustedCa’:
+	// Set property "TrustedCa":
 	if typedInput.TrustedCa != nil {
 		trustedCa := *typedInput.TrustedCa
 		config.TrustedCa = &trustedCa
@@ -9759,13 +9759,13 @@ func (identity *ManagedClusterIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ManagedClusterIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -9790,13 +9790,13 @@ func (identity *ManagedClusterIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -9935,25 +9935,25 @@ func (identity *ManagedClusterIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]ManagedClusterIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -10072,7 +10072,7 @@ func (profile *ManagedClusterOIDCIssuerProfile) ConvertToARM(resolved genruntime
 	}
 	result := &ManagedClusterOIDCIssuerProfile_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if profile.Enabled != nil {
 		enabled := *profile.Enabled
 		result.Enabled = &enabled
@@ -10092,7 +10092,7 @@ func (profile *ManagedClusterOIDCIssuerProfile) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterOIDCIssuerProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
@@ -10179,13 +10179,13 @@ func (profile *ManagedClusterOIDCIssuerProfile_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterOIDCIssuerProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘IssuerURL’:
+	// Set property "IssuerURL":
 	if typedInput.IssuerURL != nil {
 		issuerURL := *typedInput.IssuerURL
 		profile.IssuerURL = &issuerURL
@@ -10348,19 +10348,19 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 	}
 	result := &ManagedClusterPodIdentityProfile_ARM{}
 
-	// Set property ‘AllowNetworkPluginKubenet’:
+	// Set property "AllowNetworkPluginKubenet":
 	if profile.AllowNetworkPluginKubenet != nil {
 		allowNetworkPluginKubenet := *profile.AllowNetworkPluginKubenet
 		result.AllowNetworkPluginKubenet = &allowNetworkPluginKubenet
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if profile.Enabled != nil {
 		enabled := *profile.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	for _, item := range profile.UserAssignedIdentities {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -10369,7 +10369,7 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 		result.UserAssignedIdentities = append(result.UserAssignedIdentities, *item_ARM.(*ManagedClusterPodIdentity_ARM))
 	}
 
-	// Set property ‘UserAssignedIdentityExceptions’:
+	// Set property "UserAssignedIdentityExceptions":
 	for _, item := range profile.UserAssignedIdentityExceptions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -10392,19 +10392,19 @@ func (profile *ManagedClusterPodIdentityProfile) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowNetworkPluginKubenet’:
+	// Set property "AllowNetworkPluginKubenet":
 	if typedInput.AllowNetworkPluginKubenet != nil {
 		allowNetworkPluginKubenet := *typedInput.AllowNetworkPluginKubenet
 		profile.AllowNetworkPluginKubenet = &allowNetworkPluginKubenet
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	for _, item := range typedInput.UserAssignedIdentities {
 		var item1 ManagedClusterPodIdentity
 		err := item1.PopulateFromARM(owner, item)
@@ -10414,7 +10414,7 @@ func (profile *ManagedClusterPodIdentityProfile) PopulateFromARM(owner genruntim
 		profile.UserAssignedIdentities = append(profile.UserAssignedIdentities, item1)
 	}
 
-	// Set property ‘UserAssignedIdentityExceptions’:
+	// Set property "UserAssignedIdentityExceptions":
 	for _, item := range typedInput.UserAssignedIdentityExceptions {
 		var item1 ManagedClusterPodIdentityException
 		err := item1.PopulateFromARM(owner, item)
@@ -10647,19 +10647,19 @@ func (profile *ManagedClusterPodIdentityProfile_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowNetworkPluginKubenet’:
+	// Set property "AllowNetworkPluginKubenet":
 	if typedInput.AllowNetworkPluginKubenet != nil {
 		allowNetworkPluginKubenet := *typedInput.AllowNetworkPluginKubenet
 		profile.AllowNetworkPluginKubenet = &allowNetworkPluginKubenet
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	for _, item := range typedInput.UserAssignedIdentities {
 		var item1 ManagedClusterPodIdentity_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10669,7 +10669,7 @@ func (profile *ManagedClusterPodIdentityProfile_STATUS) PopulateFromARM(owner ge
 		profile.UserAssignedIdentities = append(profile.UserAssignedIdentities, item1)
 	}
 
-	// Set property ‘UserAssignedIdentityExceptions’:
+	// Set property "UserAssignedIdentityExceptions":
 	for _, item := range typedInput.UserAssignedIdentityExceptions {
 		var item1 ManagedClusterPodIdentityException_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10882,103 +10882,103 @@ func (profile *ManagedClusterProperties_AutoScalerProfile) ConvertToARM(resolved
 	}
 	result := &ManagedClusterProperties_AutoScalerProfile_ARM{}
 
-	// Set property ‘BalanceSimilarNodeGroups’:
+	// Set property "BalanceSimilarNodeGroups":
 	if profile.BalanceSimilarNodeGroups != nil {
 		balanceSimilarNodeGroups := *profile.BalanceSimilarNodeGroups
 		result.BalanceSimilarNodeGroups = &balanceSimilarNodeGroups
 	}
 
-	// Set property ‘Expander’:
+	// Set property "Expander":
 	if profile.Expander != nil {
 		expander := *profile.Expander
 		result.Expander = &expander
 	}
 
-	// Set property ‘MaxEmptyBulkDelete’:
+	// Set property "MaxEmptyBulkDelete":
 	if profile.MaxEmptyBulkDelete != nil {
 		maxEmptyBulkDelete := *profile.MaxEmptyBulkDelete
 		result.MaxEmptyBulkDelete = &maxEmptyBulkDelete
 	}
 
-	// Set property ‘MaxGracefulTerminationSec’:
+	// Set property "MaxGracefulTerminationSec":
 	if profile.MaxGracefulTerminationSec != nil {
 		maxGracefulTerminationSec := *profile.MaxGracefulTerminationSec
 		result.MaxGracefulTerminationSec = &maxGracefulTerminationSec
 	}
 
-	// Set property ‘MaxNodeProvisionTime’:
+	// Set property "MaxNodeProvisionTime":
 	if profile.MaxNodeProvisionTime != nil {
 		maxNodeProvisionTime := *profile.MaxNodeProvisionTime
 		result.MaxNodeProvisionTime = &maxNodeProvisionTime
 	}
 
-	// Set property ‘MaxTotalUnreadyPercentage’:
+	// Set property "MaxTotalUnreadyPercentage":
 	if profile.MaxTotalUnreadyPercentage != nil {
 		maxTotalUnreadyPercentage := *profile.MaxTotalUnreadyPercentage
 		result.MaxTotalUnreadyPercentage = &maxTotalUnreadyPercentage
 	}
 
-	// Set property ‘NewPodScaleUpDelay’:
+	// Set property "NewPodScaleUpDelay":
 	if profile.NewPodScaleUpDelay != nil {
 		newPodScaleUpDelay := *profile.NewPodScaleUpDelay
 		result.NewPodScaleUpDelay = &newPodScaleUpDelay
 	}
 
-	// Set property ‘OkTotalUnreadyCount’:
+	// Set property "OkTotalUnreadyCount":
 	if profile.OkTotalUnreadyCount != nil {
 		okTotalUnreadyCount := *profile.OkTotalUnreadyCount
 		result.OkTotalUnreadyCount = &okTotalUnreadyCount
 	}
 
-	// Set property ‘ScaleDownDelayAfterAdd’:
+	// Set property "ScaleDownDelayAfterAdd":
 	if profile.ScaleDownDelayAfterAdd != nil {
 		scaleDownDelayAfterAdd := *profile.ScaleDownDelayAfterAdd
 		result.ScaleDownDelayAfterAdd = &scaleDownDelayAfterAdd
 	}
 
-	// Set property ‘ScaleDownDelayAfterDelete’:
+	// Set property "ScaleDownDelayAfterDelete":
 	if profile.ScaleDownDelayAfterDelete != nil {
 		scaleDownDelayAfterDelete := *profile.ScaleDownDelayAfterDelete
 		result.ScaleDownDelayAfterDelete = &scaleDownDelayAfterDelete
 	}
 
-	// Set property ‘ScaleDownDelayAfterFailure’:
+	// Set property "ScaleDownDelayAfterFailure":
 	if profile.ScaleDownDelayAfterFailure != nil {
 		scaleDownDelayAfterFailure := *profile.ScaleDownDelayAfterFailure
 		result.ScaleDownDelayAfterFailure = &scaleDownDelayAfterFailure
 	}
 
-	// Set property ‘ScaleDownUnneededTime’:
+	// Set property "ScaleDownUnneededTime":
 	if profile.ScaleDownUnneededTime != nil {
 		scaleDownUnneededTime := *profile.ScaleDownUnneededTime
 		result.ScaleDownUnneededTime = &scaleDownUnneededTime
 	}
 
-	// Set property ‘ScaleDownUnreadyTime’:
+	// Set property "ScaleDownUnreadyTime":
 	if profile.ScaleDownUnreadyTime != nil {
 		scaleDownUnreadyTime := *profile.ScaleDownUnreadyTime
 		result.ScaleDownUnreadyTime = &scaleDownUnreadyTime
 	}
 
-	// Set property ‘ScaleDownUtilizationThreshold’:
+	// Set property "ScaleDownUtilizationThreshold":
 	if profile.ScaleDownUtilizationThreshold != nil {
 		scaleDownUtilizationThreshold := *profile.ScaleDownUtilizationThreshold
 		result.ScaleDownUtilizationThreshold = &scaleDownUtilizationThreshold
 	}
 
-	// Set property ‘ScanInterval’:
+	// Set property "ScanInterval":
 	if profile.ScanInterval != nil {
 		scanInterval := *profile.ScanInterval
 		result.ScanInterval = &scanInterval
 	}
 
-	// Set property ‘SkipNodesWithLocalStorage’:
+	// Set property "SkipNodesWithLocalStorage":
 	if profile.SkipNodesWithLocalStorage != nil {
 		skipNodesWithLocalStorage := *profile.SkipNodesWithLocalStorage
 		result.SkipNodesWithLocalStorage = &skipNodesWithLocalStorage
 	}
 
-	// Set property ‘SkipNodesWithSystemPods’:
+	// Set property "SkipNodesWithSystemPods":
 	if profile.SkipNodesWithSystemPods != nil {
 		skipNodesWithSystemPods := *profile.SkipNodesWithSystemPods
 		result.SkipNodesWithSystemPods = &skipNodesWithSystemPods
@@ -10998,103 +10998,103 @@ func (profile *ManagedClusterProperties_AutoScalerProfile) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterProperties_AutoScalerProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BalanceSimilarNodeGroups’:
+	// Set property "BalanceSimilarNodeGroups":
 	if typedInput.BalanceSimilarNodeGroups != nil {
 		balanceSimilarNodeGroups := *typedInput.BalanceSimilarNodeGroups
 		profile.BalanceSimilarNodeGroups = &balanceSimilarNodeGroups
 	}
 
-	// Set property ‘Expander’:
+	// Set property "Expander":
 	if typedInput.Expander != nil {
 		expander := *typedInput.Expander
 		profile.Expander = &expander
 	}
 
-	// Set property ‘MaxEmptyBulkDelete’:
+	// Set property "MaxEmptyBulkDelete":
 	if typedInput.MaxEmptyBulkDelete != nil {
 		maxEmptyBulkDelete := *typedInput.MaxEmptyBulkDelete
 		profile.MaxEmptyBulkDelete = &maxEmptyBulkDelete
 	}
 
-	// Set property ‘MaxGracefulTerminationSec’:
+	// Set property "MaxGracefulTerminationSec":
 	if typedInput.MaxGracefulTerminationSec != nil {
 		maxGracefulTerminationSec := *typedInput.MaxGracefulTerminationSec
 		profile.MaxGracefulTerminationSec = &maxGracefulTerminationSec
 	}
 
-	// Set property ‘MaxNodeProvisionTime’:
+	// Set property "MaxNodeProvisionTime":
 	if typedInput.MaxNodeProvisionTime != nil {
 		maxNodeProvisionTime := *typedInput.MaxNodeProvisionTime
 		profile.MaxNodeProvisionTime = &maxNodeProvisionTime
 	}
 
-	// Set property ‘MaxTotalUnreadyPercentage’:
+	// Set property "MaxTotalUnreadyPercentage":
 	if typedInput.MaxTotalUnreadyPercentage != nil {
 		maxTotalUnreadyPercentage := *typedInput.MaxTotalUnreadyPercentage
 		profile.MaxTotalUnreadyPercentage = &maxTotalUnreadyPercentage
 	}
 
-	// Set property ‘NewPodScaleUpDelay’:
+	// Set property "NewPodScaleUpDelay":
 	if typedInput.NewPodScaleUpDelay != nil {
 		newPodScaleUpDelay := *typedInput.NewPodScaleUpDelay
 		profile.NewPodScaleUpDelay = &newPodScaleUpDelay
 	}
 
-	// Set property ‘OkTotalUnreadyCount’:
+	// Set property "OkTotalUnreadyCount":
 	if typedInput.OkTotalUnreadyCount != nil {
 		okTotalUnreadyCount := *typedInput.OkTotalUnreadyCount
 		profile.OkTotalUnreadyCount = &okTotalUnreadyCount
 	}
 
-	// Set property ‘ScaleDownDelayAfterAdd’:
+	// Set property "ScaleDownDelayAfterAdd":
 	if typedInput.ScaleDownDelayAfterAdd != nil {
 		scaleDownDelayAfterAdd := *typedInput.ScaleDownDelayAfterAdd
 		profile.ScaleDownDelayAfterAdd = &scaleDownDelayAfterAdd
 	}
 
-	// Set property ‘ScaleDownDelayAfterDelete’:
+	// Set property "ScaleDownDelayAfterDelete":
 	if typedInput.ScaleDownDelayAfterDelete != nil {
 		scaleDownDelayAfterDelete := *typedInput.ScaleDownDelayAfterDelete
 		profile.ScaleDownDelayAfterDelete = &scaleDownDelayAfterDelete
 	}
 
-	// Set property ‘ScaleDownDelayAfterFailure’:
+	// Set property "ScaleDownDelayAfterFailure":
 	if typedInput.ScaleDownDelayAfterFailure != nil {
 		scaleDownDelayAfterFailure := *typedInput.ScaleDownDelayAfterFailure
 		profile.ScaleDownDelayAfterFailure = &scaleDownDelayAfterFailure
 	}
 
-	// Set property ‘ScaleDownUnneededTime’:
+	// Set property "ScaleDownUnneededTime":
 	if typedInput.ScaleDownUnneededTime != nil {
 		scaleDownUnneededTime := *typedInput.ScaleDownUnneededTime
 		profile.ScaleDownUnneededTime = &scaleDownUnneededTime
 	}
 
-	// Set property ‘ScaleDownUnreadyTime’:
+	// Set property "ScaleDownUnreadyTime":
 	if typedInput.ScaleDownUnreadyTime != nil {
 		scaleDownUnreadyTime := *typedInput.ScaleDownUnreadyTime
 		profile.ScaleDownUnreadyTime = &scaleDownUnreadyTime
 	}
 
-	// Set property ‘ScaleDownUtilizationThreshold’:
+	// Set property "ScaleDownUtilizationThreshold":
 	if typedInput.ScaleDownUtilizationThreshold != nil {
 		scaleDownUtilizationThreshold := *typedInput.ScaleDownUtilizationThreshold
 		profile.ScaleDownUtilizationThreshold = &scaleDownUtilizationThreshold
 	}
 
-	// Set property ‘ScanInterval’:
+	// Set property "ScanInterval":
 	if typedInput.ScanInterval != nil {
 		scanInterval := *typedInput.ScanInterval
 		profile.ScanInterval = &scanInterval
 	}
 
-	// Set property ‘SkipNodesWithLocalStorage’:
+	// Set property "SkipNodesWithLocalStorage":
 	if typedInput.SkipNodesWithLocalStorage != nil {
 		skipNodesWithLocalStorage := *typedInput.SkipNodesWithLocalStorage
 		profile.SkipNodesWithLocalStorage = &skipNodesWithLocalStorage
 	}
 
-	// Set property ‘SkipNodesWithSystemPods’:
+	// Set property "SkipNodesWithSystemPods":
 	if typedInput.SkipNodesWithSystemPods != nil {
 		skipNodesWithSystemPods := *typedInput.SkipNodesWithSystemPods
 		profile.SkipNodesWithSystemPods = &skipNodesWithSystemPods
@@ -11379,103 +11379,103 @@ func (profile *ManagedClusterProperties_AutoScalerProfile_STATUS) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterProperties_AutoScalerProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BalanceSimilarNodeGroups’:
+	// Set property "BalanceSimilarNodeGroups":
 	if typedInput.BalanceSimilarNodeGroups != nil {
 		balanceSimilarNodeGroups := *typedInput.BalanceSimilarNodeGroups
 		profile.BalanceSimilarNodeGroups = &balanceSimilarNodeGroups
 	}
 
-	// Set property ‘Expander’:
+	// Set property "Expander":
 	if typedInput.Expander != nil {
 		expander := *typedInput.Expander
 		profile.Expander = &expander
 	}
 
-	// Set property ‘MaxEmptyBulkDelete’:
+	// Set property "MaxEmptyBulkDelete":
 	if typedInput.MaxEmptyBulkDelete != nil {
 		maxEmptyBulkDelete := *typedInput.MaxEmptyBulkDelete
 		profile.MaxEmptyBulkDelete = &maxEmptyBulkDelete
 	}
 
-	// Set property ‘MaxGracefulTerminationSec’:
+	// Set property "MaxGracefulTerminationSec":
 	if typedInput.MaxGracefulTerminationSec != nil {
 		maxGracefulTerminationSec := *typedInput.MaxGracefulTerminationSec
 		profile.MaxGracefulTerminationSec = &maxGracefulTerminationSec
 	}
 
-	// Set property ‘MaxNodeProvisionTime’:
+	// Set property "MaxNodeProvisionTime":
 	if typedInput.MaxNodeProvisionTime != nil {
 		maxNodeProvisionTime := *typedInput.MaxNodeProvisionTime
 		profile.MaxNodeProvisionTime = &maxNodeProvisionTime
 	}
 
-	// Set property ‘MaxTotalUnreadyPercentage’:
+	// Set property "MaxTotalUnreadyPercentage":
 	if typedInput.MaxTotalUnreadyPercentage != nil {
 		maxTotalUnreadyPercentage := *typedInput.MaxTotalUnreadyPercentage
 		profile.MaxTotalUnreadyPercentage = &maxTotalUnreadyPercentage
 	}
 
-	// Set property ‘NewPodScaleUpDelay’:
+	// Set property "NewPodScaleUpDelay":
 	if typedInput.NewPodScaleUpDelay != nil {
 		newPodScaleUpDelay := *typedInput.NewPodScaleUpDelay
 		profile.NewPodScaleUpDelay = &newPodScaleUpDelay
 	}
 
-	// Set property ‘OkTotalUnreadyCount’:
+	// Set property "OkTotalUnreadyCount":
 	if typedInput.OkTotalUnreadyCount != nil {
 		okTotalUnreadyCount := *typedInput.OkTotalUnreadyCount
 		profile.OkTotalUnreadyCount = &okTotalUnreadyCount
 	}
 
-	// Set property ‘ScaleDownDelayAfterAdd’:
+	// Set property "ScaleDownDelayAfterAdd":
 	if typedInput.ScaleDownDelayAfterAdd != nil {
 		scaleDownDelayAfterAdd := *typedInput.ScaleDownDelayAfterAdd
 		profile.ScaleDownDelayAfterAdd = &scaleDownDelayAfterAdd
 	}
 
-	// Set property ‘ScaleDownDelayAfterDelete’:
+	// Set property "ScaleDownDelayAfterDelete":
 	if typedInput.ScaleDownDelayAfterDelete != nil {
 		scaleDownDelayAfterDelete := *typedInput.ScaleDownDelayAfterDelete
 		profile.ScaleDownDelayAfterDelete = &scaleDownDelayAfterDelete
 	}
 
-	// Set property ‘ScaleDownDelayAfterFailure’:
+	// Set property "ScaleDownDelayAfterFailure":
 	if typedInput.ScaleDownDelayAfterFailure != nil {
 		scaleDownDelayAfterFailure := *typedInput.ScaleDownDelayAfterFailure
 		profile.ScaleDownDelayAfterFailure = &scaleDownDelayAfterFailure
 	}
 
-	// Set property ‘ScaleDownUnneededTime’:
+	// Set property "ScaleDownUnneededTime":
 	if typedInput.ScaleDownUnneededTime != nil {
 		scaleDownUnneededTime := *typedInput.ScaleDownUnneededTime
 		profile.ScaleDownUnneededTime = &scaleDownUnneededTime
 	}
 
-	// Set property ‘ScaleDownUnreadyTime’:
+	// Set property "ScaleDownUnreadyTime":
 	if typedInput.ScaleDownUnreadyTime != nil {
 		scaleDownUnreadyTime := *typedInput.ScaleDownUnreadyTime
 		profile.ScaleDownUnreadyTime = &scaleDownUnreadyTime
 	}
 
-	// Set property ‘ScaleDownUtilizationThreshold’:
+	// Set property "ScaleDownUtilizationThreshold":
 	if typedInput.ScaleDownUtilizationThreshold != nil {
 		scaleDownUtilizationThreshold := *typedInput.ScaleDownUtilizationThreshold
 		profile.ScaleDownUtilizationThreshold = &scaleDownUtilizationThreshold
 	}
 
-	// Set property ‘ScanInterval’:
+	// Set property "ScanInterval":
 	if typedInput.ScanInterval != nil {
 		scanInterval := *typedInput.ScanInterval
 		profile.ScanInterval = &scanInterval
 	}
 
-	// Set property ‘SkipNodesWithLocalStorage’:
+	// Set property "SkipNodesWithLocalStorage":
 	if typedInput.SkipNodesWithLocalStorage != nil {
 		skipNodesWithLocalStorage := *typedInput.SkipNodesWithLocalStorage
 		profile.SkipNodesWithLocalStorage = &skipNodesWithLocalStorage
 	}
 
-	// Set property ‘SkipNodesWithSystemPods’:
+	// Set property "SkipNodesWithSystemPods":
 	if typedInput.SkipNodesWithSystemPods != nil {
 		skipNodesWithSystemPods := *typedInput.SkipNodesWithSystemPods
 		profile.SkipNodesWithSystemPods = &skipNodesWithSystemPods
@@ -11661,7 +11661,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 	}
 	result := &ManagedClusterSecurityProfile_ARM{}
 
-	// Set property ‘AzureKeyVaultKms’:
+	// Set property "AzureKeyVaultKms":
 	if profile.AzureKeyVaultKms != nil {
 		azureKeyVaultKms_ARM, err := (*profile.AzureKeyVaultKms).ConvertToARM(resolved)
 		if err != nil {
@@ -11671,7 +11671,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 		result.AzureKeyVaultKms = &azureKeyVaultKms
 	}
 
-	// Set property ‘Defender’:
+	// Set property "Defender":
 	if profile.Defender != nil {
 		defender_ARM, err := (*profile.Defender).ConvertToARM(resolved)
 		if err != nil {
@@ -11681,7 +11681,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 		result.Defender = &defender
 	}
 
-	// Set property ‘ImageCleaner’:
+	// Set property "ImageCleaner":
 	if profile.ImageCleaner != nil {
 		imageCleaner_ARM, err := (*profile.ImageCleaner).ConvertToARM(resolved)
 		if err != nil {
@@ -11691,7 +11691,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 		result.ImageCleaner = &imageCleaner
 	}
 
-	// Set property ‘WorkloadIdentity’:
+	// Set property "WorkloadIdentity":
 	if profile.WorkloadIdentity != nil {
 		workloadIdentity_ARM, err := (*profile.WorkloadIdentity).ConvertToARM(resolved)
 		if err != nil {
@@ -11715,7 +11715,7 @@ func (profile *ManagedClusterSecurityProfile) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureKeyVaultKms’:
+	// Set property "AzureKeyVaultKms":
 	if typedInput.AzureKeyVaultKms != nil {
 		var azureKeyVaultKms1 AzureKeyVaultKms
 		err := azureKeyVaultKms1.PopulateFromARM(owner, *typedInput.AzureKeyVaultKms)
@@ -11726,7 +11726,7 @@ func (profile *ManagedClusterSecurityProfile) PopulateFromARM(owner genruntime.A
 		profile.AzureKeyVaultKms = &azureKeyVaultKms
 	}
 
-	// Set property ‘Defender’:
+	// Set property "Defender":
 	if typedInput.Defender != nil {
 		var defender1 ManagedClusterSecurityProfileDefender
 		err := defender1.PopulateFromARM(owner, *typedInput.Defender)
@@ -11737,7 +11737,7 @@ func (profile *ManagedClusterSecurityProfile) PopulateFromARM(owner genruntime.A
 		profile.Defender = &defender
 	}
 
-	// Set property ‘ImageCleaner’:
+	// Set property "ImageCleaner":
 	if typedInput.ImageCleaner != nil {
 		var imageCleaner1 ManagedClusterSecurityProfileImageCleaner
 		err := imageCleaner1.PopulateFromARM(owner, *typedInput.ImageCleaner)
@@ -11748,7 +11748,7 @@ func (profile *ManagedClusterSecurityProfile) PopulateFromARM(owner genruntime.A
 		profile.ImageCleaner = &imageCleaner
 	}
 
-	// Set property ‘WorkloadIdentity’:
+	// Set property "WorkloadIdentity":
 	if typedInput.WorkloadIdentity != nil {
 		var workloadIdentity1 ManagedClusterSecurityProfileWorkloadIdentity
 		err := workloadIdentity1.PopulateFromARM(owner, *typedInput.WorkloadIdentity)
@@ -11968,7 +11968,7 @@ func (profile *ManagedClusterSecurityProfile_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureKeyVaultKms’:
+	// Set property "AzureKeyVaultKms":
 	if typedInput.AzureKeyVaultKms != nil {
 		var azureKeyVaultKms1 AzureKeyVaultKms_STATUS
 		err := azureKeyVaultKms1.PopulateFromARM(owner, *typedInput.AzureKeyVaultKms)
@@ -11979,7 +11979,7 @@ func (profile *ManagedClusterSecurityProfile_STATUS) PopulateFromARM(owner genru
 		profile.AzureKeyVaultKms = &azureKeyVaultKms
 	}
 
-	// Set property ‘Defender’:
+	// Set property "Defender":
 	if typedInput.Defender != nil {
 		var defender1 ManagedClusterSecurityProfileDefender_STATUS
 		err := defender1.PopulateFromARM(owner, *typedInput.Defender)
@@ -11990,7 +11990,7 @@ func (profile *ManagedClusterSecurityProfile_STATUS) PopulateFromARM(owner genru
 		profile.Defender = &defender
 	}
 
-	// Set property ‘ImageCleaner’:
+	// Set property "ImageCleaner":
 	if typedInput.ImageCleaner != nil {
 		var imageCleaner1 ManagedClusterSecurityProfileImageCleaner_STATUS
 		err := imageCleaner1.PopulateFromARM(owner, *typedInput.ImageCleaner)
@@ -12001,7 +12001,7 @@ func (profile *ManagedClusterSecurityProfile_STATUS) PopulateFromARM(owner genru
 		profile.ImageCleaner = &imageCleaner
 	}
 
-	// Set property ‘WorkloadIdentity’:
+	// Set property "WorkloadIdentity":
 	if typedInput.WorkloadIdentity != nil {
 		var workloadIdentity1 ManagedClusterSecurityProfileWorkloadIdentity_STATUS
 		err := workloadIdentity1.PopulateFromARM(owner, *typedInput.WorkloadIdentity)
@@ -12154,13 +12154,13 @@ func (profile *ManagedClusterServicePrincipalProfile) ConvertToARM(resolved genr
 	}
 	result := &ManagedClusterServicePrincipalProfile_ARM{}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if profile.ClientId != nil {
 		clientId := *profile.ClientId
 		result.ClientId = &clientId
 	}
 
-	// Set property ‘Secret’:
+	// Set property "Secret":
 	if profile.Secret != nil {
 		secretSecret, err := resolved.ResolvedSecrets.Lookup(*profile.Secret)
 		if err != nil {
@@ -12184,13 +12184,13 @@ func (profile *ManagedClusterServicePrincipalProfile) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterServicePrincipalProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		profile.ClientId = &clientId
 	}
 
-	// no assignment for property ‘Secret’
+	// no assignment for property "Secret"
 
 	// No error
 	return nil
@@ -12271,7 +12271,7 @@ func (profile *ManagedClusterServicePrincipalProfile_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterServicePrincipalProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		profile.ClientId = &clientId
@@ -12329,13 +12329,13 @@ func (clusterSKU *ManagedClusterSKU) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &ManagedClusterSKU_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if clusterSKU.Name != nil {
 		name := *clusterSKU.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if clusterSKU.Tier != nil {
 		tier := *clusterSKU.Tier
 		result.Tier = &tier
@@ -12355,13 +12355,13 @@ func (clusterSKU *ManagedClusterSKU) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSKU_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		clusterSKU.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		clusterSKU.Tier = &tier
@@ -12473,13 +12473,13 @@ func (clusterSKU *ManagedClusterSKU_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSKU_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		clusterSKU.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		clusterSKU.Tier = &tier
@@ -12568,7 +12568,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ManagedClusterStorageProfile_ARM{}
 
-	// Set property ‘BlobCSIDriver’:
+	// Set property "BlobCSIDriver":
 	if profile.BlobCSIDriver != nil {
 		blobCSIDriver_ARM, err := (*profile.BlobCSIDriver).ConvertToARM(resolved)
 		if err != nil {
@@ -12578,7 +12578,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 		result.BlobCSIDriver = &blobCSIDriver
 	}
 
-	// Set property ‘DiskCSIDriver’:
+	// Set property "DiskCSIDriver":
 	if profile.DiskCSIDriver != nil {
 		diskCSIDriver_ARM, err := (*profile.DiskCSIDriver).ConvertToARM(resolved)
 		if err != nil {
@@ -12588,7 +12588,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 		result.DiskCSIDriver = &diskCSIDriver
 	}
 
-	// Set property ‘FileCSIDriver’:
+	// Set property "FileCSIDriver":
 	if profile.FileCSIDriver != nil {
 		fileCSIDriver_ARM, err := (*profile.FileCSIDriver).ConvertToARM(resolved)
 		if err != nil {
@@ -12598,7 +12598,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 		result.FileCSIDriver = &fileCSIDriver
 	}
 
-	// Set property ‘SnapshotController’:
+	// Set property "SnapshotController":
 	if profile.SnapshotController != nil {
 		snapshotController_ARM, err := (*profile.SnapshotController).ConvertToARM(resolved)
 		if err != nil {
@@ -12622,7 +12622,7 @@ func (profile *ManagedClusterStorageProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobCSIDriver’:
+	// Set property "BlobCSIDriver":
 	if typedInput.BlobCSIDriver != nil {
 		var blobCSIDriver1 ManagedClusterStorageProfileBlobCSIDriver
 		err := blobCSIDriver1.PopulateFromARM(owner, *typedInput.BlobCSIDriver)
@@ -12633,7 +12633,7 @@ func (profile *ManagedClusterStorageProfile) PopulateFromARM(owner genruntime.Ar
 		profile.BlobCSIDriver = &blobCSIDriver
 	}
 
-	// Set property ‘DiskCSIDriver’:
+	// Set property "DiskCSIDriver":
 	if typedInput.DiskCSIDriver != nil {
 		var diskCSIDriver1 ManagedClusterStorageProfileDiskCSIDriver
 		err := diskCSIDriver1.PopulateFromARM(owner, *typedInput.DiskCSIDriver)
@@ -12644,7 +12644,7 @@ func (profile *ManagedClusterStorageProfile) PopulateFromARM(owner genruntime.Ar
 		profile.DiskCSIDriver = &diskCSIDriver
 	}
 
-	// Set property ‘FileCSIDriver’:
+	// Set property "FileCSIDriver":
 	if typedInput.FileCSIDriver != nil {
 		var fileCSIDriver1 ManagedClusterStorageProfileFileCSIDriver
 		err := fileCSIDriver1.PopulateFromARM(owner, *typedInput.FileCSIDriver)
@@ -12655,7 +12655,7 @@ func (profile *ManagedClusterStorageProfile) PopulateFromARM(owner genruntime.Ar
 		profile.FileCSIDriver = &fileCSIDriver
 	}
 
-	// Set property ‘SnapshotController’:
+	// Set property "SnapshotController":
 	if typedInput.SnapshotController != nil {
 		var snapshotController1 ManagedClusterStorageProfileSnapshotController
 		err := snapshotController1.PopulateFromARM(owner, *typedInput.SnapshotController)
@@ -12873,7 +12873,7 @@ func (profile *ManagedClusterStorageProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobCSIDriver’:
+	// Set property "BlobCSIDriver":
 	if typedInput.BlobCSIDriver != nil {
 		var blobCSIDriver1 ManagedClusterStorageProfileBlobCSIDriver_STATUS
 		err := blobCSIDriver1.PopulateFromARM(owner, *typedInput.BlobCSIDriver)
@@ -12884,7 +12884,7 @@ func (profile *ManagedClusterStorageProfile_STATUS) PopulateFromARM(owner genrun
 		profile.BlobCSIDriver = &blobCSIDriver
 	}
 
-	// Set property ‘DiskCSIDriver’:
+	// Set property "DiskCSIDriver":
 	if typedInput.DiskCSIDriver != nil {
 		var diskCSIDriver1 ManagedClusterStorageProfileDiskCSIDriver_STATUS
 		err := diskCSIDriver1.PopulateFromARM(owner, *typedInput.DiskCSIDriver)
@@ -12895,7 +12895,7 @@ func (profile *ManagedClusterStorageProfile_STATUS) PopulateFromARM(owner genrun
 		profile.DiskCSIDriver = &diskCSIDriver
 	}
 
-	// Set property ‘FileCSIDriver’:
+	// Set property "FileCSIDriver":
 	if typedInput.FileCSIDriver != nil {
 		var fileCSIDriver1 ManagedClusterStorageProfileFileCSIDriver_STATUS
 		err := fileCSIDriver1.PopulateFromARM(owner, *typedInput.FileCSIDriver)
@@ -12906,7 +12906,7 @@ func (profile *ManagedClusterStorageProfile_STATUS) PopulateFromARM(owner genrun
 		profile.FileCSIDriver = &fileCSIDriver
 	}
 
-	// Set property ‘SnapshotController’:
+	// Set property "SnapshotController":
 	if typedInput.SnapshotController != nil {
 		var snapshotController1 ManagedClusterStorageProfileSnapshotController_STATUS
 		err := snapshotController1.PopulateFromARM(owner, *typedInput.SnapshotController)
@@ -13085,25 +13085,25 @@ func (profile *ManagedClusterWindowsProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ManagedClusterWindowsProfile_ARM{}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if profile.AdminPassword != nil {
 		adminPassword := *profile.AdminPassword
 		result.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘EnableCSIProxy’:
+	// Set property "EnableCSIProxy":
 	if profile.EnableCSIProxy != nil {
 		enableCSIProxy := *profile.EnableCSIProxy
 		result.EnableCSIProxy = &enableCSIProxy
 	}
 
-	// Set property ‘GmsaProfile’:
+	// Set property "GmsaProfile":
 	if profile.GmsaProfile != nil {
 		gmsaProfile_ARM, err := (*profile.GmsaProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -13113,7 +13113,7 @@ func (profile *ManagedClusterWindowsProfile) ConvertToARM(resolved genruntime.Co
 		result.GmsaProfile = &gmsaProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if profile.LicenseType != nil {
 		licenseType := *profile.LicenseType
 		result.LicenseType = &licenseType
@@ -13133,25 +13133,25 @@ func (profile *ManagedClusterWindowsProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWindowsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if typedInput.AdminPassword != nil {
 		adminPassword := *typedInput.AdminPassword
 		profile.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘EnableCSIProxy’:
+	// Set property "EnableCSIProxy":
 	if typedInput.EnableCSIProxy != nil {
 		enableCSIProxy := *typedInput.EnableCSIProxy
 		profile.EnableCSIProxy = &enableCSIProxy
 	}
 
-	// Set property ‘GmsaProfile’:
+	// Set property "GmsaProfile":
 	if typedInput.GmsaProfile != nil {
 		var gmsaProfile1 WindowsGmsaProfile
 		err := gmsaProfile1.PopulateFromARM(owner, *typedInput.GmsaProfile)
@@ -13162,7 +13162,7 @@ func (profile *ManagedClusterWindowsProfile) PopulateFromARM(owner genruntime.Ar
 		profile.GmsaProfile = &gmsaProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
@@ -13353,25 +13353,25 @@ func (profile *ManagedClusterWindowsProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWindowsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if typedInput.AdminPassword != nil {
 		adminPassword := *typedInput.AdminPassword
 		profile.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘EnableCSIProxy’:
+	// Set property "EnableCSIProxy":
 	if typedInput.EnableCSIProxy != nil {
 		enableCSIProxy := *typedInput.EnableCSIProxy
 		profile.EnableCSIProxy = &enableCSIProxy
 	}
 
-	// Set property ‘GmsaProfile’:
+	// Set property "GmsaProfile":
 	if typedInput.GmsaProfile != nil {
 		var gmsaProfile1 WindowsGmsaProfile_STATUS
 		err := gmsaProfile1.PopulateFromARM(owner, *typedInput.GmsaProfile)
@@ -13382,7 +13382,7 @@ func (profile *ManagedClusterWindowsProfile_STATUS) PopulateFromARM(owner genrun
 		profile.GmsaProfile = &gmsaProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
@@ -13498,7 +13498,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) ConvertToARM(resolved ge
 	}
 	result := &ManagedClusterWorkloadAutoScalerProfile_ARM{}
 
-	// Set property ‘Keda’:
+	// Set property "Keda":
 	if profile.Keda != nil {
 		keda_ARM, err := (*profile.Keda).ConvertToARM(resolved)
 		if err != nil {
@@ -13522,7 +13522,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWorkloadAutoScalerProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Keda’:
+	// Set property "Keda":
 	if typedInput.Keda != nil {
 		var keda1 ManagedClusterWorkloadAutoScalerProfileKeda
 		err := keda1.PopulateFromARM(owner, *typedInput.Keda)
@@ -13623,7 +13623,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWorkloadAutoScalerProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Keda’:
+	// Set property "Keda":
 	if typedInput.Keda != nil {
 		var keda1 ManagedClusterWorkloadAutoScalerProfileKeda_STATUS
 		err := keda1.PopulateFromARM(owner, *typedInput.Keda)
@@ -13705,7 +13705,7 @@ func (state *PowerState_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PowerState_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		state.Code = &code
@@ -13781,13 +13781,13 @@ func (resource *PrivateLinkResource) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &PrivateLinkResource_ARM{}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if resource.GroupId != nil {
 		groupId := *resource.GroupId
 		result.GroupId = &groupId
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -13797,18 +13797,18 @@ func (resource *PrivateLinkResource) ConvertToARM(resolved genruntime.ConvertToA
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if resource.Name != nil {
 		name := *resource.Name
 		result.Name = &name
 	}
 
-	// Set property ‘RequiredMembers’:
+	// Set property "RequiredMembers":
 	for _, item := range resource.RequiredMembers {
 		result.RequiredMembers = append(result.RequiredMembers, item)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if resource.Type != nil {
 		typeVar := *resource.Type
 		result.Type = &typeVar
@@ -13828,26 +13828,26 @@ func (resource *PrivateLinkResource) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if typedInput.GroupId != nil {
 		groupId := *typedInput.GroupId
 		resource.GroupId = &groupId
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resource.Name = &name
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘RequiredMembers’:
+	// Set property "RequiredMembers":
 	for _, item := range typedInput.RequiredMembers {
 		resource.RequiredMembers = append(resource.RequiredMembers, item)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		resource.Type = &typeVar
@@ -13982,36 +13982,36 @@ func (resource *PrivateLinkResource_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if typedInput.GroupId != nil {
 		groupId := *typedInput.GroupId
 		resource.GroupId = &groupId
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resource.Name = &name
 	}
 
-	// Set property ‘PrivateLinkServiceID’:
+	// Set property "PrivateLinkServiceID":
 	if typedInput.PrivateLinkServiceID != nil {
 		privateLinkServiceID := *typedInput.PrivateLinkServiceID
 		resource.PrivateLinkServiceID = &privateLinkServiceID
 	}
 
-	// Set property ‘RequiredMembers’:
+	// Set property "RequiredMembers":
 	for _, item := range typedInput.RequiredMembers {
 		resource.RequiredMembers = append(resource.RequiredMembers, item)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		resource.Type = &typeVar
@@ -14115,37 +14115,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -14255,19 +14255,19 @@ func (identity *UserAssignedIdentity) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &UserAssignedIdentity_ARM{}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if identity.ClientId != nil {
 		clientId := *identity.ClientId
 		result.ClientId = &clientId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if identity.ObjectId != nil {
 		objectId := *identity.ObjectId
 		result.ObjectId = &objectId
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if identity.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*identity.ResourceReference)
 		if err != nil {
@@ -14291,19 +14291,19 @@ func (identity *UserAssignedIdentity) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		identity.ObjectId = &objectId
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -14407,19 +14407,19 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		identity.ObjectId = &objectId
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		identity.ResourceId = &resourceId
@@ -14500,25 +14500,25 @@ func (vaultKms *AzureKeyVaultKms) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &AzureKeyVaultKms_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if vaultKms.Enabled != nil {
 		enabled := *vaultKms.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	if vaultKms.KeyId != nil {
 		keyId := *vaultKms.KeyId
 		result.KeyId = &keyId
 	}
 
-	// Set property ‘KeyVaultNetworkAccess’:
+	// Set property "KeyVaultNetworkAccess":
 	if vaultKms.KeyVaultNetworkAccess != nil {
 		keyVaultNetworkAccess := *vaultKms.KeyVaultNetworkAccess
 		result.KeyVaultNetworkAccess = &keyVaultNetworkAccess
 	}
 
-	// Set property ‘KeyVaultResourceId’:
+	// Set property "KeyVaultResourceId":
 	if vaultKms.KeyVaultResourceReference != nil {
 		keyVaultResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*vaultKms.KeyVaultResourceReference)
 		if err != nil {
@@ -14542,25 +14542,25 @@ func (vaultKms *AzureKeyVaultKms) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureKeyVaultKms_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		vaultKms.Enabled = &enabled
 	}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	if typedInput.KeyId != nil {
 		keyId := *typedInput.KeyId
 		vaultKms.KeyId = &keyId
 	}
 
-	// Set property ‘KeyVaultNetworkAccess’:
+	// Set property "KeyVaultNetworkAccess":
 	if typedInput.KeyVaultNetworkAccess != nil {
 		keyVaultNetworkAccess := *typedInput.KeyVaultNetworkAccess
 		vaultKms.KeyVaultNetworkAccess = &keyVaultNetworkAccess
 	}
 
-	// no assignment for property ‘KeyVaultResourceReference’
+	// no assignment for property "KeyVaultResourceReference"
 
 	// No error
 	return nil
@@ -14712,25 +14712,25 @@ func (vaultKms *AzureKeyVaultKms_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureKeyVaultKms_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		vaultKms.Enabled = &enabled
 	}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	if typedInput.KeyId != nil {
 		keyId := *typedInput.KeyId
 		vaultKms.KeyId = &keyId
 	}
 
-	// Set property ‘KeyVaultNetworkAccess’:
+	// Set property "KeyVaultNetworkAccess":
 	if typedInput.KeyVaultNetworkAccess != nil {
 		keyVaultNetworkAccess := *typedInput.KeyVaultNetworkAccess
 		vaultKms.KeyVaultNetworkAccess = &keyVaultNetworkAccess
 	}
 
-	// Set property ‘KeyVaultResourceId’:
+	// Set property "KeyVaultResourceId":
 	if typedInput.KeyVaultResourceId != nil {
 		keyVaultResourceId := *typedInput.KeyVaultResourceId
 		vaultKms.KeyVaultResourceId = &keyVaultResourceId
@@ -14945,7 +14945,7 @@ func (configuration *ContainerServiceSshConfiguration) ConvertToARM(resolved gen
 	}
 	result := &ContainerServiceSshConfiguration_ARM{}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range configuration.PublicKeys {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -14968,7 +14968,7 @@ func (configuration *ContainerServiceSshConfiguration) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 ContainerServiceSshPublicKey
 		err := item1.PopulateFromARM(owner, item)
@@ -15086,7 +15086,7 @@ func (configuration *ContainerServiceSshConfiguration_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 ContainerServiceSshPublicKey_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -15204,13 +15204,13 @@ func (metrics *ManagedClusterAzureMonitorProfileMetrics) ConvertToARM(resolved g
 	}
 	result := &ManagedClusterAzureMonitorProfileMetrics_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if metrics.Enabled != nil {
 		enabled := *metrics.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘KubeStateMetrics’:
+	// Set property "KubeStateMetrics":
 	if metrics.KubeStateMetrics != nil {
 		kubeStateMetrics_ARM, err := (*metrics.KubeStateMetrics).ConvertToARM(resolved)
 		if err != nil {
@@ -15234,13 +15234,13 @@ func (metrics *ManagedClusterAzureMonitorProfileMetrics) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAzureMonitorProfileMetrics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		metrics.Enabled = &enabled
 	}
 
-	// Set property ‘KubeStateMetrics’:
+	// Set property "KubeStateMetrics":
 	if typedInput.KubeStateMetrics != nil {
 		var kubeStateMetrics1 ManagedClusterAzureMonitorProfileKubeStateMetrics
 		err := kubeStateMetrics1.PopulateFromARM(owner, *typedInput.KubeStateMetrics)
@@ -15373,13 +15373,13 @@ func (metrics *ManagedClusterAzureMonitorProfileMetrics_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAzureMonitorProfileMetrics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		metrics.Enabled = &enabled
 	}
 
-	// Set property ‘KubeStateMetrics’:
+	// Set property "KubeStateMetrics":
 	if typedInput.KubeStateMetrics != nil {
 		var kubeStateMetrics1 ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS
 		err := kubeStateMetrics1.PopulateFromARM(owner, *typedInput.KubeStateMetrics)
@@ -15479,13 +15479,13 @@ func (identities *ManagedClusterIdentity_UserAssignedIdentities_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -15569,13 +15569,13 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 	}
 	result := &ManagedClusterLoadBalancerProfile_ARM{}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	if profile.AllocatedOutboundPorts != nil {
 		allocatedOutboundPorts := *profile.AllocatedOutboundPorts
 		result.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range profile.EffectiveOutboundIPs {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -15584,19 +15584,19 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		result.EffectiveOutboundIPs = append(result.EffectiveOutboundIPs, *item_ARM.(*ResourceReference_ARM))
 	}
 
-	// Set property ‘EnableMultipleStandardLoadBalancers’:
+	// Set property "EnableMultipleStandardLoadBalancers":
 	if profile.EnableMultipleStandardLoadBalancers != nil {
 		enableMultipleStandardLoadBalancers := *profile.EnableMultipleStandardLoadBalancers
 		result.EnableMultipleStandardLoadBalancers = &enableMultipleStandardLoadBalancers
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if profile.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *profile.IdleTimeoutInMinutes
 		result.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPs’:
+	// Set property "ManagedOutboundIPs":
 	if profile.ManagedOutboundIPs != nil {
 		managedOutboundIPs_ARM, err := (*profile.ManagedOutboundIPs).ConvertToARM(resolved)
 		if err != nil {
@@ -15606,7 +15606,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		result.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
-	// Set property ‘OutboundIPPrefixes’:
+	// Set property "OutboundIPPrefixes":
 	if profile.OutboundIPPrefixes != nil {
 		outboundIPPrefixes_ARM, err := (*profile.OutboundIPPrefixes).ConvertToARM(resolved)
 		if err != nil {
@@ -15616,7 +15616,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		result.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
-	// Set property ‘OutboundIPs’:
+	// Set property "OutboundIPs":
 	if profile.OutboundIPs != nil {
 		outboundIPs_ARM, err := (*profile.OutboundIPs).ConvertToARM(resolved)
 		if err != nil {
@@ -15640,13 +15640,13 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	if typedInput.AllocatedOutboundPorts != nil {
 		allocatedOutboundPorts := *typedInput.AllocatedOutboundPorts
 		profile.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range typedInput.EffectiveOutboundIPs {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -15656,19 +15656,19 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		profile.EffectiveOutboundIPs = append(profile.EffectiveOutboundIPs, item1)
 	}
 
-	// Set property ‘EnableMultipleStandardLoadBalancers’:
+	// Set property "EnableMultipleStandardLoadBalancers":
 	if typedInput.EnableMultipleStandardLoadBalancers != nil {
 		enableMultipleStandardLoadBalancers := *typedInput.EnableMultipleStandardLoadBalancers
 		profile.EnableMultipleStandardLoadBalancers = &enableMultipleStandardLoadBalancers
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if typedInput.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *typedInput.IdleTimeoutInMinutes
 		profile.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPs’:
+	// Set property "ManagedOutboundIPs":
 	if typedInput.ManagedOutboundIPs != nil {
 		var managedOutboundIPs1 ManagedClusterLoadBalancerProfile_ManagedOutboundIPs
 		err := managedOutboundIPs1.PopulateFromARM(owner, *typedInput.ManagedOutboundIPs)
@@ -15679,7 +15679,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		profile.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
-	// Set property ‘OutboundIPPrefixes’:
+	// Set property "OutboundIPPrefixes":
 	if typedInput.OutboundIPPrefixes != nil {
 		var outboundIPPrefixes1 ManagedClusterLoadBalancerProfile_OutboundIPPrefixes
 		err := outboundIPPrefixes1.PopulateFromARM(owner, *typedInput.OutboundIPPrefixes)
@@ -15690,7 +15690,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		profile.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
-	// Set property ‘OutboundIPs’:
+	// Set property "OutboundIPs":
 	if typedInput.OutboundIPs != nil {
 		var outboundIPs1 ManagedClusterLoadBalancerProfile_OutboundIPs
 		err := outboundIPs1.PopulateFromARM(owner, *typedInput.OutboundIPs)
@@ -16009,13 +16009,13 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	if typedInput.AllocatedOutboundPorts != nil {
 		allocatedOutboundPorts := *typedInput.AllocatedOutboundPorts
 		profile.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range typedInput.EffectiveOutboundIPs {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -16025,19 +16025,19 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		profile.EffectiveOutboundIPs = append(profile.EffectiveOutboundIPs, item1)
 	}
 
-	// Set property ‘EnableMultipleStandardLoadBalancers’:
+	// Set property "EnableMultipleStandardLoadBalancers":
 	if typedInput.EnableMultipleStandardLoadBalancers != nil {
 		enableMultipleStandardLoadBalancers := *typedInput.EnableMultipleStandardLoadBalancers
 		profile.EnableMultipleStandardLoadBalancers = &enableMultipleStandardLoadBalancers
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if typedInput.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *typedInput.IdleTimeoutInMinutes
 		profile.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPs’:
+	// Set property "ManagedOutboundIPs":
 	if typedInput.ManagedOutboundIPs != nil {
 		var managedOutboundIPs1 ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS
 		err := managedOutboundIPs1.PopulateFromARM(owner, *typedInput.ManagedOutboundIPs)
@@ -16048,7 +16048,7 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		profile.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
-	// Set property ‘OutboundIPPrefixes’:
+	// Set property "OutboundIPPrefixes":
 	if typedInput.OutboundIPPrefixes != nil {
 		var outboundIPPrefixes1 ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS
 		err := outboundIPPrefixes1.PopulateFromARM(owner, *typedInput.OutboundIPPrefixes)
@@ -16059,7 +16059,7 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		profile.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
-	// Set property ‘OutboundIPs’:
+	// Set property "OutboundIPs":
 	if typedInput.OutboundIPs != nil {
 		var outboundIPs1 ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS
 		err := outboundIPs1.PopulateFromARM(owner, *typedInput.OutboundIPs)
@@ -16257,7 +16257,7 @@ func (profile *ManagedClusterNATGatewayProfile) ConvertToARM(resolved genruntime
 	}
 	result := &ManagedClusterNATGatewayProfile_ARM{}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range profile.EffectiveOutboundIPs {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -16266,13 +16266,13 @@ func (profile *ManagedClusterNATGatewayProfile) ConvertToARM(resolved genruntime
 		result.EffectiveOutboundIPs = append(result.EffectiveOutboundIPs, *item_ARM.(*ResourceReference_ARM))
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if profile.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *profile.IdleTimeoutInMinutes
 		result.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPProfile’:
+	// Set property "ManagedOutboundIPProfile":
 	if profile.ManagedOutboundIPProfile != nil {
 		managedOutboundIPProfile_ARM, err := (*profile.ManagedOutboundIPProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -16296,7 +16296,7 @@ func (profile *ManagedClusterNATGatewayProfile) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterNATGatewayProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range typedInput.EffectiveOutboundIPs {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -16306,13 +16306,13 @@ func (profile *ManagedClusterNATGatewayProfile) PopulateFromARM(owner genruntime
 		profile.EffectiveOutboundIPs = append(profile.EffectiveOutboundIPs, item1)
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if typedInput.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *typedInput.IdleTimeoutInMinutes
 		profile.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPProfile’:
+	// Set property "ManagedOutboundIPProfile":
 	if typedInput.ManagedOutboundIPProfile != nil {
 		var managedOutboundIPProfile1 ManagedClusterManagedOutboundIPProfile
 		err := managedOutboundIPProfile1.PopulateFromARM(owner, *typedInput.ManagedOutboundIPProfile)
@@ -16498,7 +16498,7 @@ func (profile *ManagedClusterNATGatewayProfile_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterNATGatewayProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range typedInput.EffectiveOutboundIPs {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -16508,13 +16508,13 @@ func (profile *ManagedClusterNATGatewayProfile_STATUS) PopulateFromARM(owner gen
 		profile.EffectiveOutboundIPs = append(profile.EffectiveOutboundIPs, item1)
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if typedInput.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *typedInput.IdleTimeoutInMinutes
 		profile.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPProfile’:
+	// Set property "ManagedOutboundIPProfile":
 	if typedInput.ManagedOutboundIPProfile != nil {
 		var managedOutboundIPProfile1 ManagedClusterManagedOutboundIPProfile_STATUS
 		err := managedOutboundIPProfile1.PopulateFromARM(owner, *typedInput.ManagedOutboundIPProfile)
@@ -16755,13 +16755,13 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ManagedClusterPodIdentity_ARM{}
 
-	// Set property ‘BindingSelector’:
+	// Set property "BindingSelector":
 	if identity.BindingSelector != nil {
 		bindingSelector := *identity.BindingSelector
 		result.BindingSelector = &bindingSelector
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if identity.Identity != nil {
 		identity_ARM, err := (*identity.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -16771,13 +16771,13 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 		result.Identity = &identity1
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if identity.Name != nil {
 		name := *identity.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if identity.Namespace != nil {
 		namespace := *identity.Namespace
 		result.Namespace = &namespace
@@ -16797,13 +16797,13 @@ func (identity *ManagedClusterPodIdentity) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BindingSelector’:
+	// Set property "BindingSelector":
 	if typedInput.BindingSelector != nil {
 		bindingSelector := *typedInput.BindingSelector
 		identity.BindingSelector = &bindingSelector
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity2 UserAssignedIdentity
 		err := identity2.PopulateFromARM(owner, *typedInput.Identity)
@@ -16814,13 +16814,13 @@ func (identity *ManagedClusterPodIdentity) PopulateFromARM(owner genruntime.Arbi
 		identity.Identity = &identity1
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		identity.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		identity.Namespace = &namespace
@@ -16956,13 +16956,13 @@ func (identity *ManagedClusterPodIdentity_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BindingSelector’:
+	// Set property "BindingSelector":
 	if typedInput.BindingSelector != nil {
 		bindingSelector := *typedInput.BindingSelector
 		identity.BindingSelector = &bindingSelector
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity2 UserAssignedIdentity_STATUS
 		err := identity2.PopulateFromARM(owner, *typedInput.Identity)
@@ -16973,19 +16973,19 @@ func (identity *ManagedClusterPodIdentity_STATUS) PopulateFromARM(owner genrunti
 		identity.Identity = &identity1
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		identity.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		identity.Namespace = &namespace
 	}
 
-	// Set property ‘ProvisioningInfo’:
+	// Set property "ProvisioningInfo":
 	if typedInput.ProvisioningInfo != nil {
 		var provisioningInfo1 ManagedClusterPodIdentity_ProvisioningInfo_STATUS
 		err := provisioningInfo1.PopulateFromARM(owner, *typedInput.ProvisioningInfo)
@@ -16996,7 +16996,7 @@ func (identity *ManagedClusterPodIdentity_STATUS) PopulateFromARM(owner genrunti
 		identity.ProvisioningInfo = &provisioningInfo
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		identity.ProvisioningState = &provisioningState
@@ -17136,19 +17136,19 @@ func (exception *ManagedClusterPodIdentityException) ConvertToARM(resolved genru
 	}
 	result := &ManagedClusterPodIdentityException_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if exception.Name != nil {
 		name := *exception.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if exception.Namespace != nil {
 		namespace := *exception.Namespace
 		result.Namespace = &namespace
 	}
 
-	// Set property ‘PodLabels’:
+	// Set property "PodLabels":
 	if exception.PodLabels != nil {
 		result.PodLabels = make(map[string]string, len(exception.PodLabels))
 		for key, value := range exception.PodLabels {
@@ -17170,19 +17170,19 @@ func (exception *ManagedClusterPodIdentityException) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityException_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		exception.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		exception.Namespace = &namespace
 	}
 
-	// Set property ‘PodLabels’:
+	// Set property "PodLabels":
 	if typedInput.PodLabels != nil {
 		exception.PodLabels = make(map[string]string, len(typedInput.PodLabels))
 		for key, value := range typedInput.PodLabels {
@@ -17278,19 +17278,19 @@ func (exception *ManagedClusterPodIdentityException_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityException_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		exception.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		exception.Namespace = &namespace
 	}
 
-	// Set property ‘PodLabels’:
+	// Set property "PodLabels":
 	if typedInput.PodLabels != nil {
 		exception.PodLabels = make(map[string]string, len(typedInput.PodLabels))
 		for key, value := range typedInput.PodLabels {
@@ -17382,7 +17382,7 @@ func (defender *ManagedClusterSecurityProfileDefender) ConvertToARM(resolved gen
 	}
 	result := &ManagedClusterSecurityProfileDefender_ARM{}
 
-	// Set property ‘LogAnalyticsWorkspaceResourceId’:
+	// Set property "LogAnalyticsWorkspaceResourceId":
 	if defender.LogAnalyticsWorkspaceResourceReference != nil {
 		logAnalyticsWorkspaceResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*defender.LogAnalyticsWorkspaceResourceReference)
 		if err != nil {
@@ -17392,7 +17392,7 @@ func (defender *ManagedClusterSecurityProfileDefender) ConvertToARM(resolved gen
 		result.LogAnalyticsWorkspaceResourceId = &logAnalyticsWorkspaceResourceReference
 	}
 
-	// Set property ‘SecurityMonitoring’:
+	// Set property "SecurityMonitoring":
 	if defender.SecurityMonitoring != nil {
 		securityMonitoring_ARM, err := (*defender.SecurityMonitoring).ConvertToARM(resolved)
 		if err != nil {
@@ -17416,9 +17416,9 @@ func (defender *ManagedClusterSecurityProfileDefender) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileDefender_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘LogAnalyticsWorkspaceResourceReference’
+	// no assignment for property "LogAnalyticsWorkspaceResourceReference"
 
-	// Set property ‘SecurityMonitoring’:
+	// Set property "SecurityMonitoring":
 	if typedInput.SecurityMonitoring != nil {
 		var securityMonitoring1 ManagedClusterSecurityProfileDefenderSecurityMonitoring
 		err := securityMonitoring1.PopulateFromARM(owner, *typedInput.SecurityMonitoring)
@@ -17548,13 +17548,13 @@ func (defender *ManagedClusterSecurityProfileDefender_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileDefender_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LogAnalyticsWorkspaceResourceId’:
+	// Set property "LogAnalyticsWorkspaceResourceId":
 	if typedInput.LogAnalyticsWorkspaceResourceId != nil {
 		logAnalyticsWorkspaceResourceId := *typedInput.LogAnalyticsWorkspaceResourceId
 		defender.LogAnalyticsWorkspaceResourceId = &logAnalyticsWorkspaceResourceId
 	}
 
-	// Set property ‘SecurityMonitoring’:
+	// Set property "SecurityMonitoring":
 	if typedInput.SecurityMonitoring != nil {
 		var securityMonitoring1 ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS
 		err := securityMonitoring1.PopulateFromARM(owner, *typedInput.SecurityMonitoring)
@@ -17641,13 +17641,13 @@ func (cleaner *ManagedClusterSecurityProfileImageCleaner) ConvertToARM(resolved 
 	}
 	result := &ManagedClusterSecurityProfileImageCleaner_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if cleaner.Enabled != nil {
 		enabled := *cleaner.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘IntervalHours’:
+	// Set property "IntervalHours":
 	if cleaner.IntervalHours != nil {
 		intervalHours := *cleaner.IntervalHours
 		result.IntervalHours = &intervalHours
@@ -17667,13 +17667,13 @@ func (cleaner *ManagedClusterSecurityProfileImageCleaner) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileImageCleaner_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		cleaner.Enabled = &enabled
 	}
 
-	// Set property ‘IntervalHours’:
+	// Set property "IntervalHours":
 	if typedInput.IntervalHours != nil {
 		intervalHours := *typedInput.IntervalHours
 		cleaner.IntervalHours = &intervalHours
@@ -17770,13 +17770,13 @@ func (cleaner *ManagedClusterSecurityProfileImageCleaner_STATUS) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileImageCleaner_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		cleaner.Enabled = &enabled
 	}
 
-	// Set property ‘IntervalHours’:
+	// Set property "IntervalHours":
 	if typedInput.IntervalHours != nil {
 		intervalHours := *typedInput.IntervalHours
 		cleaner.IntervalHours = &intervalHours
@@ -17846,7 +17846,7 @@ func (identity *ManagedClusterSecurityProfileWorkloadIdentity) ConvertToARM(reso
 	}
 	result := &ManagedClusterSecurityProfileWorkloadIdentity_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if identity.Enabled != nil {
 		enabled := *identity.Enabled
 		result.Enabled = &enabled
@@ -17866,7 +17866,7 @@ func (identity *ManagedClusterSecurityProfileWorkloadIdentity) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileWorkloadIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		identity.Enabled = &enabled
@@ -17950,7 +17950,7 @@ func (identity *ManagedClusterSecurityProfileWorkloadIdentity_STATUS) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileWorkloadIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		identity.Enabled = &enabled
@@ -18014,7 +18014,7 @@ func (driver *ManagedClusterStorageProfileBlobCSIDriver) ConvertToARM(resolved g
 	}
 	result := &ManagedClusterStorageProfileBlobCSIDriver_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if driver.Enabled != nil {
 		enabled := *driver.Enabled
 		result.Enabled = &enabled
@@ -18034,7 +18034,7 @@ func (driver *ManagedClusterStorageProfileBlobCSIDriver) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileBlobCSIDriver_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		driver.Enabled = &enabled
@@ -18118,7 +18118,7 @@ func (driver *ManagedClusterStorageProfileBlobCSIDriver_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileBlobCSIDriver_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		driver.Enabled = &enabled
@@ -18182,7 +18182,7 @@ func (driver *ManagedClusterStorageProfileDiskCSIDriver) ConvertToARM(resolved g
 	}
 	result := &ManagedClusterStorageProfileDiskCSIDriver_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if driver.Enabled != nil {
 		enabled := *driver.Enabled
 		result.Enabled = &enabled
@@ -18202,7 +18202,7 @@ func (driver *ManagedClusterStorageProfileDiskCSIDriver) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileDiskCSIDriver_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		driver.Enabled = &enabled
@@ -18286,7 +18286,7 @@ func (driver *ManagedClusterStorageProfileDiskCSIDriver_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileDiskCSIDriver_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		driver.Enabled = &enabled
@@ -18350,7 +18350,7 @@ func (driver *ManagedClusterStorageProfileFileCSIDriver) ConvertToARM(resolved g
 	}
 	result := &ManagedClusterStorageProfileFileCSIDriver_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if driver.Enabled != nil {
 		enabled := *driver.Enabled
 		result.Enabled = &enabled
@@ -18370,7 +18370,7 @@ func (driver *ManagedClusterStorageProfileFileCSIDriver) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileFileCSIDriver_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		driver.Enabled = &enabled
@@ -18454,7 +18454,7 @@ func (driver *ManagedClusterStorageProfileFileCSIDriver_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileFileCSIDriver_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		driver.Enabled = &enabled
@@ -18518,7 +18518,7 @@ func (controller *ManagedClusterStorageProfileSnapshotController) ConvertToARM(r
 	}
 	result := &ManagedClusterStorageProfileSnapshotController_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if controller.Enabled != nil {
 		enabled := *controller.Enabled
 		result.Enabled = &enabled
@@ -18538,7 +18538,7 @@ func (controller *ManagedClusterStorageProfileSnapshotController) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileSnapshotController_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		controller.Enabled = &enabled
@@ -18622,7 +18622,7 @@ func (controller *ManagedClusterStorageProfileSnapshotController_STATUS) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileSnapshotController_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		controller.Enabled = &enabled
@@ -18702,7 +18702,7 @@ func (keda *ManagedClusterWorkloadAutoScalerProfileKeda) ConvertToARM(resolved g
 	}
 	result := &ManagedClusterWorkloadAutoScalerProfileKeda_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if keda.Enabled != nil {
 		enabled := *keda.Enabled
 		result.Enabled = &enabled
@@ -18722,7 +18722,7 @@ func (keda *ManagedClusterWorkloadAutoScalerProfileKeda) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWorkloadAutoScalerProfileKeda_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		keda.Enabled = &enabled
@@ -18806,7 +18806,7 @@ func (keda *ManagedClusterWorkloadAutoScalerProfileKeda_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWorkloadAutoScalerProfileKeda_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		keda.Enabled = &enabled
@@ -18919,19 +18919,19 @@ func (profile *WindowsGmsaProfile) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &WindowsGmsaProfile_ARM{}
 
-	// Set property ‘DnsServer’:
+	// Set property "DnsServer":
 	if profile.DnsServer != nil {
 		dnsServer := *profile.DnsServer
 		result.DnsServer = &dnsServer
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if profile.Enabled != nil {
 		enabled := *profile.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘RootDomainName’:
+	// Set property "RootDomainName":
 	if profile.RootDomainName != nil {
 		rootDomainName := *profile.RootDomainName
 		result.RootDomainName = &rootDomainName
@@ -18951,19 +18951,19 @@ func (profile *WindowsGmsaProfile) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsGmsaProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServer’:
+	// Set property "DnsServer":
 	if typedInput.DnsServer != nil {
 		dnsServer := *typedInput.DnsServer
 		profile.DnsServer = &dnsServer
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘RootDomainName’:
+	// Set property "RootDomainName":
 	if typedInput.RootDomainName != nil {
 		rootDomainName := *typedInput.RootDomainName
 		profile.RootDomainName = &rootDomainName
@@ -19073,19 +19073,19 @@ func (profile *WindowsGmsaProfile_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsGmsaProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServer’:
+	// Set property "DnsServer":
 	if typedInput.DnsServer != nil {
 		dnsServer := *typedInput.DnsServer
 		profile.DnsServer = &dnsServer
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘RootDomainName’:
+	// Set property "RootDomainName":
 	if typedInput.RootDomainName != nil {
 		rootDomainName := *typedInput.RootDomainName
 		profile.RootDomainName = &rootDomainName
@@ -19178,7 +19178,7 @@ func (publicKey *ContainerServiceSshPublicKey) ConvertToARM(resolved genruntime.
 	}
 	result := &ContainerServiceSshPublicKey_ARM{}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if publicKey.KeyData != nil {
 		keyData := *publicKey.KeyData
 		result.KeyData = &keyData
@@ -19198,7 +19198,7 @@ func (publicKey *ContainerServiceSshPublicKey) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshPublicKey_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
@@ -19268,7 +19268,7 @@ func (publicKey *ContainerServiceSshPublicKey_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshPublicKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
@@ -19331,13 +19331,13 @@ func (metrics *ManagedClusterAzureMonitorProfileKubeStateMetrics) ConvertToARM(r
 	}
 	result := &ManagedClusterAzureMonitorProfileKubeStateMetrics_ARM{}
 
-	// Set property ‘MetricAnnotationsAllowList’:
+	// Set property "MetricAnnotationsAllowList":
 	if metrics.MetricAnnotationsAllowList != nil {
 		metricAnnotationsAllowList := *metrics.MetricAnnotationsAllowList
 		result.MetricAnnotationsAllowList = &metricAnnotationsAllowList
 	}
 
-	// Set property ‘MetricLabelsAllowlist’:
+	// Set property "MetricLabelsAllowlist":
 	if metrics.MetricLabelsAllowlist != nil {
 		metricLabelsAllowlist := *metrics.MetricLabelsAllowlist
 		result.MetricLabelsAllowlist = &metricLabelsAllowlist
@@ -19357,13 +19357,13 @@ func (metrics *ManagedClusterAzureMonitorProfileKubeStateMetrics) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAzureMonitorProfileKubeStateMetrics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MetricAnnotationsAllowList’:
+	// Set property "MetricAnnotationsAllowList":
 	if typedInput.MetricAnnotationsAllowList != nil {
 		metricAnnotationsAllowList := *typedInput.MetricAnnotationsAllowList
 		metrics.MetricAnnotationsAllowList = &metricAnnotationsAllowList
 	}
 
-	// Set property ‘MetricLabelsAllowlist’:
+	// Set property "MetricLabelsAllowlist":
 	if typedInput.MetricLabelsAllowlist != nil {
 		metricLabelsAllowlist := *typedInput.MetricLabelsAllowlist
 		metrics.MetricLabelsAllowlist = &metricLabelsAllowlist
@@ -19450,13 +19450,13 @@ func (metrics *ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MetricAnnotationsAllowList’:
+	// Set property "MetricAnnotationsAllowList":
 	if typedInput.MetricAnnotationsAllowList != nil {
 		metricAnnotationsAllowList := *typedInput.MetricAnnotationsAllowList
 		metrics.MetricAnnotationsAllowList = &metricAnnotationsAllowList
 	}
 
-	// Set property ‘MetricLabelsAllowlist’:
+	// Set property "MetricLabelsAllowlist":
 	if typedInput.MetricLabelsAllowlist != nil {
 		metricLabelsAllowlist := *typedInput.MetricLabelsAllowlist
 		metrics.MetricLabelsAllowlist = &metricLabelsAllowlist
@@ -19524,13 +19524,13 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) ConvertToARM(re
 	}
 	result := &ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if iPs.Count != nil {
 		count := *iPs.Count
 		result.Count = &count
 	}
 
-	// Set property ‘CountIPv6’:
+	// Set property "CountIPv6":
 	if iPs.CountIPv6 != nil {
 		countIPv6 := *iPs.CountIPv6
 		result.CountIPv6 = &countIPv6
@@ -19550,13 +19550,13 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		iPs.Count = &count
 	}
 
-	// Set property ‘CountIPv6’:
+	// Set property "CountIPv6":
 	if typedInput.CountIPv6 != nil {
 		countIPv6 := *typedInput.CountIPv6
 		iPs.CountIPv6 = &countIPv6
@@ -19668,13 +19668,13 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		iPs.Count = &count
 	}
 
-	// Set property ‘CountIPv6’:
+	// Set property "CountIPv6":
 	if typedInput.CountIPv6 != nil {
 		countIPv6 := *typedInput.CountIPv6
 		iPs.CountIPv6 = &countIPv6
@@ -19733,7 +19733,7 @@ func (prefixes *ManagedClusterLoadBalancerProfile_OutboundIPPrefixes) ConvertToA
 	}
 	result := &ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_ARM{}
 
-	// Set property ‘PublicIPPrefixes’:
+	// Set property "PublicIPPrefixes":
 	for _, item := range prefixes.PublicIPPrefixes {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -19756,7 +19756,7 @@ func (prefixes *ManagedClusterLoadBalancerProfile_OutboundIPPrefixes) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPPrefixes’:
+	// Set property "PublicIPPrefixes":
 	for _, item := range typedInput.PublicIPPrefixes {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -19873,7 +19873,7 @@ func (prefixes *ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPPrefixes’:
+	// Set property "PublicIPPrefixes":
 	for _, item := range typedInput.PublicIPPrefixes {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -19960,7 +19960,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_OutboundIPs) ConvertToARM(resolved 
 	}
 	result := &ManagedClusterLoadBalancerProfile_OutboundIPs_ARM{}
 
-	// Set property ‘PublicIPs’:
+	// Set property "PublicIPs":
 	for _, item := range iPs.PublicIPs {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -19983,7 +19983,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_OutboundIPs) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPs_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPs’:
+	// Set property "PublicIPs":
 	for _, item := range typedInput.PublicIPs {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -20100,7 +20100,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPs’:
+	// Set property "PublicIPs":
 	for _, item := range typedInput.PublicIPs {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -20191,7 +20191,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) ConvertToARM(resolved gen
 	}
 	result := &ManagedClusterManagedOutboundIPProfile_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if profile.Count != nil {
 		count := *profile.Count
 		result.Count = &count
@@ -20211,7 +20211,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterManagedOutboundIPProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		profile.Count = &count
@@ -20296,7 +20296,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterManagedOutboundIPProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		profile.Count = &count
@@ -20354,7 +20354,7 @@ func (info *ManagedClusterPodIdentity_ProvisioningInfo_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentity_ProvisioningInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ManagedClusterPodIdentityProvisioningError_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -20442,7 +20442,7 @@ func (monitoring *ManagedClusterSecurityProfileDefenderSecurityMonitoring) Conve
 	}
 	result := &ManagedClusterSecurityProfileDefenderSecurityMonitoring_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if monitoring.Enabled != nil {
 		enabled := *monitoring.Enabled
 		result.Enabled = &enabled
@@ -20462,7 +20462,7 @@ func (monitoring *ManagedClusterSecurityProfileDefenderSecurityMonitoring) Popul
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileDefenderSecurityMonitoring_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		monitoring.Enabled = &enabled
@@ -20546,7 +20546,7 @@ func (monitoring *ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		monitoring.Enabled = &enabled
@@ -20610,7 +20610,7 @@ func (reference *ResourceReference) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ResourceReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -20634,7 +20634,7 @@ func (reference *ResourceReference) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceReference_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -20714,7 +20714,7 @@ func (reference *ResourceReference_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
@@ -20773,7 +20773,7 @@ func (error *ManagedClusterPodIdentityProvisioningError_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProvisioningError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error2 ManagedClusterPodIdentityProvisioningErrorBody_STATUS
 		err := error2.PopulateFromARM(owner, *typedInput.Error)
@@ -20864,13 +20864,13 @@ func (body *ManagedClusterPodIdentityProvisioningErrorBody_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProvisioningErrorBody_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		body.Code = &code
 	}
 
-	// Set property ‘Details’:
+	// Set property "Details":
 	for _, item := range typedInput.Details {
 		var item1 ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled
 		err := item1.PopulateFromARM(owner, item)
@@ -20880,13 +20880,13 @@ func (body *ManagedClusterPodIdentityProvisioningErrorBody_STATUS) PopulateFromA
 		body.Details = append(body.Details, item1)
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		body.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		body.Target = &target
@@ -20998,19 +20998,19 @@ func (unrolled *ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		unrolled.Code = &code
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		unrolled.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		unrolled.Target = &target

--- a/v2/api/containerservice/v1api20230201/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20230201/managed_clusters_agent_pool_types_gen.go
@@ -479,10 +479,10 @@ func (pool *ManagedClusters_AgentPool_Spec) ConvertToARM(resolved genruntime.Con
 	}
 	result := &ManagedClusters_AgentPool_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if pool.AvailabilityZones != nil ||
 		pool.Count != nil ||
 		pool.CreationData != nil ||
@@ -732,7 +732,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusters_AgentPool_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AvailabilityZones {
@@ -740,10 +740,10 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	pool.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Count != nil {
@@ -752,7 +752,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -766,7 +766,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutoScaling != nil {
@@ -775,7 +775,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableEncryptionAtHost != nil {
@@ -784,7 +784,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFIPS != nil {
@@ -793,7 +793,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNodePublicIP != nil {
@@ -802,7 +802,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableUltraSSD != nil {
@@ -811,7 +811,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GpuInstanceProfile != nil {
@@ -820,9 +820,9 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘HostGroupReference’
+	// no assignment for property "HostGroupReference"
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletConfig != nil {
@@ -836,7 +836,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletDiskType != nil {
@@ -845,7 +845,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxOSConfig != nil {
@@ -859,7 +859,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxCount != nil {
@@ -868,7 +868,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxPods != nil {
@@ -877,7 +877,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinCount != nil {
@@ -886,7 +886,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Mode != nil {
@@ -895,7 +895,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeLabels != nil {
@@ -906,9 +906,9 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘NodePublicIPPrefixReference’
+	// no assignment for property "NodePublicIPPrefixReference"
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NodeTaints {
@@ -916,7 +916,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestratorVersion != nil {
@@ -925,7 +925,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
@@ -934,7 +934,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskType != nil {
@@ -943,7 +943,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsSKU != nil {
@@ -952,7 +952,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -961,12 +961,12 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	pool.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// no assignment for property ‘PodSubnetReference’
+	// no assignment for property "PodSubnetReference"
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PowerState != nil {
@@ -980,9 +980,9 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘ProximityPlacementGroupReference’
+	// no assignment for property "ProximityPlacementGroupReference"
 
-	// Set property ‘ScaleDownMode’:
+	// Set property "ScaleDownMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleDownMode != nil {
@@ -991,7 +991,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetEvictionPolicy != nil {
@@ -1000,7 +1000,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetPriority != nil {
@@ -1009,7 +1009,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotMaxPrice != nil {
@@ -1018,7 +1018,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tags != nil {
@@ -1029,7 +1029,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -1038,7 +1038,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradeSettings != nil {
@@ -1052,7 +1052,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VmSize != nil {
@@ -1061,9 +1061,9 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘VnetSubnetReference’
+	// no assignment for property "VnetSubnetReference"
 
-	// Set property ‘WorkloadRuntime’:
+	// Set property "WorkloadRuntime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkloadRuntime != nil {
@@ -2210,7 +2210,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusters_AgentPool_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AvailabilityZones {
@@ -2218,9 +2218,9 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Count != nil {
@@ -2229,7 +2229,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -2243,7 +2243,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘CurrentOrchestratorVersion’:
+	// Set property "CurrentOrchestratorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CurrentOrchestratorVersion != nil {
@@ -2252,7 +2252,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutoScaling != nil {
@@ -2261,7 +2261,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableEncryptionAtHost != nil {
@@ -2270,7 +2270,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFIPS != nil {
@@ -2279,7 +2279,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNodePublicIP != nil {
@@ -2288,7 +2288,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableUltraSSD != nil {
@@ -2297,7 +2297,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GpuInstanceProfile != nil {
@@ -2306,7 +2306,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘HostGroupID’:
+	// Set property "HostGroupID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroupID != nil {
@@ -2315,13 +2315,13 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		pool.Id = &id
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletConfig != nil {
@@ -2335,7 +2335,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletDiskType != nil {
@@ -2344,7 +2344,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxOSConfig != nil {
@@ -2358,7 +2358,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxCount != nil {
@@ -2367,7 +2367,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxPods != nil {
@@ -2376,7 +2376,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinCount != nil {
@@ -2385,7 +2385,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Mode != nil {
@@ -2394,13 +2394,13 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pool.Name = &name
 	}
 
-	// Set property ‘NodeImageVersion’:
+	// Set property "NodeImageVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeImageVersion != nil {
@@ -2409,7 +2409,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeLabels != nil {
@@ -2420,7 +2420,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘NodePublicIPPrefixID’:
+	// Set property "NodePublicIPPrefixID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodePublicIPPrefixID != nil {
@@ -2429,7 +2429,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NodeTaints {
@@ -2437,7 +2437,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestratorVersion != nil {
@@ -2446,7 +2446,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
@@ -2455,7 +2455,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskType != nil {
@@ -2464,7 +2464,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsSKU != nil {
@@ -2473,7 +2473,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -2482,7 +2482,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘PodSubnetID’:
+	// Set property "PodSubnetID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PodSubnetID != nil {
@@ -2491,7 +2491,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PowerState != nil {
@@ -2505,7 +2505,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘PropertiesType’:
+	// Set property "PropertiesType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -2514,7 +2514,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2523,7 +2523,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroupID != nil {
@@ -2532,7 +2532,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ScaleDownMode’:
+	// Set property "ScaleDownMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleDownMode != nil {
@@ -2541,7 +2541,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetEvictionPolicy != nil {
@@ -2550,7 +2550,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetPriority != nil {
@@ -2559,7 +2559,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotMaxPrice != nil {
@@ -2568,7 +2568,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tags != nil {
@@ -2579,13 +2579,13 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		pool.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradeSettings != nil {
@@ -2599,7 +2599,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VmSize != nil {
@@ -2608,7 +2608,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘VnetSubnetID’:
+	// Set property "VnetSubnetID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetSubnetID != nil {
@@ -2617,7 +2617,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘WorkloadRuntime’:
+	// Set property "WorkloadRuntime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkloadRuntime != nil {
@@ -3237,7 +3237,7 @@ func (settings *AgentPoolUpgradeSettings) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &AgentPoolUpgradeSettings_ARM{}
 
-	// Set property ‘MaxSurge’:
+	// Set property "MaxSurge":
 	if settings.MaxSurge != nil {
 		maxSurge := *settings.MaxSurge
 		result.MaxSurge = &maxSurge
@@ -3257,7 +3257,7 @@ func (settings *AgentPoolUpgradeSettings) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AgentPoolUpgradeSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxSurge’:
+	// Set property "MaxSurge":
 	if typedInput.MaxSurge != nil {
 		maxSurge := *typedInput.MaxSurge
 		settings.MaxSurge = &maxSurge
@@ -3329,7 +3329,7 @@ func (settings *AgentPoolUpgradeSettings_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AgentPoolUpgradeSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxSurge’:
+	// Set property "MaxSurge":
 	if typedInput.MaxSurge != nil {
 		maxSurge := *typedInput.MaxSurge
 		settings.MaxSurge = &maxSurge
@@ -3387,7 +3387,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &CreationData_ARM{}
 
-	// Set property ‘SourceResourceId’:
+	// Set property "SourceResourceId":
 	if data.SourceResourceReference != nil {
 		sourceResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*data.SourceResourceReference)
 		if err != nil {
@@ -3411,7 +3411,7 @@ func (data *CreationData) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CreationData_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘SourceResourceReference’
+	// no assignment for property "SourceResourceReference"
 
 	// No error
 	return nil
@@ -3491,7 +3491,7 @@ func (data *CreationData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CreationData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceResourceId’:
+	// Set property "SourceResourceId":
 	if typedInput.SourceResourceId != nil {
 		sourceResourceId := *typedInput.SourceResourceId
 		data.SourceResourceId = &sourceResourceId
@@ -3605,66 +3605,66 @@ func (config *KubeletConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &KubeletConfig_ARM{}
 
-	// Set property ‘AllowedUnsafeSysctls’:
+	// Set property "AllowedUnsafeSysctls":
 	for _, item := range config.AllowedUnsafeSysctls {
 		result.AllowedUnsafeSysctls = append(result.AllowedUnsafeSysctls, item)
 	}
 
-	// Set property ‘ContainerLogMaxFiles’:
+	// Set property "ContainerLogMaxFiles":
 	if config.ContainerLogMaxFiles != nil {
 		containerLogMaxFiles := *config.ContainerLogMaxFiles
 		result.ContainerLogMaxFiles = &containerLogMaxFiles
 	}
 
-	// Set property ‘ContainerLogMaxSizeMB’:
+	// Set property "ContainerLogMaxSizeMB":
 	if config.ContainerLogMaxSizeMB != nil {
 		containerLogMaxSizeMB := *config.ContainerLogMaxSizeMB
 		result.ContainerLogMaxSizeMB = &containerLogMaxSizeMB
 	}
 
-	// Set property ‘CpuCfsQuota’:
+	// Set property "CpuCfsQuota":
 	if config.CpuCfsQuota != nil {
 		cpuCfsQuota := *config.CpuCfsQuota
 		result.CpuCfsQuota = &cpuCfsQuota
 	}
 
-	// Set property ‘CpuCfsQuotaPeriod’:
+	// Set property "CpuCfsQuotaPeriod":
 	if config.CpuCfsQuotaPeriod != nil {
 		cpuCfsQuotaPeriod := *config.CpuCfsQuotaPeriod
 		result.CpuCfsQuotaPeriod = &cpuCfsQuotaPeriod
 	}
 
-	// Set property ‘CpuManagerPolicy’:
+	// Set property "CpuManagerPolicy":
 	if config.CpuManagerPolicy != nil {
 		cpuManagerPolicy := *config.CpuManagerPolicy
 		result.CpuManagerPolicy = &cpuManagerPolicy
 	}
 
-	// Set property ‘FailSwapOn’:
+	// Set property "FailSwapOn":
 	if config.FailSwapOn != nil {
 		failSwapOn := *config.FailSwapOn
 		result.FailSwapOn = &failSwapOn
 	}
 
-	// Set property ‘ImageGcHighThreshold’:
+	// Set property "ImageGcHighThreshold":
 	if config.ImageGcHighThreshold != nil {
 		imageGcHighThreshold := *config.ImageGcHighThreshold
 		result.ImageGcHighThreshold = &imageGcHighThreshold
 	}
 
-	// Set property ‘ImageGcLowThreshold’:
+	// Set property "ImageGcLowThreshold":
 	if config.ImageGcLowThreshold != nil {
 		imageGcLowThreshold := *config.ImageGcLowThreshold
 		result.ImageGcLowThreshold = &imageGcLowThreshold
 	}
 
-	// Set property ‘PodMaxPids’:
+	// Set property "PodMaxPids":
 	if config.PodMaxPids != nil {
 		podMaxPids := *config.PodMaxPids
 		result.PodMaxPids = &podMaxPids
 	}
 
-	// Set property ‘TopologyManagerPolicy’:
+	// Set property "TopologyManagerPolicy":
 	if config.TopologyManagerPolicy != nil {
 		topologyManagerPolicy := *config.TopologyManagerPolicy
 		result.TopologyManagerPolicy = &topologyManagerPolicy
@@ -3684,66 +3684,66 @@ func (config *KubeletConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubeletConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedUnsafeSysctls’:
+	// Set property "AllowedUnsafeSysctls":
 	for _, item := range typedInput.AllowedUnsafeSysctls {
 		config.AllowedUnsafeSysctls = append(config.AllowedUnsafeSysctls, item)
 	}
 
-	// Set property ‘ContainerLogMaxFiles’:
+	// Set property "ContainerLogMaxFiles":
 	if typedInput.ContainerLogMaxFiles != nil {
 		containerLogMaxFiles := *typedInput.ContainerLogMaxFiles
 		config.ContainerLogMaxFiles = &containerLogMaxFiles
 	}
 
-	// Set property ‘ContainerLogMaxSizeMB’:
+	// Set property "ContainerLogMaxSizeMB":
 	if typedInput.ContainerLogMaxSizeMB != nil {
 		containerLogMaxSizeMB := *typedInput.ContainerLogMaxSizeMB
 		config.ContainerLogMaxSizeMB = &containerLogMaxSizeMB
 	}
 
-	// Set property ‘CpuCfsQuota’:
+	// Set property "CpuCfsQuota":
 	if typedInput.CpuCfsQuota != nil {
 		cpuCfsQuota := *typedInput.CpuCfsQuota
 		config.CpuCfsQuota = &cpuCfsQuota
 	}
 
-	// Set property ‘CpuCfsQuotaPeriod’:
+	// Set property "CpuCfsQuotaPeriod":
 	if typedInput.CpuCfsQuotaPeriod != nil {
 		cpuCfsQuotaPeriod := *typedInput.CpuCfsQuotaPeriod
 		config.CpuCfsQuotaPeriod = &cpuCfsQuotaPeriod
 	}
 
-	// Set property ‘CpuManagerPolicy’:
+	// Set property "CpuManagerPolicy":
 	if typedInput.CpuManagerPolicy != nil {
 		cpuManagerPolicy := *typedInput.CpuManagerPolicy
 		config.CpuManagerPolicy = &cpuManagerPolicy
 	}
 
-	// Set property ‘FailSwapOn’:
+	// Set property "FailSwapOn":
 	if typedInput.FailSwapOn != nil {
 		failSwapOn := *typedInput.FailSwapOn
 		config.FailSwapOn = &failSwapOn
 	}
 
-	// Set property ‘ImageGcHighThreshold’:
+	// Set property "ImageGcHighThreshold":
 	if typedInput.ImageGcHighThreshold != nil {
 		imageGcHighThreshold := *typedInput.ImageGcHighThreshold
 		config.ImageGcHighThreshold = &imageGcHighThreshold
 	}
 
-	// Set property ‘ImageGcLowThreshold’:
+	// Set property "ImageGcLowThreshold":
 	if typedInput.ImageGcLowThreshold != nil {
 		imageGcLowThreshold := *typedInput.ImageGcLowThreshold
 		config.ImageGcLowThreshold = &imageGcLowThreshold
 	}
 
-	// Set property ‘PodMaxPids’:
+	// Set property "PodMaxPids":
 	if typedInput.PodMaxPids != nil {
 		podMaxPids := *typedInput.PodMaxPids
 		config.PodMaxPids = &podMaxPids
 	}
 
-	// Set property ‘TopologyManagerPolicy’:
+	// Set property "TopologyManagerPolicy":
 	if typedInput.TopologyManagerPolicy != nil {
 		topologyManagerPolicy := *typedInput.TopologyManagerPolicy
 		config.TopologyManagerPolicy = &topologyManagerPolicy
@@ -3983,66 +3983,66 @@ func (config *KubeletConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubeletConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedUnsafeSysctls’:
+	// Set property "AllowedUnsafeSysctls":
 	for _, item := range typedInput.AllowedUnsafeSysctls {
 		config.AllowedUnsafeSysctls = append(config.AllowedUnsafeSysctls, item)
 	}
 
-	// Set property ‘ContainerLogMaxFiles’:
+	// Set property "ContainerLogMaxFiles":
 	if typedInput.ContainerLogMaxFiles != nil {
 		containerLogMaxFiles := *typedInput.ContainerLogMaxFiles
 		config.ContainerLogMaxFiles = &containerLogMaxFiles
 	}
 
-	// Set property ‘ContainerLogMaxSizeMB’:
+	// Set property "ContainerLogMaxSizeMB":
 	if typedInput.ContainerLogMaxSizeMB != nil {
 		containerLogMaxSizeMB := *typedInput.ContainerLogMaxSizeMB
 		config.ContainerLogMaxSizeMB = &containerLogMaxSizeMB
 	}
 
-	// Set property ‘CpuCfsQuota’:
+	// Set property "CpuCfsQuota":
 	if typedInput.CpuCfsQuota != nil {
 		cpuCfsQuota := *typedInput.CpuCfsQuota
 		config.CpuCfsQuota = &cpuCfsQuota
 	}
 
-	// Set property ‘CpuCfsQuotaPeriod’:
+	// Set property "CpuCfsQuotaPeriod":
 	if typedInput.CpuCfsQuotaPeriod != nil {
 		cpuCfsQuotaPeriod := *typedInput.CpuCfsQuotaPeriod
 		config.CpuCfsQuotaPeriod = &cpuCfsQuotaPeriod
 	}
 
-	// Set property ‘CpuManagerPolicy’:
+	// Set property "CpuManagerPolicy":
 	if typedInput.CpuManagerPolicy != nil {
 		cpuManagerPolicy := *typedInput.CpuManagerPolicy
 		config.CpuManagerPolicy = &cpuManagerPolicy
 	}
 
-	// Set property ‘FailSwapOn’:
+	// Set property "FailSwapOn":
 	if typedInput.FailSwapOn != nil {
 		failSwapOn := *typedInput.FailSwapOn
 		config.FailSwapOn = &failSwapOn
 	}
 
-	// Set property ‘ImageGcHighThreshold’:
+	// Set property "ImageGcHighThreshold":
 	if typedInput.ImageGcHighThreshold != nil {
 		imageGcHighThreshold := *typedInput.ImageGcHighThreshold
 		config.ImageGcHighThreshold = &imageGcHighThreshold
 	}
 
-	// Set property ‘ImageGcLowThreshold’:
+	// Set property "ImageGcLowThreshold":
 	if typedInput.ImageGcLowThreshold != nil {
 		imageGcLowThreshold := *typedInput.ImageGcLowThreshold
 		config.ImageGcLowThreshold = &imageGcLowThreshold
 	}
 
-	// Set property ‘PodMaxPids’:
+	// Set property "PodMaxPids":
 	if typedInput.PodMaxPids != nil {
 		podMaxPids := *typedInput.PodMaxPids
 		config.PodMaxPids = &podMaxPids
 	}
 
-	// Set property ‘TopologyManagerPolicy’:
+	// Set property "TopologyManagerPolicy":
 	if typedInput.TopologyManagerPolicy != nil {
 		topologyManagerPolicy := *typedInput.TopologyManagerPolicy
 		config.TopologyManagerPolicy = &topologyManagerPolicy
@@ -4206,13 +4206,13 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &LinuxOSConfig_ARM{}
 
-	// Set property ‘SwapFileSizeMB’:
+	// Set property "SwapFileSizeMB":
 	if config.SwapFileSizeMB != nil {
 		swapFileSizeMB := *config.SwapFileSizeMB
 		result.SwapFileSizeMB = &swapFileSizeMB
 	}
 
-	// Set property ‘Sysctls’:
+	// Set property "Sysctls":
 	if config.Sysctls != nil {
 		sysctls_ARM, err := (*config.Sysctls).ConvertToARM(resolved)
 		if err != nil {
@@ -4222,13 +4222,13 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Sysctls = &sysctls
 	}
 
-	// Set property ‘TransparentHugePageDefrag’:
+	// Set property "TransparentHugePageDefrag":
 	if config.TransparentHugePageDefrag != nil {
 		transparentHugePageDefrag := *config.TransparentHugePageDefrag
 		result.TransparentHugePageDefrag = &transparentHugePageDefrag
 	}
 
-	// Set property ‘TransparentHugePageEnabled’:
+	// Set property "TransparentHugePageEnabled":
 	if config.TransparentHugePageEnabled != nil {
 		transparentHugePageEnabled := *config.TransparentHugePageEnabled
 		result.TransparentHugePageEnabled = &transparentHugePageEnabled
@@ -4248,13 +4248,13 @@ func (config *LinuxOSConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxOSConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SwapFileSizeMB’:
+	// Set property "SwapFileSizeMB":
 	if typedInput.SwapFileSizeMB != nil {
 		swapFileSizeMB := *typedInput.SwapFileSizeMB
 		config.SwapFileSizeMB = &swapFileSizeMB
 	}
 
-	// Set property ‘Sysctls’:
+	// Set property "Sysctls":
 	if typedInput.Sysctls != nil {
 		var sysctls1 SysctlConfig
 		err := sysctls1.PopulateFromARM(owner, *typedInput.Sysctls)
@@ -4265,13 +4265,13 @@ func (config *LinuxOSConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		config.Sysctls = &sysctls
 	}
 
-	// Set property ‘TransparentHugePageDefrag’:
+	// Set property "TransparentHugePageDefrag":
 	if typedInput.TransparentHugePageDefrag != nil {
 		transparentHugePageDefrag := *typedInput.TransparentHugePageDefrag
 		config.TransparentHugePageDefrag = &transparentHugePageDefrag
 	}
 
-	// Set property ‘TransparentHugePageEnabled’:
+	// Set property "TransparentHugePageEnabled":
 	if typedInput.TransparentHugePageEnabled != nil {
 		transparentHugePageEnabled := *typedInput.TransparentHugePageEnabled
 		config.TransparentHugePageEnabled = &transparentHugePageEnabled
@@ -4407,13 +4407,13 @@ func (config *LinuxOSConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxOSConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SwapFileSizeMB’:
+	// Set property "SwapFileSizeMB":
 	if typedInput.SwapFileSizeMB != nil {
 		swapFileSizeMB := *typedInput.SwapFileSizeMB
 		config.SwapFileSizeMB = &swapFileSizeMB
 	}
 
-	// Set property ‘Sysctls’:
+	// Set property "Sysctls":
 	if typedInput.Sysctls != nil {
 		var sysctls1 SysctlConfig_STATUS
 		err := sysctls1.PopulateFromARM(owner, *typedInput.Sysctls)
@@ -4424,13 +4424,13 @@ func (config *LinuxOSConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		config.Sysctls = &sysctls
 	}
 
-	// Set property ‘TransparentHugePageDefrag’:
+	// Set property "TransparentHugePageDefrag":
 	if typedInput.TransparentHugePageDefrag != nil {
 		transparentHugePageDefrag := *typedInput.TransparentHugePageDefrag
 		config.TransparentHugePageDefrag = &transparentHugePageDefrag
 	}
 
-	// Set property ‘TransparentHugePageEnabled’:
+	// Set property "TransparentHugePageEnabled":
 	if typedInput.TransparentHugePageEnabled != nil {
 		transparentHugePageEnabled := *typedInput.TransparentHugePageEnabled
 		config.TransparentHugePageEnabled = &transparentHugePageEnabled
@@ -4581,7 +4581,7 @@ func (state *PowerState) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &PowerState_ARM{}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if state.Code != nil {
 		code := *state.Code
 		result.Code = &code
@@ -4601,7 +4601,7 @@ func (state *PowerState) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PowerState_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		state.Code = &code
@@ -4841,169 +4841,169 @@ func (config *SysctlConfig) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &SysctlConfig_ARM{}
 
-	// Set property ‘FsAioMaxNr’:
+	// Set property "FsAioMaxNr":
 	if config.FsAioMaxNr != nil {
 		fsAioMaxNr := *config.FsAioMaxNr
 		result.FsAioMaxNr = &fsAioMaxNr
 	}
 
-	// Set property ‘FsFileMax’:
+	// Set property "FsFileMax":
 	if config.FsFileMax != nil {
 		fsFileMax := *config.FsFileMax
 		result.FsFileMax = &fsFileMax
 	}
 
-	// Set property ‘FsInotifyMaxUserWatches’:
+	// Set property "FsInotifyMaxUserWatches":
 	if config.FsInotifyMaxUserWatches != nil {
 		fsInotifyMaxUserWatches := *config.FsInotifyMaxUserWatches
 		result.FsInotifyMaxUserWatches = &fsInotifyMaxUserWatches
 	}
 
-	// Set property ‘FsNrOpen’:
+	// Set property "FsNrOpen":
 	if config.FsNrOpen != nil {
 		fsNrOpen := *config.FsNrOpen
 		result.FsNrOpen = &fsNrOpen
 	}
 
-	// Set property ‘KernelThreadsMax’:
+	// Set property "KernelThreadsMax":
 	if config.KernelThreadsMax != nil {
 		kernelThreadsMax := *config.KernelThreadsMax
 		result.KernelThreadsMax = &kernelThreadsMax
 	}
 
-	// Set property ‘NetCoreNetdevMaxBacklog’:
+	// Set property "NetCoreNetdevMaxBacklog":
 	if config.NetCoreNetdevMaxBacklog != nil {
 		netCoreNetdevMaxBacklog := *config.NetCoreNetdevMaxBacklog
 		result.NetCoreNetdevMaxBacklog = &netCoreNetdevMaxBacklog
 	}
 
-	// Set property ‘NetCoreOptmemMax’:
+	// Set property "NetCoreOptmemMax":
 	if config.NetCoreOptmemMax != nil {
 		netCoreOptmemMax := *config.NetCoreOptmemMax
 		result.NetCoreOptmemMax = &netCoreOptmemMax
 	}
 
-	// Set property ‘NetCoreRmemDefault’:
+	// Set property "NetCoreRmemDefault":
 	if config.NetCoreRmemDefault != nil {
 		netCoreRmemDefault := *config.NetCoreRmemDefault
 		result.NetCoreRmemDefault = &netCoreRmemDefault
 	}
 
-	// Set property ‘NetCoreRmemMax’:
+	// Set property "NetCoreRmemMax":
 	if config.NetCoreRmemMax != nil {
 		netCoreRmemMax := *config.NetCoreRmemMax
 		result.NetCoreRmemMax = &netCoreRmemMax
 	}
 
-	// Set property ‘NetCoreSomaxconn’:
+	// Set property "NetCoreSomaxconn":
 	if config.NetCoreSomaxconn != nil {
 		netCoreSomaxconn := *config.NetCoreSomaxconn
 		result.NetCoreSomaxconn = &netCoreSomaxconn
 	}
 
-	// Set property ‘NetCoreWmemDefault’:
+	// Set property "NetCoreWmemDefault":
 	if config.NetCoreWmemDefault != nil {
 		netCoreWmemDefault := *config.NetCoreWmemDefault
 		result.NetCoreWmemDefault = &netCoreWmemDefault
 	}
 
-	// Set property ‘NetCoreWmemMax’:
+	// Set property "NetCoreWmemMax":
 	if config.NetCoreWmemMax != nil {
 		netCoreWmemMax := *config.NetCoreWmemMax
 		result.NetCoreWmemMax = &netCoreWmemMax
 	}
 
-	// Set property ‘NetIpv4IpLocalPortRange’:
+	// Set property "NetIpv4IpLocalPortRange":
 	if config.NetIpv4IpLocalPortRange != nil {
 		netIpv4IpLocalPortRange := *config.NetIpv4IpLocalPortRange
 		result.NetIpv4IpLocalPortRange = &netIpv4IpLocalPortRange
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh1’:
+	// Set property "NetIpv4NeighDefaultGcThresh1":
 	if config.NetIpv4NeighDefaultGcThresh1 != nil {
 		netIpv4NeighDefaultGcThresh1 := *config.NetIpv4NeighDefaultGcThresh1
 		result.NetIpv4NeighDefaultGcThresh1 = &netIpv4NeighDefaultGcThresh1
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh2’:
+	// Set property "NetIpv4NeighDefaultGcThresh2":
 	if config.NetIpv4NeighDefaultGcThresh2 != nil {
 		netIpv4NeighDefaultGcThresh2 := *config.NetIpv4NeighDefaultGcThresh2
 		result.NetIpv4NeighDefaultGcThresh2 = &netIpv4NeighDefaultGcThresh2
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh3’:
+	// Set property "NetIpv4NeighDefaultGcThresh3":
 	if config.NetIpv4NeighDefaultGcThresh3 != nil {
 		netIpv4NeighDefaultGcThresh3 := *config.NetIpv4NeighDefaultGcThresh3
 		result.NetIpv4NeighDefaultGcThresh3 = &netIpv4NeighDefaultGcThresh3
 	}
 
-	// Set property ‘NetIpv4TcpFinTimeout’:
+	// Set property "NetIpv4TcpFinTimeout":
 	if config.NetIpv4TcpFinTimeout != nil {
 		netIpv4TcpFinTimeout := *config.NetIpv4TcpFinTimeout
 		result.NetIpv4TcpFinTimeout = &netIpv4TcpFinTimeout
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveProbes’:
+	// Set property "NetIpv4TcpKeepaliveProbes":
 	if config.NetIpv4TcpKeepaliveProbes != nil {
 		netIpv4TcpKeepaliveProbes := *config.NetIpv4TcpKeepaliveProbes
 		result.NetIpv4TcpKeepaliveProbes = &netIpv4TcpKeepaliveProbes
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveTime’:
+	// Set property "NetIpv4TcpKeepaliveTime":
 	if config.NetIpv4TcpKeepaliveTime != nil {
 		netIpv4TcpKeepaliveTime := *config.NetIpv4TcpKeepaliveTime
 		result.NetIpv4TcpKeepaliveTime = &netIpv4TcpKeepaliveTime
 	}
 
-	// Set property ‘NetIpv4TcpMaxSynBacklog’:
+	// Set property "NetIpv4TcpMaxSynBacklog":
 	if config.NetIpv4TcpMaxSynBacklog != nil {
 		netIpv4TcpMaxSynBacklog := *config.NetIpv4TcpMaxSynBacklog
 		result.NetIpv4TcpMaxSynBacklog = &netIpv4TcpMaxSynBacklog
 	}
 
-	// Set property ‘NetIpv4TcpMaxTwBuckets’:
+	// Set property "NetIpv4TcpMaxTwBuckets":
 	if config.NetIpv4TcpMaxTwBuckets != nil {
 		netIpv4TcpMaxTwBuckets := *config.NetIpv4TcpMaxTwBuckets
 		result.NetIpv4TcpMaxTwBuckets = &netIpv4TcpMaxTwBuckets
 	}
 
-	// Set property ‘NetIpv4TcpTwReuse’:
+	// Set property "NetIpv4TcpTwReuse":
 	if config.NetIpv4TcpTwReuse != nil {
 		netIpv4TcpTwReuse := *config.NetIpv4TcpTwReuse
 		result.NetIpv4TcpTwReuse = &netIpv4TcpTwReuse
 	}
 
-	// Set property ‘NetIpv4TcpkeepaliveIntvl’:
+	// Set property "NetIpv4TcpkeepaliveIntvl":
 	if config.NetIpv4TcpkeepaliveIntvl != nil {
 		netIpv4TcpkeepaliveIntvl := *config.NetIpv4TcpkeepaliveIntvl
 		result.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
 	}
 
-	// Set property ‘NetNetfilterNfConntrackBuckets’:
+	// Set property "NetNetfilterNfConntrackBuckets":
 	if config.NetNetfilterNfConntrackBuckets != nil {
 		netNetfilterNfConntrackBuckets := *config.NetNetfilterNfConntrackBuckets
 		result.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBuckets
 	}
 
-	// Set property ‘NetNetfilterNfConntrackMax’:
+	// Set property "NetNetfilterNfConntrackMax":
 	if config.NetNetfilterNfConntrackMax != nil {
 		netNetfilterNfConntrackMax := *config.NetNetfilterNfConntrackMax
 		result.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
 	}
 
-	// Set property ‘VmMaxMapCount’:
+	// Set property "VmMaxMapCount":
 	if config.VmMaxMapCount != nil {
 		vmMaxMapCount := *config.VmMaxMapCount
 		result.VmMaxMapCount = &vmMaxMapCount
 	}
 
-	// Set property ‘VmSwappiness’:
+	// Set property "VmSwappiness":
 	if config.VmSwappiness != nil {
 		vmSwappiness := *config.VmSwappiness
 		result.VmSwappiness = &vmSwappiness
 	}
 
-	// Set property ‘VmVfsCachePressure’:
+	// Set property "VmVfsCachePressure":
 	if config.VmVfsCachePressure != nil {
 		vmVfsCachePressure := *config.VmVfsCachePressure
 		result.VmVfsCachePressure = &vmVfsCachePressure
@@ -5023,169 +5023,169 @@ func (config *SysctlConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SysctlConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FsAioMaxNr’:
+	// Set property "FsAioMaxNr":
 	if typedInput.FsAioMaxNr != nil {
 		fsAioMaxNr := *typedInput.FsAioMaxNr
 		config.FsAioMaxNr = &fsAioMaxNr
 	}
 
-	// Set property ‘FsFileMax’:
+	// Set property "FsFileMax":
 	if typedInput.FsFileMax != nil {
 		fsFileMax := *typedInput.FsFileMax
 		config.FsFileMax = &fsFileMax
 	}
 
-	// Set property ‘FsInotifyMaxUserWatches’:
+	// Set property "FsInotifyMaxUserWatches":
 	if typedInput.FsInotifyMaxUserWatches != nil {
 		fsInotifyMaxUserWatches := *typedInput.FsInotifyMaxUserWatches
 		config.FsInotifyMaxUserWatches = &fsInotifyMaxUserWatches
 	}
 
-	// Set property ‘FsNrOpen’:
+	// Set property "FsNrOpen":
 	if typedInput.FsNrOpen != nil {
 		fsNrOpen := *typedInput.FsNrOpen
 		config.FsNrOpen = &fsNrOpen
 	}
 
-	// Set property ‘KernelThreadsMax’:
+	// Set property "KernelThreadsMax":
 	if typedInput.KernelThreadsMax != nil {
 		kernelThreadsMax := *typedInput.KernelThreadsMax
 		config.KernelThreadsMax = &kernelThreadsMax
 	}
 
-	// Set property ‘NetCoreNetdevMaxBacklog’:
+	// Set property "NetCoreNetdevMaxBacklog":
 	if typedInput.NetCoreNetdevMaxBacklog != nil {
 		netCoreNetdevMaxBacklog := *typedInput.NetCoreNetdevMaxBacklog
 		config.NetCoreNetdevMaxBacklog = &netCoreNetdevMaxBacklog
 	}
 
-	// Set property ‘NetCoreOptmemMax’:
+	// Set property "NetCoreOptmemMax":
 	if typedInput.NetCoreOptmemMax != nil {
 		netCoreOptmemMax := *typedInput.NetCoreOptmemMax
 		config.NetCoreOptmemMax = &netCoreOptmemMax
 	}
 
-	// Set property ‘NetCoreRmemDefault’:
+	// Set property "NetCoreRmemDefault":
 	if typedInput.NetCoreRmemDefault != nil {
 		netCoreRmemDefault := *typedInput.NetCoreRmemDefault
 		config.NetCoreRmemDefault = &netCoreRmemDefault
 	}
 
-	// Set property ‘NetCoreRmemMax’:
+	// Set property "NetCoreRmemMax":
 	if typedInput.NetCoreRmemMax != nil {
 		netCoreRmemMax := *typedInput.NetCoreRmemMax
 		config.NetCoreRmemMax = &netCoreRmemMax
 	}
 
-	// Set property ‘NetCoreSomaxconn’:
+	// Set property "NetCoreSomaxconn":
 	if typedInput.NetCoreSomaxconn != nil {
 		netCoreSomaxconn := *typedInput.NetCoreSomaxconn
 		config.NetCoreSomaxconn = &netCoreSomaxconn
 	}
 
-	// Set property ‘NetCoreWmemDefault’:
+	// Set property "NetCoreWmemDefault":
 	if typedInput.NetCoreWmemDefault != nil {
 		netCoreWmemDefault := *typedInput.NetCoreWmemDefault
 		config.NetCoreWmemDefault = &netCoreWmemDefault
 	}
 
-	// Set property ‘NetCoreWmemMax’:
+	// Set property "NetCoreWmemMax":
 	if typedInput.NetCoreWmemMax != nil {
 		netCoreWmemMax := *typedInput.NetCoreWmemMax
 		config.NetCoreWmemMax = &netCoreWmemMax
 	}
 
-	// Set property ‘NetIpv4IpLocalPortRange’:
+	// Set property "NetIpv4IpLocalPortRange":
 	if typedInput.NetIpv4IpLocalPortRange != nil {
 		netIpv4IpLocalPortRange := *typedInput.NetIpv4IpLocalPortRange
 		config.NetIpv4IpLocalPortRange = &netIpv4IpLocalPortRange
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh1’:
+	// Set property "NetIpv4NeighDefaultGcThresh1":
 	if typedInput.NetIpv4NeighDefaultGcThresh1 != nil {
 		netIpv4NeighDefaultGcThresh1 := *typedInput.NetIpv4NeighDefaultGcThresh1
 		config.NetIpv4NeighDefaultGcThresh1 = &netIpv4NeighDefaultGcThresh1
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh2’:
+	// Set property "NetIpv4NeighDefaultGcThresh2":
 	if typedInput.NetIpv4NeighDefaultGcThresh2 != nil {
 		netIpv4NeighDefaultGcThresh2 := *typedInput.NetIpv4NeighDefaultGcThresh2
 		config.NetIpv4NeighDefaultGcThresh2 = &netIpv4NeighDefaultGcThresh2
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh3’:
+	// Set property "NetIpv4NeighDefaultGcThresh3":
 	if typedInput.NetIpv4NeighDefaultGcThresh3 != nil {
 		netIpv4NeighDefaultGcThresh3 := *typedInput.NetIpv4NeighDefaultGcThresh3
 		config.NetIpv4NeighDefaultGcThresh3 = &netIpv4NeighDefaultGcThresh3
 	}
 
-	// Set property ‘NetIpv4TcpFinTimeout’:
+	// Set property "NetIpv4TcpFinTimeout":
 	if typedInput.NetIpv4TcpFinTimeout != nil {
 		netIpv4TcpFinTimeout := *typedInput.NetIpv4TcpFinTimeout
 		config.NetIpv4TcpFinTimeout = &netIpv4TcpFinTimeout
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveProbes’:
+	// Set property "NetIpv4TcpKeepaliveProbes":
 	if typedInput.NetIpv4TcpKeepaliveProbes != nil {
 		netIpv4TcpKeepaliveProbes := *typedInput.NetIpv4TcpKeepaliveProbes
 		config.NetIpv4TcpKeepaliveProbes = &netIpv4TcpKeepaliveProbes
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveTime’:
+	// Set property "NetIpv4TcpKeepaliveTime":
 	if typedInput.NetIpv4TcpKeepaliveTime != nil {
 		netIpv4TcpKeepaliveTime := *typedInput.NetIpv4TcpKeepaliveTime
 		config.NetIpv4TcpKeepaliveTime = &netIpv4TcpKeepaliveTime
 	}
 
-	// Set property ‘NetIpv4TcpMaxSynBacklog’:
+	// Set property "NetIpv4TcpMaxSynBacklog":
 	if typedInput.NetIpv4TcpMaxSynBacklog != nil {
 		netIpv4TcpMaxSynBacklog := *typedInput.NetIpv4TcpMaxSynBacklog
 		config.NetIpv4TcpMaxSynBacklog = &netIpv4TcpMaxSynBacklog
 	}
 
-	// Set property ‘NetIpv4TcpMaxTwBuckets’:
+	// Set property "NetIpv4TcpMaxTwBuckets":
 	if typedInput.NetIpv4TcpMaxTwBuckets != nil {
 		netIpv4TcpMaxTwBuckets := *typedInput.NetIpv4TcpMaxTwBuckets
 		config.NetIpv4TcpMaxTwBuckets = &netIpv4TcpMaxTwBuckets
 	}
 
-	// Set property ‘NetIpv4TcpTwReuse’:
+	// Set property "NetIpv4TcpTwReuse":
 	if typedInput.NetIpv4TcpTwReuse != nil {
 		netIpv4TcpTwReuse := *typedInput.NetIpv4TcpTwReuse
 		config.NetIpv4TcpTwReuse = &netIpv4TcpTwReuse
 	}
 
-	// Set property ‘NetIpv4TcpkeepaliveIntvl’:
+	// Set property "NetIpv4TcpkeepaliveIntvl":
 	if typedInput.NetIpv4TcpkeepaliveIntvl != nil {
 		netIpv4TcpkeepaliveIntvl := *typedInput.NetIpv4TcpkeepaliveIntvl
 		config.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
 	}
 
-	// Set property ‘NetNetfilterNfConntrackBuckets’:
+	// Set property "NetNetfilterNfConntrackBuckets":
 	if typedInput.NetNetfilterNfConntrackBuckets != nil {
 		netNetfilterNfConntrackBuckets := *typedInput.NetNetfilterNfConntrackBuckets
 		config.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBuckets
 	}
 
-	// Set property ‘NetNetfilterNfConntrackMax’:
+	// Set property "NetNetfilterNfConntrackMax":
 	if typedInput.NetNetfilterNfConntrackMax != nil {
 		netNetfilterNfConntrackMax := *typedInput.NetNetfilterNfConntrackMax
 		config.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
 	}
 
-	// Set property ‘VmMaxMapCount’:
+	// Set property "VmMaxMapCount":
 	if typedInput.VmMaxMapCount != nil {
 		vmMaxMapCount := *typedInput.VmMaxMapCount
 		config.VmMaxMapCount = &vmMaxMapCount
 	}
 
-	// Set property ‘VmSwappiness’:
+	// Set property "VmSwappiness":
 	if typedInput.VmSwappiness != nil {
 		vmSwappiness := *typedInput.VmSwappiness
 		config.VmSwappiness = &vmSwappiness
 	}
 
-	// Set property ‘VmVfsCachePressure’:
+	// Set property "VmVfsCachePressure":
 	if typedInput.VmVfsCachePressure != nil {
 		vmVfsCachePressure := *typedInput.VmVfsCachePressure
 		config.VmVfsCachePressure = &vmVfsCachePressure
@@ -5593,169 +5593,169 @@ func (config *SysctlConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SysctlConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FsAioMaxNr’:
+	// Set property "FsAioMaxNr":
 	if typedInput.FsAioMaxNr != nil {
 		fsAioMaxNr := *typedInput.FsAioMaxNr
 		config.FsAioMaxNr = &fsAioMaxNr
 	}
 
-	// Set property ‘FsFileMax’:
+	// Set property "FsFileMax":
 	if typedInput.FsFileMax != nil {
 		fsFileMax := *typedInput.FsFileMax
 		config.FsFileMax = &fsFileMax
 	}
 
-	// Set property ‘FsInotifyMaxUserWatches’:
+	// Set property "FsInotifyMaxUserWatches":
 	if typedInput.FsInotifyMaxUserWatches != nil {
 		fsInotifyMaxUserWatches := *typedInput.FsInotifyMaxUserWatches
 		config.FsInotifyMaxUserWatches = &fsInotifyMaxUserWatches
 	}
 
-	// Set property ‘FsNrOpen’:
+	// Set property "FsNrOpen":
 	if typedInput.FsNrOpen != nil {
 		fsNrOpen := *typedInput.FsNrOpen
 		config.FsNrOpen = &fsNrOpen
 	}
 
-	// Set property ‘KernelThreadsMax’:
+	// Set property "KernelThreadsMax":
 	if typedInput.KernelThreadsMax != nil {
 		kernelThreadsMax := *typedInput.KernelThreadsMax
 		config.KernelThreadsMax = &kernelThreadsMax
 	}
 
-	// Set property ‘NetCoreNetdevMaxBacklog’:
+	// Set property "NetCoreNetdevMaxBacklog":
 	if typedInput.NetCoreNetdevMaxBacklog != nil {
 		netCoreNetdevMaxBacklog := *typedInput.NetCoreNetdevMaxBacklog
 		config.NetCoreNetdevMaxBacklog = &netCoreNetdevMaxBacklog
 	}
 
-	// Set property ‘NetCoreOptmemMax’:
+	// Set property "NetCoreOptmemMax":
 	if typedInput.NetCoreOptmemMax != nil {
 		netCoreOptmemMax := *typedInput.NetCoreOptmemMax
 		config.NetCoreOptmemMax = &netCoreOptmemMax
 	}
 
-	// Set property ‘NetCoreRmemDefault’:
+	// Set property "NetCoreRmemDefault":
 	if typedInput.NetCoreRmemDefault != nil {
 		netCoreRmemDefault := *typedInput.NetCoreRmemDefault
 		config.NetCoreRmemDefault = &netCoreRmemDefault
 	}
 
-	// Set property ‘NetCoreRmemMax’:
+	// Set property "NetCoreRmemMax":
 	if typedInput.NetCoreRmemMax != nil {
 		netCoreRmemMax := *typedInput.NetCoreRmemMax
 		config.NetCoreRmemMax = &netCoreRmemMax
 	}
 
-	// Set property ‘NetCoreSomaxconn’:
+	// Set property "NetCoreSomaxconn":
 	if typedInput.NetCoreSomaxconn != nil {
 		netCoreSomaxconn := *typedInput.NetCoreSomaxconn
 		config.NetCoreSomaxconn = &netCoreSomaxconn
 	}
 
-	// Set property ‘NetCoreWmemDefault’:
+	// Set property "NetCoreWmemDefault":
 	if typedInput.NetCoreWmemDefault != nil {
 		netCoreWmemDefault := *typedInput.NetCoreWmemDefault
 		config.NetCoreWmemDefault = &netCoreWmemDefault
 	}
 
-	// Set property ‘NetCoreWmemMax’:
+	// Set property "NetCoreWmemMax":
 	if typedInput.NetCoreWmemMax != nil {
 		netCoreWmemMax := *typedInput.NetCoreWmemMax
 		config.NetCoreWmemMax = &netCoreWmemMax
 	}
 
-	// Set property ‘NetIpv4IpLocalPortRange’:
+	// Set property "NetIpv4IpLocalPortRange":
 	if typedInput.NetIpv4IpLocalPortRange != nil {
 		netIpv4IpLocalPortRange := *typedInput.NetIpv4IpLocalPortRange
 		config.NetIpv4IpLocalPortRange = &netIpv4IpLocalPortRange
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh1’:
+	// Set property "NetIpv4NeighDefaultGcThresh1":
 	if typedInput.NetIpv4NeighDefaultGcThresh1 != nil {
 		netIpv4NeighDefaultGcThresh1 := *typedInput.NetIpv4NeighDefaultGcThresh1
 		config.NetIpv4NeighDefaultGcThresh1 = &netIpv4NeighDefaultGcThresh1
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh2’:
+	// Set property "NetIpv4NeighDefaultGcThresh2":
 	if typedInput.NetIpv4NeighDefaultGcThresh2 != nil {
 		netIpv4NeighDefaultGcThresh2 := *typedInput.NetIpv4NeighDefaultGcThresh2
 		config.NetIpv4NeighDefaultGcThresh2 = &netIpv4NeighDefaultGcThresh2
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh3’:
+	// Set property "NetIpv4NeighDefaultGcThresh3":
 	if typedInput.NetIpv4NeighDefaultGcThresh3 != nil {
 		netIpv4NeighDefaultGcThresh3 := *typedInput.NetIpv4NeighDefaultGcThresh3
 		config.NetIpv4NeighDefaultGcThresh3 = &netIpv4NeighDefaultGcThresh3
 	}
 
-	// Set property ‘NetIpv4TcpFinTimeout’:
+	// Set property "NetIpv4TcpFinTimeout":
 	if typedInput.NetIpv4TcpFinTimeout != nil {
 		netIpv4TcpFinTimeout := *typedInput.NetIpv4TcpFinTimeout
 		config.NetIpv4TcpFinTimeout = &netIpv4TcpFinTimeout
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveProbes’:
+	// Set property "NetIpv4TcpKeepaliveProbes":
 	if typedInput.NetIpv4TcpKeepaliveProbes != nil {
 		netIpv4TcpKeepaliveProbes := *typedInput.NetIpv4TcpKeepaliveProbes
 		config.NetIpv4TcpKeepaliveProbes = &netIpv4TcpKeepaliveProbes
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveTime’:
+	// Set property "NetIpv4TcpKeepaliveTime":
 	if typedInput.NetIpv4TcpKeepaliveTime != nil {
 		netIpv4TcpKeepaliveTime := *typedInput.NetIpv4TcpKeepaliveTime
 		config.NetIpv4TcpKeepaliveTime = &netIpv4TcpKeepaliveTime
 	}
 
-	// Set property ‘NetIpv4TcpMaxSynBacklog’:
+	// Set property "NetIpv4TcpMaxSynBacklog":
 	if typedInput.NetIpv4TcpMaxSynBacklog != nil {
 		netIpv4TcpMaxSynBacklog := *typedInput.NetIpv4TcpMaxSynBacklog
 		config.NetIpv4TcpMaxSynBacklog = &netIpv4TcpMaxSynBacklog
 	}
 
-	// Set property ‘NetIpv4TcpMaxTwBuckets’:
+	// Set property "NetIpv4TcpMaxTwBuckets":
 	if typedInput.NetIpv4TcpMaxTwBuckets != nil {
 		netIpv4TcpMaxTwBuckets := *typedInput.NetIpv4TcpMaxTwBuckets
 		config.NetIpv4TcpMaxTwBuckets = &netIpv4TcpMaxTwBuckets
 	}
 
-	// Set property ‘NetIpv4TcpTwReuse’:
+	// Set property "NetIpv4TcpTwReuse":
 	if typedInput.NetIpv4TcpTwReuse != nil {
 		netIpv4TcpTwReuse := *typedInput.NetIpv4TcpTwReuse
 		config.NetIpv4TcpTwReuse = &netIpv4TcpTwReuse
 	}
 
-	// Set property ‘NetIpv4TcpkeepaliveIntvl’:
+	// Set property "NetIpv4TcpkeepaliveIntvl":
 	if typedInput.NetIpv4TcpkeepaliveIntvl != nil {
 		netIpv4TcpkeepaliveIntvl := *typedInput.NetIpv4TcpkeepaliveIntvl
 		config.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
 	}
 
-	// Set property ‘NetNetfilterNfConntrackBuckets’:
+	// Set property "NetNetfilterNfConntrackBuckets":
 	if typedInput.NetNetfilterNfConntrackBuckets != nil {
 		netNetfilterNfConntrackBuckets := *typedInput.NetNetfilterNfConntrackBuckets
 		config.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBuckets
 	}
 
-	// Set property ‘NetNetfilterNfConntrackMax’:
+	// Set property "NetNetfilterNfConntrackMax":
 	if typedInput.NetNetfilterNfConntrackMax != nil {
 		netNetfilterNfConntrackMax := *typedInput.NetNetfilterNfConntrackMax
 		config.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
 	}
 
-	// Set property ‘VmMaxMapCount’:
+	// Set property "VmMaxMapCount":
 	if typedInput.VmMaxMapCount != nil {
 		vmMaxMapCount := *typedInput.VmMaxMapCount
 		config.VmMaxMapCount = &vmMaxMapCount
 	}
 
-	// Set property ‘VmSwappiness’:
+	// Set property "VmSwappiness":
 	if typedInput.VmSwappiness != nil {
 		vmSwappiness := *typedInput.VmSwappiness
 		config.VmSwappiness = &vmSwappiness
 	}
 
-	// Set property ‘VmVfsCachePressure’:
+	// Set property "VmVfsCachePressure":
 	if typedInput.VmVfsCachePressure != nil {
 		vmVfsCachePressure := *typedInput.VmVfsCachePressure
 		config.VmVfsCachePressure = &vmVfsCachePressure

--- a/v2/api/containerservice/v1api20230202preview/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20230202preview/managed_cluster_types_gen.go
@@ -540,7 +540,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ManagedCluster_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if cluster.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*cluster.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -550,7 +550,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if cluster.Identity != nil {
 		identity_ARM, err := (*cluster.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -560,16 +560,16 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if cluster.Location != nil {
 		location := *cluster.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if cluster.AadProfile != nil ||
 		cluster.AddonProfiles != nil ||
 		cluster.AgentPoolProfiles != nil ||
@@ -854,7 +854,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.WorkloadAutoScalerProfile = &workloadAutoScalerProfile
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if cluster.Sku != nil {
 		sku_ARM, err := (*cluster.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -864,7 +864,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if cluster.Tags != nil {
 		result.Tags = make(map[string]string, len(cluster.Tags))
 		for key, value := range cluster.Tags {
@@ -886,7 +886,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedCluster_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadProfile’:
+	// Set property "AadProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AadProfile != nil {
@@ -900,7 +900,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AddonProfiles’:
+	// Set property "AddonProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddonProfiles != nil {
@@ -916,7 +916,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AgentPoolProfiles’:
+	// Set property "AgentPoolProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AgentPoolProfiles {
@@ -929,7 +929,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ApiServerAccessProfile’:
+	// Set property "ApiServerAccessProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApiServerAccessProfile != nil {
@@ -943,7 +943,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AutoScalerProfile’:
+	// Set property "AutoScalerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoScalerProfile != nil {
@@ -957,7 +957,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AutoUpgradeProfile’:
+	// Set property "AutoUpgradeProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeProfile != nil {
@@ -971,7 +971,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureMonitorProfile’:
+	// Set property "AzureMonitorProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureMonitorProfile != nil {
@@ -985,10 +985,10 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	cluster.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -1002,7 +1002,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DisableLocalAccounts’:
+	// Set property "DisableLocalAccounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAccounts != nil {
@@ -1011,9 +1011,9 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘DiskEncryptionSetReference’
+	// no assignment for property "DiskEncryptionSetReference"
 
-	// Set property ‘DnsPrefix’:
+	// Set property "DnsPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsPrefix != nil {
@@ -1022,7 +1022,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableNamespaceResources’:
+	// Set property "EnableNamespaceResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNamespaceResources != nil {
@@ -1031,7 +1031,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnablePodSecurityPolicy’:
+	// Set property "EnablePodSecurityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePodSecurityPolicy != nil {
@@ -1040,7 +1040,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableRBAC’:
+	// Set property "EnableRBAC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableRBAC != nil {
@@ -1049,7 +1049,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1060,7 +1060,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		cluster.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FqdnSubdomain’:
+	// Set property "FqdnSubdomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FqdnSubdomain != nil {
@@ -1069,7 +1069,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘GuardrailsProfile’:
+	// Set property "GuardrailsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GuardrailsProfile != nil {
@@ -1083,7 +1083,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘HttpProxyConfig’:
+	// Set property "HttpProxyConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpProxyConfig != nil {
@@ -1097,7 +1097,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedClusterIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1108,7 +1108,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		cluster.Identity = &identity
 	}
 
-	// Set property ‘IdentityProfile’:
+	// Set property "IdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdentityProfile != nil {
@@ -1124,7 +1124,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘IngressProfile’:
+	// Set property "IngressProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IngressProfile != nil {
@@ -1138,7 +1138,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘KubernetesVersion’:
+	// Set property "KubernetesVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubernetesVersion != nil {
@@ -1147,7 +1147,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘LinuxProfile’:
+	// Set property "LinuxProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxProfile != nil {
@@ -1161,13 +1161,13 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		cluster.Location = &location
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -1181,7 +1181,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘NodeResourceGroup’:
+	// Set property "NodeResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeResourceGroup != nil {
@@ -1190,7 +1190,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘NodeResourceGroupProfile’:
+	// Set property "NodeResourceGroupProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeResourceGroupProfile != nil {
@@ -1204,7 +1204,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘OidcIssuerProfile’:
+	// Set property "OidcIssuerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OidcIssuerProfile != nil {
@@ -1218,12 +1218,12 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	cluster.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PodIdentityProfile’:
+	// Set property "PodIdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PodIdentityProfile != nil {
@@ -1237,7 +1237,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘PrivateLinkResources’:
+	// Set property "PrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkResources {
@@ -1250,7 +1250,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1259,7 +1259,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecurityProfile != nil {
@@ -1273,7 +1273,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ServiceMeshProfile’:
+	// Set property "ServiceMeshProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceMeshProfile != nil {
@@ -1287,7 +1287,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ServicePrincipalProfile’:
+	// Set property "ServicePrincipalProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServicePrincipalProfile != nil {
@@ -1301,7 +1301,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 ManagedClusterSKU
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1312,7 +1312,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		cluster.Sku = &sku
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -1326,7 +1326,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		cluster.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1334,7 +1334,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradeSettings != nil {
@@ -1348,7 +1348,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘WindowsProfile’:
+	// Set property "WindowsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WindowsProfile != nil {
@@ -1362,7 +1362,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘WorkloadAutoScalerProfile’:
+	// Set property "WorkloadAutoScalerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkloadAutoScalerProfile != nil {
@@ -2601,7 +2601,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedCluster_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadProfile’:
+	// Set property "AadProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AadProfile != nil {
@@ -2615,7 +2615,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AddonProfiles’:
+	// Set property "AddonProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddonProfiles != nil {
@@ -2631,7 +2631,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AgentPoolProfiles’:
+	// Set property "AgentPoolProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AgentPoolProfiles {
@@ -2644,7 +2644,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ApiServerAccessProfile’:
+	// Set property "ApiServerAccessProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApiServerAccessProfile != nil {
@@ -2658,7 +2658,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AutoScalerProfile’:
+	// Set property "AutoScalerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoScalerProfile != nil {
@@ -2672,7 +2672,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AutoUpgradeProfile’:
+	// Set property "AutoUpgradeProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeProfile != nil {
@@ -2686,7 +2686,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AzureMonitorProfile’:
+	// Set property "AzureMonitorProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureMonitorProfile != nil {
@@ -2700,7 +2700,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AzurePortalFQDN’:
+	// Set property "AzurePortalFQDN":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzurePortalFQDN != nil {
@@ -2709,9 +2709,9 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -2725,7 +2725,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘CurrentKubernetesVersion’:
+	// Set property "CurrentKubernetesVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CurrentKubernetesVersion != nil {
@@ -2734,7 +2734,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DisableLocalAccounts’:
+	// Set property "DisableLocalAccounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAccounts != nil {
@@ -2743,7 +2743,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DiskEncryptionSetID’:
+	// Set property "DiskEncryptionSetID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskEncryptionSetID != nil {
@@ -2752,7 +2752,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DnsPrefix’:
+	// Set property "DnsPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsPrefix != nil {
@@ -2761,7 +2761,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableNamespaceResources’:
+	// Set property "EnableNamespaceResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNamespaceResources != nil {
@@ -2770,7 +2770,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnablePodSecurityPolicy’:
+	// Set property "EnablePodSecurityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePodSecurityPolicy != nil {
@@ -2779,7 +2779,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableRBAC’:
+	// Set property "EnableRBAC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableRBAC != nil {
@@ -2788,7 +2788,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -2799,7 +2799,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -2808,7 +2808,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘FqdnSubdomain’:
+	// Set property "FqdnSubdomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FqdnSubdomain != nil {
@@ -2817,7 +2817,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘GuardrailsProfile’:
+	// Set property "GuardrailsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GuardrailsProfile != nil {
@@ -2831,7 +2831,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘HttpProxyConfig’:
+	// Set property "HttpProxyConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpProxyConfig != nil {
@@ -2845,13 +2845,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		cluster.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedClusterIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2862,7 +2862,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.Identity = &identity
 	}
 
-	// Set property ‘IdentityProfile’:
+	// Set property "IdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdentityProfile != nil {
@@ -2878,7 +2878,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘IngressProfile’:
+	// Set property "IngressProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IngressProfile != nil {
@@ -2892,7 +2892,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘KubernetesVersion’:
+	// Set property "KubernetesVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubernetesVersion != nil {
@@ -2901,7 +2901,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LinuxProfile’:
+	// Set property "LinuxProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxProfile != nil {
@@ -2915,13 +2915,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		cluster.Location = &location
 	}
 
-	// Set property ‘MaxAgentPools’:
+	// Set property "MaxAgentPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxAgentPools != nil {
@@ -2930,13 +2930,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		cluster.Name = &name
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -2950,7 +2950,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘NodeResourceGroup’:
+	// Set property "NodeResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeResourceGroup != nil {
@@ -2959,7 +2959,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘NodeResourceGroupProfile’:
+	// Set property "NodeResourceGroupProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeResourceGroupProfile != nil {
@@ -2973,7 +2973,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘OidcIssuerProfile’:
+	// Set property "OidcIssuerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OidcIssuerProfile != nil {
@@ -2987,7 +2987,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PodIdentityProfile’:
+	// Set property "PodIdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PodIdentityProfile != nil {
@@ -3001,7 +3001,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PowerState != nil {
@@ -3015,7 +3015,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrivateFQDN’:
+	// Set property "PrivateFQDN":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateFQDN != nil {
@@ -3024,7 +3024,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrivateLinkResources’:
+	// Set property "PrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkResources {
@@ -3037,7 +3037,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -3046,7 +3046,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -3055,7 +3055,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SecurityProfile’:
+	// Set property "SecurityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecurityProfile != nil {
@@ -3069,7 +3069,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ServiceMeshProfile’:
+	// Set property "ServiceMeshProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceMeshProfile != nil {
@@ -3083,7 +3083,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ServicePrincipalProfile’:
+	// Set property "ServicePrincipalProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServicePrincipalProfile != nil {
@@ -3097,7 +3097,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 ManagedClusterSKU_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -3108,7 +3108,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.Sku = &sku
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -3122,7 +3122,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -3133,7 +3133,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		cluster.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -3141,13 +3141,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		cluster.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradeSettings != nil {
@@ -3161,7 +3161,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘WindowsProfile’:
+	// Set property "WindowsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WindowsProfile != nil {
@@ -3175,7 +3175,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘WorkloadAutoScalerProfile’:
+	// Set property "WorkloadAutoScalerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkloadAutoScalerProfile != nil {
@@ -4181,7 +4181,7 @@ func (settings *ClusterUpgradeSettings) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ClusterUpgradeSettings_ARM{}
 
-	// Set property ‘OverrideSettings’:
+	// Set property "OverrideSettings":
 	if settings.OverrideSettings != nil {
 		overrideSettings_ARM, err := (*settings.OverrideSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -4205,7 +4205,7 @@ func (settings *ClusterUpgradeSettings) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ClusterUpgradeSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘OverrideSettings’:
+	// Set property "OverrideSettings":
 	if typedInput.OverrideSettings != nil {
 		var overrideSettings1 UpgradeOverrideSettings
 		err := overrideSettings1.PopulateFromARM(owner, *typedInput.OverrideSettings)
@@ -4287,7 +4287,7 @@ func (settings *ClusterUpgradeSettings_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ClusterUpgradeSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘OverrideSettings’:
+	// Set property "OverrideSettings":
 	if typedInput.OverrideSettings != nil {
 		var overrideSettings1 UpgradeOverrideSettings_STATUS
 		err := overrideSettings1.PopulateFromARM(owner, *typedInput.OverrideSettings)
@@ -4370,13 +4370,13 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ContainerServiceLinuxProfile_ARM{}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if profile.Ssh != nil {
 		ssh_ARM, err := (*profile.Ssh).ConvertToARM(resolved)
 		if err != nil {
@@ -4400,13 +4400,13 @@ func (profile *ContainerServiceLinuxProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceLinuxProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 ContainerServiceSshConfiguration
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -4507,13 +4507,13 @@ func (profile *ContainerServiceLinuxProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceLinuxProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 ContainerServiceSshConfiguration_STATUS
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -4659,24 +4659,24 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 	}
 	result := &ContainerServiceNetworkProfile_ARM{}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if profile.DnsServiceIP != nil {
 		dnsServiceIP := *profile.DnsServiceIP
 		result.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if profile.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *profile.DockerBridgeCidr
 		result.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘IpFamilies’:
+	// Set property "IpFamilies":
 	for _, item := range profile.IpFamilies {
 		result.IpFamilies = append(result.IpFamilies, item)
 	}
 
-	// Set property ‘KubeProxyConfig’:
+	// Set property "KubeProxyConfig":
 	if profile.KubeProxyConfig != nil {
 		kubeProxyConfig_ARM, err := (*profile.KubeProxyConfig).ConvertToARM(resolved)
 		if err != nil {
@@ -4686,7 +4686,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 		result.KubeProxyConfig = &kubeProxyConfig
 	}
 
-	// Set property ‘LoadBalancerProfile’:
+	// Set property "LoadBalancerProfile":
 	if profile.LoadBalancerProfile != nil {
 		loadBalancerProfile_ARM, err := (*profile.LoadBalancerProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4696,13 +4696,13 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 		result.LoadBalancerProfile = &loadBalancerProfile
 	}
 
-	// Set property ‘LoadBalancerSku’:
+	// Set property "LoadBalancerSku":
 	if profile.LoadBalancerSku != nil {
 		loadBalancerSku := *profile.LoadBalancerSku
 		result.LoadBalancerSku = &loadBalancerSku
 	}
 
-	// Set property ‘NatGatewayProfile’:
+	// Set property "NatGatewayProfile":
 	if profile.NatGatewayProfile != nil {
 		natGatewayProfile_ARM, err := (*profile.NatGatewayProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -4712,60 +4712,60 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 		result.NatGatewayProfile = &natGatewayProfile
 	}
 
-	// Set property ‘NetworkDataplane’:
+	// Set property "NetworkDataplane":
 	if profile.NetworkDataplane != nil {
 		networkDataplane := *profile.NetworkDataplane
 		result.NetworkDataplane = &networkDataplane
 	}
 
-	// Set property ‘NetworkMode’:
+	// Set property "NetworkMode":
 	if profile.NetworkMode != nil {
 		networkMode := *profile.NetworkMode
 		result.NetworkMode = &networkMode
 	}
 
-	// Set property ‘NetworkPlugin’:
+	// Set property "NetworkPlugin":
 	if profile.NetworkPlugin != nil {
 		networkPlugin := *profile.NetworkPlugin
 		result.NetworkPlugin = &networkPlugin
 	}
 
-	// Set property ‘NetworkPluginMode’:
+	// Set property "NetworkPluginMode":
 	if profile.NetworkPluginMode != nil {
 		networkPluginMode := *profile.NetworkPluginMode
 		result.NetworkPluginMode = &networkPluginMode
 	}
 
-	// Set property ‘NetworkPolicy’:
+	// Set property "NetworkPolicy":
 	if profile.NetworkPolicy != nil {
 		networkPolicy := *profile.NetworkPolicy
 		result.NetworkPolicy = &networkPolicy
 	}
 
-	// Set property ‘OutboundType’:
+	// Set property "OutboundType":
 	if profile.OutboundType != nil {
 		outboundType := *profile.OutboundType
 		result.OutboundType = &outboundType
 	}
 
-	// Set property ‘PodCidr’:
+	// Set property "PodCidr":
 	if profile.PodCidr != nil {
 		podCidr := *profile.PodCidr
 		result.PodCidr = &podCidr
 	}
 
-	// Set property ‘PodCidrs’:
+	// Set property "PodCidrs":
 	for _, item := range profile.PodCidrs {
 		result.PodCidrs = append(result.PodCidrs, item)
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if profile.ServiceCidr != nil {
 		serviceCidr := *profile.ServiceCidr
 		result.ServiceCidr = &serviceCidr
 	}
 
-	// Set property ‘ServiceCidrs’:
+	// Set property "ServiceCidrs":
 	for _, item := range profile.ServiceCidrs {
 		result.ServiceCidrs = append(result.ServiceCidrs, item)
 	}
@@ -4784,24 +4784,24 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceNetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if typedInput.DnsServiceIP != nil {
 		dnsServiceIP := *typedInput.DnsServiceIP
 		profile.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if typedInput.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *typedInput.DockerBridgeCidr
 		profile.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘IpFamilies’:
+	// Set property "IpFamilies":
 	for _, item := range typedInput.IpFamilies {
 		profile.IpFamilies = append(profile.IpFamilies, item)
 	}
 
-	// Set property ‘KubeProxyConfig’:
+	// Set property "KubeProxyConfig":
 	if typedInput.KubeProxyConfig != nil {
 		var kubeProxyConfig1 ContainerServiceNetworkProfile_KubeProxyConfig
 		err := kubeProxyConfig1.PopulateFromARM(owner, *typedInput.KubeProxyConfig)
@@ -4812,7 +4812,7 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 		profile.KubeProxyConfig = &kubeProxyConfig
 	}
 
-	// Set property ‘LoadBalancerProfile’:
+	// Set property "LoadBalancerProfile":
 	if typedInput.LoadBalancerProfile != nil {
 		var loadBalancerProfile1 ManagedClusterLoadBalancerProfile
 		err := loadBalancerProfile1.PopulateFromARM(owner, *typedInput.LoadBalancerProfile)
@@ -4823,13 +4823,13 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 		profile.LoadBalancerProfile = &loadBalancerProfile
 	}
 
-	// Set property ‘LoadBalancerSku’:
+	// Set property "LoadBalancerSku":
 	if typedInput.LoadBalancerSku != nil {
 		loadBalancerSku := *typedInput.LoadBalancerSku
 		profile.LoadBalancerSku = &loadBalancerSku
 	}
 
-	// Set property ‘NatGatewayProfile’:
+	// Set property "NatGatewayProfile":
 	if typedInput.NatGatewayProfile != nil {
 		var natGatewayProfile1 ManagedClusterNATGatewayProfile
 		err := natGatewayProfile1.PopulateFromARM(owner, *typedInput.NatGatewayProfile)
@@ -4840,60 +4840,60 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 		profile.NatGatewayProfile = &natGatewayProfile
 	}
 
-	// Set property ‘NetworkDataplane’:
+	// Set property "NetworkDataplane":
 	if typedInput.NetworkDataplane != nil {
 		networkDataplane := *typedInput.NetworkDataplane
 		profile.NetworkDataplane = &networkDataplane
 	}
 
-	// Set property ‘NetworkMode’:
+	// Set property "NetworkMode":
 	if typedInput.NetworkMode != nil {
 		networkMode := *typedInput.NetworkMode
 		profile.NetworkMode = &networkMode
 	}
 
-	// Set property ‘NetworkPlugin’:
+	// Set property "NetworkPlugin":
 	if typedInput.NetworkPlugin != nil {
 		networkPlugin := *typedInput.NetworkPlugin
 		profile.NetworkPlugin = &networkPlugin
 	}
 
-	// Set property ‘NetworkPluginMode’:
+	// Set property "NetworkPluginMode":
 	if typedInput.NetworkPluginMode != nil {
 		networkPluginMode := *typedInput.NetworkPluginMode
 		profile.NetworkPluginMode = &networkPluginMode
 	}
 
-	// Set property ‘NetworkPolicy’:
+	// Set property "NetworkPolicy":
 	if typedInput.NetworkPolicy != nil {
 		networkPolicy := *typedInput.NetworkPolicy
 		profile.NetworkPolicy = &networkPolicy
 	}
 
-	// Set property ‘OutboundType’:
+	// Set property "OutboundType":
 	if typedInput.OutboundType != nil {
 		outboundType := *typedInput.OutboundType
 		profile.OutboundType = &outboundType
 	}
 
-	// Set property ‘PodCidr’:
+	// Set property "PodCidr":
 	if typedInput.PodCidr != nil {
 		podCidr := *typedInput.PodCidr
 		profile.PodCidr = &podCidr
 	}
 
-	// Set property ‘PodCidrs’:
+	// Set property "PodCidrs":
 	for _, item := range typedInput.PodCidrs {
 		profile.PodCidrs = append(profile.PodCidrs, item)
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if typedInput.ServiceCidr != nil {
 		serviceCidr := *typedInput.ServiceCidr
 		profile.ServiceCidr = &serviceCidr
 	}
 
-	// Set property ‘ServiceCidrs’:
+	// Set property "ServiceCidrs":
 	for _, item := range typedInput.ServiceCidrs {
 		profile.ServiceCidrs = append(profile.ServiceCidrs, item)
 	}
@@ -5290,24 +5290,24 @@ func (profile *ContainerServiceNetworkProfile_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceNetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if typedInput.DnsServiceIP != nil {
 		dnsServiceIP := *typedInput.DnsServiceIP
 		profile.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if typedInput.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *typedInput.DockerBridgeCidr
 		profile.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘IpFamilies’:
+	// Set property "IpFamilies":
 	for _, item := range typedInput.IpFamilies {
 		profile.IpFamilies = append(profile.IpFamilies, item)
 	}
 
-	// Set property ‘KubeProxyConfig’:
+	// Set property "KubeProxyConfig":
 	if typedInput.KubeProxyConfig != nil {
 		var kubeProxyConfig1 ContainerServiceNetworkProfile_KubeProxyConfig_STATUS
 		err := kubeProxyConfig1.PopulateFromARM(owner, *typedInput.KubeProxyConfig)
@@ -5318,7 +5318,7 @@ func (profile *ContainerServiceNetworkProfile_STATUS) PopulateFromARM(owner genr
 		profile.KubeProxyConfig = &kubeProxyConfig
 	}
 
-	// Set property ‘LoadBalancerProfile’:
+	// Set property "LoadBalancerProfile":
 	if typedInput.LoadBalancerProfile != nil {
 		var loadBalancerProfile1 ManagedClusterLoadBalancerProfile_STATUS
 		err := loadBalancerProfile1.PopulateFromARM(owner, *typedInput.LoadBalancerProfile)
@@ -5329,13 +5329,13 @@ func (profile *ContainerServiceNetworkProfile_STATUS) PopulateFromARM(owner genr
 		profile.LoadBalancerProfile = &loadBalancerProfile
 	}
 
-	// Set property ‘LoadBalancerSku’:
+	// Set property "LoadBalancerSku":
 	if typedInput.LoadBalancerSku != nil {
 		loadBalancerSku := *typedInput.LoadBalancerSku
 		profile.LoadBalancerSku = &loadBalancerSku
 	}
 
-	// Set property ‘NatGatewayProfile’:
+	// Set property "NatGatewayProfile":
 	if typedInput.NatGatewayProfile != nil {
 		var natGatewayProfile1 ManagedClusterNATGatewayProfile_STATUS
 		err := natGatewayProfile1.PopulateFromARM(owner, *typedInput.NatGatewayProfile)
@@ -5346,60 +5346,60 @@ func (profile *ContainerServiceNetworkProfile_STATUS) PopulateFromARM(owner genr
 		profile.NatGatewayProfile = &natGatewayProfile
 	}
 
-	// Set property ‘NetworkDataplane’:
+	// Set property "NetworkDataplane":
 	if typedInput.NetworkDataplane != nil {
 		networkDataplane := *typedInput.NetworkDataplane
 		profile.NetworkDataplane = &networkDataplane
 	}
 
-	// Set property ‘NetworkMode’:
+	// Set property "NetworkMode":
 	if typedInput.NetworkMode != nil {
 		networkMode := *typedInput.NetworkMode
 		profile.NetworkMode = &networkMode
 	}
 
-	// Set property ‘NetworkPlugin’:
+	// Set property "NetworkPlugin":
 	if typedInput.NetworkPlugin != nil {
 		networkPlugin := *typedInput.NetworkPlugin
 		profile.NetworkPlugin = &networkPlugin
 	}
 
-	// Set property ‘NetworkPluginMode’:
+	// Set property "NetworkPluginMode":
 	if typedInput.NetworkPluginMode != nil {
 		networkPluginMode := *typedInput.NetworkPluginMode
 		profile.NetworkPluginMode = &networkPluginMode
 	}
 
-	// Set property ‘NetworkPolicy’:
+	// Set property "NetworkPolicy":
 	if typedInput.NetworkPolicy != nil {
 		networkPolicy := *typedInput.NetworkPolicy
 		profile.NetworkPolicy = &networkPolicy
 	}
 
-	// Set property ‘OutboundType’:
+	// Set property "OutboundType":
 	if typedInput.OutboundType != nil {
 		outboundType := *typedInput.OutboundType
 		profile.OutboundType = &outboundType
 	}
 
-	// Set property ‘PodCidr’:
+	// Set property "PodCidr":
 	if typedInput.PodCidr != nil {
 		podCidr := *typedInput.PodCidr
 		profile.PodCidr = &podCidr
 	}
 
-	// Set property ‘PodCidrs’:
+	// Set property "PodCidrs":
 	for _, item := range typedInput.PodCidrs {
 		profile.PodCidrs = append(profile.PodCidrs, item)
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if typedInput.ServiceCidr != nil {
 		serviceCidr := *typedInput.ServiceCidr
 		profile.ServiceCidr = &serviceCidr
 	}
 
-	// Set property ‘ServiceCidrs’:
+	// Set property "ServiceCidrs":
 	for _, item := range typedInput.ServiceCidrs {
 		profile.ServiceCidrs = append(profile.ServiceCidrs, item)
 	}
@@ -5692,7 +5692,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &CreationData_ARM{}
 
-	// Set property ‘SourceResourceId’:
+	// Set property "SourceResourceId":
 	if data.SourceResourceReference != nil {
 		sourceResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*data.SourceResourceReference)
 		if err != nil {
@@ -5716,7 +5716,7 @@ func (data *CreationData) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CreationData_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘SourceResourceReference’
+	// no assignment for property "SourceResourceReference"
 
 	// No error
 	return nil
@@ -5781,7 +5781,7 @@ func (data *CreationData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CreationData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceResourceId’:
+	// Set property "SourceResourceId":
 	if typedInput.SourceResourceId != nil {
 		sourceResourceId := *typedInput.SourceResourceId
 		data.SourceResourceId = &sourceResourceId
@@ -5838,13 +5838,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -5864,13 +5864,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -5948,13 +5948,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -6033,18 +6033,18 @@ func (profile *GuardrailsProfile) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &GuardrailsProfile_ARM{}
 
-	// Set property ‘ExcludedNamespaces’:
+	// Set property "ExcludedNamespaces":
 	for _, item := range profile.ExcludedNamespaces {
 		result.ExcludedNamespaces = append(result.ExcludedNamespaces, item)
 	}
 
-	// Set property ‘Level’:
+	// Set property "Level":
 	if profile.Level != nil {
 		level := *profile.Level
 		result.Level = &level
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if profile.Version != nil {
 		version := *profile.Version
 		result.Version = &version
@@ -6064,18 +6064,18 @@ func (profile *GuardrailsProfile) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GuardrailsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExcludedNamespaces’:
+	// Set property "ExcludedNamespaces":
 	for _, item := range typedInput.ExcludedNamespaces {
 		profile.ExcludedNamespaces = append(profile.ExcludedNamespaces, item)
 	}
 
-	// Set property ‘Level’:
+	// Set property "Level":
 	if typedInput.Level != nil {
 		level := *typedInput.Level
 		profile.Level = &level
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		profile.Version = &version
@@ -6166,23 +6166,23 @@ func (profile *GuardrailsProfile_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GuardrailsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExcludedNamespaces’:
+	// Set property "ExcludedNamespaces":
 	for _, item := range typedInput.ExcludedNamespaces {
 		profile.ExcludedNamespaces = append(profile.ExcludedNamespaces, item)
 	}
 
-	// Set property ‘Level’:
+	// Set property "Level":
 	if typedInput.Level != nil {
 		level := *typedInput.Level
 		profile.Level = &level
 	}
 
-	// Set property ‘SystemExcludedNamespaces’:
+	// Set property "SystemExcludedNamespaces":
 	for _, item := range typedInput.SystemExcludedNamespaces {
 		profile.SystemExcludedNamespaces = append(profile.SystemExcludedNamespaces, item)
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		profile.Version = &version
@@ -6283,42 +6283,42 @@ func (profile *ManagedClusterAADProfile) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &ManagedClusterAADProfile_ARM{}
 
-	// Set property ‘AdminGroupObjectIDs’:
+	// Set property "AdminGroupObjectIDs":
 	for _, item := range profile.AdminGroupObjectIDs {
 		result.AdminGroupObjectIDs = append(result.AdminGroupObjectIDs, item)
 	}
 
-	// Set property ‘ClientAppID’:
+	// Set property "ClientAppID":
 	if profile.ClientAppID != nil {
 		clientAppID := *profile.ClientAppID
 		result.ClientAppID = &clientAppID
 	}
 
-	// Set property ‘EnableAzureRBAC’:
+	// Set property "EnableAzureRBAC":
 	if profile.EnableAzureRBAC != nil {
 		enableAzureRBAC := *profile.EnableAzureRBAC
 		result.EnableAzureRBAC = &enableAzureRBAC
 	}
 
-	// Set property ‘Managed’:
+	// Set property "Managed":
 	if profile.Managed != nil {
 		managed := *profile.Managed
 		result.Managed = &managed
 	}
 
-	// Set property ‘ServerAppID’:
+	// Set property "ServerAppID":
 	if profile.ServerAppID != nil {
 		serverAppID := *profile.ServerAppID
 		result.ServerAppID = &serverAppID
 	}
 
-	// Set property ‘ServerAppSecret’:
+	// Set property "ServerAppSecret":
 	if profile.ServerAppSecret != nil {
 		serverAppSecret := *profile.ServerAppSecret
 		result.ServerAppSecret = &serverAppSecret
 	}
 
-	// Set property ‘TenantID’:
+	// Set property "TenantID":
 	if profile.TenantID != nil {
 		tenantID := *profile.TenantID
 		result.TenantID = &tenantID
@@ -6338,42 +6338,42 @@ func (profile *ManagedClusterAADProfile) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAADProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminGroupObjectIDs’:
+	// Set property "AdminGroupObjectIDs":
 	for _, item := range typedInput.AdminGroupObjectIDs {
 		profile.AdminGroupObjectIDs = append(profile.AdminGroupObjectIDs, item)
 	}
 
-	// Set property ‘ClientAppID’:
+	// Set property "ClientAppID":
 	if typedInput.ClientAppID != nil {
 		clientAppID := *typedInput.ClientAppID
 		profile.ClientAppID = &clientAppID
 	}
 
-	// Set property ‘EnableAzureRBAC’:
+	// Set property "EnableAzureRBAC":
 	if typedInput.EnableAzureRBAC != nil {
 		enableAzureRBAC := *typedInput.EnableAzureRBAC
 		profile.EnableAzureRBAC = &enableAzureRBAC
 	}
 
-	// Set property ‘Managed’:
+	// Set property "Managed":
 	if typedInput.Managed != nil {
 		managed := *typedInput.Managed
 		profile.Managed = &managed
 	}
 
-	// Set property ‘ServerAppID’:
+	// Set property "ServerAppID":
 	if typedInput.ServerAppID != nil {
 		serverAppID := *typedInput.ServerAppID
 		profile.ServerAppID = &serverAppID
 	}
 
-	// Set property ‘ServerAppSecret’:
+	// Set property "ServerAppSecret":
 	if typedInput.ServerAppSecret != nil {
 		serverAppSecret := *typedInput.ServerAppSecret
 		profile.ServerAppSecret = &serverAppSecret
 	}
 
-	// Set property ‘TenantID’:
+	// Set property "TenantID":
 	if typedInput.TenantID != nil {
 		tenantID := *typedInput.TenantID
 		profile.TenantID = &tenantID
@@ -6507,42 +6507,42 @@ func (profile *ManagedClusterAADProfile_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAADProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminGroupObjectIDs’:
+	// Set property "AdminGroupObjectIDs":
 	for _, item := range typedInput.AdminGroupObjectIDs {
 		profile.AdminGroupObjectIDs = append(profile.AdminGroupObjectIDs, item)
 	}
 
-	// Set property ‘ClientAppID’:
+	// Set property "ClientAppID":
 	if typedInput.ClientAppID != nil {
 		clientAppID := *typedInput.ClientAppID
 		profile.ClientAppID = &clientAppID
 	}
 
-	// Set property ‘EnableAzureRBAC’:
+	// Set property "EnableAzureRBAC":
 	if typedInput.EnableAzureRBAC != nil {
 		enableAzureRBAC := *typedInput.EnableAzureRBAC
 		profile.EnableAzureRBAC = &enableAzureRBAC
 	}
 
-	// Set property ‘Managed’:
+	// Set property "Managed":
 	if typedInput.Managed != nil {
 		managed := *typedInput.Managed
 		profile.Managed = &managed
 	}
 
-	// Set property ‘ServerAppID’:
+	// Set property "ServerAppID":
 	if typedInput.ServerAppID != nil {
 		serverAppID := *typedInput.ServerAppID
 		profile.ServerAppID = &serverAppID
 	}
 
-	// Set property ‘ServerAppSecret’:
+	// Set property "ServerAppSecret":
 	if typedInput.ServerAppSecret != nil {
 		serverAppSecret := *typedInput.ServerAppSecret
 		profile.ServerAppSecret = &serverAppSecret
 	}
 
-	// Set property ‘TenantID’:
+	// Set property "TenantID":
 	if typedInput.TenantID != nil {
 		tenantID := *typedInput.TenantID
 		profile.TenantID = &tenantID
@@ -6656,7 +6656,7 @@ func (profile *ManagedClusterAddonProfile) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ManagedClusterAddonProfile_ARM{}
 
-	// Set property ‘Config’:
+	// Set property "Config":
 	if profile.Config != nil {
 		result.Config = make(map[string]string, len(profile.Config))
 		for key, value := range profile.Config {
@@ -6664,7 +6664,7 @@ func (profile *ManagedClusterAddonProfile) ConvertToARM(resolved genruntime.Conv
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if profile.Enabled != nil {
 		enabled := *profile.Enabled
 		result.Enabled = &enabled
@@ -6684,7 +6684,7 @@ func (profile *ManagedClusterAddonProfile) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAddonProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Config’:
+	// Set property "Config":
 	if typedInput.Config != nil {
 		profile.Config = make(map[string]string, len(typedInput.Config))
 		for key, value := range typedInput.Config {
@@ -6692,7 +6692,7 @@ func (profile *ManagedClusterAddonProfile) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
@@ -6773,7 +6773,7 @@ func (profile *ManagedClusterAddonProfile_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAddonProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Config’:
+	// Set property "Config":
 	if typedInput.Config != nil {
 		profile.Config = make(map[string]string, len(typedInput.Config))
 		for key, value := range typedInput.Config {
@@ -6781,13 +6781,13 @@ func (profile *ManagedClusterAddonProfile_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 UserAssignedIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -7055,24 +7055,24 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 	}
 	result := &ManagedClusterAgentPoolProfile_ARM{}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	for _, item := range profile.AvailabilityZones {
 		result.AvailabilityZones = append(result.AvailabilityZones, item)
 	}
 
-	// Set property ‘CapacityReservationGroupID’:
+	// Set property "CapacityReservationGroupID":
 	if profile.CapacityReservationGroupID != nil {
 		capacityReservationGroupID := *profile.CapacityReservationGroupID
 		result.CapacityReservationGroupID = &capacityReservationGroupID
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if profile.Count != nil {
 		count := *profile.Count
 		result.Count = &count
 	}
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	if profile.CreationData != nil {
 		creationData_ARM, err := (*profile.CreationData).ConvertToARM(resolved)
 		if err != nil {
@@ -7082,49 +7082,49 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.CreationData = &creationData
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	if profile.EnableAutoScaling != nil {
 		enableAutoScaling := *profile.EnableAutoScaling
 		result.EnableAutoScaling = &enableAutoScaling
 	}
 
-	// Set property ‘EnableCustomCATrust’:
+	// Set property "EnableCustomCATrust":
 	if profile.EnableCustomCATrust != nil {
 		enableCustomCATrust := *profile.EnableCustomCATrust
 		result.EnableCustomCATrust = &enableCustomCATrust
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	if profile.EnableEncryptionAtHost != nil {
 		enableEncryptionAtHost := *profile.EnableEncryptionAtHost
 		result.EnableEncryptionAtHost = &enableEncryptionAtHost
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	if profile.EnableFIPS != nil {
 		enableFIPS := *profile.EnableFIPS
 		result.EnableFIPS = &enableFIPS
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	if profile.EnableNodePublicIP != nil {
 		enableNodePublicIP := *profile.EnableNodePublicIP
 		result.EnableNodePublicIP = &enableNodePublicIP
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	if profile.EnableUltraSSD != nil {
 		enableUltraSSD := *profile.EnableUltraSSD
 		result.EnableUltraSSD = &enableUltraSSD
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	if profile.GpuInstanceProfile != nil {
 		gpuInstanceProfile := *profile.GpuInstanceProfile
 		result.GpuInstanceProfile = &gpuInstanceProfile
 	}
 
-	// Set property ‘HostGroupID’:
+	// Set property "HostGroupID":
 	if profile.HostGroupReference != nil {
 		hostGroupReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.HostGroupReference)
 		if err != nil {
@@ -7134,7 +7134,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.HostGroupID = &hostGroupReference
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	if profile.KubeletConfig != nil {
 		kubeletConfig_ARM, err := (*profile.KubeletConfig).ConvertToARM(resolved)
 		if err != nil {
@@ -7144,13 +7144,13 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.KubeletConfig = &kubeletConfig
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	if profile.KubeletDiskType != nil {
 		kubeletDiskType := *profile.KubeletDiskType
 		result.KubeletDiskType = &kubeletDiskType
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	if profile.LinuxOSConfig != nil {
 		linuxOSConfig_ARM, err := (*profile.LinuxOSConfig).ConvertToARM(resolved)
 		if err != nil {
@@ -7160,43 +7160,43 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.LinuxOSConfig = &linuxOSConfig
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	if profile.MaxCount != nil {
 		maxCount := *profile.MaxCount
 		result.MaxCount = &maxCount
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	if profile.MaxPods != nil {
 		maxPods := *profile.MaxPods
 		result.MaxPods = &maxPods
 	}
 
-	// Set property ‘MessageOfTheDay’:
+	// Set property "MessageOfTheDay":
 	if profile.MessageOfTheDay != nil {
 		messageOfTheDay := *profile.MessageOfTheDay
 		result.MessageOfTheDay = &messageOfTheDay
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	if profile.MinCount != nil {
 		minCount := *profile.MinCount
 		result.MinCount = &minCount
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if profile.Mode != nil {
 		mode := *profile.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if profile.Name != nil {
 		name := *profile.Name
 		result.Name = &name
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if profile.NetworkProfile != nil {
 		networkProfile_ARM, err := (*profile.NetworkProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -7206,7 +7206,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	if profile.NodeLabels != nil {
 		result.NodeLabels = make(map[string]string, len(profile.NodeLabels))
 		for key, value := range profile.NodeLabels {
@@ -7214,7 +7214,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		}
 	}
 
-	// Set property ‘NodePublicIPPrefixID’:
+	// Set property "NodePublicIPPrefixID":
 	if profile.NodePublicIPPrefixReference != nil {
 		nodePublicIPPrefixReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.NodePublicIPPrefixReference)
 		if err != nil {
@@ -7224,42 +7224,42 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.NodePublicIPPrefixID = &nodePublicIPPrefixReference
 	}
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	for _, item := range profile.NodeTaints {
 		result.NodeTaints = append(result.NodeTaints, item)
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	if profile.OrchestratorVersion != nil {
 		orchestratorVersion := *profile.OrchestratorVersion
 		result.OrchestratorVersion = &orchestratorVersion
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	if profile.OsDiskSizeGB != nil {
 		osDiskSizeGB := *profile.OsDiskSizeGB
 		result.OsDiskSizeGB = &osDiskSizeGB
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	if profile.OsDiskType != nil {
 		osDiskType := *profile.OsDiskType
 		result.OsDiskType = &osDiskType
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	if profile.OsSKU != nil {
 		osSKU := *profile.OsSKU
 		result.OsSKU = &osSKU
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if profile.OsType != nil {
 		osType := *profile.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘PodSubnetID’:
+	// Set property "PodSubnetID":
 	if profile.PodSubnetReference != nil {
 		podSubnetReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.PodSubnetReference)
 		if err != nil {
@@ -7269,7 +7269,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.PodSubnetID = &podSubnetReference
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	if profile.PowerState != nil {
 		powerState_ARM, err := (*profile.PowerState).ConvertToARM(resolved)
 		if err != nil {
@@ -7279,7 +7279,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.PowerState = &powerState
 	}
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	if profile.ProximityPlacementGroupReference != nil {
 		proximityPlacementGroupReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.ProximityPlacementGroupReference)
 		if err != nil {
@@ -7289,31 +7289,31 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.ProximityPlacementGroupID = &proximityPlacementGroupReference
 	}
 
-	// Set property ‘ScaleDownMode’:
+	// Set property "ScaleDownMode":
 	if profile.ScaleDownMode != nil {
 		scaleDownMode := *profile.ScaleDownMode
 		result.ScaleDownMode = &scaleDownMode
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	if profile.ScaleSetEvictionPolicy != nil {
 		scaleSetEvictionPolicy := *profile.ScaleSetEvictionPolicy
 		result.ScaleSetEvictionPolicy = &scaleSetEvictionPolicy
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	if profile.ScaleSetPriority != nil {
 		scaleSetPriority := *profile.ScaleSetPriority
 		result.ScaleSetPriority = &scaleSetPriority
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	if profile.SpotMaxPrice != nil {
 		spotMaxPrice := *profile.SpotMaxPrice
 		result.SpotMaxPrice = &spotMaxPrice
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if profile.Tags != nil {
 		result.Tags = make(map[string]string, len(profile.Tags))
 		for key, value := range profile.Tags {
@@ -7321,13 +7321,13 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if profile.Type != nil {
 		typeVar := *profile.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	if profile.UpgradeSettings != nil {
 		upgradeSettings_ARM, err := (*profile.UpgradeSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -7337,13 +7337,13 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.UpgradeSettings = &upgradeSettings
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if profile.VmSize != nil {
 		vmSize := *profile.VmSize
 		result.VmSize = &vmSize
 	}
 
-	// Set property ‘VnetSubnetID’:
+	// Set property "VnetSubnetID":
 	if profile.VnetSubnetReference != nil {
 		vnetSubnetReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.VnetSubnetReference)
 		if err != nil {
@@ -7353,7 +7353,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.VnetSubnetID = &vnetSubnetReference
 	}
 
-	// Set property ‘WindowsProfile’:
+	// Set property "WindowsProfile":
 	if profile.WindowsProfile != nil {
 		windowsProfile_ARM, err := (*profile.WindowsProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -7363,7 +7363,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.WindowsProfile = &windowsProfile
 	}
 
-	// Set property ‘WorkloadRuntime’:
+	// Set property "WorkloadRuntime":
 	if profile.WorkloadRuntime != nil {
 		workloadRuntime := *profile.WorkloadRuntime
 		result.WorkloadRuntime = &workloadRuntime
@@ -7383,24 +7383,24 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAgentPoolProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	for _, item := range typedInput.AvailabilityZones {
 		profile.AvailabilityZones = append(profile.AvailabilityZones, item)
 	}
 
-	// Set property ‘CapacityReservationGroupID’:
+	// Set property "CapacityReservationGroupID":
 	if typedInput.CapacityReservationGroupID != nil {
 		capacityReservationGroupID := *typedInput.CapacityReservationGroupID
 		profile.CapacityReservationGroupID = &capacityReservationGroupID
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		profile.Count = &count
 	}
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	if typedInput.CreationData != nil {
 		var creationData1 CreationData
 		err := creationData1.PopulateFromARM(owner, *typedInput.CreationData)
@@ -7411,51 +7411,51 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.CreationData = &creationData
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	if typedInput.EnableAutoScaling != nil {
 		enableAutoScaling := *typedInput.EnableAutoScaling
 		profile.EnableAutoScaling = &enableAutoScaling
 	}
 
-	// Set property ‘EnableCustomCATrust’:
+	// Set property "EnableCustomCATrust":
 	if typedInput.EnableCustomCATrust != nil {
 		enableCustomCATrust := *typedInput.EnableCustomCATrust
 		profile.EnableCustomCATrust = &enableCustomCATrust
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	if typedInput.EnableEncryptionAtHost != nil {
 		enableEncryptionAtHost := *typedInput.EnableEncryptionAtHost
 		profile.EnableEncryptionAtHost = &enableEncryptionAtHost
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	if typedInput.EnableFIPS != nil {
 		enableFIPS := *typedInput.EnableFIPS
 		profile.EnableFIPS = &enableFIPS
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	if typedInput.EnableNodePublicIP != nil {
 		enableNodePublicIP := *typedInput.EnableNodePublicIP
 		profile.EnableNodePublicIP = &enableNodePublicIP
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	if typedInput.EnableUltraSSD != nil {
 		enableUltraSSD := *typedInput.EnableUltraSSD
 		profile.EnableUltraSSD = &enableUltraSSD
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	if typedInput.GpuInstanceProfile != nil {
 		gpuInstanceProfile := *typedInput.GpuInstanceProfile
 		profile.GpuInstanceProfile = &gpuInstanceProfile
 	}
 
-	// no assignment for property ‘HostGroupReference’
+	// no assignment for property "HostGroupReference"
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	if typedInput.KubeletConfig != nil {
 		var kubeletConfig1 KubeletConfig
 		err := kubeletConfig1.PopulateFromARM(owner, *typedInput.KubeletConfig)
@@ -7466,13 +7466,13 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.KubeletConfig = &kubeletConfig
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	if typedInput.KubeletDiskType != nil {
 		kubeletDiskType := *typedInput.KubeletDiskType
 		profile.KubeletDiskType = &kubeletDiskType
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	if typedInput.LinuxOSConfig != nil {
 		var linuxOSConfig1 LinuxOSConfig
 		err := linuxOSConfig1.PopulateFromARM(owner, *typedInput.LinuxOSConfig)
@@ -7483,43 +7483,43 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.LinuxOSConfig = &linuxOSConfig
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	if typedInput.MaxCount != nil {
 		maxCount := *typedInput.MaxCount
 		profile.MaxCount = &maxCount
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	if typedInput.MaxPods != nil {
 		maxPods := *typedInput.MaxPods
 		profile.MaxPods = &maxPods
 	}
 
-	// Set property ‘MessageOfTheDay’:
+	// Set property "MessageOfTheDay":
 	if typedInput.MessageOfTheDay != nil {
 		messageOfTheDay := *typedInput.MessageOfTheDay
 		profile.MessageOfTheDay = &messageOfTheDay
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	if typedInput.MinCount != nil {
 		minCount := *typedInput.MinCount
 		profile.MinCount = &minCount
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		profile.Mode = &mode
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if typedInput.NetworkProfile != nil {
 		var networkProfile1 AgentPoolNetworkProfile
 		err := networkProfile1.PopulateFromARM(owner, *typedInput.NetworkProfile)
@@ -7530,7 +7530,7 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	if typedInput.NodeLabels != nil {
 		profile.NodeLabels = make(map[string]string, len(typedInput.NodeLabels))
 		for key, value := range typedInput.NodeLabels {
@@ -7538,46 +7538,46 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// no assignment for property ‘NodePublicIPPrefixReference’
+	// no assignment for property "NodePublicIPPrefixReference"
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	for _, item := range typedInput.NodeTaints {
 		profile.NodeTaints = append(profile.NodeTaints, item)
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	if typedInput.OrchestratorVersion != nil {
 		orchestratorVersion := *typedInput.OrchestratorVersion
 		profile.OrchestratorVersion = &orchestratorVersion
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
 		osDiskSizeGB := *typedInput.OsDiskSizeGB
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	if typedInput.OsDiskType != nil {
 		osDiskType := *typedInput.OsDiskType
 		profile.OsDiskType = &osDiskType
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	if typedInput.OsSKU != nil {
 		osSKU := *typedInput.OsSKU
 		profile.OsSKU = &osSKU
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		profile.OsType = &osType
 	}
 
-	// no assignment for property ‘PodSubnetReference’
+	// no assignment for property "PodSubnetReference"
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	if typedInput.PowerState != nil {
 		var powerState1 PowerState
 		err := powerState1.PopulateFromARM(owner, *typedInput.PowerState)
@@ -7588,33 +7588,33 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.PowerState = &powerState
 	}
 
-	// no assignment for property ‘ProximityPlacementGroupReference’
+	// no assignment for property "ProximityPlacementGroupReference"
 
-	// Set property ‘ScaleDownMode’:
+	// Set property "ScaleDownMode":
 	if typedInput.ScaleDownMode != nil {
 		scaleDownMode := *typedInput.ScaleDownMode
 		profile.ScaleDownMode = &scaleDownMode
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	if typedInput.ScaleSetEvictionPolicy != nil {
 		scaleSetEvictionPolicy := *typedInput.ScaleSetEvictionPolicy
 		profile.ScaleSetEvictionPolicy = &scaleSetEvictionPolicy
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	if typedInput.ScaleSetPriority != nil {
 		scaleSetPriority := *typedInput.ScaleSetPriority
 		profile.ScaleSetPriority = &scaleSetPriority
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	if typedInput.SpotMaxPrice != nil {
 		spotMaxPrice := *typedInput.SpotMaxPrice
 		profile.SpotMaxPrice = &spotMaxPrice
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		profile.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -7622,13 +7622,13 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	if typedInput.UpgradeSettings != nil {
 		var upgradeSettings1 AgentPoolUpgradeSettings
 		err := upgradeSettings1.PopulateFromARM(owner, *typedInput.UpgradeSettings)
@@ -7639,15 +7639,15 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.UpgradeSettings = &upgradeSettings
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
 	}
 
-	// no assignment for property ‘VnetSubnetReference’
+	// no assignment for property "VnetSubnetReference"
 
-	// Set property ‘WindowsProfile’:
+	// Set property "WindowsProfile":
 	if typedInput.WindowsProfile != nil {
 		var windowsProfile1 AgentPoolWindowsProfile
 		err := windowsProfile1.PopulateFromARM(owner, *typedInput.WindowsProfile)
@@ -7658,7 +7658,7 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.WindowsProfile = &windowsProfile
 	}
 
-	// Set property ‘WorkloadRuntime’:
+	// Set property "WorkloadRuntime":
 	if typedInput.WorkloadRuntime != nil {
 		workloadRuntime := *typedInput.WorkloadRuntime
 		profile.WorkloadRuntime = &workloadRuntime
@@ -8529,24 +8529,24 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAgentPoolProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	for _, item := range typedInput.AvailabilityZones {
 		profile.AvailabilityZones = append(profile.AvailabilityZones, item)
 	}
 
-	// Set property ‘CapacityReservationGroupID’:
+	// Set property "CapacityReservationGroupID":
 	if typedInput.CapacityReservationGroupID != nil {
 		capacityReservationGroupID := *typedInput.CapacityReservationGroupID
 		profile.CapacityReservationGroupID = &capacityReservationGroupID
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		profile.Count = &count
 	}
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	if typedInput.CreationData != nil {
 		var creationData1 CreationData_STATUS
 		err := creationData1.PopulateFromARM(owner, *typedInput.CreationData)
@@ -8557,61 +8557,61 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.CreationData = &creationData
 	}
 
-	// Set property ‘CurrentOrchestratorVersion’:
+	// Set property "CurrentOrchestratorVersion":
 	if typedInput.CurrentOrchestratorVersion != nil {
 		currentOrchestratorVersion := *typedInput.CurrentOrchestratorVersion
 		profile.CurrentOrchestratorVersion = &currentOrchestratorVersion
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	if typedInput.EnableAutoScaling != nil {
 		enableAutoScaling := *typedInput.EnableAutoScaling
 		profile.EnableAutoScaling = &enableAutoScaling
 	}
 
-	// Set property ‘EnableCustomCATrust’:
+	// Set property "EnableCustomCATrust":
 	if typedInput.EnableCustomCATrust != nil {
 		enableCustomCATrust := *typedInput.EnableCustomCATrust
 		profile.EnableCustomCATrust = &enableCustomCATrust
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	if typedInput.EnableEncryptionAtHost != nil {
 		enableEncryptionAtHost := *typedInput.EnableEncryptionAtHost
 		profile.EnableEncryptionAtHost = &enableEncryptionAtHost
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	if typedInput.EnableFIPS != nil {
 		enableFIPS := *typedInput.EnableFIPS
 		profile.EnableFIPS = &enableFIPS
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	if typedInput.EnableNodePublicIP != nil {
 		enableNodePublicIP := *typedInput.EnableNodePublicIP
 		profile.EnableNodePublicIP = &enableNodePublicIP
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	if typedInput.EnableUltraSSD != nil {
 		enableUltraSSD := *typedInput.EnableUltraSSD
 		profile.EnableUltraSSD = &enableUltraSSD
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	if typedInput.GpuInstanceProfile != nil {
 		gpuInstanceProfile := *typedInput.GpuInstanceProfile
 		profile.GpuInstanceProfile = &gpuInstanceProfile
 	}
 
-	// Set property ‘HostGroupID’:
+	// Set property "HostGroupID":
 	if typedInput.HostGroupID != nil {
 		hostGroupID := *typedInput.HostGroupID
 		profile.HostGroupID = &hostGroupID
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	if typedInput.KubeletConfig != nil {
 		var kubeletConfig1 KubeletConfig_STATUS
 		err := kubeletConfig1.PopulateFromARM(owner, *typedInput.KubeletConfig)
@@ -8622,13 +8622,13 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.KubeletConfig = &kubeletConfig
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	if typedInput.KubeletDiskType != nil {
 		kubeletDiskType := *typedInput.KubeletDiskType
 		profile.KubeletDiskType = &kubeletDiskType
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	if typedInput.LinuxOSConfig != nil {
 		var linuxOSConfig1 LinuxOSConfig_STATUS
 		err := linuxOSConfig1.PopulateFromARM(owner, *typedInput.LinuxOSConfig)
@@ -8639,43 +8639,43 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.LinuxOSConfig = &linuxOSConfig
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	if typedInput.MaxCount != nil {
 		maxCount := *typedInput.MaxCount
 		profile.MaxCount = &maxCount
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	if typedInput.MaxPods != nil {
 		maxPods := *typedInput.MaxPods
 		profile.MaxPods = &maxPods
 	}
 
-	// Set property ‘MessageOfTheDay’:
+	// Set property "MessageOfTheDay":
 	if typedInput.MessageOfTheDay != nil {
 		messageOfTheDay := *typedInput.MessageOfTheDay
 		profile.MessageOfTheDay = &messageOfTheDay
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	if typedInput.MinCount != nil {
 		minCount := *typedInput.MinCount
 		profile.MinCount = &minCount
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		profile.Mode = &mode
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	if typedInput.NetworkProfile != nil {
 		var networkProfile1 AgentPoolNetworkProfile_STATUS
 		err := networkProfile1.PopulateFromARM(owner, *typedInput.NetworkProfile)
@@ -8686,13 +8686,13 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.NetworkProfile = &networkProfile
 	}
 
-	// Set property ‘NodeImageVersion’:
+	// Set property "NodeImageVersion":
 	if typedInput.NodeImageVersion != nil {
 		nodeImageVersion := *typedInput.NodeImageVersion
 		profile.NodeImageVersion = &nodeImageVersion
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	if typedInput.NodeLabels != nil {
 		profile.NodeLabels = make(map[string]string, len(typedInput.NodeLabels))
 		for key, value := range typedInput.NodeLabels {
@@ -8700,54 +8700,54 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘NodePublicIPPrefixID’:
+	// Set property "NodePublicIPPrefixID":
 	if typedInput.NodePublicIPPrefixID != nil {
 		nodePublicIPPrefixID := *typedInput.NodePublicIPPrefixID
 		profile.NodePublicIPPrefixID = &nodePublicIPPrefixID
 	}
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	for _, item := range typedInput.NodeTaints {
 		profile.NodeTaints = append(profile.NodeTaints, item)
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	if typedInput.OrchestratorVersion != nil {
 		orchestratorVersion := *typedInput.OrchestratorVersion
 		profile.OrchestratorVersion = &orchestratorVersion
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
 		osDiskSizeGB := *typedInput.OsDiskSizeGB
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	if typedInput.OsDiskType != nil {
 		osDiskType := *typedInput.OsDiskType
 		profile.OsDiskType = &osDiskType
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	if typedInput.OsSKU != nil {
 		osSKU := *typedInput.OsSKU
 		profile.OsSKU = &osSKU
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		profile.OsType = &osType
 	}
 
-	// Set property ‘PodSubnetID’:
+	// Set property "PodSubnetID":
 	if typedInput.PodSubnetID != nil {
 		podSubnetID := *typedInput.PodSubnetID
 		profile.PodSubnetID = &podSubnetID
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	if typedInput.PowerState != nil {
 		var powerState1 PowerState_STATUS
 		err := powerState1.PopulateFromARM(owner, *typedInput.PowerState)
@@ -8758,43 +8758,43 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.PowerState = &powerState
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		profile.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	if typedInput.ProximityPlacementGroupID != nil {
 		proximityPlacementGroupID := *typedInput.ProximityPlacementGroupID
 		profile.ProximityPlacementGroupID = &proximityPlacementGroupID
 	}
 
-	// Set property ‘ScaleDownMode’:
+	// Set property "ScaleDownMode":
 	if typedInput.ScaleDownMode != nil {
 		scaleDownMode := *typedInput.ScaleDownMode
 		profile.ScaleDownMode = &scaleDownMode
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	if typedInput.ScaleSetEvictionPolicy != nil {
 		scaleSetEvictionPolicy := *typedInput.ScaleSetEvictionPolicy
 		profile.ScaleSetEvictionPolicy = &scaleSetEvictionPolicy
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	if typedInput.ScaleSetPriority != nil {
 		scaleSetPriority := *typedInput.ScaleSetPriority
 		profile.ScaleSetPriority = &scaleSetPriority
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	if typedInput.SpotMaxPrice != nil {
 		spotMaxPrice := *typedInput.SpotMaxPrice
 		profile.SpotMaxPrice = &spotMaxPrice
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		profile.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -8802,13 +8802,13 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	if typedInput.UpgradeSettings != nil {
 		var upgradeSettings1 AgentPoolUpgradeSettings_STATUS
 		err := upgradeSettings1.PopulateFromARM(owner, *typedInput.UpgradeSettings)
@@ -8819,19 +8819,19 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.UpgradeSettings = &upgradeSettings
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
 	}
 
-	// Set property ‘VnetSubnetID’:
+	// Set property "VnetSubnetID":
 	if typedInput.VnetSubnetID != nil {
 		vnetSubnetID := *typedInput.VnetSubnetID
 		profile.VnetSubnetID = &vnetSubnetID
 	}
 
-	// Set property ‘WindowsProfile’:
+	// Set property "WindowsProfile":
 	if typedInput.WindowsProfile != nil {
 		var windowsProfile1 AgentPoolWindowsProfile_STATUS
 		err := windowsProfile1.PopulateFromARM(owner, *typedInput.WindowsProfile)
@@ -8842,7 +8842,7 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.WindowsProfile = &windowsProfile
 	}
 
-	// Set property ‘WorkloadRuntime’:
+	// Set property "WorkloadRuntime":
 	if typedInput.WorkloadRuntime != nil {
 		workloadRuntime := *typedInput.WorkloadRuntime
 		profile.WorkloadRuntime = &workloadRuntime
@@ -9502,42 +9502,42 @@ func (profile *ManagedClusterAPIServerAccessProfile) ConvertToARM(resolved genru
 	}
 	result := &ManagedClusterAPIServerAccessProfile_ARM{}
 
-	// Set property ‘AuthorizedIPRanges’:
+	// Set property "AuthorizedIPRanges":
 	for _, item := range profile.AuthorizedIPRanges {
 		result.AuthorizedIPRanges = append(result.AuthorizedIPRanges, item)
 	}
 
-	// Set property ‘DisableRunCommand’:
+	// Set property "DisableRunCommand":
 	if profile.DisableRunCommand != nil {
 		disableRunCommand := *profile.DisableRunCommand
 		result.DisableRunCommand = &disableRunCommand
 	}
 
-	// Set property ‘EnablePrivateCluster’:
+	// Set property "EnablePrivateCluster":
 	if profile.EnablePrivateCluster != nil {
 		enablePrivateCluster := *profile.EnablePrivateCluster
 		result.EnablePrivateCluster = &enablePrivateCluster
 	}
 
-	// Set property ‘EnablePrivateClusterPublicFQDN’:
+	// Set property "EnablePrivateClusterPublicFQDN":
 	if profile.EnablePrivateClusterPublicFQDN != nil {
 		enablePrivateClusterPublicFQDN := *profile.EnablePrivateClusterPublicFQDN
 		result.EnablePrivateClusterPublicFQDN = &enablePrivateClusterPublicFQDN
 	}
 
-	// Set property ‘EnableVnetIntegration’:
+	// Set property "EnableVnetIntegration":
 	if profile.EnableVnetIntegration != nil {
 		enableVnetIntegration := *profile.EnableVnetIntegration
 		result.EnableVnetIntegration = &enableVnetIntegration
 	}
 
-	// Set property ‘PrivateDNSZone’:
+	// Set property "PrivateDNSZone":
 	if profile.PrivateDNSZone != nil {
 		privateDNSZone := *profile.PrivateDNSZone
 		result.PrivateDNSZone = &privateDNSZone
 	}
 
-	// Set property ‘SubnetId’:
+	// Set property "SubnetId":
 	if profile.SubnetId != nil {
 		subnetId := *profile.SubnetId
 		result.SubnetId = &subnetId
@@ -9557,42 +9557,42 @@ func (profile *ManagedClusterAPIServerAccessProfile) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAPIServerAccessProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthorizedIPRanges’:
+	// Set property "AuthorizedIPRanges":
 	for _, item := range typedInput.AuthorizedIPRanges {
 		profile.AuthorizedIPRanges = append(profile.AuthorizedIPRanges, item)
 	}
 
-	// Set property ‘DisableRunCommand’:
+	// Set property "DisableRunCommand":
 	if typedInput.DisableRunCommand != nil {
 		disableRunCommand := *typedInput.DisableRunCommand
 		profile.DisableRunCommand = &disableRunCommand
 	}
 
-	// Set property ‘EnablePrivateCluster’:
+	// Set property "EnablePrivateCluster":
 	if typedInput.EnablePrivateCluster != nil {
 		enablePrivateCluster := *typedInput.EnablePrivateCluster
 		profile.EnablePrivateCluster = &enablePrivateCluster
 	}
 
-	// Set property ‘EnablePrivateClusterPublicFQDN’:
+	// Set property "EnablePrivateClusterPublicFQDN":
 	if typedInput.EnablePrivateClusterPublicFQDN != nil {
 		enablePrivateClusterPublicFQDN := *typedInput.EnablePrivateClusterPublicFQDN
 		profile.EnablePrivateClusterPublicFQDN = &enablePrivateClusterPublicFQDN
 	}
 
-	// Set property ‘EnableVnetIntegration’:
+	// Set property "EnableVnetIntegration":
 	if typedInput.EnableVnetIntegration != nil {
 		enableVnetIntegration := *typedInput.EnableVnetIntegration
 		profile.EnableVnetIntegration = &enableVnetIntegration
 	}
 
-	// Set property ‘PrivateDNSZone’:
+	// Set property "PrivateDNSZone":
 	if typedInput.PrivateDNSZone != nil {
 		privateDNSZone := *typedInput.PrivateDNSZone
 		profile.PrivateDNSZone = &privateDNSZone
 	}
 
-	// Set property ‘SubnetId’:
+	// Set property "SubnetId":
 	if typedInput.SubnetId != nil {
 		subnetId := *typedInput.SubnetId
 		profile.SubnetId = &subnetId
@@ -9751,42 +9751,42 @@ func (profile *ManagedClusterAPIServerAccessProfile_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAPIServerAccessProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthorizedIPRanges’:
+	// Set property "AuthorizedIPRanges":
 	for _, item := range typedInput.AuthorizedIPRanges {
 		profile.AuthorizedIPRanges = append(profile.AuthorizedIPRanges, item)
 	}
 
-	// Set property ‘DisableRunCommand’:
+	// Set property "DisableRunCommand":
 	if typedInput.DisableRunCommand != nil {
 		disableRunCommand := *typedInput.DisableRunCommand
 		profile.DisableRunCommand = &disableRunCommand
 	}
 
-	// Set property ‘EnablePrivateCluster’:
+	// Set property "EnablePrivateCluster":
 	if typedInput.EnablePrivateCluster != nil {
 		enablePrivateCluster := *typedInput.EnablePrivateCluster
 		profile.EnablePrivateCluster = &enablePrivateCluster
 	}
 
-	// Set property ‘EnablePrivateClusterPublicFQDN’:
+	// Set property "EnablePrivateClusterPublicFQDN":
 	if typedInput.EnablePrivateClusterPublicFQDN != nil {
 		enablePrivateClusterPublicFQDN := *typedInput.EnablePrivateClusterPublicFQDN
 		profile.EnablePrivateClusterPublicFQDN = &enablePrivateClusterPublicFQDN
 	}
 
-	// Set property ‘EnableVnetIntegration’:
+	// Set property "EnableVnetIntegration":
 	if typedInput.EnableVnetIntegration != nil {
 		enableVnetIntegration := *typedInput.EnableVnetIntegration
 		profile.EnableVnetIntegration = &enableVnetIntegration
 	}
 
-	// Set property ‘PrivateDNSZone’:
+	// Set property "PrivateDNSZone":
 	if typedInput.PrivateDNSZone != nil {
 		privateDNSZone := *typedInput.PrivateDNSZone
 		profile.PrivateDNSZone = &privateDNSZone
 	}
 
-	// Set property ‘SubnetId’:
+	// Set property "SubnetId":
 	if typedInput.SubnetId != nil {
 		subnetId := *typedInput.SubnetId
 		profile.SubnetId = &subnetId
@@ -9920,13 +9920,13 @@ func (profile *ManagedClusterAutoUpgradeProfile) ConvertToARM(resolved genruntim
 	}
 	result := &ManagedClusterAutoUpgradeProfile_ARM{}
 
-	// Set property ‘NodeOSUpgradeChannel’:
+	// Set property "NodeOSUpgradeChannel":
 	if profile.NodeOSUpgradeChannel != nil {
 		nodeOSUpgradeChannel := *profile.NodeOSUpgradeChannel
 		result.NodeOSUpgradeChannel = &nodeOSUpgradeChannel
 	}
 
-	// Set property ‘UpgradeChannel’:
+	// Set property "UpgradeChannel":
 	if profile.UpgradeChannel != nil {
 		upgradeChannel := *profile.UpgradeChannel
 		result.UpgradeChannel = &upgradeChannel
@@ -9946,13 +9946,13 @@ func (profile *ManagedClusterAutoUpgradeProfile) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAutoUpgradeProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NodeOSUpgradeChannel’:
+	// Set property "NodeOSUpgradeChannel":
 	if typedInput.NodeOSUpgradeChannel != nil {
 		nodeOSUpgradeChannel := *typedInput.NodeOSUpgradeChannel
 		profile.NodeOSUpgradeChannel = &nodeOSUpgradeChannel
 	}
 
-	// Set property ‘UpgradeChannel’:
+	// Set property "UpgradeChannel":
 	if typedInput.UpgradeChannel != nil {
 		upgradeChannel := *typedInput.UpgradeChannel
 		profile.UpgradeChannel = &upgradeChannel
@@ -10041,13 +10041,13 @@ func (profile *ManagedClusterAutoUpgradeProfile_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAutoUpgradeProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NodeOSUpgradeChannel’:
+	// Set property "NodeOSUpgradeChannel":
 	if typedInput.NodeOSUpgradeChannel != nil {
 		nodeOSUpgradeChannel := *typedInput.NodeOSUpgradeChannel
 		profile.NodeOSUpgradeChannel = &nodeOSUpgradeChannel
 	}
 
-	// Set property ‘UpgradeChannel’:
+	// Set property "UpgradeChannel":
 	if typedInput.UpgradeChannel != nil {
 		upgradeChannel := *typedInput.UpgradeChannel
 		profile.UpgradeChannel = &upgradeChannel
@@ -10127,7 +10127,7 @@ func (profile *ManagedClusterAzureMonitorProfile) ConvertToARM(resolved genrunti
 	}
 	result := &ManagedClusterAzureMonitorProfile_ARM{}
 
-	// Set property ‘Metrics’:
+	// Set property "Metrics":
 	if profile.Metrics != nil {
 		metrics_ARM, err := (*profile.Metrics).ConvertToARM(resolved)
 		if err != nil {
@@ -10151,7 +10151,7 @@ func (profile *ManagedClusterAzureMonitorProfile) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAzureMonitorProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Metrics’:
+	// Set property "Metrics":
 	if typedInput.Metrics != nil {
 		var metrics1 ManagedClusterAzureMonitorProfileMetrics
 		err := metrics1.PopulateFromARM(owner, *typedInput.Metrics)
@@ -10233,7 +10233,7 @@ func (profile *ManagedClusterAzureMonitorProfile_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAzureMonitorProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Metrics’:
+	// Set property "Metrics":
 	if typedInput.Metrics != nil {
 		var metrics1 ManagedClusterAzureMonitorProfileMetrics_STATUS
 		err := metrics1.PopulateFromARM(owner, *typedInput.Metrics)
@@ -10319,24 +10319,24 @@ func (config *ManagedClusterHTTPProxyConfig) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ManagedClusterHTTPProxyConfig_ARM{}
 
-	// Set property ‘HttpProxy’:
+	// Set property "HttpProxy":
 	if config.HttpProxy != nil {
 		httpProxy := *config.HttpProxy
 		result.HttpProxy = &httpProxy
 	}
 
-	// Set property ‘HttpsProxy’:
+	// Set property "HttpsProxy":
 	if config.HttpsProxy != nil {
 		httpsProxy := *config.HttpsProxy
 		result.HttpsProxy = &httpsProxy
 	}
 
-	// Set property ‘NoProxy’:
+	// Set property "NoProxy":
 	for _, item := range config.NoProxy {
 		result.NoProxy = append(result.NoProxy, item)
 	}
 
-	// Set property ‘TrustedCa’:
+	// Set property "TrustedCa":
 	if config.TrustedCa != nil {
 		trustedCa := *config.TrustedCa
 		result.TrustedCa = &trustedCa
@@ -10356,24 +10356,24 @@ func (config *ManagedClusterHTTPProxyConfig) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterHTTPProxyConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpProxy’:
+	// Set property "HttpProxy":
 	if typedInput.HttpProxy != nil {
 		httpProxy := *typedInput.HttpProxy
 		config.HttpProxy = &httpProxy
 	}
 
-	// Set property ‘HttpsProxy’:
+	// Set property "HttpsProxy":
 	if typedInput.HttpsProxy != nil {
 		httpsProxy := *typedInput.HttpsProxy
 		config.HttpsProxy = &httpsProxy
 	}
 
-	// Set property ‘NoProxy’:
+	// Set property "NoProxy":
 	for _, item := range typedInput.NoProxy {
 		config.NoProxy = append(config.NoProxy, item)
 	}
 
-	// Set property ‘TrustedCa’:
+	// Set property "TrustedCa":
 	if typedInput.TrustedCa != nil {
 		trustedCa := *typedInput.TrustedCa
 		config.TrustedCa = &trustedCa
@@ -10463,29 +10463,29 @@ func (config *ManagedClusterHTTPProxyConfig_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterHTTPProxyConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EffectiveNoProxy’:
+	// Set property "EffectiveNoProxy":
 	for _, item := range typedInput.EffectiveNoProxy {
 		config.EffectiveNoProxy = append(config.EffectiveNoProxy, item)
 	}
 
-	// Set property ‘HttpProxy’:
+	// Set property "HttpProxy":
 	if typedInput.HttpProxy != nil {
 		httpProxy := *typedInput.HttpProxy
 		config.HttpProxy = &httpProxy
 	}
 
-	// Set property ‘HttpsProxy’:
+	// Set property "HttpsProxy":
 	if typedInput.HttpsProxy != nil {
 		httpsProxy := *typedInput.HttpsProxy
 		config.HttpsProxy = &httpsProxy
 	}
 
-	// Set property ‘NoProxy’:
+	// Set property "NoProxy":
 	for _, item := range typedInput.NoProxy {
 		config.NoProxy = append(config.NoProxy, item)
 	}
 
-	// Set property ‘TrustedCa’:
+	// Set property "TrustedCa":
 	if typedInput.TrustedCa != nil {
 		trustedCa := *typedInput.TrustedCa
 		config.TrustedCa = &trustedCa
@@ -10568,13 +10568,13 @@ func (identity *ManagedClusterIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ManagedClusterIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -10599,13 +10599,13 @@ func (identity *ManagedClusterIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -10717,25 +10717,25 @@ func (identity *ManagedClusterIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]ManagedClusterIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -10854,7 +10854,7 @@ func (profile *ManagedClusterIngressProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ManagedClusterIngressProfile_ARM{}
 
-	// Set property ‘WebAppRouting’:
+	// Set property "WebAppRouting":
 	if profile.WebAppRouting != nil {
 		webAppRouting_ARM, err := (*profile.WebAppRouting).ConvertToARM(resolved)
 		if err != nil {
@@ -10878,7 +10878,7 @@ func (profile *ManagedClusterIngressProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIngressProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘WebAppRouting’:
+	// Set property "WebAppRouting":
 	if typedInput.WebAppRouting != nil {
 		var webAppRouting1 ManagedClusterIngressProfileWebAppRouting
 		err := webAppRouting1.PopulateFromARM(owner, *typedInput.WebAppRouting)
@@ -10960,7 +10960,7 @@ func (profile *ManagedClusterIngressProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIngressProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘WebAppRouting’:
+	// Set property "WebAppRouting":
 	if typedInput.WebAppRouting != nil {
 		var webAppRouting1 ManagedClusterIngressProfileWebAppRouting_STATUS
 		err := webAppRouting1.PopulateFromARM(owner, *typedInput.WebAppRouting)
@@ -11037,7 +11037,7 @@ func (profile *ManagedClusterNodeResourceGroupProfile) ConvertToARM(resolved gen
 	}
 	result := &ManagedClusterNodeResourceGroupProfile_ARM{}
 
-	// Set property ‘RestrictionLevel’:
+	// Set property "RestrictionLevel":
 	if profile.RestrictionLevel != nil {
 		restrictionLevel := *profile.RestrictionLevel
 		result.RestrictionLevel = &restrictionLevel
@@ -11057,7 +11057,7 @@ func (profile *ManagedClusterNodeResourceGroupProfile) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterNodeResourceGroupProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RestrictionLevel’:
+	// Set property "RestrictionLevel":
 	if typedInput.RestrictionLevel != nil {
 		restrictionLevel := *typedInput.RestrictionLevel
 		profile.RestrictionLevel = &restrictionLevel
@@ -11126,7 +11126,7 @@ func (profile *ManagedClusterNodeResourceGroupProfile_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterNodeResourceGroupProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RestrictionLevel’:
+	// Set property "RestrictionLevel":
 	if typedInput.RestrictionLevel != nil {
 		restrictionLevel := *typedInput.RestrictionLevel
 		profile.RestrictionLevel = &restrictionLevel
@@ -11190,7 +11190,7 @@ func (profile *ManagedClusterOIDCIssuerProfile) ConvertToARM(resolved genruntime
 	}
 	result := &ManagedClusterOIDCIssuerProfile_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if profile.Enabled != nil {
 		enabled := *profile.Enabled
 		result.Enabled = &enabled
@@ -11210,7 +11210,7 @@ func (profile *ManagedClusterOIDCIssuerProfile) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterOIDCIssuerProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
@@ -11282,13 +11282,13 @@ func (profile *ManagedClusterOIDCIssuerProfile_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterOIDCIssuerProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘IssuerURL’:
+	// Set property "IssuerURL":
 	if typedInput.IssuerURL != nil {
 		issuerURL := *typedInput.IssuerURL
 		profile.IssuerURL = &issuerURL
@@ -11451,19 +11451,19 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 	}
 	result := &ManagedClusterPodIdentityProfile_ARM{}
 
-	// Set property ‘AllowNetworkPluginKubenet’:
+	// Set property "AllowNetworkPluginKubenet":
 	if profile.AllowNetworkPluginKubenet != nil {
 		allowNetworkPluginKubenet := *profile.AllowNetworkPluginKubenet
 		result.AllowNetworkPluginKubenet = &allowNetworkPluginKubenet
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if profile.Enabled != nil {
 		enabled := *profile.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	for _, item := range profile.UserAssignedIdentities {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -11472,7 +11472,7 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 		result.UserAssignedIdentities = append(result.UserAssignedIdentities, *item_ARM.(*ManagedClusterPodIdentity_ARM))
 	}
 
-	// Set property ‘UserAssignedIdentityExceptions’:
+	// Set property "UserAssignedIdentityExceptions":
 	for _, item := range profile.UserAssignedIdentityExceptions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -11495,19 +11495,19 @@ func (profile *ManagedClusterPodIdentityProfile) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowNetworkPluginKubenet’:
+	// Set property "AllowNetworkPluginKubenet":
 	if typedInput.AllowNetworkPluginKubenet != nil {
 		allowNetworkPluginKubenet := *typedInput.AllowNetworkPluginKubenet
 		profile.AllowNetworkPluginKubenet = &allowNetworkPluginKubenet
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	for _, item := range typedInput.UserAssignedIdentities {
 		var item1 ManagedClusterPodIdentity
 		err := item1.PopulateFromARM(owner, item)
@@ -11517,7 +11517,7 @@ func (profile *ManagedClusterPodIdentityProfile) PopulateFromARM(owner genruntim
 		profile.UserAssignedIdentities = append(profile.UserAssignedIdentities, item1)
 	}
 
-	// Set property ‘UserAssignedIdentityExceptions’:
+	// Set property "UserAssignedIdentityExceptions":
 	for _, item := range typedInput.UserAssignedIdentityExceptions {
 		var item1 ManagedClusterPodIdentityException
 		err := item1.PopulateFromARM(owner, item)
@@ -11691,19 +11691,19 @@ func (profile *ManagedClusterPodIdentityProfile_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowNetworkPluginKubenet’:
+	// Set property "AllowNetworkPluginKubenet":
 	if typedInput.AllowNetworkPluginKubenet != nil {
 		allowNetworkPluginKubenet := *typedInput.AllowNetworkPluginKubenet
 		profile.AllowNetworkPluginKubenet = &allowNetworkPluginKubenet
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	for _, item := range typedInput.UserAssignedIdentities {
 		var item1 ManagedClusterPodIdentity_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11713,7 +11713,7 @@ func (profile *ManagedClusterPodIdentityProfile_STATUS) PopulateFromARM(owner ge
 		profile.UserAssignedIdentities = append(profile.UserAssignedIdentities, item1)
 	}
 
-	// Set property ‘UserAssignedIdentityExceptions’:
+	// Set property "UserAssignedIdentityExceptions":
 	for _, item := range typedInput.UserAssignedIdentityExceptions {
 		var item1 ManagedClusterPodIdentityException_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11926,103 +11926,103 @@ func (profile *ManagedClusterProperties_AutoScalerProfile) ConvertToARM(resolved
 	}
 	result := &ManagedClusterProperties_AutoScalerProfile_ARM{}
 
-	// Set property ‘BalanceSimilarNodeGroups’:
+	// Set property "BalanceSimilarNodeGroups":
 	if profile.BalanceSimilarNodeGroups != nil {
 		balanceSimilarNodeGroups := *profile.BalanceSimilarNodeGroups
 		result.BalanceSimilarNodeGroups = &balanceSimilarNodeGroups
 	}
 
-	// Set property ‘Expander’:
+	// Set property "Expander":
 	if profile.Expander != nil {
 		expander := *profile.Expander
 		result.Expander = &expander
 	}
 
-	// Set property ‘MaxEmptyBulkDelete’:
+	// Set property "MaxEmptyBulkDelete":
 	if profile.MaxEmptyBulkDelete != nil {
 		maxEmptyBulkDelete := *profile.MaxEmptyBulkDelete
 		result.MaxEmptyBulkDelete = &maxEmptyBulkDelete
 	}
 
-	// Set property ‘MaxGracefulTerminationSec’:
+	// Set property "MaxGracefulTerminationSec":
 	if profile.MaxGracefulTerminationSec != nil {
 		maxGracefulTerminationSec := *profile.MaxGracefulTerminationSec
 		result.MaxGracefulTerminationSec = &maxGracefulTerminationSec
 	}
 
-	// Set property ‘MaxNodeProvisionTime’:
+	// Set property "MaxNodeProvisionTime":
 	if profile.MaxNodeProvisionTime != nil {
 		maxNodeProvisionTime := *profile.MaxNodeProvisionTime
 		result.MaxNodeProvisionTime = &maxNodeProvisionTime
 	}
 
-	// Set property ‘MaxTotalUnreadyPercentage’:
+	// Set property "MaxTotalUnreadyPercentage":
 	if profile.MaxTotalUnreadyPercentage != nil {
 		maxTotalUnreadyPercentage := *profile.MaxTotalUnreadyPercentage
 		result.MaxTotalUnreadyPercentage = &maxTotalUnreadyPercentage
 	}
 
-	// Set property ‘NewPodScaleUpDelay’:
+	// Set property "NewPodScaleUpDelay":
 	if profile.NewPodScaleUpDelay != nil {
 		newPodScaleUpDelay := *profile.NewPodScaleUpDelay
 		result.NewPodScaleUpDelay = &newPodScaleUpDelay
 	}
 
-	// Set property ‘OkTotalUnreadyCount’:
+	// Set property "OkTotalUnreadyCount":
 	if profile.OkTotalUnreadyCount != nil {
 		okTotalUnreadyCount := *profile.OkTotalUnreadyCount
 		result.OkTotalUnreadyCount = &okTotalUnreadyCount
 	}
 
-	// Set property ‘ScaleDownDelayAfterAdd’:
+	// Set property "ScaleDownDelayAfterAdd":
 	if profile.ScaleDownDelayAfterAdd != nil {
 		scaleDownDelayAfterAdd := *profile.ScaleDownDelayAfterAdd
 		result.ScaleDownDelayAfterAdd = &scaleDownDelayAfterAdd
 	}
 
-	// Set property ‘ScaleDownDelayAfterDelete’:
+	// Set property "ScaleDownDelayAfterDelete":
 	if profile.ScaleDownDelayAfterDelete != nil {
 		scaleDownDelayAfterDelete := *profile.ScaleDownDelayAfterDelete
 		result.ScaleDownDelayAfterDelete = &scaleDownDelayAfterDelete
 	}
 
-	// Set property ‘ScaleDownDelayAfterFailure’:
+	// Set property "ScaleDownDelayAfterFailure":
 	if profile.ScaleDownDelayAfterFailure != nil {
 		scaleDownDelayAfterFailure := *profile.ScaleDownDelayAfterFailure
 		result.ScaleDownDelayAfterFailure = &scaleDownDelayAfterFailure
 	}
 
-	// Set property ‘ScaleDownUnneededTime’:
+	// Set property "ScaleDownUnneededTime":
 	if profile.ScaleDownUnneededTime != nil {
 		scaleDownUnneededTime := *profile.ScaleDownUnneededTime
 		result.ScaleDownUnneededTime = &scaleDownUnneededTime
 	}
 
-	// Set property ‘ScaleDownUnreadyTime’:
+	// Set property "ScaleDownUnreadyTime":
 	if profile.ScaleDownUnreadyTime != nil {
 		scaleDownUnreadyTime := *profile.ScaleDownUnreadyTime
 		result.ScaleDownUnreadyTime = &scaleDownUnreadyTime
 	}
 
-	// Set property ‘ScaleDownUtilizationThreshold’:
+	// Set property "ScaleDownUtilizationThreshold":
 	if profile.ScaleDownUtilizationThreshold != nil {
 		scaleDownUtilizationThreshold := *profile.ScaleDownUtilizationThreshold
 		result.ScaleDownUtilizationThreshold = &scaleDownUtilizationThreshold
 	}
 
-	// Set property ‘ScanInterval’:
+	// Set property "ScanInterval":
 	if profile.ScanInterval != nil {
 		scanInterval := *profile.ScanInterval
 		result.ScanInterval = &scanInterval
 	}
 
-	// Set property ‘SkipNodesWithLocalStorage’:
+	// Set property "SkipNodesWithLocalStorage":
 	if profile.SkipNodesWithLocalStorage != nil {
 		skipNodesWithLocalStorage := *profile.SkipNodesWithLocalStorage
 		result.SkipNodesWithLocalStorage = &skipNodesWithLocalStorage
 	}
 
-	// Set property ‘SkipNodesWithSystemPods’:
+	// Set property "SkipNodesWithSystemPods":
 	if profile.SkipNodesWithSystemPods != nil {
 		skipNodesWithSystemPods := *profile.SkipNodesWithSystemPods
 		result.SkipNodesWithSystemPods = &skipNodesWithSystemPods
@@ -12042,103 +12042,103 @@ func (profile *ManagedClusterProperties_AutoScalerProfile) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterProperties_AutoScalerProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BalanceSimilarNodeGroups’:
+	// Set property "BalanceSimilarNodeGroups":
 	if typedInput.BalanceSimilarNodeGroups != nil {
 		balanceSimilarNodeGroups := *typedInput.BalanceSimilarNodeGroups
 		profile.BalanceSimilarNodeGroups = &balanceSimilarNodeGroups
 	}
 
-	// Set property ‘Expander’:
+	// Set property "Expander":
 	if typedInput.Expander != nil {
 		expander := *typedInput.Expander
 		profile.Expander = &expander
 	}
 
-	// Set property ‘MaxEmptyBulkDelete’:
+	// Set property "MaxEmptyBulkDelete":
 	if typedInput.MaxEmptyBulkDelete != nil {
 		maxEmptyBulkDelete := *typedInput.MaxEmptyBulkDelete
 		profile.MaxEmptyBulkDelete = &maxEmptyBulkDelete
 	}
 
-	// Set property ‘MaxGracefulTerminationSec’:
+	// Set property "MaxGracefulTerminationSec":
 	if typedInput.MaxGracefulTerminationSec != nil {
 		maxGracefulTerminationSec := *typedInput.MaxGracefulTerminationSec
 		profile.MaxGracefulTerminationSec = &maxGracefulTerminationSec
 	}
 
-	// Set property ‘MaxNodeProvisionTime’:
+	// Set property "MaxNodeProvisionTime":
 	if typedInput.MaxNodeProvisionTime != nil {
 		maxNodeProvisionTime := *typedInput.MaxNodeProvisionTime
 		profile.MaxNodeProvisionTime = &maxNodeProvisionTime
 	}
 
-	// Set property ‘MaxTotalUnreadyPercentage’:
+	// Set property "MaxTotalUnreadyPercentage":
 	if typedInput.MaxTotalUnreadyPercentage != nil {
 		maxTotalUnreadyPercentage := *typedInput.MaxTotalUnreadyPercentage
 		profile.MaxTotalUnreadyPercentage = &maxTotalUnreadyPercentage
 	}
 
-	// Set property ‘NewPodScaleUpDelay’:
+	// Set property "NewPodScaleUpDelay":
 	if typedInput.NewPodScaleUpDelay != nil {
 		newPodScaleUpDelay := *typedInput.NewPodScaleUpDelay
 		profile.NewPodScaleUpDelay = &newPodScaleUpDelay
 	}
 
-	// Set property ‘OkTotalUnreadyCount’:
+	// Set property "OkTotalUnreadyCount":
 	if typedInput.OkTotalUnreadyCount != nil {
 		okTotalUnreadyCount := *typedInput.OkTotalUnreadyCount
 		profile.OkTotalUnreadyCount = &okTotalUnreadyCount
 	}
 
-	// Set property ‘ScaleDownDelayAfterAdd’:
+	// Set property "ScaleDownDelayAfterAdd":
 	if typedInput.ScaleDownDelayAfterAdd != nil {
 		scaleDownDelayAfterAdd := *typedInput.ScaleDownDelayAfterAdd
 		profile.ScaleDownDelayAfterAdd = &scaleDownDelayAfterAdd
 	}
 
-	// Set property ‘ScaleDownDelayAfterDelete’:
+	// Set property "ScaleDownDelayAfterDelete":
 	if typedInput.ScaleDownDelayAfterDelete != nil {
 		scaleDownDelayAfterDelete := *typedInput.ScaleDownDelayAfterDelete
 		profile.ScaleDownDelayAfterDelete = &scaleDownDelayAfterDelete
 	}
 
-	// Set property ‘ScaleDownDelayAfterFailure’:
+	// Set property "ScaleDownDelayAfterFailure":
 	if typedInput.ScaleDownDelayAfterFailure != nil {
 		scaleDownDelayAfterFailure := *typedInput.ScaleDownDelayAfterFailure
 		profile.ScaleDownDelayAfterFailure = &scaleDownDelayAfterFailure
 	}
 
-	// Set property ‘ScaleDownUnneededTime’:
+	// Set property "ScaleDownUnneededTime":
 	if typedInput.ScaleDownUnneededTime != nil {
 		scaleDownUnneededTime := *typedInput.ScaleDownUnneededTime
 		profile.ScaleDownUnneededTime = &scaleDownUnneededTime
 	}
 
-	// Set property ‘ScaleDownUnreadyTime’:
+	// Set property "ScaleDownUnreadyTime":
 	if typedInput.ScaleDownUnreadyTime != nil {
 		scaleDownUnreadyTime := *typedInput.ScaleDownUnreadyTime
 		profile.ScaleDownUnreadyTime = &scaleDownUnreadyTime
 	}
 
-	// Set property ‘ScaleDownUtilizationThreshold’:
+	// Set property "ScaleDownUtilizationThreshold":
 	if typedInput.ScaleDownUtilizationThreshold != nil {
 		scaleDownUtilizationThreshold := *typedInput.ScaleDownUtilizationThreshold
 		profile.ScaleDownUtilizationThreshold = &scaleDownUtilizationThreshold
 	}
 
-	// Set property ‘ScanInterval’:
+	// Set property "ScanInterval":
 	if typedInput.ScanInterval != nil {
 		scanInterval := *typedInput.ScanInterval
 		profile.ScanInterval = &scanInterval
 	}
 
-	// Set property ‘SkipNodesWithLocalStorage’:
+	// Set property "SkipNodesWithLocalStorage":
 	if typedInput.SkipNodesWithLocalStorage != nil {
 		skipNodesWithLocalStorage := *typedInput.SkipNodesWithLocalStorage
 		profile.SkipNodesWithLocalStorage = &skipNodesWithLocalStorage
 	}
 
-	// Set property ‘SkipNodesWithSystemPods’:
+	// Set property "SkipNodesWithSystemPods":
 	if typedInput.SkipNodesWithSystemPods != nil {
 		skipNodesWithSystemPods := *typedInput.SkipNodesWithSystemPods
 		profile.SkipNodesWithSystemPods = &skipNodesWithSystemPods
@@ -12360,103 +12360,103 @@ func (profile *ManagedClusterProperties_AutoScalerProfile_STATUS) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterProperties_AutoScalerProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BalanceSimilarNodeGroups’:
+	// Set property "BalanceSimilarNodeGroups":
 	if typedInput.BalanceSimilarNodeGroups != nil {
 		balanceSimilarNodeGroups := *typedInput.BalanceSimilarNodeGroups
 		profile.BalanceSimilarNodeGroups = &balanceSimilarNodeGroups
 	}
 
-	// Set property ‘Expander’:
+	// Set property "Expander":
 	if typedInput.Expander != nil {
 		expander := *typedInput.Expander
 		profile.Expander = &expander
 	}
 
-	// Set property ‘MaxEmptyBulkDelete’:
+	// Set property "MaxEmptyBulkDelete":
 	if typedInput.MaxEmptyBulkDelete != nil {
 		maxEmptyBulkDelete := *typedInput.MaxEmptyBulkDelete
 		profile.MaxEmptyBulkDelete = &maxEmptyBulkDelete
 	}
 
-	// Set property ‘MaxGracefulTerminationSec’:
+	// Set property "MaxGracefulTerminationSec":
 	if typedInput.MaxGracefulTerminationSec != nil {
 		maxGracefulTerminationSec := *typedInput.MaxGracefulTerminationSec
 		profile.MaxGracefulTerminationSec = &maxGracefulTerminationSec
 	}
 
-	// Set property ‘MaxNodeProvisionTime’:
+	// Set property "MaxNodeProvisionTime":
 	if typedInput.MaxNodeProvisionTime != nil {
 		maxNodeProvisionTime := *typedInput.MaxNodeProvisionTime
 		profile.MaxNodeProvisionTime = &maxNodeProvisionTime
 	}
 
-	// Set property ‘MaxTotalUnreadyPercentage’:
+	// Set property "MaxTotalUnreadyPercentage":
 	if typedInput.MaxTotalUnreadyPercentage != nil {
 		maxTotalUnreadyPercentage := *typedInput.MaxTotalUnreadyPercentage
 		profile.MaxTotalUnreadyPercentage = &maxTotalUnreadyPercentage
 	}
 
-	// Set property ‘NewPodScaleUpDelay’:
+	// Set property "NewPodScaleUpDelay":
 	if typedInput.NewPodScaleUpDelay != nil {
 		newPodScaleUpDelay := *typedInput.NewPodScaleUpDelay
 		profile.NewPodScaleUpDelay = &newPodScaleUpDelay
 	}
 
-	// Set property ‘OkTotalUnreadyCount’:
+	// Set property "OkTotalUnreadyCount":
 	if typedInput.OkTotalUnreadyCount != nil {
 		okTotalUnreadyCount := *typedInput.OkTotalUnreadyCount
 		profile.OkTotalUnreadyCount = &okTotalUnreadyCount
 	}
 
-	// Set property ‘ScaleDownDelayAfterAdd’:
+	// Set property "ScaleDownDelayAfterAdd":
 	if typedInput.ScaleDownDelayAfterAdd != nil {
 		scaleDownDelayAfterAdd := *typedInput.ScaleDownDelayAfterAdd
 		profile.ScaleDownDelayAfterAdd = &scaleDownDelayAfterAdd
 	}
 
-	// Set property ‘ScaleDownDelayAfterDelete’:
+	// Set property "ScaleDownDelayAfterDelete":
 	if typedInput.ScaleDownDelayAfterDelete != nil {
 		scaleDownDelayAfterDelete := *typedInput.ScaleDownDelayAfterDelete
 		profile.ScaleDownDelayAfterDelete = &scaleDownDelayAfterDelete
 	}
 
-	// Set property ‘ScaleDownDelayAfterFailure’:
+	// Set property "ScaleDownDelayAfterFailure":
 	if typedInput.ScaleDownDelayAfterFailure != nil {
 		scaleDownDelayAfterFailure := *typedInput.ScaleDownDelayAfterFailure
 		profile.ScaleDownDelayAfterFailure = &scaleDownDelayAfterFailure
 	}
 
-	// Set property ‘ScaleDownUnneededTime’:
+	// Set property "ScaleDownUnneededTime":
 	if typedInput.ScaleDownUnneededTime != nil {
 		scaleDownUnneededTime := *typedInput.ScaleDownUnneededTime
 		profile.ScaleDownUnneededTime = &scaleDownUnneededTime
 	}
 
-	// Set property ‘ScaleDownUnreadyTime’:
+	// Set property "ScaleDownUnreadyTime":
 	if typedInput.ScaleDownUnreadyTime != nil {
 		scaleDownUnreadyTime := *typedInput.ScaleDownUnreadyTime
 		profile.ScaleDownUnreadyTime = &scaleDownUnreadyTime
 	}
 
-	// Set property ‘ScaleDownUtilizationThreshold’:
+	// Set property "ScaleDownUtilizationThreshold":
 	if typedInput.ScaleDownUtilizationThreshold != nil {
 		scaleDownUtilizationThreshold := *typedInput.ScaleDownUtilizationThreshold
 		profile.ScaleDownUtilizationThreshold = &scaleDownUtilizationThreshold
 	}
 
-	// Set property ‘ScanInterval’:
+	// Set property "ScanInterval":
 	if typedInput.ScanInterval != nil {
 		scanInterval := *typedInput.ScanInterval
 		profile.ScanInterval = &scanInterval
 	}
 
-	// Set property ‘SkipNodesWithLocalStorage’:
+	// Set property "SkipNodesWithLocalStorage":
 	if typedInput.SkipNodesWithLocalStorage != nil {
 		skipNodesWithLocalStorage := *typedInput.SkipNodesWithLocalStorage
 		profile.SkipNodesWithLocalStorage = &skipNodesWithLocalStorage
 	}
 
-	// Set property ‘SkipNodesWithSystemPods’:
+	// Set property "SkipNodesWithSystemPods":
 	if typedInput.SkipNodesWithSystemPods != nil {
 		skipNodesWithSystemPods := *typedInput.SkipNodesWithSystemPods
 		profile.SkipNodesWithSystemPods = &skipNodesWithSystemPods
@@ -12654,7 +12654,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 	}
 	result := &ManagedClusterSecurityProfile_ARM{}
 
-	// Set property ‘AzureKeyVaultKms’:
+	// Set property "AzureKeyVaultKms":
 	if profile.AzureKeyVaultKms != nil {
 		azureKeyVaultKms_ARM, err := (*profile.AzureKeyVaultKms).ConvertToARM(resolved)
 		if err != nil {
@@ -12664,10 +12664,10 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 		result.AzureKeyVaultKms = &azureKeyVaultKms
 	}
 
-	// Set property ‘CustomCATrustCertificates’:
+	// Set property "CustomCATrustCertificates":
 	result.CustomCATrustCertificates = profile.CustomCATrustCertificates
 
-	// Set property ‘Defender’:
+	// Set property "Defender":
 	if profile.Defender != nil {
 		defender_ARM, err := (*profile.Defender).ConvertToARM(resolved)
 		if err != nil {
@@ -12677,7 +12677,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 		result.Defender = &defender
 	}
 
-	// Set property ‘ImageCleaner’:
+	// Set property "ImageCleaner":
 	if profile.ImageCleaner != nil {
 		imageCleaner_ARM, err := (*profile.ImageCleaner).ConvertToARM(resolved)
 		if err != nil {
@@ -12687,7 +12687,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 		result.ImageCleaner = &imageCleaner
 	}
 
-	// Set property ‘NodeRestriction’:
+	// Set property "NodeRestriction":
 	if profile.NodeRestriction != nil {
 		nodeRestriction_ARM, err := (*profile.NodeRestriction).ConvertToARM(resolved)
 		if err != nil {
@@ -12697,7 +12697,7 @@ func (profile *ManagedClusterSecurityProfile) ConvertToARM(resolved genruntime.C
 		result.NodeRestriction = &nodeRestriction
 	}
 
-	// Set property ‘WorkloadIdentity’:
+	// Set property "WorkloadIdentity":
 	if profile.WorkloadIdentity != nil {
 		workloadIdentity_ARM, err := (*profile.WorkloadIdentity).ConvertToARM(resolved)
 		if err != nil {
@@ -12721,7 +12721,7 @@ func (profile *ManagedClusterSecurityProfile) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureKeyVaultKms’:
+	// Set property "AzureKeyVaultKms":
 	if typedInput.AzureKeyVaultKms != nil {
 		var azureKeyVaultKms1 AzureKeyVaultKms
 		err := azureKeyVaultKms1.PopulateFromARM(owner, *typedInput.AzureKeyVaultKms)
@@ -12732,10 +12732,10 @@ func (profile *ManagedClusterSecurityProfile) PopulateFromARM(owner genruntime.A
 		profile.AzureKeyVaultKms = &azureKeyVaultKms
 	}
 
-	// Set property ‘CustomCATrustCertificates’:
+	// Set property "CustomCATrustCertificates":
 	profile.CustomCATrustCertificates = typedInput.CustomCATrustCertificates
 
-	// Set property ‘Defender’:
+	// Set property "Defender":
 	if typedInput.Defender != nil {
 		var defender1 ManagedClusterSecurityProfileDefender
 		err := defender1.PopulateFromARM(owner, *typedInput.Defender)
@@ -12746,7 +12746,7 @@ func (profile *ManagedClusterSecurityProfile) PopulateFromARM(owner genruntime.A
 		profile.Defender = &defender
 	}
 
-	// Set property ‘ImageCleaner’:
+	// Set property "ImageCleaner":
 	if typedInput.ImageCleaner != nil {
 		var imageCleaner1 ManagedClusterSecurityProfileImageCleaner
 		err := imageCleaner1.PopulateFromARM(owner, *typedInput.ImageCleaner)
@@ -12757,7 +12757,7 @@ func (profile *ManagedClusterSecurityProfile) PopulateFromARM(owner genruntime.A
 		profile.ImageCleaner = &imageCleaner
 	}
 
-	// Set property ‘NodeRestriction’:
+	// Set property "NodeRestriction":
 	if typedInput.NodeRestriction != nil {
 		var nodeRestriction1 ManagedClusterSecurityProfileNodeRestriction
 		err := nodeRestriction1.PopulateFromARM(owner, *typedInput.NodeRestriction)
@@ -12768,7 +12768,7 @@ func (profile *ManagedClusterSecurityProfile) PopulateFromARM(owner genruntime.A
 		profile.NodeRestriction = &nodeRestriction
 	}
 
-	// Set property ‘WorkloadIdentity’:
+	// Set property "WorkloadIdentity":
 	if typedInput.WorkloadIdentity != nil {
 		var workloadIdentity1 ManagedClusterSecurityProfileWorkloadIdentity
 		err := workloadIdentity1.PopulateFromARM(owner, *typedInput.WorkloadIdentity)
@@ -12973,7 +12973,7 @@ func (profile *ManagedClusterSecurityProfile_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureKeyVaultKms’:
+	// Set property "AzureKeyVaultKms":
 	if typedInput.AzureKeyVaultKms != nil {
 		var azureKeyVaultKms1 AzureKeyVaultKms_STATUS
 		err := azureKeyVaultKms1.PopulateFromARM(owner, *typedInput.AzureKeyVaultKms)
@@ -12984,12 +12984,12 @@ func (profile *ManagedClusterSecurityProfile_STATUS) PopulateFromARM(owner genru
 		profile.AzureKeyVaultKms = &azureKeyVaultKms
 	}
 
-	// Set property ‘CustomCATrustCertificates’:
+	// Set property "CustomCATrustCertificates":
 	for _, item := range typedInput.CustomCATrustCertificates {
 		profile.CustomCATrustCertificates = append(profile.CustomCATrustCertificates, item)
 	}
 
-	// Set property ‘Defender’:
+	// Set property "Defender":
 	if typedInput.Defender != nil {
 		var defender1 ManagedClusterSecurityProfileDefender_STATUS
 		err := defender1.PopulateFromARM(owner, *typedInput.Defender)
@@ -13000,7 +13000,7 @@ func (profile *ManagedClusterSecurityProfile_STATUS) PopulateFromARM(owner genru
 		profile.Defender = &defender
 	}
 
-	// Set property ‘ImageCleaner’:
+	// Set property "ImageCleaner":
 	if typedInput.ImageCleaner != nil {
 		var imageCleaner1 ManagedClusterSecurityProfileImageCleaner_STATUS
 		err := imageCleaner1.PopulateFromARM(owner, *typedInput.ImageCleaner)
@@ -13011,7 +13011,7 @@ func (profile *ManagedClusterSecurityProfile_STATUS) PopulateFromARM(owner genru
 		profile.ImageCleaner = &imageCleaner
 	}
 
-	// Set property ‘NodeRestriction’:
+	// Set property "NodeRestriction":
 	if typedInput.NodeRestriction != nil {
 		var nodeRestriction1 ManagedClusterSecurityProfileNodeRestriction_STATUS
 		err := nodeRestriction1.PopulateFromARM(owner, *typedInput.NodeRestriction)
@@ -13022,7 +13022,7 @@ func (profile *ManagedClusterSecurityProfile_STATUS) PopulateFromARM(owner genru
 		profile.NodeRestriction = &nodeRestriction
 	}
 
-	// Set property ‘WorkloadIdentity’:
+	// Set property "WorkloadIdentity":
 	if typedInput.WorkloadIdentity != nil {
 		var workloadIdentity1 ManagedClusterSecurityProfileWorkloadIdentity_STATUS
 		err := workloadIdentity1.PopulateFromARM(owner, *typedInput.WorkloadIdentity)
@@ -13205,13 +13205,13 @@ func (profile *ManagedClusterServicePrincipalProfile) ConvertToARM(resolved genr
 	}
 	result := &ManagedClusterServicePrincipalProfile_ARM{}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if profile.ClientId != nil {
 		clientId := *profile.ClientId
 		result.ClientId = &clientId
 	}
 
-	// Set property ‘Secret’:
+	// Set property "Secret":
 	if profile.Secret != nil {
 		secretSecret, err := resolved.ResolvedSecrets.Lookup(*profile.Secret)
 		if err != nil {
@@ -13235,13 +13235,13 @@ func (profile *ManagedClusterServicePrincipalProfile) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterServicePrincipalProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		profile.ClientId = &clientId
 	}
 
-	// no assignment for property ‘Secret’
+	// no assignment for property "Secret"
 
 	// No error
 	return nil
@@ -13312,7 +13312,7 @@ func (profile *ManagedClusterServicePrincipalProfile_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterServicePrincipalProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		profile.ClientId = &clientId
@@ -13370,13 +13370,13 @@ func (clusterSKU *ManagedClusterSKU) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &ManagedClusterSKU_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if clusterSKU.Name != nil {
 		name := *clusterSKU.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if clusterSKU.Tier != nil {
 		tier := *clusterSKU.Tier
 		result.Tier = &tier
@@ -13396,13 +13396,13 @@ func (clusterSKU *ManagedClusterSKU) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSKU_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		clusterSKU.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		clusterSKU.Tier = &tier
@@ -13491,13 +13491,13 @@ func (clusterSKU *ManagedClusterSKU_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSKU_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		clusterSKU.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		clusterSKU.Tier = &tier
@@ -13586,7 +13586,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ManagedClusterStorageProfile_ARM{}
 
-	// Set property ‘BlobCSIDriver’:
+	// Set property "BlobCSIDriver":
 	if profile.BlobCSIDriver != nil {
 		blobCSIDriver_ARM, err := (*profile.BlobCSIDriver).ConvertToARM(resolved)
 		if err != nil {
@@ -13596,7 +13596,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 		result.BlobCSIDriver = &blobCSIDriver
 	}
 
-	// Set property ‘DiskCSIDriver’:
+	// Set property "DiskCSIDriver":
 	if profile.DiskCSIDriver != nil {
 		diskCSIDriver_ARM, err := (*profile.DiskCSIDriver).ConvertToARM(resolved)
 		if err != nil {
@@ -13606,7 +13606,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 		result.DiskCSIDriver = &diskCSIDriver
 	}
 
-	// Set property ‘FileCSIDriver’:
+	// Set property "FileCSIDriver":
 	if profile.FileCSIDriver != nil {
 		fileCSIDriver_ARM, err := (*profile.FileCSIDriver).ConvertToARM(resolved)
 		if err != nil {
@@ -13616,7 +13616,7 @@ func (profile *ManagedClusterStorageProfile) ConvertToARM(resolved genruntime.Co
 		result.FileCSIDriver = &fileCSIDriver
 	}
 
-	// Set property ‘SnapshotController’:
+	// Set property "SnapshotController":
 	if profile.SnapshotController != nil {
 		snapshotController_ARM, err := (*profile.SnapshotController).ConvertToARM(resolved)
 		if err != nil {
@@ -13640,7 +13640,7 @@ func (profile *ManagedClusterStorageProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobCSIDriver’:
+	// Set property "BlobCSIDriver":
 	if typedInput.BlobCSIDriver != nil {
 		var blobCSIDriver1 ManagedClusterStorageProfileBlobCSIDriver
 		err := blobCSIDriver1.PopulateFromARM(owner, *typedInput.BlobCSIDriver)
@@ -13651,7 +13651,7 @@ func (profile *ManagedClusterStorageProfile) PopulateFromARM(owner genruntime.Ar
 		profile.BlobCSIDriver = &blobCSIDriver
 	}
 
-	// Set property ‘DiskCSIDriver’:
+	// Set property "DiskCSIDriver":
 	if typedInput.DiskCSIDriver != nil {
 		var diskCSIDriver1 ManagedClusterStorageProfileDiskCSIDriver
 		err := diskCSIDriver1.PopulateFromARM(owner, *typedInput.DiskCSIDriver)
@@ -13662,7 +13662,7 @@ func (profile *ManagedClusterStorageProfile) PopulateFromARM(owner genruntime.Ar
 		profile.DiskCSIDriver = &diskCSIDriver
 	}
 
-	// Set property ‘FileCSIDriver’:
+	// Set property "FileCSIDriver":
 	if typedInput.FileCSIDriver != nil {
 		var fileCSIDriver1 ManagedClusterStorageProfileFileCSIDriver
 		err := fileCSIDriver1.PopulateFromARM(owner, *typedInput.FileCSIDriver)
@@ -13673,7 +13673,7 @@ func (profile *ManagedClusterStorageProfile) PopulateFromARM(owner genruntime.Ar
 		profile.FileCSIDriver = &fileCSIDriver
 	}
 
-	// Set property ‘SnapshotController’:
+	// Set property "SnapshotController":
 	if typedInput.SnapshotController != nil {
 		var snapshotController1 ManagedClusterStorageProfileSnapshotController
 		err := snapshotController1.PopulateFromARM(owner, *typedInput.SnapshotController)
@@ -13836,7 +13836,7 @@ func (profile *ManagedClusterStorageProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobCSIDriver’:
+	// Set property "BlobCSIDriver":
 	if typedInput.BlobCSIDriver != nil {
 		var blobCSIDriver1 ManagedClusterStorageProfileBlobCSIDriver_STATUS
 		err := blobCSIDriver1.PopulateFromARM(owner, *typedInput.BlobCSIDriver)
@@ -13847,7 +13847,7 @@ func (profile *ManagedClusterStorageProfile_STATUS) PopulateFromARM(owner genrun
 		profile.BlobCSIDriver = &blobCSIDriver
 	}
 
-	// Set property ‘DiskCSIDriver’:
+	// Set property "DiskCSIDriver":
 	if typedInput.DiskCSIDriver != nil {
 		var diskCSIDriver1 ManagedClusterStorageProfileDiskCSIDriver_STATUS
 		err := diskCSIDriver1.PopulateFromARM(owner, *typedInput.DiskCSIDriver)
@@ -13858,7 +13858,7 @@ func (profile *ManagedClusterStorageProfile_STATUS) PopulateFromARM(owner genrun
 		profile.DiskCSIDriver = &diskCSIDriver
 	}
 
-	// Set property ‘FileCSIDriver’:
+	// Set property "FileCSIDriver":
 	if typedInput.FileCSIDriver != nil {
 		var fileCSIDriver1 ManagedClusterStorageProfileFileCSIDriver_STATUS
 		err := fileCSIDriver1.PopulateFromARM(owner, *typedInput.FileCSIDriver)
@@ -13869,7 +13869,7 @@ func (profile *ManagedClusterStorageProfile_STATUS) PopulateFromARM(owner genrun
 		profile.FileCSIDriver = &fileCSIDriver
 	}
 
-	// Set property ‘SnapshotController’:
+	// Set property "SnapshotController":
 	if typedInput.SnapshotController != nil {
 		var snapshotController1 ManagedClusterStorageProfileSnapshotController_STATUS
 		err := snapshotController1.PopulateFromARM(owner, *typedInput.SnapshotController)
@@ -14048,25 +14048,25 @@ func (profile *ManagedClusterWindowsProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ManagedClusterWindowsProfile_ARM{}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if profile.AdminPassword != nil {
 		adminPassword := *profile.AdminPassword
 		result.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘EnableCSIProxy’:
+	// Set property "EnableCSIProxy":
 	if profile.EnableCSIProxy != nil {
 		enableCSIProxy := *profile.EnableCSIProxy
 		result.EnableCSIProxy = &enableCSIProxy
 	}
 
-	// Set property ‘GmsaProfile’:
+	// Set property "GmsaProfile":
 	if profile.GmsaProfile != nil {
 		gmsaProfile_ARM, err := (*profile.GmsaProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -14076,7 +14076,7 @@ func (profile *ManagedClusterWindowsProfile) ConvertToARM(resolved genruntime.Co
 		result.GmsaProfile = &gmsaProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if profile.LicenseType != nil {
 		licenseType := *profile.LicenseType
 		result.LicenseType = &licenseType
@@ -14096,25 +14096,25 @@ func (profile *ManagedClusterWindowsProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWindowsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if typedInput.AdminPassword != nil {
 		adminPassword := *typedInput.AdminPassword
 		profile.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘EnableCSIProxy’:
+	// Set property "EnableCSIProxy":
 	if typedInput.EnableCSIProxy != nil {
 		enableCSIProxy := *typedInput.EnableCSIProxy
 		profile.EnableCSIProxy = &enableCSIProxy
 	}
 
-	// Set property ‘GmsaProfile’:
+	// Set property "GmsaProfile":
 	if typedInput.GmsaProfile != nil {
 		var gmsaProfile1 WindowsGmsaProfile
 		err := gmsaProfile1.PopulateFromARM(owner, *typedInput.GmsaProfile)
@@ -14125,7 +14125,7 @@ func (profile *ManagedClusterWindowsProfile) PopulateFromARM(owner genruntime.Ar
 		profile.GmsaProfile = &gmsaProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
@@ -14275,25 +14275,25 @@ func (profile *ManagedClusterWindowsProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWindowsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if typedInput.AdminPassword != nil {
 		adminPassword := *typedInput.AdminPassword
 		profile.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘EnableCSIProxy’:
+	// Set property "EnableCSIProxy":
 	if typedInput.EnableCSIProxy != nil {
 		enableCSIProxy := *typedInput.EnableCSIProxy
 		profile.EnableCSIProxy = &enableCSIProxy
 	}
 
-	// Set property ‘GmsaProfile’:
+	// Set property "GmsaProfile":
 	if typedInput.GmsaProfile != nil {
 		var gmsaProfile1 WindowsGmsaProfile_STATUS
 		err := gmsaProfile1.PopulateFromARM(owner, *typedInput.GmsaProfile)
@@ -14304,7 +14304,7 @@ func (profile *ManagedClusterWindowsProfile_STATUS) PopulateFromARM(owner genrun
 		profile.GmsaProfile = &gmsaProfile
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
@@ -14421,7 +14421,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) ConvertToARM(resolved ge
 	}
 	result := &ManagedClusterWorkloadAutoScalerProfile_ARM{}
 
-	// Set property ‘Keda’:
+	// Set property "Keda":
 	if profile.Keda != nil {
 		keda_ARM, err := (*profile.Keda).ConvertToARM(resolved)
 		if err != nil {
@@ -14431,7 +14431,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) ConvertToARM(resolved ge
 		result.Keda = &keda
 	}
 
-	// Set property ‘VerticalPodAutoscaler’:
+	// Set property "VerticalPodAutoscaler":
 	if profile.VerticalPodAutoscaler != nil {
 		verticalPodAutoscaler_ARM, err := (*profile.VerticalPodAutoscaler).ConvertToARM(resolved)
 		if err != nil {
@@ -14455,7 +14455,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWorkloadAutoScalerProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Keda’:
+	// Set property "Keda":
 	if typedInput.Keda != nil {
 		var keda1 ManagedClusterWorkloadAutoScalerProfileKeda
 		err := keda1.PopulateFromARM(owner, *typedInput.Keda)
@@ -14466,7 +14466,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile) PopulateFromARM(owner ge
 		profile.Keda = &keda
 	}
 
-	// Set property ‘VerticalPodAutoscaler’:
+	// Set property "VerticalPodAutoscaler":
 	if typedInput.VerticalPodAutoscaler != nil {
 		var verticalPodAutoscaler1 ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler
 		err := verticalPodAutoscaler1.PopulateFromARM(owner, *typedInput.VerticalPodAutoscaler)
@@ -14573,7 +14573,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWorkloadAutoScalerProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Keda’:
+	// Set property "Keda":
 	if typedInput.Keda != nil {
 		var keda1 ManagedClusterWorkloadAutoScalerProfileKeda_STATUS
 		err := keda1.PopulateFromARM(owner, *typedInput.Keda)
@@ -14584,7 +14584,7 @@ func (profile *ManagedClusterWorkloadAutoScalerProfile_STATUS) PopulateFromARM(o
 		profile.Keda = &keda
 	}
 
-	// Set property ‘VerticalPodAutoscaler’:
+	// Set property "VerticalPodAutoscaler":
 	if typedInput.VerticalPodAutoscaler != nil {
 		var verticalPodAutoscaler1 ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS
 		err := verticalPodAutoscaler1.PopulateFromARM(owner, *typedInput.VerticalPodAutoscaler)
@@ -14690,7 +14690,7 @@ func (state *PowerState_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PowerState_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		state.Code = &code
@@ -14766,13 +14766,13 @@ func (resource *PrivateLinkResource) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &PrivateLinkResource_ARM{}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if resource.GroupId != nil {
 		groupId := *resource.GroupId
 		result.GroupId = &groupId
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -14782,18 +14782,18 @@ func (resource *PrivateLinkResource) ConvertToARM(resolved genruntime.ConvertToA
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if resource.Name != nil {
 		name := *resource.Name
 		result.Name = &name
 	}
 
-	// Set property ‘RequiredMembers’:
+	// Set property "RequiredMembers":
 	for _, item := range resource.RequiredMembers {
 		result.RequiredMembers = append(result.RequiredMembers, item)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if resource.Type != nil {
 		typeVar := *resource.Type
 		result.Type = &typeVar
@@ -14813,26 +14813,26 @@ func (resource *PrivateLinkResource) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if typedInput.GroupId != nil {
 		groupId := *typedInput.GroupId
 		resource.GroupId = &groupId
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resource.Name = &name
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘RequiredMembers’:
+	// Set property "RequiredMembers":
 	for _, item := range typedInput.RequiredMembers {
 		resource.RequiredMembers = append(resource.RequiredMembers, item)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		resource.Type = &typeVar
@@ -14940,36 +14940,36 @@ func (resource *PrivateLinkResource_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if typedInput.GroupId != nil {
 		groupId := *typedInput.GroupId
 		resource.GroupId = &groupId
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resource.Name = &name
 	}
 
-	// Set property ‘PrivateLinkServiceID’:
+	// Set property "PrivateLinkServiceID":
 	if typedInput.PrivateLinkServiceID != nil {
 		privateLinkServiceID := *typedInput.PrivateLinkServiceID
 		resource.PrivateLinkServiceID = &privateLinkServiceID
 	}
 
-	// Set property ‘RequiredMembers’:
+	// Set property "RequiredMembers":
 	for _, item := range typedInput.RequiredMembers {
 		resource.RequiredMembers = append(resource.RequiredMembers, item)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		resource.Type = &typeVar
@@ -15057,7 +15057,7 @@ func (profile *ServiceMeshProfile) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &ServiceMeshProfile_ARM{}
 
-	// Set property ‘Istio’:
+	// Set property "Istio":
 	if profile.Istio != nil {
 		istio_ARM, err := (*profile.Istio).ConvertToARM(resolved)
 		if err != nil {
@@ -15067,7 +15067,7 @@ func (profile *ServiceMeshProfile) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Istio = &istio
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if profile.Mode != nil {
 		mode := *profile.Mode
 		result.Mode = &mode
@@ -15087,7 +15087,7 @@ func (profile *ServiceMeshProfile) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceMeshProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Istio’:
+	// Set property "Istio":
 	if typedInput.Istio != nil {
 		var istio1 IstioServiceMesh
 		err := istio1.PopulateFromARM(owner, *typedInput.Istio)
@@ -15098,7 +15098,7 @@ func (profile *ServiceMeshProfile) PopulateFromARM(owner genruntime.ArbitraryOwn
 		profile.Istio = &istio
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		profile.Mode = &mode
@@ -15194,7 +15194,7 @@ func (profile *ServiceMeshProfile_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceMeshProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Istio’:
+	// Set property "Istio":
 	if typedInput.Istio != nil {
 		var istio1 IstioServiceMesh_STATUS
 		err := istio1.PopulateFromARM(owner, *typedInput.Istio)
@@ -15205,7 +15205,7 @@ func (profile *ServiceMeshProfile_STATUS) PopulateFromARM(owner genruntime.Arbit
 		profile.Istio = &istio
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		profile.Mode = &mode
@@ -15313,37 +15313,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -15453,19 +15453,19 @@ func (identity *UserAssignedIdentity) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &UserAssignedIdentity_ARM{}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if identity.ClientId != nil {
 		clientId := *identity.ClientId
 		result.ClientId = &clientId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if identity.ObjectId != nil {
 		objectId := *identity.ObjectId
 		result.ObjectId = &objectId
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if identity.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*identity.ResourceReference)
 		if err != nil {
@@ -15489,19 +15489,19 @@ func (identity *UserAssignedIdentity) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		identity.ObjectId = &objectId
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -15584,19 +15584,19 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		identity.ObjectId = &objectId
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		identity.ResourceId = &resourceId
@@ -15677,25 +15677,25 @@ func (vaultKms *AzureKeyVaultKms) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &AzureKeyVaultKms_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if vaultKms.Enabled != nil {
 		enabled := *vaultKms.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	if vaultKms.KeyId != nil {
 		keyId := *vaultKms.KeyId
 		result.KeyId = &keyId
 	}
 
-	// Set property ‘KeyVaultNetworkAccess’:
+	// Set property "KeyVaultNetworkAccess":
 	if vaultKms.KeyVaultNetworkAccess != nil {
 		keyVaultNetworkAccess := *vaultKms.KeyVaultNetworkAccess
 		result.KeyVaultNetworkAccess = &keyVaultNetworkAccess
 	}
 
-	// Set property ‘KeyVaultResourceId’:
+	// Set property "KeyVaultResourceId":
 	if vaultKms.KeyVaultResourceReference != nil {
 		keyVaultResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*vaultKms.KeyVaultResourceReference)
 		if err != nil {
@@ -15719,25 +15719,25 @@ func (vaultKms *AzureKeyVaultKms) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureKeyVaultKms_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		vaultKms.Enabled = &enabled
 	}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	if typedInput.KeyId != nil {
 		keyId := *typedInput.KeyId
 		vaultKms.KeyId = &keyId
 	}
 
-	// Set property ‘KeyVaultNetworkAccess’:
+	// Set property "KeyVaultNetworkAccess":
 	if typedInput.KeyVaultNetworkAccess != nil {
 		keyVaultNetworkAccess := *typedInput.KeyVaultNetworkAccess
 		vaultKms.KeyVaultNetworkAccess = &keyVaultNetworkAccess
 	}
 
-	// no assignment for property ‘KeyVaultResourceReference’
+	// no assignment for property "KeyVaultResourceReference"
 
 	// No error
 	return nil
@@ -15855,25 +15855,25 @@ func (vaultKms *AzureKeyVaultKms_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureKeyVaultKms_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		vaultKms.Enabled = &enabled
 	}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	if typedInput.KeyId != nil {
 		keyId := *typedInput.KeyId
 		vaultKms.KeyId = &keyId
 	}
 
-	// Set property ‘KeyVaultNetworkAccess’:
+	// Set property "KeyVaultNetworkAccess":
 	if typedInput.KeyVaultNetworkAccess != nil {
 		keyVaultNetworkAccess := *typedInput.KeyVaultNetworkAccess
 		vaultKms.KeyVaultNetworkAccess = &keyVaultNetworkAccess
 	}
 
-	// Set property ‘KeyVaultResourceId’:
+	// Set property "KeyVaultResourceId":
 	if typedInput.KeyVaultResourceId != nil {
 		keyVaultResourceId := *typedInput.KeyVaultResourceId
 		vaultKms.KeyVaultResourceId = &keyVaultResourceId
@@ -15986,13 +15986,13 @@ func (config *ContainerServiceNetworkProfile_KubeProxyConfig) ConvertToARM(resol
 	}
 	result := &ContainerServiceNetworkProfile_KubeProxyConfig_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if config.Enabled != nil {
 		enabled := *config.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘IpvsConfig’:
+	// Set property "IpvsConfig":
 	if config.IpvsConfig != nil {
 		ipvsConfig_ARM, err := (*config.IpvsConfig).ConvertToARM(resolved)
 		if err != nil {
@@ -16002,7 +16002,7 @@ func (config *ContainerServiceNetworkProfile_KubeProxyConfig) ConvertToARM(resol
 		result.IpvsConfig = &ipvsConfig
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if config.Mode != nil {
 		mode := *config.Mode
 		result.Mode = &mode
@@ -16022,13 +16022,13 @@ func (config *ContainerServiceNetworkProfile_KubeProxyConfig) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceNetworkProfile_KubeProxyConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		config.Enabled = &enabled
 	}
 
-	// Set property ‘IpvsConfig’:
+	// Set property "IpvsConfig":
 	if typedInput.IpvsConfig != nil {
 		var ipvsConfig1 ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig
 		err := ipvsConfig1.PopulateFromARM(owner, *typedInput.IpvsConfig)
@@ -16039,7 +16039,7 @@ func (config *ContainerServiceNetworkProfile_KubeProxyConfig) PopulateFromARM(ow
 		config.IpvsConfig = &ipvsConfig
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		config.Mode = &mode
@@ -16154,13 +16154,13 @@ func (config *ContainerServiceNetworkProfile_KubeProxyConfig_STATUS) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceNetworkProfile_KubeProxyConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		config.Enabled = &enabled
 	}
 
-	// Set property ‘IpvsConfig’:
+	// Set property "IpvsConfig":
 	if typedInput.IpvsConfig != nil {
 		var ipvsConfig1 ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS
 		err := ipvsConfig1.PopulateFromARM(owner, *typedInput.IpvsConfig)
@@ -16171,7 +16171,7 @@ func (config *ContainerServiceNetworkProfile_KubeProxyConfig_STATUS) PopulateFro
 		config.IpvsConfig = &ipvsConfig
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		config.Mode = &mode
@@ -16295,7 +16295,7 @@ func (configuration *ContainerServiceSshConfiguration) ConvertToARM(resolved gen
 	}
 	result := &ContainerServiceSshConfiguration_ARM{}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range configuration.PublicKeys {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -16318,7 +16318,7 @@ func (configuration *ContainerServiceSshConfiguration) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 ContainerServiceSshPublicKey
 		err := item1.PopulateFromARM(owner, item)
@@ -16411,7 +16411,7 @@ func (configuration *ContainerServiceSshConfiguration_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 ContainerServiceSshPublicKey_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -16516,7 +16516,7 @@ func (mesh *IstioServiceMesh) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &IstioServiceMesh_ARM{}
 
-	// Set property ‘Components’:
+	// Set property "Components":
 	if mesh.Components != nil {
 		components_ARM, err := (*mesh.Components).ConvertToARM(resolved)
 		if err != nil {
@@ -16540,7 +16540,7 @@ func (mesh *IstioServiceMesh) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IstioServiceMesh_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Components’:
+	// Set property "Components":
 	if typedInput.Components != nil {
 		var components1 IstioComponents
 		err := components1.PopulateFromARM(owner, *typedInput.Components)
@@ -16622,7 +16622,7 @@ func (mesh *IstioServiceMesh_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IstioServiceMesh_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Components’:
+	// Set property "Components":
 	if typedInput.Components != nil {
 		var components1 IstioComponents_STATUS
 		err := components1.PopulateFromARM(owner, *typedInput.Components)
@@ -16762,13 +16762,13 @@ func (metrics *ManagedClusterAzureMonitorProfileMetrics) ConvertToARM(resolved g
 	}
 	result := &ManagedClusterAzureMonitorProfileMetrics_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if metrics.Enabled != nil {
 		enabled := *metrics.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘KubeStateMetrics’:
+	// Set property "KubeStateMetrics":
 	if metrics.KubeStateMetrics != nil {
 		kubeStateMetrics_ARM, err := (*metrics.KubeStateMetrics).ConvertToARM(resolved)
 		if err != nil {
@@ -16792,13 +16792,13 @@ func (metrics *ManagedClusterAzureMonitorProfileMetrics) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAzureMonitorProfileMetrics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		metrics.Enabled = &enabled
 	}
 
-	// Set property ‘KubeStateMetrics’:
+	// Set property "KubeStateMetrics":
 	if typedInput.KubeStateMetrics != nil {
 		var kubeStateMetrics1 ManagedClusterAzureMonitorProfileKubeStateMetrics
 		err := kubeStateMetrics1.PopulateFromARM(owner, *typedInput.KubeStateMetrics)
@@ -16899,13 +16899,13 @@ func (metrics *ManagedClusterAzureMonitorProfileMetrics_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAzureMonitorProfileMetrics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		metrics.Enabled = &enabled
 	}
 
-	// Set property ‘KubeStateMetrics’:
+	// Set property "KubeStateMetrics":
 	if typedInput.KubeStateMetrics != nil {
 		var kubeStateMetrics1 ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS
 		err := kubeStateMetrics1.PopulateFromARM(owner, *typedInput.KubeStateMetrics)
@@ -17005,13 +17005,13 @@ func (identities *ManagedClusterIdentity_UserAssignedIdentities_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -17075,7 +17075,7 @@ func (routing *ManagedClusterIngressProfileWebAppRouting) ConvertToARM(resolved 
 	}
 	result := &ManagedClusterIngressProfileWebAppRouting_ARM{}
 
-	// Set property ‘DnsZoneResourceId’:
+	// Set property "DnsZoneResourceId":
 	if routing.DnsZoneResourceReference != nil {
 		dnsZoneResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*routing.DnsZoneResourceReference)
 		if err != nil {
@@ -17085,7 +17085,7 @@ func (routing *ManagedClusterIngressProfileWebAppRouting) ConvertToARM(resolved 
 		result.DnsZoneResourceId = &dnsZoneResourceReference
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if routing.Enabled != nil {
 		enabled := *routing.Enabled
 		result.Enabled = &enabled
@@ -17105,9 +17105,9 @@ func (routing *ManagedClusterIngressProfileWebAppRouting) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIngressProfileWebAppRouting_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘DnsZoneResourceReference’
+	// no assignment for property "DnsZoneResourceReference"
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		routing.Enabled = &enabled
@@ -17202,19 +17202,19 @@ func (routing *ManagedClusterIngressProfileWebAppRouting_STATUS) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIngressProfileWebAppRouting_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsZoneResourceId’:
+	// Set property "DnsZoneResourceId":
 	if typedInput.DnsZoneResourceId != nil {
 		dnsZoneResourceId := *typedInput.DnsZoneResourceId
 		routing.DnsZoneResourceId = &dnsZoneResourceId
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		routing.Enabled = &enabled
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 UserAssignedIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -17340,19 +17340,19 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 	}
 	result := &ManagedClusterLoadBalancerProfile_ARM{}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	if profile.AllocatedOutboundPorts != nil {
 		allocatedOutboundPorts := *profile.AllocatedOutboundPorts
 		result.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 
-	// Set property ‘BackendPoolType’:
+	// Set property "BackendPoolType":
 	if profile.BackendPoolType != nil {
 		backendPoolType := *profile.BackendPoolType
 		result.BackendPoolType = &backendPoolType
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range profile.EffectiveOutboundIPs {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -17361,19 +17361,19 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		result.EffectiveOutboundIPs = append(result.EffectiveOutboundIPs, *item_ARM.(*ResourceReference_ARM))
 	}
 
-	// Set property ‘EnableMultipleStandardLoadBalancers’:
+	// Set property "EnableMultipleStandardLoadBalancers":
 	if profile.EnableMultipleStandardLoadBalancers != nil {
 		enableMultipleStandardLoadBalancers := *profile.EnableMultipleStandardLoadBalancers
 		result.EnableMultipleStandardLoadBalancers = &enableMultipleStandardLoadBalancers
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if profile.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *profile.IdleTimeoutInMinutes
 		result.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPs’:
+	// Set property "ManagedOutboundIPs":
 	if profile.ManagedOutboundIPs != nil {
 		managedOutboundIPs_ARM, err := (*profile.ManagedOutboundIPs).ConvertToARM(resolved)
 		if err != nil {
@@ -17383,7 +17383,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		result.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
-	// Set property ‘OutboundIPPrefixes’:
+	// Set property "OutboundIPPrefixes":
 	if profile.OutboundIPPrefixes != nil {
 		outboundIPPrefixes_ARM, err := (*profile.OutboundIPPrefixes).ConvertToARM(resolved)
 		if err != nil {
@@ -17393,7 +17393,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		result.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
-	// Set property ‘OutboundIPs’:
+	// Set property "OutboundIPs":
 	if profile.OutboundIPs != nil {
 		outboundIPs_ARM, err := (*profile.OutboundIPs).ConvertToARM(resolved)
 		if err != nil {
@@ -17417,19 +17417,19 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	if typedInput.AllocatedOutboundPorts != nil {
 		allocatedOutboundPorts := *typedInput.AllocatedOutboundPorts
 		profile.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 
-	// Set property ‘BackendPoolType’:
+	// Set property "BackendPoolType":
 	if typedInput.BackendPoolType != nil {
 		backendPoolType := *typedInput.BackendPoolType
 		profile.BackendPoolType = &backendPoolType
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range typedInput.EffectiveOutboundIPs {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -17439,19 +17439,19 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		profile.EffectiveOutboundIPs = append(profile.EffectiveOutboundIPs, item1)
 	}
 
-	// Set property ‘EnableMultipleStandardLoadBalancers’:
+	// Set property "EnableMultipleStandardLoadBalancers":
 	if typedInput.EnableMultipleStandardLoadBalancers != nil {
 		enableMultipleStandardLoadBalancers := *typedInput.EnableMultipleStandardLoadBalancers
 		profile.EnableMultipleStandardLoadBalancers = &enableMultipleStandardLoadBalancers
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if typedInput.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *typedInput.IdleTimeoutInMinutes
 		profile.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPs’:
+	// Set property "ManagedOutboundIPs":
 	if typedInput.ManagedOutboundIPs != nil {
 		var managedOutboundIPs1 ManagedClusterLoadBalancerProfile_ManagedOutboundIPs
 		err := managedOutboundIPs1.PopulateFromARM(owner, *typedInput.ManagedOutboundIPs)
@@ -17462,7 +17462,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		profile.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
-	// Set property ‘OutboundIPPrefixes’:
+	// Set property "OutboundIPPrefixes":
 	if typedInput.OutboundIPPrefixes != nil {
 		var outboundIPPrefixes1 ManagedClusterLoadBalancerProfile_OutboundIPPrefixes
 		err := outboundIPPrefixes1.PopulateFromARM(owner, *typedInput.OutboundIPPrefixes)
@@ -17473,7 +17473,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		profile.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
-	// Set property ‘OutboundIPs’:
+	// Set property "OutboundIPs":
 	if typedInput.OutboundIPs != nil {
 		var outboundIPs1 ManagedClusterLoadBalancerProfile_OutboundIPs
 		err := outboundIPs1.PopulateFromARM(owner, *typedInput.OutboundIPs)
@@ -17726,19 +17726,19 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	if typedInput.AllocatedOutboundPorts != nil {
 		allocatedOutboundPorts := *typedInput.AllocatedOutboundPorts
 		profile.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 
-	// Set property ‘BackendPoolType’:
+	// Set property "BackendPoolType":
 	if typedInput.BackendPoolType != nil {
 		backendPoolType := *typedInput.BackendPoolType
 		profile.BackendPoolType = &backendPoolType
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range typedInput.EffectiveOutboundIPs {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -17748,19 +17748,19 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		profile.EffectiveOutboundIPs = append(profile.EffectiveOutboundIPs, item1)
 	}
 
-	// Set property ‘EnableMultipleStandardLoadBalancers’:
+	// Set property "EnableMultipleStandardLoadBalancers":
 	if typedInput.EnableMultipleStandardLoadBalancers != nil {
 		enableMultipleStandardLoadBalancers := *typedInput.EnableMultipleStandardLoadBalancers
 		profile.EnableMultipleStandardLoadBalancers = &enableMultipleStandardLoadBalancers
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if typedInput.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *typedInput.IdleTimeoutInMinutes
 		profile.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPs’:
+	// Set property "ManagedOutboundIPs":
 	if typedInput.ManagedOutboundIPs != nil {
 		var managedOutboundIPs1 ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS
 		err := managedOutboundIPs1.PopulateFromARM(owner, *typedInput.ManagedOutboundIPs)
@@ -17771,7 +17771,7 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		profile.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
-	// Set property ‘OutboundIPPrefixes’:
+	// Set property "OutboundIPPrefixes":
 	if typedInput.OutboundIPPrefixes != nil {
 		var outboundIPPrefixes1 ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS
 		err := outboundIPPrefixes1.PopulateFromARM(owner, *typedInput.OutboundIPPrefixes)
@@ -17782,7 +17782,7 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		profile.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
-	// Set property ‘OutboundIPs’:
+	// Set property "OutboundIPs":
 	if typedInput.OutboundIPs != nil {
 		var outboundIPs1 ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS
 		err := outboundIPs1.PopulateFromARM(owner, *typedInput.OutboundIPs)
@@ -17996,7 +17996,7 @@ func (profile *ManagedClusterNATGatewayProfile) ConvertToARM(resolved genruntime
 	}
 	result := &ManagedClusterNATGatewayProfile_ARM{}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range profile.EffectiveOutboundIPs {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -18005,13 +18005,13 @@ func (profile *ManagedClusterNATGatewayProfile) ConvertToARM(resolved genruntime
 		result.EffectiveOutboundIPs = append(result.EffectiveOutboundIPs, *item_ARM.(*ResourceReference_ARM))
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if profile.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *profile.IdleTimeoutInMinutes
 		result.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPProfile’:
+	// Set property "ManagedOutboundIPProfile":
 	if profile.ManagedOutboundIPProfile != nil {
 		managedOutboundIPProfile_ARM, err := (*profile.ManagedOutboundIPProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -18035,7 +18035,7 @@ func (profile *ManagedClusterNATGatewayProfile) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterNATGatewayProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range typedInput.EffectiveOutboundIPs {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -18045,13 +18045,13 @@ func (profile *ManagedClusterNATGatewayProfile) PopulateFromARM(owner genruntime
 		profile.EffectiveOutboundIPs = append(profile.EffectiveOutboundIPs, item1)
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if typedInput.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *typedInput.IdleTimeoutInMinutes
 		profile.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPProfile’:
+	// Set property "ManagedOutboundIPProfile":
 	if typedInput.ManagedOutboundIPProfile != nil {
 		var managedOutboundIPProfile1 ManagedClusterManagedOutboundIPProfile
 		err := managedOutboundIPProfile1.PopulateFromARM(owner, *typedInput.ManagedOutboundIPProfile)
@@ -18192,7 +18192,7 @@ func (profile *ManagedClusterNATGatewayProfile_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterNATGatewayProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range typedInput.EffectiveOutboundIPs {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -18202,13 +18202,13 @@ func (profile *ManagedClusterNATGatewayProfile_STATUS) PopulateFromARM(owner gen
 		profile.EffectiveOutboundIPs = append(profile.EffectiveOutboundIPs, item1)
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if typedInput.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *typedInput.IdleTimeoutInMinutes
 		profile.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPProfile’:
+	// Set property "ManagedOutboundIPProfile":
 	if typedInput.ManagedOutboundIPProfile != nil {
 		var managedOutboundIPProfile1 ManagedClusterManagedOutboundIPProfile_STATUS
 		err := managedOutboundIPProfile1.PopulateFromARM(owner, *typedInput.ManagedOutboundIPProfile)
@@ -18464,13 +18464,13 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ManagedClusterPodIdentity_ARM{}
 
-	// Set property ‘BindingSelector’:
+	// Set property "BindingSelector":
 	if identity.BindingSelector != nil {
 		bindingSelector := *identity.BindingSelector
 		result.BindingSelector = &bindingSelector
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if identity.Identity != nil {
 		identity_ARM, err := (*identity.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -18480,13 +18480,13 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 		result.Identity = &identity1
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if identity.Name != nil {
 		name := *identity.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if identity.Namespace != nil {
 		namespace := *identity.Namespace
 		result.Namespace = &namespace
@@ -18506,13 +18506,13 @@ func (identity *ManagedClusterPodIdentity) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BindingSelector’:
+	// Set property "BindingSelector":
 	if typedInput.BindingSelector != nil {
 		bindingSelector := *typedInput.BindingSelector
 		identity.BindingSelector = &bindingSelector
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity2 UserAssignedIdentity
 		err := identity2.PopulateFromARM(owner, *typedInput.Identity)
@@ -18523,13 +18523,13 @@ func (identity *ManagedClusterPodIdentity) PopulateFromARM(owner genruntime.Arbi
 		identity.Identity = &identity1
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		identity.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		identity.Namespace = &namespace
@@ -18637,13 +18637,13 @@ func (identity *ManagedClusterPodIdentity_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BindingSelector’:
+	// Set property "BindingSelector":
 	if typedInput.BindingSelector != nil {
 		bindingSelector := *typedInput.BindingSelector
 		identity.BindingSelector = &bindingSelector
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity2 UserAssignedIdentity_STATUS
 		err := identity2.PopulateFromARM(owner, *typedInput.Identity)
@@ -18654,19 +18654,19 @@ func (identity *ManagedClusterPodIdentity_STATUS) PopulateFromARM(owner genrunti
 		identity.Identity = &identity1
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		identity.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		identity.Namespace = &namespace
 	}
 
-	// Set property ‘ProvisioningInfo’:
+	// Set property "ProvisioningInfo":
 	if typedInput.ProvisioningInfo != nil {
 		var provisioningInfo1 ManagedClusterPodIdentity_ProvisioningInfo_STATUS
 		err := provisioningInfo1.PopulateFromARM(owner, *typedInput.ProvisioningInfo)
@@ -18677,7 +18677,7 @@ func (identity *ManagedClusterPodIdentity_STATUS) PopulateFromARM(owner genrunti
 		identity.ProvisioningInfo = &provisioningInfo
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		identity.ProvisioningState = &provisioningState
@@ -18817,19 +18817,19 @@ func (exception *ManagedClusterPodIdentityException) ConvertToARM(resolved genru
 	}
 	result := &ManagedClusterPodIdentityException_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if exception.Name != nil {
 		name := *exception.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if exception.Namespace != nil {
 		namespace := *exception.Namespace
 		result.Namespace = &namespace
 	}
 
-	// Set property ‘PodLabels’:
+	// Set property "PodLabels":
 	if exception.PodLabels != nil {
 		result.PodLabels = make(map[string]string, len(exception.PodLabels))
 		for key, value := range exception.PodLabels {
@@ -18851,19 +18851,19 @@ func (exception *ManagedClusterPodIdentityException) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityException_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		exception.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		exception.Namespace = &namespace
 	}
 
-	// Set property ‘PodLabels’:
+	// Set property "PodLabels":
 	if typedInput.PodLabels != nil {
 		exception.PodLabels = make(map[string]string, len(typedInput.PodLabels))
 		for key, value := range typedInput.PodLabels {
@@ -18943,19 +18943,19 @@ func (exception *ManagedClusterPodIdentityException_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityException_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		exception.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		exception.Namespace = &namespace
 	}
 
-	// Set property ‘PodLabels’:
+	// Set property "PodLabels":
 	if typedInput.PodLabels != nil {
 		exception.PodLabels = make(map[string]string, len(typedInput.PodLabels))
 		for key, value := range typedInput.PodLabels {
@@ -19051,7 +19051,7 @@ func (defender *ManagedClusterSecurityProfileDefender) ConvertToARM(resolved gen
 	}
 	result := &ManagedClusterSecurityProfileDefender_ARM{}
 
-	// Set property ‘LogAnalyticsWorkspaceResourceId’:
+	// Set property "LogAnalyticsWorkspaceResourceId":
 	if defender.LogAnalyticsWorkspaceResourceReference != nil {
 		logAnalyticsWorkspaceResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*defender.LogAnalyticsWorkspaceResourceReference)
 		if err != nil {
@@ -19061,7 +19061,7 @@ func (defender *ManagedClusterSecurityProfileDefender) ConvertToARM(resolved gen
 		result.LogAnalyticsWorkspaceResourceId = &logAnalyticsWorkspaceResourceReference
 	}
 
-	// Set property ‘SecurityMonitoring’:
+	// Set property "SecurityMonitoring":
 	if defender.SecurityMonitoring != nil {
 		securityMonitoring_ARM, err := (*defender.SecurityMonitoring).ConvertToARM(resolved)
 		if err != nil {
@@ -19085,9 +19085,9 @@ func (defender *ManagedClusterSecurityProfileDefender) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileDefender_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘LogAnalyticsWorkspaceResourceReference’
+	// no assignment for property "LogAnalyticsWorkspaceResourceReference"
 
-	// Set property ‘SecurityMonitoring’:
+	// Set property "SecurityMonitoring":
 	if typedInput.SecurityMonitoring != nil {
 		var securityMonitoring1 ManagedClusterSecurityProfileDefenderSecurityMonitoring
 		err := securityMonitoring1.PopulateFromARM(owner, *typedInput.SecurityMonitoring)
@@ -19190,13 +19190,13 @@ func (defender *ManagedClusterSecurityProfileDefender_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileDefender_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LogAnalyticsWorkspaceResourceId’:
+	// Set property "LogAnalyticsWorkspaceResourceId":
 	if typedInput.LogAnalyticsWorkspaceResourceId != nil {
 		logAnalyticsWorkspaceResourceId := *typedInput.LogAnalyticsWorkspaceResourceId
 		defender.LogAnalyticsWorkspaceResourceId = &logAnalyticsWorkspaceResourceId
 	}
 
-	// Set property ‘SecurityMonitoring’:
+	// Set property "SecurityMonitoring":
 	if typedInput.SecurityMonitoring != nil {
 		var securityMonitoring1 ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS
 		err := securityMonitoring1.PopulateFromARM(owner, *typedInput.SecurityMonitoring)
@@ -19283,13 +19283,13 @@ func (cleaner *ManagedClusterSecurityProfileImageCleaner) ConvertToARM(resolved 
 	}
 	result := &ManagedClusterSecurityProfileImageCleaner_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if cleaner.Enabled != nil {
 		enabled := *cleaner.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘IntervalHours’:
+	// Set property "IntervalHours":
 	if cleaner.IntervalHours != nil {
 		intervalHours := *cleaner.IntervalHours
 		result.IntervalHours = &intervalHours
@@ -19309,13 +19309,13 @@ func (cleaner *ManagedClusterSecurityProfileImageCleaner) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileImageCleaner_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		cleaner.Enabled = &enabled
 	}
 
-	// Set property ‘IntervalHours’:
+	// Set property "IntervalHours":
 	if typedInput.IntervalHours != nil {
 		intervalHours := *typedInput.IntervalHours
 		cleaner.IntervalHours = &intervalHours
@@ -19394,13 +19394,13 @@ func (cleaner *ManagedClusterSecurityProfileImageCleaner_STATUS) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileImageCleaner_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		cleaner.Enabled = &enabled
 	}
 
-	// Set property ‘IntervalHours’:
+	// Set property "IntervalHours":
 	if typedInput.IntervalHours != nil {
 		intervalHours := *typedInput.IntervalHours
 		cleaner.IntervalHours = &intervalHours
@@ -19470,7 +19470,7 @@ func (restriction *ManagedClusterSecurityProfileNodeRestriction) ConvertToARM(re
 	}
 	result := &ManagedClusterSecurityProfileNodeRestriction_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if restriction.Enabled != nil {
 		enabled := *restriction.Enabled
 		result.Enabled = &enabled
@@ -19490,7 +19490,7 @@ func (restriction *ManagedClusterSecurityProfileNodeRestriction) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileNodeRestriction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		restriction.Enabled = &enabled
@@ -19559,7 +19559,7 @@ func (restriction *ManagedClusterSecurityProfileNodeRestriction_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileNodeRestriction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		restriction.Enabled = &enabled
@@ -19623,7 +19623,7 @@ func (identity *ManagedClusterSecurityProfileWorkloadIdentity) ConvertToARM(reso
 	}
 	result := &ManagedClusterSecurityProfileWorkloadIdentity_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if identity.Enabled != nil {
 		enabled := *identity.Enabled
 		result.Enabled = &enabled
@@ -19643,7 +19643,7 @@ func (identity *ManagedClusterSecurityProfileWorkloadIdentity) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileWorkloadIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		identity.Enabled = &enabled
@@ -19712,7 +19712,7 @@ func (identity *ManagedClusterSecurityProfileWorkloadIdentity_STATUS) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileWorkloadIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		identity.Enabled = &enabled
@@ -19776,7 +19776,7 @@ func (driver *ManagedClusterStorageProfileBlobCSIDriver) ConvertToARM(resolved g
 	}
 	result := &ManagedClusterStorageProfileBlobCSIDriver_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if driver.Enabled != nil {
 		enabled := *driver.Enabled
 		result.Enabled = &enabled
@@ -19796,7 +19796,7 @@ func (driver *ManagedClusterStorageProfileBlobCSIDriver) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileBlobCSIDriver_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		driver.Enabled = &enabled
@@ -19865,7 +19865,7 @@ func (driver *ManagedClusterStorageProfileBlobCSIDriver_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileBlobCSIDriver_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		driver.Enabled = &enabled
@@ -19932,13 +19932,13 @@ func (driver *ManagedClusterStorageProfileDiskCSIDriver) ConvertToARM(resolved g
 	}
 	result := &ManagedClusterStorageProfileDiskCSIDriver_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if driver.Enabled != nil {
 		enabled := *driver.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if driver.Version != nil {
 		version := *driver.Version
 		result.Version = &version
@@ -19958,13 +19958,13 @@ func (driver *ManagedClusterStorageProfileDiskCSIDriver) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileDiskCSIDriver_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		driver.Enabled = &enabled
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		driver.Version = &version
@@ -20042,13 +20042,13 @@ func (driver *ManagedClusterStorageProfileDiskCSIDriver_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileDiskCSIDriver_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		driver.Enabled = &enabled
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		driver.Version = &version
@@ -20118,7 +20118,7 @@ func (driver *ManagedClusterStorageProfileFileCSIDriver) ConvertToARM(resolved g
 	}
 	result := &ManagedClusterStorageProfileFileCSIDriver_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if driver.Enabled != nil {
 		enabled := *driver.Enabled
 		result.Enabled = &enabled
@@ -20138,7 +20138,7 @@ func (driver *ManagedClusterStorageProfileFileCSIDriver) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileFileCSIDriver_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		driver.Enabled = &enabled
@@ -20207,7 +20207,7 @@ func (driver *ManagedClusterStorageProfileFileCSIDriver_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileFileCSIDriver_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		driver.Enabled = &enabled
@@ -20271,7 +20271,7 @@ func (controller *ManagedClusterStorageProfileSnapshotController) ConvertToARM(r
 	}
 	result := &ManagedClusterStorageProfileSnapshotController_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if controller.Enabled != nil {
 		enabled := *controller.Enabled
 		result.Enabled = &enabled
@@ -20291,7 +20291,7 @@ func (controller *ManagedClusterStorageProfileSnapshotController) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileSnapshotController_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		controller.Enabled = &enabled
@@ -20360,7 +20360,7 @@ func (controller *ManagedClusterStorageProfileSnapshotController_STATUS) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterStorageProfileSnapshotController_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		controller.Enabled = &enabled
@@ -20440,7 +20440,7 @@ func (keda *ManagedClusterWorkloadAutoScalerProfileKeda) ConvertToARM(resolved g
 	}
 	result := &ManagedClusterWorkloadAutoScalerProfileKeda_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if keda.Enabled != nil {
 		enabled := *keda.Enabled
 		result.Enabled = &enabled
@@ -20460,7 +20460,7 @@ func (keda *ManagedClusterWorkloadAutoScalerProfileKeda) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWorkloadAutoScalerProfileKeda_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		keda.Enabled = &enabled
@@ -20529,7 +20529,7 @@ func (keda *ManagedClusterWorkloadAutoScalerProfileKeda_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWorkloadAutoScalerProfileKeda_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		keda.Enabled = &enabled
@@ -20603,19 +20603,19 @@ func (autoscaler *ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler) 
 	}
 	result := &ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_ARM{}
 
-	// Set property ‘ControlledValues’:
+	// Set property "ControlledValues":
 	if autoscaler.ControlledValues != nil {
 		controlledValues := *autoscaler.ControlledValues
 		result.ControlledValues = &controlledValues
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if autoscaler.Enabled != nil {
 		enabled := *autoscaler.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘UpdateMode’:
+	// Set property "UpdateMode":
 	if autoscaler.UpdateMode != nil {
 		updateMode := *autoscaler.UpdateMode
 		result.UpdateMode = &updateMode
@@ -20635,19 +20635,19 @@ func (autoscaler *ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ControlledValues’:
+	// Set property "ControlledValues":
 	if typedInput.ControlledValues != nil {
 		controlledValues := *typedInput.ControlledValues
 		autoscaler.ControlledValues = &controlledValues
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		autoscaler.Enabled = &enabled
 	}
 
-	// Set property ‘UpdateMode’:
+	// Set property "UpdateMode":
 	if typedInput.UpdateMode != nil {
 		updateMode := *typedInput.UpdateMode
 		autoscaler.UpdateMode = &updateMode
@@ -20755,19 +20755,19 @@ func (autoscaler *ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_S
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ControlledValues’:
+	// Set property "ControlledValues":
 	if typedInput.ControlledValues != nil {
 		controlledValues := *typedInput.ControlledValues
 		autoscaler.ControlledValues = &controlledValues
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		autoscaler.Enabled = &enabled
 	}
 
-	// Set property ‘UpdateMode’:
+	// Set property "UpdateMode":
 	if typedInput.UpdateMode != nil {
 		updateMode := *typedInput.UpdateMode
 		autoscaler.UpdateMode = &updateMode
@@ -20973,12 +20973,12 @@ func (settings *UpgradeOverrideSettings) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &UpgradeOverrideSettings_ARM{}
 
-	// Set property ‘ControlPlaneOverrides’:
+	// Set property "ControlPlaneOverrides":
 	for _, item := range settings.ControlPlaneOverrides {
 		result.ControlPlaneOverrides = append(result.ControlPlaneOverrides, item)
 	}
 
-	// Set property ‘Until’:
+	// Set property "Until":
 	if settings.Until != nil {
 		until := *settings.Until
 		result.Until = &until
@@ -20998,12 +20998,12 @@ func (settings *UpgradeOverrideSettings) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpgradeOverrideSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ControlPlaneOverrides’:
+	// Set property "ControlPlaneOverrides":
 	for _, item := range typedInput.ControlPlaneOverrides {
 		settings.ControlPlaneOverrides = append(settings.ControlPlaneOverrides, item)
 	}
 
-	// Set property ‘Until’:
+	// Set property "Until":
 	if typedInput.Until != nil {
 		until := *typedInput.Until
 		settings.Until = &until
@@ -21093,12 +21093,12 @@ func (settings *UpgradeOverrideSettings_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpgradeOverrideSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ControlPlaneOverrides’:
+	// Set property "ControlPlaneOverrides":
 	for _, item := range typedInput.ControlPlaneOverrides {
 		settings.ControlPlaneOverrides = append(settings.ControlPlaneOverrides, item)
 	}
 
-	// Set property ‘Until’:
+	// Set property "Until":
 	if typedInput.Until != nil {
 		until := *typedInput.Until
 		settings.Until = &until
@@ -21220,19 +21220,19 @@ func (profile *WindowsGmsaProfile) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &WindowsGmsaProfile_ARM{}
 
-	// Set property ‘DnsServer’:
+	// Set property "DnsServer":
 	if profile.DnsServer != nil {
 		dnsServer := *profile.DnsServer
 		result.DnsServer = &dnsServer
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if profile.Enabled != nil {
 		enabled := *profile.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘RootDomainName’:
+	// Set property "RootDomainName":
 	if profile.RootDomainName != nil {
 		rootDomainName := *profile.RootDomainName
 		result.RootDomainName = &rootDomainName
@@ -21252,19 +21252,19 @@ func (profile *WindowsGmsaProfile) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsGmsaProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServer’:
+	// Set property "DnsServer":
 	if typedInput.DnsServer != nil {
 		dnsServer := *typedInput.DnsServer
 		profile.DnsServer = &dnsServer
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘RootDomainName’:
+	// Set property "RootDomainName":
 	if typedInput.RootDomainName != nil {
 		rootDomainName := *typedInput.RootDomainName
 		profile.RootDomainName = &rootDomainName
@@ -21353,19 +21353,19 @@ func (profile *WindowsGmsaProfile_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WindowsGmsaProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServer’:
+	// Set property "DnsServer":
 	if typedInput.DnsServer != nil {
 		dnsServer := *typedInput.DnsServer
 		profile.DnsServer = &dnsServer
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘RootDomainName’:
+	// Set property "RootDomainName":
 	if typedInput.RootDomainName != nil {
 		rootDomainName := *typedInput.RootDomainName
 		profile.RootDomainName = &rootDomainName
@@ -21465,25 +21465,25 @@ func (config *ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig) Convert
 	}
 	result := &ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_ARM{}
 
-	// Set property ‘Scheduler’:
+	// Set property "Scheduler":
 	if config.Scheduler != nil {
 		scheduler := *config.Scheduler
 		result.Scheduler = &scheduler
 	}
 
-	// Set property ‘TcpFinTimeoutSeconds’:
+	// Set property "TcpFinTimeoutSeconds":
 	if config.TcpFinTimeoutSeconds != nil {
 		tcpFinTimeoutSeconds := *config.TcpFinTimeoutSeconds
 		result.TcpFinTimeoutSeconds = &tcpFinTimeoutSeconds
 	}
 
-	// Set property ‘TcpTimeoutSeconds’:
+	// Set property "TcpTimeoutSeconds":
 	if config.TcpTimeoutSeconds != nil {
 		tcpTimeoutSeconds := *config.TcpTimeoutSeconds
 		result.TcpTimeoutSeconds = &tcpTimeoutSeconds
 	}
 
-	// Set property ‘UdpTimeoutSeconds’:
+	// Set property "UdpTimeoutSeconds":
 	if config.UdpTimeoutSeconds != nil {
 		udpTimeoutSeconds := *config.UdpTimeoutSeconds
 		result.UdpTimeoutSeconds = &udpTimeoutSeconds
@@ -21503,25 +21503,25 @@ func (config *ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Scheduler’:
+	// Set property "Scheduler":
 	if typedInput.Scheduler != nil {
 		scheduler := *typedInput.Scheduler
 		config.Scheduler = &scheduler
 	}
 
-	// Set property ‘TcpFinTimeoutSeconds’:
+	// Set property "TcpFinTimeoutSeconds":
 	if typedInput.TcpFinTimeoutSeconds != nil {
 		tcpFinTimeoutSeconds := *typedInput.TcpFinTimeoutSeconds
 		config.TcpFinTimeoutSeconds = &tcpFinTimeoutSeconds
 	}
 
-	// Set property ‘TcpTimeoutSeconds’:
+	// Set property "TcpTimeoutSeconds":
 	if typedInput.TcpTimeoutSeconds != nil {
 		tcpTimeoutSeconds := *typedInput.TcpTimeoutSeconds
 		config.TcpTimeoutSeconds = &tcpTimeoutSeconds
 	}
 
-	// Set property ‘UdpTimeoutSeconds’:
+	// Set property "UdpTimeoutSeconds":
 	if typedInput.UdpTimeoutSeconds != nil {
 		udpTimeoutSeconds := *typedInput.UdpTimeoutSeconds
 		config.UdpTimeoutSeconds = &udpTimeoutSeconds
@@ -21617,25 +21617,25 @@ func (config *ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceNetworkProfile_KubeProxyConfig_IpvsConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Scheduler’:
+	// Set property "Scheduler":
 	if typedInput.Scheduler != nil {
 		scheduler := *typedInput.Scheduler
 		config.Scheduler = &scheduler
 	}
 
-	// Set property ‘TcpFinTimeoutSeconds’:
+	// Set property "TcpFinTimeoutSeconds":
 	if typedInput.TcpFinTimeoutSeconds != nil {
 		tcpFinTimeoutSeconds := *typedInput.TcpFinTimeoutSeconds
 		config.TcpFinTimeoutSeconds = &tcpFinTimeoutSeconds
 	}
 
-	// Set property ‘TcpTimeoutSeconds’:
+	// Set property "TcpTimeoutSeconds":
 	if typedInput.TcpTimeoutSeconds != nil {
 		tcpTimeoutSeconds := *typedInput.TcpTimeoutSeconds
 		config.TcpTimeoutSeconds = &tcpTimeoutSeconds
 	}
 
-	// Set property ‘UdpTimeoutSeconds’:
+	// Set property "UdpTimeoutSeconds":
 	if typedInput.UdpTimeoutSeconds != nil {
 		udpTimeoutSeconds := *typedInput.UdpTimeoutSeconds
 		config.UdpTimeoutSeconds = &udpTimeoutSeconds
@@ -21734,7 +21734,7 @@ func (publicKey *ContainerServiceSshPublicKey) ConvertToARM(resolved genruntime.
 	}
 	result := &ContainerServiceSshPublicKey_ARM{}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if publicKey.KeyData != nil {
 		keyData := *publicKey.KeyData
 		result.KeyData = &keyData
@@ -21754,7 +21754,7 @@ func (publicKey *ContainerServiceSshPublicKey) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshPublicKey_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
@@ -21814,7 +21814,7 @@ func (publicKey *ContainerServiceSshPublicKey_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshPublicKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
@@ -21879,7 +21879,7 @@ func (components *IstioComponents) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &IstioComponents_ARM{}
 
-	// Set property ‘IngressGateways’:
+	// Set property "IngressGateways":
 	for _, item := range components.IngressGateways {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -21902,7 +21902,7 @@ func (components *IstioComponents) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IstioComponents_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IngressGateways’:
+	// Set property "IngressGateways":
 	for _, item := range typedInput.IngressGateways {
 		var item1 IstioIngressGateway
 		err := item1.PopulateFromARM(owner, item)
@@ -21995,7 +21995,7 @@ func (components *IstioComponents_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IstioComponents_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IngressGateways’:
+	// Set property "IngressGateways":
 	for _, item := range typedInput.IngressGateways {
 		var item1 IstioIngressGateway_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -22088,13 +22088,13 @@ func (metrics *ManagedClusterAzureMonitorProfileKubeStateMetrics) ConvertToARM(r
 	}
 	result := &ManagedClusterAzureMonitorProfileKubeStateMetrics_ARM{}
 
-	// Set property ‘MetricAnnotationsAllowList’:
+	// Set property "MetricAnnotationsAllowList":
 	if metrics.MetricAnnotationsAllowList != nil {
 		metricAnnotationsAllowList := *metrics.MetricAnnotationsAllowList
 		result.MetricAnnotationsAllowList = &metricAnnotationsAllowList
 	}
 
-	// Set property ‘MetricLabelsAllowlist’:
+	// Set property "MetricLabelsAllowlist":
 	if metrics.MetricLabelsAllowlist != nil {
 		metricLabelsAllowlist := *metrics.MetricLabelsAllowlist
 		result.MetricLabelsAllowlist = &metricLabelsAllowlist
@@ -22114,13 +22114,13 @@ func (metrics *ManagedClusterAzureMonitorProfileKubeStateMetrics) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAzureMonitorProfileKubeStateMetrics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MetricAnnotationsAllowList’:
+	// Set property "MetricAnnotationsAllowList":
 	if typedInput.MetricAnnotationsAllowList != nil {
 		metricAnnotationsAllowList := *typedInput.MetricAnnotationsAllowList
 		metrics.MetricAnnotationsAllowList = &metricAnnotationsAllowList
 	}
 
-	// Set property ‘MetricLabelsAllowlist’:
+	// Set property "MetricLabelsAllowlist":
 	if typedInput.MetricLabelsAllowlist != nil {
 		metricLabelsAllowlist := *typedInput.MetricLabelsAllowlist
 		metrics.MetricLabelsAllowlist = &metricLabelsAllowlist
@@ -22190,13 +22190,13 @@ func (metrics *ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAzureMonitorProfileKubeStateMetrics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MetricAnnotationsAllowList’:
+	// Set property "MetricAnnotationsAllowList":
 	if typedInput.MetricAnnotationsAllowList != nil {
 		metricAnnotationsAllowList := *typedInput.MetricAnnotationsAllowList
 		metrics.MetricAnnotationsAllowList = &metricAnnotationsAllowList
 	}
 
-	// Set property ‘MetricLabelsAllowlist’:
+	// Set property "MetricLabelsAllowlist":
 	if typedInput.MetricLabelsAllowlist != nil {
 		metricLabelsAllowlist := *typedInput.MetricLabelsAllowlist
 		metrics.MetricLabelsAllowlist = &metricLabelsAllowlist
@@ -22279,13 +22279,13 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) ConvertToARM(re
 	}
 	result := &ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if iPs.Count != nil {
 		count := *iPs.Count
 		result.Count = &count
 	}
 
-	// Set property ‘CountIPv6’:
+	// Set property "CountIPv6":
 	if iPs.CountIPv6 != nil {
 		countIPv6 := *iPs.CountIPv6
 		result.CountIPv6 = &countIPv6
@@ -22305,13 +22305,13 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		iPs.Count = &count
 	}
 
-	// Set property ‘CountIPv6’:
+	// Set property "CountIPv6":
 	if typedInput.CountIPv6 != nil {
 		countIPv6 := *typedInput.CountIPv6
 		iPs.CountIPv6 = &countIPv6
@@ -22400,13 +22400,13 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		iPs.Count = &count
 	}
 
-	// Set property ‘CountIPv6’:
+	// Set property "CountIPv6":
 	if typedInput.CountIPv6 != nil {
 		countIPv6 := *typedInput.CountIPv6
 		iPs.CountIPv6 = &countIPv6
@@ -22465,7 +22465,7 @@ func (prefixes *ManagedClusterLoadBalancerProfile_OutboundIPPrefixes) ConvertToA
 	}
 	result := &ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_ARM{}
 
-	// Set property ‘PublicIPPrefixes’:
+	// Set property "PublicIPPrefixes":
 	for _, item := range prefixes.PublicIPPrefixes {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -22488,7 +22488,7 @@ func (prefixes *ManagedClusterLoadBalancerProfile_OutboundIPPrefixes) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPPrefixes’:
+	// Set property "PublicIPPrefixes":
 	for _, item := range typedInput.PublicIPPrefixes {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -22580,7 +22580,7 @@ func (prefixes *ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPPrefixes’:
+	// Set property "PublicIPPrefixes":
 	for _, item := range typedInput.PublicIPPrefixes {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -22667,7 +22667,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_OutboundIPs) ConvertToARM(resolved 
 	}
 	result := &ManagedClusterLoadBalancerProfile_OutboundIPs_ARM{}
 
-	// Set property ‘PublicIPs’:
+	// Set property "PublicIPs":
 	for _, item := range iPs.PublicIPs {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -22690,7 +22690,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_OutboundIPs) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPs_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPs’:
+	// Set property "PublicIPs":
 	for _, item := range typedInput.PublicIPs {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -22782,7 +22782,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPs’:
+	// Set property "PublicIPs":
 	for _, item := range typedInput.PublicIPs {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -22873,7 +22873,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) ConvertToARM(resolved gen
 	}
 	result := &ManagedClusterManagedOutboundIPProfile_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if profile.Count != nil {
 		count := *profile.Count
 		result.Count = &count
@@ -22893,7 +22893,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterManagedOutboundIPProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		profile.Count = &count
@@ -22963,7 +22963,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterManagedOutboundIPProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		profile.Count = &count
@@ -23021,7 +23021,7 @@ func (info *ManagedClusterPodIdentity_ProvisioningInfo_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentity_ProvisioningInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ManagedClusterPodIdentityProvisioningError_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -23109,7 +23109,7 @@ func (monitoring *ManagedClusterSecurityProfileDefenderSecurityMonitoring) Conve
 	}
 	result := &ManagedClusterSecurityProfileDefenderSecurityMonitoring_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if monitoring.Enabled != nil {
 		enabled := *monitoring.Enabled
 		result.Enabled = &enabled
@@ -23129,7 +23129,7 @@ func (monitoring *ManagedClusterSecurityProfileDefenderSecurityMonitoring) Popul
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileDefenderSecurityMonitoring_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		monitoring.Enabled = &enabled
@@ -23198,7 +23198,7 @@ func (monitoring *ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSecurityProfileDefenderSecurityMonitoring_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		monitoring.Enabled = &enabled
@@ -23296,7 +23296,7 @@ func (reference *ResourceReference) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ResourceReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -23320,7 +23320,7 @@ func (reference *ResourceReference) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceReference_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -23385,7 +23385,7 @@ func (reference *ResourceReference_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
@@ -23460,13 +23460,13 @@ func (gateway *IstioIngressGateway) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &IstioIngressGateway_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if gateway.Enabled != nil {
 		enabled := *gateway.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if gateway.Mode != nil {
 		mode := *gateway.Mode
 		result.Mode = &mode
@@ -23486,13 +23486,13 @@ func (gateway *IstioIngressGateway) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IstioIngressGateway_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		gateway.Enabled = &enabled
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		gateway.Mode = &mode
@@ -23581,13 +23581,13 @@ func (gateway *IstioIngressGateway_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IstioIngressGateway_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		gateway.Enabled = &enabled
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		gateway.Mode = &mode
@@ -23672,7 +23672,7 @@ func (error *ManagedClusterPodIdentityProvisioningError_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProvisioningError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error2 ManagedClusterPodIdentityProvisioningErrorBody_STATUS
 		err := error2.PopulateFromARM(owner, *typedInput.Error)
@@ -23778,13 +23778,13 @@ func (body *ManagedClusterPodIdentityProvisioningErrorBody_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProvisioningErrorBody_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		body.Code = &code
 	}
 
-	// Set property ‘Details’:
+	// Set property "Details":
 	for _, item := range typedInput.Details {
 		var item1 ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled
 		err := item1.PopulateFromARM(owner, item)
@@ -23794,13 +23794,13 @@ func (body *ManagedClusterPodIdentityProvisioningErrorBody_STATUS) PopulateFromA
 		body.Details = append(body.Details, item1)
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		body.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		body.Target = &target
@@ -23912,19 +23912,19 @@ func (unrolled *ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		unrolled.Code = &code
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		unrolled.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		unrolled.Target = &target

--- a/v2/api/containerservice/v1api20230202preview/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20230202preview/managed_clusters_agent_pool_types_gen.go
@@ -501,10 +501,10 @@ func (pool *ManagedClusters_AgentPool_Spec) ConvertToARM(resolved genruntime.Con
 	}
 	result := &ManagedClusters_AgentPool_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if pool.AvailabilityZones != nil ||
 		pool.CapacityReservationGroupID != nil ||
 		pool.Count != nil ||
@@ -787,7 +787,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusters_AgentPool_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AvailabilityZones {
@@ -795,10 +795,10 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	pool.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CapacityReservationGroupID’:
+	// Set property "CapacityReservationGroupID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CapacityReservationGroupID != nil {
@@ -807,7 +807,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Count != nil {
@@ -816,7 +816,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -830,7 +830,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutoScaling != nil {
@@ -839,7 +839,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableCustomCATrust’:
+	// Set property "EnableCustomCATrust":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableCustomCATrust != nil {
@@ -848,7 +848,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableEncryptionAtHost != nil {
@@ -857,7 +857,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFIPS != nil {
@@ -866,7 +866,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNodePublicIP != nil {
@@ -875,7 +875,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableUltraSSD != nil {
@@ -884,7 +884,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GpuInstanceProfile != nil {
@@ -893,9 +893,9 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘HostGroupReference’
+	// no assignment for property "HostGroupReference"
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletConfig != nil {
@@ -909,7 +909,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletDiskType != nil {
@@ -918,7 +918,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxOSConfig != nil {
@@ -932,7 +932,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxCount != nil {
@@ -941,7 +941,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxPods != nil {
@@ -950,7 +950,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MessageOfTheDay’:
+	// Set property "MessageOfTheDay":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MessageOfTheDay != nil {
@@ -959,7 +959,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinCount != nil {
@@ -968,7 +968,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Mode != nil {
@@ -977,7 +977,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -991,7 +991,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeLabels != nil {
@@ -1002,9 +1002,9 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘NodePublicIPPrefixReference’
+	// no assignment for property "NodePublicIPPrefixReference"
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NodeTaints {
@@ -1012,7 +1012,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestratorVersion != nil {
@@ -1021,7 +1021,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
@@ -1030,7 +1030,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskType != nil {
@@ -1039,7 +1039,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsSKU != nil {
@@ -1048,7 +1048,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -1057,12 +1057,12 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	pool.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// no assignment for property ‘PodSubnetReference’
+	// no assignment for property "PodSubnetReference"
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PowerState != nil {
@@ -1076,9 +1076,9 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘ProximityPlacementGroupReference’
+	// no assignment for property "ProximityPlacementGroupReference"
 
-	// Set property ‘ScaleDownMode’:
+	// Set property "ScaleDownMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleDownMode != nil {
@@ -1087,7 +1087,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetEvictionPolicy != nil {
@@ -1096,7 +1096,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetPriority != nil {
@@ -1105,7 +1105,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotMaxPrice != nil {
@@ -1114,7 +1114,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tags != nil {
@@ -1125,7 +1125,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -1134,7 +1134,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradeSettings != nil {
@@ -1148,7 +1148,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VmSize != nil {
@@ -1157,9 +1157,9 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘VnetSubnetReference’
+	// no assignment for property "VnetSubnetReference"
 
-	// Set property ‘WindowsProfile’:
+	// Set property "WindowsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WindowsProfile != nil {
@@ -1173,7 +1173,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘WorkloadRuntime’:
+	// Set property "WorkloadRuntime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkloadRuntime != nil {
@@ -2174,7 +2174,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusters_AgentPool_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AvailabilityZones {
@@ -2182,7 +2182,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘CapacityReservationGroupID’:
+	// Set property "CapacityReservationGroupID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CapacityReservationGroupID != nil {
@@ -2191,9 +2191,9 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Count != nil {
@@ -2202,7 +2202,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘CreationData’:
+	// Set property "CreationData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationData != nil {
@@ -2216,7 +2216,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘CurrentOrchestratorVersion’:
+	// Set property "CurrentOrchestratorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CurrentOrchestratorVersion != nil {
@@ -2225,7 +2225,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutoScaling != nil {
@@ -2234,7 +2234,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableCustomCATrust’:
+	// Set property "EnableCustomCATrust":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableCustomCATrust != nil {
@@ -2243,7 +2243,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableEncryptionAtHost != nil {
@@ -2252,7 +2252,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFIPS != nil {
@@ -2261,7 +2261,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNodePublicIP != nil {
@@ -2270,7 +2270,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableUltraSSD != nil {
@@ -2279,7 +2279,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GpuInstanceProfile != nil {
@@ -2288,7 +2288,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘HostGroupID’:
+	// Set property "HostGroupID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostGroupID != nil {
@@ -2297,13 +2297,13 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		pool.Id = &id
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletConfig != nil {
@@ -2317,7 +2317,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletDiskType != nil {
@@ -2326,7 +2326,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxOSConfig != nil {
@@ -2340,7 +2340,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxCount != nil {
@@ -2349,7 +2349,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxPods != nil {
@@ -2358,7 +2358,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘MessageOfTheDay’:
+	// Set property "MessageOfTheDay":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MessageOfTheDay != nil {
@@ -2367,7 +2367,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinCount != nil {
@@ -2376,7 +2376,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Mode != nil {
@@ -2385,13 +2385,13 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pool.Name = &name
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -2405,7 +2405,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘NodeImageVersion’:
+	// Set property "NodeImageVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeImageVersion != nil {
@@ -2414,7 +2414,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeLabels != nil {
@@ -2425,7 +2425,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘NodePublicIPPrefixID’:
+	// Set property "NodePublicIPPrefixID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodePublicIPPrefixID != nil {
@@ -2434,7 +2434,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NodeTaints {
@@ -2442,7 +2442,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestratorVersion != nil {
@@ -2451,7 +2451,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
@@ -2460,7 +2460,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskType != nil {
@@ -2469,7 +2469,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsSKU != nil {
@@ -2478,7 +2478,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -2487,7 +2487,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘PodSubnetID’:
+	// Set property "PodSubnetID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PodSubnetID != nil {
@@ -2496,7 +2496,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PowerState != nil {
@@ -2510,7 +2510,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘PropertiesType’:
+	// Set property "PropertiesType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -2519,7 +2519,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2528,7 +2528,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroupID != nil {
@@ -2537,7 +2537,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ScaleDownMode’:
+	// Set property "ScaleDownMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleDownMode != nil {
@@ -2546,7 +2546,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetEvictionPolicy != nil {
@@ -2555,7 +2555,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetPriority != nil {
@@ -2564,7 +2564,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotMaxPrice != nil {
@@ -2573,7 +2573,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tags != nil {
@@ -2584,13 +2584,13 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		pool.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradeSettings != nil {
@@ -2604,7 +2604,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VmSize != nil {
@@ -2613,7 +2613,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘VnetSubnetID’:
+	// Set property "VnetSubnetID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetSubnetID != nil {
@@ -2622,7 +2622,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘WindowsProfile’:
+	// Set property "WindowsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WindowsProfile != nil {
@@ -2636,7 +2636,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘WorkloadRuntime’:
+	// Set property "WorkloadRuntime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkloadRuntime != nil {
@@ -3319,7 +3319,7 @@ func (profile *AgentPoolNetworkProfile) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &AgentPoolNetworkProfile_ARM{}
 
-	// Set property ‘AllowedHostPorts’:
+	// Set property "AllowedHostPorts":
 	for _, item := range profile.AllowedHostPorts {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3328,7 +3328,7 @@ func (profile *AgentPoolNetworkProfile) ConvertToARM(resolved genruntime.Convert
 		result.AllowedHostPorts = append(result.AllowedHostPorts, *item_ARM.(*PortRange_ARM))
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	for _, item := range profile.ApplicationSecurityGroupsReferences {
 		itemARMID, err := resolved.ResolvedReferences.Lookup(item)
 		if err != nil {
@@ -3337,7 +3337,7 @@ func (profile *AgentPoolNetworkProfile) ConvertToARM(resolved genruntime.Convert
 		result.ApplicationSecurityGroups = append(result.ApplicationSecurityGroups, itemARMID)
 	}
 
-	// Set property ‘NodePublicIPTags’:
+	// Set property "NodePublicIPTags":
 	for _, item := range profile.NodePublicIPTags {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3360,7 +3360,7 @@ func (profile *AgentPoolNetworkProfile) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AgentPoolNetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedHostPorts’:
+	// Set property "AllowedHostPorts":
 	for _, item := range typedInput.AllowedHostPorts {
 		var item1 PortRange
 		err := item1.PopulateFromARM(owner, item)
@@ -3370,9 +3370,9 @@ func (profile *AgentPoolNetworkProfile) PopulateFromARM(owner genruntime.Arbitra
 		profile.AllowedHostPorts = append(profile.AllowedHostPorts, item1)
 	}
 
-	// no assignment for property ‘ApplicationSecurityGroupsReferences’
+	// no assignment for property "ApplicationSecurityGroupsReferences"
 
-	// Set property ‘NodePublicIPTags’:
+	// Set property "NodePublicIPTags":
 	for _, item := range typedInput.NodePublicIPTags {
 		var item1 IPTag
 		err := item1.PopulateFromARM(owner, item)
@@ -3533,7 +3533,7 @@ func (profile *AgentPoolNetworkProfile_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AgentPoolNetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedHostPorts’:
+	// Set property "AllowedHostPorts":
 	for _, item := range typedInput.AllowedHostPorts {
 		var item1 PortRange_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3543,12 +3543,12 @@ func (profile *AgentPoolNetworkProfile_STATUS) PopulateFromARM(owner genruntime.
 		profile.AllowedHostPorts = append(profile.AllowedHostPorts, item1)
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	for _, item := range typedInput.ApplicationSecurityGroups {
 		profile.ApplicationSecurityGroups = append(profile.ApplicationSecurityGroups, item)
 	}
 
-	// Set property ‘NodePublicIPTags’:
+	// Set property "NodePublicIPTags":
 	for _, item := range typedInput.NodePublicIPTags {
 		var item1 IPTag_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3698,7 +3698,7 @@ func (settings *AgentPoolUpgradeSettings) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &AgentPoolUpgradeSettings_ARM{}
 
-	// Set property ‘MaxSurge’:
+	// Set property "MaxSurge":
 	if settings.MaxSurge != nil {
 		maxSurge := *settings.MaxSurge
 		result.MaxSurge = &maxSurge
@@ -3718,7 +3718,7 @@ func (settings *AgentPoolUpgradeSettings) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AgentPoolUpgradeSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxSurge’:
+	// Set property "MaxSurge":
 	if typedInput.MaxSurge != nil {
 		maxSurge := *typedInput.MaxSurge
 		settings.MaxSurge = &maxSurge
@@ -3780,7 +3780,7 @@ func (settings *AgentPoolUpgradeSettings_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AgentPoolUpgradeSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxSurge’:
+	// Set property "MaxSurge":
 	if typedInput.MaxSurge != nil {
 		maxSurge := *typedInput.MaxSurge
 		settings.MaxSurge = &maxSurge
@@ -3835,7 +3835,7 @@ func (profile *AgentPoolWindowsProfile) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &AgentPoolWindowsProfile_ARM{}
 
-	// Set property ‘DisableOutboundNat’:
+	// Set property "DisableOutboundNat":
 	if profile.DisableOutboundNat != nil {
 		disableOutboundNat := *profile.DisableOutboundNat
 		result.DisableOutboundNat = &disableOutboundNat
@@ -3855,7 +3855,7 @@ func (profile *AgentPoolWindowsProfile) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AgentPoolWindowsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisableOutboundNat’:
+	// Set property "DisableOutboundNat":
 	if typedInput.DisableOutboundNat != nil {
 		disableOutboundNat := *typedInput.DisableOutboundNat
 		profile.DisableOutboundNat = &disableOutboundNat
@@ -3925,7 +3925,7 @@ func (profile *AgentPoolWindowsProfile_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AgentPoolWindowsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisableOutboundNat’:
+	// Set property "DisableOutboundNat":
 	if typedInput.DisableOutboundNat != nil {
 		disableOutboundNat := *typedInput.DisableOutboundNat
 		profile.DisableOutboundNat = &disableOutboundNat
@@ -4053,66 +4053,66 @@ func (config *KubeletConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &KubeletConfig_ARM{}
 
-	// Set property ‘AllowedUnsafeSysctls’:
+	// Set property "AllowedUnsafeSysctls":
 	for _, item := range config.AllowedUnsafeSysctls {
 		result.AllowedUnsafeSysctls = append(result.AllowedUnsafeSysctls, item)
 	}
 
-	// Set property ‘ContainerLogMaxFiles’:
+	// Set property "ContainerLogMaxFiles":
 	if config.ContainerLogMaxFiles != nil {
 		containerLogMaxFiles := *config.ContainerLogMaxFiles
 		result.ContainerLogMaxFiles = &containerLogMaxFiles
 	}
 
-	// Set property ‘ContainerLogMaxSizeMB’:
+	// Set property "ContainerLogMaxSizeMB":
 	if config.ContainerLogMaxSizeMB != nil {
 		containerLogMaxSizeMB := *config.ContainerLogMaxSizeMB
 		result.ContainerLogMaxSizeMB = &containerLogMaxSizeMB
 	}
 
-	// Set property ‘CpuCfsQuota’:
+	// Set property "CpuCfsQuota":
 	if config.CpuCfsQuota != nil {
 		cpuCfsQuota := *config.CpuCfsQuota
 		result.CpuCfsQuota = &cpuCfsQuota
 	}
 
-	// Set property ‘CpuCfsQuotaPeriod’:
+	// Set property "CpuCfsQuotaPeriod":
 	if config.CpuCfsQuotaPeriod != nil {
 		cpuCfsQuotaPeriod := *config.CpuCfsQuotaPeriod
 		result.CpuCfsQuotaPeriod = &cpuCfsQuotaPeriod
 	}
 
-	// Set property ‘CpuManagerPolicy’:
+	// Set property "CpuManagerPolicy":
 	if config.CpuManagerPolicy != nil {
 		cpuManagerPolicy := *config.CpuManagerPolicy
 		result.CpuManagerPolicy = &cpuManagerPolicy
 	}
 
-	// Set property ‘FailSwapOn’:
+	// Set property "FailSwapOn":
 	if config.FailSwapOn != nil {
 		failSwapOn := *config.FailSwapOn
 		result.FailSwapOn = &failSwapOn
 	}
 
-	// Set property ‘ImageGcHighThreshold’:
+	// Set property "ImageGcHighThreshold":
 	if config.ImageGcHighThreshold != nil {
 		imageGcHighThreshold := *config.ImageGcHighThreshold
 		result.ImageGcHighThreshold = &imageGcHighThreshold
 	}
 
-	// Set property ‘ImageGcLowThreshold’:
+	// Set property "ImageGcLowThreshold":
 	if config.ImageGcLowThreshold != nil {
 		imageGcLowThreshold := *config.ImageGcLowThreshold
 		result.ImageGcLowThreshold = &imageGcLowThreshold
 	}
 
-	// Set property ‘PodMaxPids’:
+	// Set property "PodMaxPids":
 	if config.PodMaxPids != nil {
 		podMaxPids := *config.PodMaxPids
 		result.PodMaxPids = &podMaxPids
 	}
 
-	// Set property ‘TopologyManagerPolicy’:
+	// Set property "TopologyManagerPolicy":
 	if config.TopologyManagerPolicy != nil {
 		topologyManagerPolicy := *config.TopologyManagerPolicy
 		result.TopologyManagerPolicy = &topologyManagerPolicy
@@ -4132,66 +4132,66 @@ func (config *KubeletConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubeletConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedUnsafeSysctls’:
+	// Set property "AllowedUnsafeSysctls":
 	for _, item := range typedInput.AllowedUnsafeSysctls {
 		config.AllowedUnsafeSysctls = append(config.AllowedUnsafeSysctls, item)
 	}
 
-	// Set property ‘ContainerLogMaxFiles’:
+	// Set property "ContainerLogMaxFiles":
 	if typedInput.ContainerLogMaxFiles != nil {
 		containerLogMaxFiles := *typedInput.ContainerLogMaxFiles
 		config.ContainerLogMaxFiles = &containerLogMaxFiles
 	}
 
-	// Set property ‘ContainerLogMaxSizeMB’:
+	// Set property "ContainerLogMaxSizeMB":
 	if typedInput.ContainerLogMaxSizeMB != nil {
 		containerLogMaxSizeMB := *typedInput.ContainerLogMaxSizeMB
 		config.ContainerLogMaxSizeMB = &containerLogMaxSizeMB
 	}
 
-	// Set property ‘CpuCfsQuota’:
+	// Set property "CpuCfsQuota":
 	if typedInput.CpuCfsQuota != nil {
 		cpuCfsQuota := *typedInput.CpuCfsQuota
 		config.CpuCfsQuota = &cpuCfsQuota
 	}
 
-	// Set property ‘CpuCfsQuotaPeriod’:
+	// Set property "CpuCfsQuotaPeriod":
 	if typedInput.CpuCfsQuotaPeriod != nil {
 		cpuCfsQuotaPeriod := *typedInput.CpuCfsQuotaPeriod
 		config.CpuCfsQuotaPeriod = &cpuCfsQuotaPeriod
 	}
 
-	// Set property ‘CpuManagerPolicy’:
+	// Set property "CpuManagerPolicy":
 	if typedInput.CpuManagerPolicy != nil {
 		cpuManagerPolicy := *typedInput.CpuManagerPolicy
 		config.CpuManagerPolicy = &cpuManagerPolicy
 	}
 
-	// Set property ‘FailSwapOn’:
+	// Set property "FailSwapOn":
 	if typedInput.FailSwapOn != nil {
 		failSwapOn := *typedInput.FailSwapOn
 		config.FailSwapOn = &failSwapOn
 	}
 
-	// Set property ‘ImageGcHighThreshold’:
+	// Set property "ImageGcHighThreshold":
 	if typedInput.ImageGcHighThreshold != nil {
 		imageGcHighThreshold := *typedInput.ImageGcHighThreshold
 		config.ImageGcHighThreshold = &imageGcHighThreshold
 	}
 
-	// Set property ‘ImageGcLowThreshold’:
+	// Set property "ImageGcLowThreshold":
 	if typedInput.ImageGcLowThreshold != nil {
 		imageGcLowThreshold := *typedInput.ImageGcLowThreshold
 		config.ImageGcLowThreshold = &imageGcLowThreshold
 	}
 
-	// Set property ‘PodMaxPids’:
+	// Set property "PodMaxPids":
 	if typedInput.PodMaxPids != nil {
 		podMaxPids := *typedInput.PodMaxPids
 		config.PodMaxPids = &podMaxPids
 	}
 
-	// Set property ‘TopologyManagerPolicy’:
+	// Set property "TopologyManagerPolicy":
 	if typedInput.TopologyManagerPolicy != nil {
 		topologyManagerPolicy := *typedInput.TopologyManagerPolicy
 		config.TopologyManagerPolicy = &topologyManagerPolicy
@@ -4376,66 +4376,66 @@ func (config *KubeletConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubeletConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedUnsafeSysctls’:
+	// Set property "AllowedUnsafeSysctls":
 	for _, item := range typedInput.AllowedUnsafeSysctls {
 		config.AllowedUnsafeSysctls = append(config.AllowedUnsafeSysctls, item)
 	}
 
-	// Set property ‘ContainerLogMaxFiles’:
+	// Set property "ContainerLogMaxFiles":
 	if typedInput.ContainerLogMaxFiles != nil {
 		containerLogMaxFiles := *typedInput.ContainerLogMaxFiles
 		config.ContainerLogMaxFiles = &containerLogMaxFiles
 	}
 
-	// Set property ‘ContainerLogMaxSizeMB’:
+	// Set property "ContainerLogMaxSizeMB":
 	if typedInput.ContainerLogMaxSizeMB != nil {
 		containerLogMaxSizeMB := *typedInput.ContainerLogMaxSizeMB
 		config.ContainerLogMaxSizeMB = &containerLogMaxSizeMB
 	}
 
-	// Set property ‘CpuCfsQuota’:
+	// Set property "CpuCfsQuota":
 	if typedInput.CpuCfsQuota != nil {
 		cpuCfsQuota := *typedInput.CpuCfsQuota
 		config.CpuCfsQuota = &cpuCfsQuota
 	}
 
-	// Set property ‘CpuCfsQuotaPeriod’:
+	// Set property "CpuCfsQuotaPeriod":
 	if typedInput.CpuCfsQuotaPeriod != nil {
 		cpuCfsQuotaPeriod := *typedInput.CpuCfsQuotaPeriod
 		config.CpuCfsQuotaPeriod = &cpuCfsQuotaPeriod
 	}
 
-	// Set property ‘CpuManagerPolicy’:
+	// Set property "CpuManagerPolicy":
 	if typedInput.CpuManagerPolicy != nil {
 		cpuManagerPolicy := *typedInput.CpuManagerPolicy
 		config.CpuManagerPolicy = &cpuManagerPolicy
 	}
 
-	// Set property ‘FailSwapOn’:
+	// Set property "FailSwapOn":
 	if typedInput.FailSwapOn != nil {
 		failSwapOn := *typedInput.FailSwapOn
 		config.FailSwapOn = &failSwapOn
 	}
 
-	// Set property ‘ImageGcHighThreshold’:
+	// Set property "ImageGcHighThreshold":
 	if typedInput.ImageGcHighThreshold != nil {
 		imageGcHighThreshold := *typedInput.ImageGcHighThreshold
 		config.ImageGcHighThreshold = &imageGcHighThreshold
 	}
 
-	// Set property ‘ImageGcLowThreshold’:
+	// Set property "ImageGcLowThreshold":
 	if typedInput.ImageGcLowThreshold != nil {
 		imageGcLowThreshold := *typedInput.ImageGcLowThreshold
 		config.ImageGcLowThreshold = &imageGcLowThreshold
 	}
 
-	// Set property ‘PodMaxPids’:
+	// Set property "PodMaxPids":
 	if typedInput.PodMaxPids != nil {
 		podMaxPids := *typedInput.PodMaxPids
 		config.PodMaxPids = &podMaxPids
 	}
 
-	// Set property ‘TopologyManagerPolicy’:
+	// Set property "TopologyManagerPolicy":
 	if typedInput.TopologyManagerPolicy != nil {
 		topologyManagerPolicy := *typedInput.TopologyManagerPolicy
 		config.TopologyManagerPolicy = &topologyManagerPolicy
@@ -4599,13 +4599,13 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &LinuxOSConfig_ARM{}
 
-	// Set property ‘SwapFileSizeMB’:
+	// Set property "SwapFileSizeMB":
 	if config.SwapFileSizeMB != nil {
 		swapFileSizeMB := *config.SwapFileSizeMB
 		result.SwapFileSizeMB = &swapFileSizeMB
 	}
 
-	// Set property ‘Sysctls’:
+	// Set property "Sysctls":
 	if config.Sysctls != nil {
 		sysctls_ARM, err := (*config.Sysctls).ConvertToARM(resolved)
 		if err != nil {
@@ -4615,13 +4615,13 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Sysctls = &sysctls
 	}
 
-	// Set property ‘TransparentHugePageDefrag’:
+	// Set property "TransparentHugePageDefrag":
 	if config.TransparentHugePageDefrag != nil {
 		transparentHugePageDefrag := *config.TransparentHugePageDefrag
 		result.TransparentHugePageDefrag = &transparentHugePageDefrag
 	}
 
-	// Set property ‘TransparentHugePageEnabled’:
+	// Set property "TransparentHugePageEnabled":
 	if config.TransparentHugePageEnabled != nil {
 		transparentHugePageEnabled := *config.TransparentHugePageEnabled
 		result.TransparentHugePageEnabled = &transparentHugePageEnabled
@@ -4641,13 +4641,13 @@ func (config *LinuxOSConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxOSConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SwapFileSizeMB’:
+	// Set property "SwapFileSizeMB":
 	if typedInput.SwapFileSizeMB != nil {
 		swapFileSizeMB := *typedInput.SwapFileSizeMB
 		config.SwapFileSizeMB = &swapFileSizeMB
 	}
 
-	// Set property ‘Sysctls’:
+	// Set property "Sysctls":
 	if typedInput.Sysctls != nil {
 		var sysctls1 SysctlConfig
 		err := sysctls1.PopulateFromARM(owner, *typedInput.Sysctls)
@@ -4658,13 +4658,13 @@ func (config *LinuxOSConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		config.Sysctls = &sysctls
 	}
 
-	// Set property ‘TransparentHugePageDefrag’:
+	// Set property "TransparentHugePageDefrag":
 	if typedInput.TransparentHugePageDefrag != nil {
 		transparentHugePageDefrag := *typedInput.TransparentHugePageDefrag
 		config.TransparentHugePageDefrag = &transparentHugePageDefrag
 	}
 
-	// Set property ‘TransparentHugePageEnabled’:
+	// Set property "TransparentHugePageEnabled":
 	if typedInput.TransparentHugePageEnabled != nil {
 		transparentHugePageEnabled := *typedInput.TransparentHugePageEnabled
 		config.TransparentHugePageEnabled = &transparentHugePageEnabled
@@ -4772,13 +4772,13 @@ func (config *LinuxOSConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxOSConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SwapFileSizeMB’:
+	// Set property "SwapFileSizeMB":
 	if typedInput.SwapFileSizeMB != nil {
 		swapFileSizeMB := *typedInput.SwapFileSizeMB
 		config.SwapFileSizeMB = &swapFileSizeMB
 	}
 
-	// Set property ‘Sysctls’:
+	// Set property "Sysctls":
 	if typedInput.Sysctls != nil {
 		var sysctls1 SysctlConfig_STATUS
 		err := sysctls1.PopulateFromARM(owner, *typedInput.Sysctls)
@@ -4789,13 +4789,13 @@ func (config *LinuxOSConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		config.Sysctls = &sysctls
 	}
 
-	// Set property ‘TransparentHugePageDefrag’:
+	// Set property "TransparentHugePageDefrag":
 	if typedInput.TransparentHugePageDefrag != nil {
 		transparentHugePageDefrag := *typedInput.TransparentHugePageDefrag
 		config.TransparentHugePageDefrag = &transparentHugePageDefrag
 	}
 
-	// Set property ‘TransparentHugePageEnabled’:
+	// Set property "TransparentHugePageEnabled":
 	if typedInput.TransparentHugePageEnabled != nil {
 		transparentHugePageEnabled := *typedInput.TransparentHugePageEnabled
 		config.TransparentHugePageEnabled = &transparentHugePageEnabled
@@ -4948,7 +4948,7 @@ func (state *PowerState) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &PowerState_ARM{}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if state.Code != nil {
 		code := *state.Code
 		result.Code = &code
@@ -4968,7 +4968,7 @@ func (state *PowerState) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PowerState_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		state.Code = &code
@@ -5109,13 +5109,13 @@ func (ipTag *IPTag) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &IPTag_ARM{}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if ipTag.IpTagType != nil {
 		ipTagType := *ipTag.IpTagType
 		result.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if ipTag.Tag != nil {
 		tag := *ipTag.Tag
 		result.Tag = &tag
@@ -5135,13 +5135,13 @@ func (ipTag *IPTag) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPTag_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -5209,13 +5209,13 @@ func (ipTag *IPTag_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPTag_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -5287,19 +5287,19 @@ func (portRange *PortRange) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &PortRange_ARM{}
 
-	// Set property ‘PortEnd’:
+	// Set property "PortEnd":
 	if portRange.PortEnd != nil {
 		portEnd := *portRange.PortEnd
 		result.PortEnd = &portEnd
 	}
 
-	// Set property ‘PortStart’:
+	// Set property "PortStart":
 	if portRange.PortStart != nil {
 		portStart := *portRange.PortStart
 		result.PortStart = &portStart
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if portRange.Protocol != nil {
 		protocol := *portRange.Protocol
 		result.Protocol = &protocol
@@ -5319,19 +5319,19 @@ func (portRange *PortRange) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PortRange_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PortEnd’:
+	// Set property "PortEnd":
 	if typedInput.PortEnd != nil {
 		portEnd := *typedInput.PortEnd
 		portRange.PortEnd = &portEnd
 	}
 
-	// Set property ‘PortStart’:
+	// Set property "PortStart":
 	if typedInput.PortStart != nil {
 		portStart := *typedInput.PortStart
 		portRange.PortStart = &portStart
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		portRange.Protocol = &protocol
@@ -5440,19 +5440,19 @@ func (portRange *PortRange_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PortRange_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PortEnd’:
+	// Set property "PortEnd":
 	if typedInput.PortEnd != nil {
 		portEnd := *typedInput.PortEnd
 		portRange.PortEnd = &portEnd
 	}
 
-	// Set property ‘PortStart’:
+	// Set property "PortStart":
 	if typedInput.PortStart != nil {
 		portStart := *typedInput.PortStart
 		portRange.PortStart = &portStart
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	if typedInput.Protocol != nil {
 		protocol := *typedInput.Protocol
 		portRange.Protocol = &protocol
@@ -5617,169 +5617,169 @@ func (config *SysctlConfig) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &SysctlConfig_ARM{}
 
-	// Set property ‘FsAioMaxNr’:
+	// Set property "FsAioMaxNr":
 	if config.FsAioMaxNr != nil {
 		fsAioMaxNr := *config.FsAioMaxNr
 		result.FsAioMaxNr = &fsAioMaxNr
 	}
 
-	// Set property ‘FsFileMax’:
+	// Set property "FsFileMax":
 	if config.FsFileMax != nil {
 		fsFileMax := *config.FsFileMax
 		result.FsFileMax = &fsFileMax
 	}
 
-	// Set property ‘FsInotifyMaxUserWatches’:
+	// Set property "FsInotifyMaxUserWatches":
 	if config.FsInotifyMaxUserWatches != nil {
 		fsInotifyMaxUserWatches := *config.FsInotifyMaxUserWatches
 		result.FsInotifyMaxUserWatches = &fsInotifyMaxUserWatches
 	}
 
-	// Set property ‘FsNrOpen’:
+	// Set property "FsNrOpen":
 	if config.FsNrOpen != nil {
 		fsNrOpen := *config.FsNrOpen
 		result.FsNrOpen = &fsNrOpen
 	}
 
-	// Set property ‘KernelThreadsMax’:
+	// Set property "KernelThreadsMax":
 	if config.KernelThreadsMax != nil {
 		kernelThreadsMax := *config.KernelThreadsMax
 		result.KernelThreadsMax = &kernelThreadsMax
 	}
 
-	// Set property ‘NetCoreNetdevMaxBacklog’:
+	// Set property "NetCoreNetdevMaxBacklog":
 	if config.NetCoreNetdevMaxBacklog != nil {
 		netCoreNetdevMaxBacklog := *config.NetCoreNetdevMaxBacklog
 		result.NetCoreNetdevMaxBacklog = &netCoreNetdevMaxBacklog
 	}
 
-	// Set property ‘NetCoreOptmemMax’:
+	// Set property "NetCoreOptmemMax":
 	if config.NetCoreOptmemMax != nil {
 		netCoreOptmemMax := *config.NetCoreOptmemMax
 		result.NetCoreOptmemMax = &netCoreOptmemMax
 	}
 
-	// Set property ‘NetCoreRmemDefault’:
+	// Set property "NetCoreRmemDefault":
 	if config.NetCoreRmemDefault != nil {
 		netCoreRmemDefault := *config.NetCoreRmemDefault
 		result.NetCoreRmemDefault = &netCoreRmemDefault
 	}
 
-	// Set property ‘NetCoreRmemMax’:
+	// Set property "NetCoreRmemMax":
 	if config.NetCoreRmemMax != nil {
 		netCoreRmemMax := *config.NetCoreRmemMax
 		result.NetCoreRmemMax = &netCoreRmemMax
 	}
 
-	// Set property ‘NetCoreSomaxconn’:
+	// Set property "NetCoreSomaxconn":
 	if config.NetCoreSomaxconn != nil {
 		netCoreSomaxconn := *config.NetCoreSomaxconn
 		result.NetCoreSomaxconn = &netCoreSomaxconn
 	}
 
-	// Set property ‘NetCoreWmemDefault’:
+	// Set property "NetCoreWmemDefault":
 	if config.NetCoreWmemDefault != nil {
 		netCoreWmemDefault := *config.NetCoreWmemDefault
 		result.NetCoreWmemDefault = &netCoreWmemDefault
 	}
 
-	// Set property ‘NetCoreWmemMax’:
+	// Set property "NetCoreWmemMax":
 	if config.NetCoreWmemMax != nil {
 		netCoreWmemMax := *config.NetCoreWmemMax
 		result.NetCoreWmemMax = &netCoreWmemMax
 	}
 
-	// Set property ‘NetIpv4IpLocalPortRange’:
+	// Set property "NetIpv4IpLocalPortRange":
 	if config.NetIpv4IpLocalPortRange != nil {
 		netIpv4IpLocalPortRange := *config.NetIpv4IpLocalPortRange
 		result.NetIpv4IpLocalPortRange = &netIpv4IpLocalPortRange
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh1’:
+	// Set property "NetIpv4NeighDefaultGcThresh1":
 	if config.NetIpv4NeighDefaultGcThresh1 != nil {
 		netIpv4NeighDefaultGcThresh1 := *config.NetIpv4NeighDefaultGcThresh1
 		result.NetIpv4NeighDefaultGcThresh1 = &netIpv4NeighDefaultGcThresh1
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh2’:
+	// Set property "NetIpv4NeighDefaultGcThresh2":
 	if config.NetIpv4NeighDefaultGcThresh2 != nil {
 		netIpv4NeighDefaultGcThresh2 := *config.NetIpv4NeighDefaultGcThresh2
 		result.NetIpv4NeighDefaultGcThresh2 = &netIpv4NeighDefaultGcThresh2
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh3’:
+	// Set property "NetIpv4NeighDefaultGcThresh3":
 	if config.NetIpv4NeighDefaultGcThresh3 != nil {
 		netIpv4NeighDefaultGcThresh3 := *config.NetIpv4NeighDefaultGcThresh3
 		result.NetIpv4NeighDefaultGcThresh3 = &netIpv4NeighDefaultGcThresh3
 	}
 
-	// Set property ‘NetIpv4TcpFinTimeout’:
+	// Set property "NetIpv4TcpFinTimeout":
 	if config.NetIpv4TcpFinTimeout != nil {
 		netIpv4TcpFinTimeout := *config.NetIpv4TcpFinTimeout
 		result.NetIpv4TcpFinTimeout = &netIpv4TcpFinTimeout
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveProbes’:
+	// Set property "NetIpv4TcpKeepaliveProbes":
 	if config.NetIpv4TcpKeepaliveProbes != nil {
 		netIpv4TcpKeepaliveProbes := *config.NetIpv4TcpKeepaliveProbes
 		result.NetIpv4TcpKeepaliveProbes = &netIpv4TcpKeepaliveProbes
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveTime’:
+	// Set property "NetIpv4TcpKeepaliveTime":
 	if config.NetIpv4TcpKeepaliveTime != nil {
 		netIpv4TcpKeepaliveTime := *config.NetIpv4TcpKeepaliveTime
 		result.NetIpv4TcpKeepaliveTime = &netIpv4TcpKeepaliveTime
 	}
 
-	// Set property ‘NetIpv4TcpMaxSynBacklog’:
+	// Set property "NetIpv4TcpMaxSynBacklog":
 	if config.NetIpv4TcpMaxSynBacklog != nil {
 		netIpv4TcpMaxSynBacklog := *config.NetIpv4TcpMaxSynBacklog
 		result.NetIpv4TcpMaxSynBacklog = &netIpv4TcpMaxSynBacklog
 	}
 
-	// Set property ‘NetIpv4TcpMaxTwBuckets’:
+	// Set property "NetIpv4TcpMaxTwBuckets":
 	if config.NetIpv4TcpMaxTwBuckets != nil {
 		netIpv4TcpMaxTwBuckets := *config.NetIpv4TcpMaxTwBuckets
 		result.NetIpv4TcpMaxTwBuckets = &netIpv4TcpMaxTwBuckets
 	}
 
-	// Set property ‘NetIpv4TcpTwReuse’:
+	// Set property "NetIpv4TcpTwReuse":
 	if config.NetIpv4TcpTwReuse != nil {
 		netIpv4TcpTwReuse := *config.NetIpv4TcpTwReuse
 		result.NetIpv4TcpTwReuse = &netIpv4TcpTwReuse
 	}
 
-	// Set property ‘NetIpv4TcpkeepaliveIntvl’:
+	// Set property "NetIpv4TcpkeepaliveIntvl":
 	if config.NetIpv4TcpkeepaliveIntvl != nil {
 		netIpv4TcpkeepaliveIntvl := *config.NetIpv4TcpkeepaliveIntvl
 		result.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
 	}
 
-	// Set property ‘NetNetfilterNfConntrackBuckets’:
+	// Set property "NetNetfilterNfConntrackBuckets":
 	if config.NetNetfilterNfConntrackBuckets != nil {
 		netNetfilterNfConntrackBuckets := *config.NetNetfilterNfConntrackBuckets
 		result.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBuckets
 	}
 
-	// Set property ‘NetNetfilterNfConntrackMax’:
+	// Set property "NetNetfilterNfConntrackMax":
 	if config.NetNetfilterNfConntrackMax != nil {
 		netNetfilterNfConntrackMax := *config.NetNetfilterNfConntrackMax
 		result.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
 	}
 
-	// Set property ‘VmMaxMapCount’:
+	// Set property "VmMaxMapCount":
 	if config.VmMaxMapCount != nil {
 		vmMaxMapCount := *config.VmMaxMapCount
 		result.VmMaxMapCount = &vmMaxMapCount
 	}
 
-	// Set property ‘VmSwappiness’:
+	// Set property "VmSwappiness":
 	if config.VmSwappiness != nil {
 		vmSwappiness := *config.VmSwappiness
 		result.VmSwappiness = &vmSwappiness
 	}
 
-	// Set property ‘VmVfsCachePressure’:
+	// Set property "VmVfsCachePressure":
 	if config.VmVfsCachePressure != nil {
 		vmVfsCachePressure := *config.VmVfsCachePressure
 		result.VmVfsCachePressure = &vmVfsCachePressure
@@ -5799,169 +5799,169 @@ func (config *SysctlConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SysctlConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FsAioMaxNr’:
+	// Set property "FsAioMaxNr":
 	if typedInput.FsAioMaxNr != nil {
 		fsAioMaxNr := *typedInput.FsAioMaxNr
 		config.FsAioMaxNr = &fsAioMaxNr
 	}
 
-	// Set property ‘FsFileMax’:
+	// Set property "FsFileMax":
 	if typedInput.FsFileMax != nil {
 		fsFileMax := *typedInput.FsFileMax
 		config.FsFileMax = &fsFileMax
 	}
 
-	// Set property ‘FsInotifyMaxUserWatches’:
+	// Set property "FsInotifyMaxUserWatches":
 	if typedInput.FsInotifyMaxUserWatches != nil {
 		fsInotifyMaxUserWatches := *typedInput.FsInotifyMaxUserWatches
 		config.FsInotifyMaxUserWatches = &fsInotifyMaxUserWatches
 	}
 
-	// Set property ‘FsNrOpen’:
+	// Set property "FsNrOpen":
 	if typedInput.FsNrOpen != nil {
 		fsNrOpen := *typedInput.FsNrOpen
 		config.FsNrOpen = &fsNrOpen
 	}
 
-	// Set property ‘KernelThreadsMax’:
+	// Set property "KernelThreadsMax":
 	if typedInput.KernelThreadsMax != nil {
 		kernelThreadsMax := *typedInput.KernelThreadsMax
 		config.KernelThreadsMax = &kernelThreadsMax
 	}
 
-	// Set property ‘NetCoreNetdevMaxBacklog’:
+	// Set property "NetCoreNetdevMaxBacklog":
 	if typedInput.NetCoreNetdevMaxBacklog != nil {
 		netCoreNetdevMaxBacklog := *typedInput.NetCoreNetdevMaxBacklog
 		config.NetCoreNetdevMaxBacklog = &netCoreNetdevMaxBacklog
 	}
 
-	// Set property ‘NetCoreOptmemMax’:
+	// Set property "NetCoreOptmemMax":
 	if typedInput.NetCoreOptmemMax != nil {
 		netCoreOptmemMax := *typedInput.NetCoreOptmemMax
 		config.NetCoreOptmemMax = &netCoreOptmemMax
 	}
 
-	// Set property ‘NetCoreRmemDefault’:
+	// Set property "NetCoreRmemDefault":
 	if typedInput.NetCoreRmemDefault != nil {
 		netCoreRmemDefault := *typedInput.NetCoreRmemDefault
 		config.NetCoreRmemDefault = &netCoreRmemDefault
 	}
 
-	// Set property ‘NetCoreRmemMax’:
+	// Set property "NetCoreRmemMax":
 	if typedInput.NetCoreRmemMax != nil {
 		netCoreRmemMax := *typedInput.NetCoreRmemMax
 		config.NetCoreRmemMax = &netCoreRmemMax
 	}
 
-	// Set property ‘NetCoreSomaxconn’:
+	// Set property "NetCoreSomaxconn":
 	if typedInput.NetCoreSomaxconn != nil {
 		netCoreSomaxconn := *typedInput.NetCoreSomaxconn
 		config.NetCoreSomaxconn = &netCoreSomaxconn
 	}
 
-	// Set property ‘NetCoreWmemDefault’:
+	// Set property "NetCoreWmemDefault":
 	if typedInput.NetCoreWmemDefault != nil {
 		netCoreWmemDefault := *typedInput.NetCoreWmemDefault
 		config.NetCoreWmemDefault = &netCoreWmemDefault
 	}
 
-	// Set property ‘NetCoreWmemMax’:
+	// Set property "NetCoreWmemMax":
 	if typedInput.NetCoreWmemMax != nil {
 		netCoreWmemMax := *typedInput.NetCoreWmemMax
 		config.NetCoreWmemMax = &netCoreWmemMax
 	}
 
-	// Set property ‘NetIpv4IpLocalPortRange’:
+	// Set property "NetIpv4IpLocalPortRange":
 	if typedInput.NetIpv4IpLocalPortRange != nil {
 		netIpv4IpLocalPortRange := *typedInput.NetIpv4IpLocalPortRange
 		config.NetIpv4IpLocalPortRange = &netIpv4IpLocalPortRange
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh1’:
+	// Set property "NetIpv4NeighDefaultGcThresh1":
 	if typedInput.NetIpv4NeighDefaultGcThresh1 != nil {
 		netIpv4NeighDefaultGcThresh1 := *typedInput.NetIpv4NeighDefaultGcThresh1
 		config.NetIpv4NeighDefaultGcThresh1 = &netIpv4NeighDefaultGcThresh1
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh2’:
+	// Set property "NetIpv4NeighDefaultGcThresh2":
 	if typedInput.NetIpv4NeighDefaultGcThresh2 != nil {
 		netIpv4NeighDefaultGcThresh2 := *typedInput.NetIpv4NeighDefaultGcThresh2
 		config.NetIpv4NeighDefaultGcThresh2 = &netIpv4NeighDefaultGcThresh2
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh3’:
+	// Set property "NetIpv4NeighDefaultGcThresh3":
 	if typedInput.NetIpv4NeighDefaultGcThresh3 != nil {
 		netIpv4NeighDefaultGcThresh3 := *typedInput.NetIpv4NeighDefaultGcThresh3
 		config.NetIpv4NeighDefaultGcThresh3 = &netIpv4NeighDefaultGcThresh3
 	}
 
-	// Set property ‘NetIpv4TcpFinTimeout’:
+	// Set property "NetIpv4TcpFinTimeout":
 	if typedInput.NetIpv4TcpFinTimeout != nil {
 		netIpv4TcpFinTimeout := *typedInput.NetIpv4TcpFinTimeout
 		config.NetIpv4TcpFinTimeout = &netIpv4TcpFinTimeout
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveProbes’:
+	// Set property "NetIpv4TcpKeepaliveProbes":
 	if typedInput.NetIpv4TcpKeepaliveProbes != nil {
 		netIpv4TcpKeepaliveProbes := *typedInput.NetIpv4TcpKeepaliveProbes
 		config.NetIpv4TcpKeepaliveProbes = &netIpv4TcpKeepaliveProbes
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveTime’:
+	// Set property "NetIpv4TcpKeepaliveTime":
 	if typedInput.NetIpv4TcpKeepaliveTime != nil {
 		netIpv4TcpKeepaliveTime := *typedInput.NetIpv4TcpKeepaliveTime
 		config.NetIpv4TcpKeepaliveTime = &netIpv4TcpKeepaliveTime
 	}
 
-	// Set property ‘NetIpv4TcpMaxSynBacklog’:
+	// Set property "NetIpv4TcpMaxSynBacklog":
 	if typedInput.NetIpv4TcpMaxSynBacklog != nil {
 		netIpv4TcpMaxSynBacklog := *typedInput.NetIpv4TcpMaxSynBacklog
 		config.NetIpv4TcpMaxSynBacklog = &netIpv4TcpMaxSynBacklog
 	}
 
-	// Set property ‘NetIpv4TcpMaxTwBuckets’:
+	// Set property "NetIpv4TcpMaxTwBuckets":
 	if typedInput.NetIpv4TcpMaxTwBuckets != nil {
 		netIpv4TcpMaxTwBuckets := *typedInput.NetIpv4TcpMaxTwBuckets
 		config.NetIpv4TcpMaxTwBuckets = &netIpv4TcpMaxTwBuckets
 	}
 
-	// Set property ‘NetIpv4TcpTwReuse’:
+	// Set property "NetIpv4TcpTwReuse":
 	if typedInput.NetIpv4TcpTwReuse != nil {
 		netIpv4TcpTwReuse := *typedInput.NetIpv4TcpTwReuse
 		config.NetIpv4TcpTwReuse = &netIpv4TcpTwReuse
 	}
 
-	// Set property ‘NetIpv4TcpkeepaliveIntvl’:
+	// Set property "NetIpv4TcpkeepaliveIntvl":
 	if typedInput.NetIpv4TcpkeepaliveIntvl != nil {
 		netIpv4TcpkeepaliveIntvl := *typedInput.NetIpv4TcpkeepaliveIntvl
 		config.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
 	}
 
-	// Set property ‘NetNetfilterNfConntrackBuckets’:
+	// Set property "NetNetfilterNfConntrackBuckets":
 	if typedInput.NetNetfilterNfConntrackBuckets != nil {
 		netNetfilterNfConntrackBuckets := *typedInput.NetNetfilterNfConntrackBuckets
 		config.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBuckets
 	}
 
-	// Set property ‘NetNetfilterNfConntrackMax’:
+	// Set property "NetNetfilterNfConntrackMax":
 	if typedInput.NetNetfilterNfConntrackMax != nil {
 		netNetfilterNfConntrackMax := *typedInput.NetNetfilterNfConntrackMax
 		config.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
 	}
 
-	// Set property ‘VmMaxMapCount’:
+	// Set property "VmMaxMapCount":
 	if typedInput.VmMaxMapCount != nil {
 		vmMaxMapCount := *typedInput.VmMaxMapCount
 		config.VmMaxMapCount = &vmMaxMapCount
 	}
 
-	// Set property ‘VmSwappiness’:
+	// Set property "VmSwappiness":
 	if typedInput.VmSwappiness != nil {
 		vmSwappiness := *typedInput.VmSwappiness
 		config.VmSwappiness = &vmSwappiness
 	}
 
-	// Set property ‘VmVfsCachePressure’:
+	// Set property "VmVfsCachePressure":
 	if typedInput.VmVfsCachePressure != nil {
 		vmVfsCachePressure := *typedInput.VmVfsCachePressure
 		config.VmVfsCachePressure = &vmVfsCachePressure
@@ -6273,169 +6273,169 @@ func (config *SysctlConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SysctlConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FsAioMaxNr’:
+	// Set property "FsAioMaxNr":
 	if typedInput.FsAioMaxNr != nil {
 		fsAioMaxNr := *typedInput.FsAioMaxNr
 		config.FsAioMaxNr = &fsAioMaxNr
 	}
 
-	// Set property ‘FsFileMax’:
+	// Set property "FsFileMax":
 	if typedInput.FsFileMax != nil {
 		fsFileMax := *typedInput.FsFileMax
 		config.FsFileMax = &fsFileMax
 	}
 
-	// Set property ‘FsInotifyMaxUserWatches’:
+	// Set property "FsInotifyMaxUserWatches":
 	if typedInput.FsInotifyMaxUserWatches != nil {
 		fsInotifyMaxUserWatches := *typedInput.FsInotifyMaxUserWatches
 		config.FsInotifyMaxUserWatches = &fsInotifyMaxUserWatches
 	}
 
-	// Set property ‘FsNrOpen’:
+	// Set property "FsNrOpen":
 	if typedInput.FsNrOpen != nil {
 		fsNrOpen := *typedInput.FsNrOpen
 		config.FsNrOpen = &fsNrOpen
 	}
 
-	// Set property ‘KernelThreadsMax’:
+	// Set property "KernelThreadsMax":
 	if typedInput.KernelThreadsMax != nil {
 		kernelThreadsMax := *typedInput.KernelThreadsMax
 		config.KernelThreadsMax = &kernelThreadsMax
 	}
 
-	// Set property ‘NetCoreNetdevMaxBacklog’:
+	// Set property "NetCoreNetdevMaxBacklog":
 	if typedInput.NetCoreNetdevMaxBacklog != nil {
 		netCoreNetdevMaxBacklog := *typedInput.NetCoreNetdevMaxBacklog
 		config.NetCoreNetdevMaxBacklog = &netCoreNetdevMaxBacklog
 	}
 
-	// Set property ‘NetCoreOptmemMax’:
+	// Set property "NetCoreOptmemMax":
 	if typedInput.NetCoreOptmemMax != nil {
 		netCoreOptmemMax := *typedInput.NetCoreOptmemMax
 		config.NetCoreOptmemMax = &netCoreOptmemMax
 	}
 
-	// Set property ‘NetCoreRmemDefault’:
+	// Set property "NetCoreRmemDefault":
 	if typedInput.NetCoreRmemDefault != nil {
 		netCoreRmemDefault := *typedInput.NetCoreRmemDefault
 		config.NetCoreRmemDefault = &netCoreRmemDefault
 	}
 
-	// Set property ‘NetCoreRmemMax’:
+	// Set property "NetCoreRmemMax":
 	if typedInput.NetCoreRmemMax != nil {
 		netCoreRmemMax := *typedInput.NetCoreRmemMax
 		config.NetCoreRmemMax = &netCoreRmemMax
 	}
 
-	// Set property ‘NetCoreSomaxconn’:
+	// Set property "NetCoreSomaxconn":
 	if typedInput.NetCoreSomaxconn != nil {
 		netCoreSomaxconn := *typedInput.NetCoreSomaxconn
 		config.NetCoreSomaxconn = &netCoreSomaxconn
 	}
 
-	// Set property ‘NetCoreWmemDefault’:
+	// Set property "NetCoreWmemDefault":
 	if typedInput.NetCoreWmemDefault != nil {
 		netCoreWmemDefault := *typedInput.NetCoreWmemDefault
 		config.NetCoreWmemDefault = &netCoreWmemDefault
 	}
 
-	// Set property ‘NetCoreWmemMax’:
+	// Set property "NetCoreWmemMax":
 	if typedInput.NetCoreWmemMax != nil {
 		netCoreWmemMax := *typedInput.NetCoreWmemMax
 		config.NetCoreWmemMax = &netCoreWmemMax
 	}
 
-	// Set property ‘NetIpv4IpLocalPortRange’:
+	// Set property "NetIpv4IpLocalPortRange":
 	if typedInput.NetIpv4IpLocalPortRange != nil {
 		netIpv4IpLocalPortRange := *typedInput.NetIpv4IpLocalPortRange
 		config.NetIpv4IpLocalPortRange = &netIpv4IpLocalPortRange
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh1’:
+	// Set property "NetIpv4NeighDefaultGcThresh1":
 	if typedInput.NetIpv4NeighDefaultGcThresh1 != nil {
 		netIpv4NeighDefaultGcThresh1 := *typedInput.NetIpv4NeighDefaultGcThresh1
 		config.NetIpv4NeighDefaultGcThresh1 = &netIpv4NeighDefaultGcThresh1
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh2’:
+	// Set property "NetIpv4NeighDefaultGcThresh2":
 	if typedInput.NetIpv4NeighDefaultGcThresh2 != nil {
 		netIpv4NeighDefaultGcThresh2 := *typedInput.NetIpv4NeighDefaultGcThresh2
 		config.NetIpv4NeighDefaultGcThresh2 = &netIpv4NeighDefaultGcThresh2
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh3’:
+	// Set property "NetIpv4NeighDefaultGcThresh3":
 	if typedInput.NetIpv4NeighDefaultGcThresh3 != nil {
 		netIpv4NeighDefaultGcThresh3 := *typedInput.NetIpv4NeighDefaultGcThresh3
 		config.NetIpv4NeighDefaultGcThresh3 = &netIpv4NeighDefaultGcThresh3
 	}
 
-	// Set property ‘NetIpv4TcpFinTimeout’:
+	// Set property "NetIpv4TcpFinTimeout":
 	if typedInput.NetIpv4TcpFinTimeout != nil {
 		netIpv4TcpFinTimeout := *typedInput.NetIpv4TcpFinTimeout
 		config.NetIpv4TcpFinTimeout = &netIpv4TcpFinTimeout
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveProbes’:
+	// Set property "NetIpv4TcpKeepaliveProbes":
 	if typedInput.NetIpv4TcpKeepaliveProbes != nil {
 		netIpv4TcpKeepaliveProbes := *typedInput.NetIpv4TcpKeepaliveProbes
 		config.NetIpv4TcpKeepaliveProbes = &netIpv4TcpKeepaliveProbes
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveTime’:
+	// Set property "NetIpv4TcpKeepaliveTime":
 	if typedInput.NetIpv4TcpKeepaliveTime != nil {
 		netIpv4TcpKeepaliveTime := *typedInput.NetIpv4TcpKeepaliveTime
 		config.NetIpv4TcpKeepaliveTime = &netIpv4TcpKeepaliveTime
 	}
 
-	// Set property ‘NetIpv4TcpMaxSynBacklog’:
+	// Set property "NetIpv4TcpMaxSynBacklog":
 	if typedInput.NetIpv4TcpMaxSynBacklog != nil {
 		netIpv4TcpMaxSynBacklog := *typedInput.NetIpv4TcpMaxSynBacklog
 		config.NetIpv4TcpMaxSynBacklog = &netIpv4TcpMaxSynBacklog
 	}
 
-	// Set property ‘NetIpv4TcpMaxTwBuckets’:
+	// Set property "NetIpv4TcpMaxTwBuckets":
 	if typedInput.NetIpv4TcpMaxTwBuckets != nil {
 		netIpv4TcpMaxTwBuckets := *typedInput.NetIpv4TcpMaxTwBuckets
 		config.NetIpv4TcpMaxTwBuckets = &netIpv4TcpMaxTwBuckets
 	}
 
-	// Set property ‘NetIpv4TcpTwReuse’:
+	// Set property "NetIpv4TcpTwReuse":
 	if typedInput.NetIpv4TcpTwReuse != nil {
 		netIpv4TcpTwReuse := *typedInput.NetIpv4TcpTwReuse
 		config.NetIpv4TcpTwReuse = &netIpv4TcpTwReuse
 	}
 
-	// Set property ‘NetIpv4TcpkeepaliveIntvl’:
+	// Set property "NetIpv4TcpkeepaliveIntvl":
 	if typedInput.NetIpv4TcpkeepaliveIntvl != nil {
 		netIpv4TcpkeepaliveIntvl := *typedInput.NetIpv4TcpkeepaliveIntvl
 		config.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
 	}
 
-	// Set property ‘NetNetfilterNfConntrackBuckets’:
+	// Set property "NetNetfilterNfConntrackBuckets":
 	if typedInput.NetNetfilterNfConntrackBuckets != nil {
 		netNetfilterNfConntrackBuckets := *typedInput.NetNetfilterNfConntrackBuckets
 		config.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBuckets
 	}
 
-	// Set property ‘NetNetfilterNfConntrackMax’:
+	// Set property "NetNetfilterNfConntrackMax":
 	if typedInput.NetNetfilterNfConntrackMax != nil {
 		netNetfilterNfConntrackMax := *typedInput.NetNetfilterNfConntrackMax
 		config.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
 	}
 
-	// Set property ‘VmMaxMapCount’:
+	// Set property "VmMaxMapCount":
 	if typedInput.VmMaxMapCount != nil {
 		vmMaxMapCount := *typedInput.VmMaxMapCount
 		config.VmMaxMapCount = &vmMaxMapCount
 	}
 
-	// Set property ‘VmSwappiness’:
+	// Set property "VmSwappiness":
 	if typedInput.VmSwappiness != nil {
 		vmSwappiness := *typedInput.VmSwappiness
 		config.VmSwappiness = &vmSwappiness
 	}
 
-	// Set property ‘VmVfsCachePressure’:
+	// Set property "VmVfsCachePressure":
 	if typedInput.VmVfsCachePressure != nil {
 		vmVfsCachePressure := *typedInput.VmVfsCachePressure
 		config.VmVfsCachePressure = &vmVfsCachePressure

--- a/v2/api/containerservice/v1api20230202preview/trusted_access_role_binding_types_gen.go
+++ b/v2/api/containerservice/v1api20230202preview/trusted_access_role_binding_types_gen.go
@@ -343,10 +343,10 @@ func (binding *ManagedClusters_TrustedAccessRoleBinding_Spec) ConvertToARM(resol
 	}
 	result := &ManagedClusters_TrustedAccessRoleBinding_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if binding.Roles != nil || binding.SourceResourceReference != nil {
 		result.Properties = &TrustedAccessRoleBindingProperties_ARM{}
 	}
@@ -376,13 +376,13 @@ func (binding *ManagedClusters_TrustedAccessRoleBinding_Spec) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusters_TrustedAccessRoleBinding_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	binding.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	binding.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Roles’:
+	// Set property "Roles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Roles {
@@ -390,7 +390,7 @@ func (binding *ManagedClusters_TrustedAccessRoleBinding_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// no assignment for property ‘SourceResourceReference’
+	// no assignment for property "SourceResourceReference"
 
 	// No error
 	return nil
@@ -636,21 +636,21 @@ func (binding *ManagedClusters_TrustedAccessRoleBinding_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusters_TrustedAccessRoleBinding_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		binding.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		binding.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -659,7 +659,7 @@ func (binding *ManagedClusters_TrustedAccessRoleBinding_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Roles’:
+	// Set property "Roles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Roles {
@@ -667,7 +667,7 @@ func (binding *ManagedClusters_TrustedAccessRoleBinding_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘SourceResourceId’:
+	// Set property "SourceResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceResourceId != nil {
@@ -676,7 +676,7 @@ func (binding *ManagedClusters_TrustedAccessRoleBinding_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -687,7 +687,7 @@ func (binding *ManagedClusters_TrustedAccessRoleBinding_STATUS) PopulateFromARM(
 		binding.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		binding.Type = &typeVar

--- a/v2/api/containerservice/v1beta20210501/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1beta20210501/managed_cluster_types_gen.go
@@ -392,7 +392,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ManagedCluster_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if cluster.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*cluster.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -402,7 +402,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if cluster.Identity != nil {
 		identity_ARM, err := (*cluster.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -412,16 +412,16 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if cluster.Location != nil {
 		location := *cluster.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if cluster.AadProfile != nil ||
 		cluster.AddonProfiles != nil ||
 		cluster.AgentPoolProfiles != nil ||
@@ -597,7 +597,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.WindowsProfile = &windowsProfile
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if cluster.Sku != nil {
 		sku_ARM, err := (*cluster.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -607,7 +607,7 @@ func (cluster *ManagedCluster_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if cluster.Tags != nil {
 		result.Tags = make(map[string]string, len(cluster.Tags))
 		for key, value := range cluster.Tags {
@@ -629,7 +629,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedCluster_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadProfile’:
+	// Set property "AadProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AadProfile != nil {
@@ -643,7 +643,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AddonProfiles’:
+	// Set property "AddonProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddonProfiles != nil {
@@ -659,7 +659,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AgentPoolProfiles’:
+	// Set property "AgentPoolProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AgentPoolProfiles {
@@ -672,7 +672,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ApiServerAccessProfile’:
+	// Set property "ApiServerAccessProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApiServerAccessProfile != nil {
@@ -686,7 +686,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AutoScalerProfile’:
+	// Set property "AutoScalerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoScalerProfile != nil {
@@ -700,7 +700,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AutoUpgradeProfile’:
+	// Set property "AutoUpgradeProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeProfile != nil {
@@ -714,10 +714,10 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	cluster.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DisableLocalAccounts’:
+	// Set property "DisableLocalAccounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAccounts != nil {
@@ -726,9 +726,9 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘DiskEncryptionSetIDReference’
+	// no assignment for property "DiskEncryptionSetIDReference"
 
-	// Set property ‘DnsPrefix’:
+	// Set property "DnsPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsPrefix != nil {
@@ -737,7 +737,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnablePodSecurityPolicy’:
+	// Set property "EnablePodSecurityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePodSecurityPolicy != nil {
@@ -746,7 +746,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableRBAC’:
+	// Set property "EnableRBAC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableRBAC != nil {
@@ -755,7 +755,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -766,7 +766,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		cluster.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FqdnSubdomain’:
+	// Set property "FqdnSubdomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FqdnSubdomain != nil {
@@ -775,7 +775,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘HttpProxyConfig’:
+	// Set property "HttpProxyConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpProxyConfig != nil {
@@ -789,7 +789,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedClusterIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -800,7 +800,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		cluster.Identity = &identity
 	}
 
-	// Set property ‘IdentityProfile’:
+	// Set property "IdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdentityProfile != nil {
@@ -816,7 +816,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘KubernetesVersion’:
+	// Set property "KubernetesVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubernetesVersion != nil {
@@ -825,7 +825,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘LinuxProfile’:
+	// Set property "LinuxProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxProfile != nil {
@@ -839,13 +839,13 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		cluster.Location = &location
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -859,7 +859,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘NodeResourceGroup’:
+	// Set property "NodeResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeResourceGroup != nil {
@@ -868,12 +868,12 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	cluster.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PodIdentityProfile’:
+	// Set property "PodIdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PodIdentityProfile != nil {
@@ -887,7 +887,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘PrivateLinkResources’:
+	// Set property "PrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkResources {
@@ -900,7 +900,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ServicePrincipalProfile’:
+	// Set property "ServicePrincipalProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServicePrincipalProfile != nil {
@@ -914,7 +914,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 ManagedClusterSKU
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -925,7 +925,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		cluster.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		cluster.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -933,7 +933,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘WindowsProfile’:
+	// Set property "WindowsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WindowsProfile != nil {
@@ -1744,7 +1744,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedCluster_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadProfile’:
+	// Set property "AadProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AadProfile != nil {
@@ -1758,7 +1758,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AddonProfiles’:
+	// Set property "AddonProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddonProfiles != nil {
@@ -1774,7 +1774,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AgentPoolProfiles’:
+	// Set property "AgentPoolProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AgentPoolProfiles {
@@ -1787,7 +1787,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ApiServerAccessProfile’:
+	// Set property "ApiServerAccessProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApiServerAccessProfile != nil {
@@ -1801,7 +1801,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AutoScalerProfile’:
+	// Set property "AutoScalerProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoScalerProfile != nil {
@@ -1815,7 +1815,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AutoUpgradeProfile’:
+	// Set property "AutoUpgradeProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoUpgradeProfile != nil {
@@ -1829,7 +1829,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AzurePortalFQDN’:
+	// Set property "AzurePortalFQDN":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzurePortalFQDN != nil {
@@ -1838,9 +1838,9 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DisableLocalAccounts’:
+	// Set property "DisableLocalAccounts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAccounts != nil {
@@ -1849,7 +1849,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DiskEncryptionSetID’:
+	// Set property "DiskEncryptionSetID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiskEncryptionSetID != nil {
@@ -1858,7 +1858,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DnsPrefix’:
+	// Set property "DnsPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsPrefix != nil {
@@ -1867,7 +1867,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnablePodSecurityPolicy’:
+	// Set property "EnablePodSecurityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePodSecurityPolicy != nil {
@@ -1876,7 +1876,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableRBAC’:
+	// Set property "EnableRBAC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableRBAC != nil {
@@ -1885,7 +1885,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1896,7 +1896,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1905,7 +1905,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘FqdnSubdomain’:
+	// Set property "FqdnSubdomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FqdnSubdomain != nil {
@@ -1914,7 +1914,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘HttpProxyConfig’:
+	// Set property "HttpProxyConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpProxyConfig != nil {
@@ -1928,13 +1928,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		cluster.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedClusterIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1945,7 +1945,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.Identity = &identity
 	}
 
-	// Set property ‘IdentityProfile’:
+	// Set property "IdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdentityProfile != nil {
@@ -1961,7 +1961,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘KubernetesVersion’:
+	// Set property "KubernetesVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubernetesVersion != nil {
@@ -1970,7 +1970,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LinuxProfile’:
+	// Set property "LinuxProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxProfile != nil {
@@ -1984,13 +1984,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		cluster.Location = &location
 	}
 
-	// Set property ‘MaxAgentPools’:
+	// Set property "MaxAgentPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxAgentPools != nil {
@@ -1999,13 +1999,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		cluster.Name = &name
 	}
 
-	// Set property ‘NetworkProfile’:
+	// Set property "NetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkProfile != nil {
@@ -2019,7 +2019,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘NodeResourceGroup’:
+	// Set property "NodeResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeResourceGroup != nil {
@@ -2028,7 +2028,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PodIdentityProfile’:
+	// Set property "PodIdentityProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PodIdentityProfile != nil {
@@ -2042,7 +2042,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PowerState != nil {
@@ -2056,7 +2056,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrivateFQDN’:
+	// Set property "PrivateFQDN":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateFQDN != nil {
@@ -2065,7 +2065,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrivateLinkResources’:
+	// Set property "PrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkResources {
@@ -2078,7 +2078,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2087,7 +2087,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ServicePrincipalProfile’:
+	// Set property "ServicePrincipalProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServicePrincipalProfile != nil {
@@ -2101,7 +2101,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 ManagedClusterSKU_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -2112,7 +2112,7 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		cluster.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		cluster.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -2120,13 +2120,13 @@ func (cluster *ManagedCluster_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		cluster.Type = &typeVar
 	}
 
-	// Set property ‘WindowsProfile’:
+	// Set property "WindowsProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WindowsProfile != nil {
@@ -2810,13 +2810,13 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ContainerServiceLinuxProfile_ARM{}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if profile.Ssh != nil {
 		ssh_ARM, err := (*profile.Ssh).ConvertToARM(resolved)
 		if err != nil {
@@ -2840,13 +2840,13 @@ func (profile *ContainerServiceLinuxProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceLinuxProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 ContainerServiceSshConfiguration
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -2944,13 +2944,13 @@ func (profile *ContainerServiceLinuxProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceLinuxProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘Ssh’:
+	// Set property "Ssh":
 	if typedInput.Ssh != nil {
 		var ssh1 ContainerServiceSshConfiguration_STATUS
 		err := ssh1.PopulateFromARM(owner, *typedInput.Ssh)
@@ -3048,19 +3048,19 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 	}
 	result := &ContainerServiceNetworkProfile_ARM{}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if profile.DnsServiceIP != nil {
 		dnsServiceIP := *profile.DnsServiceIP
 		result.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if profile.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *profile.DockerBridgeCidr
 		result.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘LoadBalancerProfile’:
+	// Set property "LoadBalancerProfile":
 	if profile.LoadBalancerProfile != nil {
 		loadBalancerProfile_ARM, err := (*profile.LoadBalancerProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3070,43 +3070,43 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 		result.LoadBalancerProfile = &loadBalancerProfile
 	}
 
-	// Set property ‘LoadBalancerSku’:
+	// Set property "LoadBalancerSku":
 	if profile.LoadBalancerSku != nil {
 		loadBalancerSku := *profile.LoadBalancerSku
 		result.LoadBalancerSku = &loadBalancerSku
 	}
 
-	// Set property ‘NetworkMode’:
+	// Set property "NetworkMode":
 	if profile.NetworkMode != nil {
 		networkMode := *profile.NetworkMode
 		result.NetworkMode = &networkMode
 	}
 
-	// Set property ‘NetworkPlugin’:
+	// Set property "NetworkPlugin":
 	if profile.NetworkPlugin != nil {
 		networkPlugin := *profile.NetworkPlugin
 		result.NetworkPlugin = &networkPlugin
 	}
 
-	// Set property ‘NetworkPolicy’:
+	// Set property "NetworkPolicy":
 	if profile.NetworkPolicy != nil {
 		networkPolicy := *profile.NetworkPolicy
 		result.NetworkPolicy = &networkPolicy
 	}
 
-	// Set property ‘OutboundType’:
+	// Set property "OutboundType":
 	if profile.OutboundType != nil {
 		outboundType := *profile.OutboundType
 		result.OutboundType = &outboundType
 	}
 
-	// Set property ‘PodCidr’:
+	// Set property "PodCidr":
 	if profile.PodCidr != nil {
 		podCidr := *profile.PodCidr
 		result.PodCidr = &podCidr
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if profile.ServiceCidr != nil {
 		serviceCidr := *profile.ServiceCidr
 		result.ServiceCidr = &serviceCidr
@@ -3126,19 +3126,19 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceNetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if typedInput.DnsServiceIP != nil {
 		dnsServiceIP := *typedInput.DnsServiceIP
 		profile.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if typedInput.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *typedInput.DockerBridgeCidr
 		profile.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘LoadBalancerProfile’:
+	// Set property "LoadBalancerProfile":
 	if typedInput.LoadBalancerProfile != nil {
 		var loadBalancerProfile1 ManagedClusterLoadBalancerProfile
 		err := loadBalancerProfile1.PopulateFromARM(owner, *typedInput.LoadBalancerProfile)
@@ -3149,43 +3149,43 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 		profile.LoadBalancerProfile = &loadBalancerProfile
 	}
 
-	// Set property ‘LoadBalancerSku’:
+	// Set property "LoadBalancerSku":
 	if typedInput.LoadBalancerSku != nil {
 		loadBalancerSku := *typedInput.LoadBalancerSku
 		profile.LoadBalancerSku = &loadBalancerSku
 	}
 
-	// Set property ‘NetworkMode’:
+	// Set property "NetworkMode":
 	if typedInput.NetworkMode != nil {
 		networkMode := *typedInput.NetworkMode
 		profile.NetworkMode = &networkMode
 	}
 
-	// Set property ‘NetworkPlugin’:
+	// Set property "NetworkPlugin":
 	if typedInput.NetworkPlugin != nil {
 		networkPlugin := *typedInput.NetworkPlugin
 		profile.NetworkPlugin = &networkPlugin
 	}
 
-	// Set property ‘NetworkPolicy’:
+	// Set property "NetworkPolicy":
 	if typedInput.NetworkPolicy != nil {
 		networkPolicy := *typedInput.NetworkPolicy
 		profile.NetworkPolicy = &networkPolicy
 	}
 
-	// Set property ‘OutboundType’:
+	// Set property "OutboundType":
 	if typedInput.OutboundType != nil {
 		outboundType := *typedInput.OutboundType
 		profile.OutboundType = &outboundType
 	}
 
-	// Set property ‘PodCidr’:
+	// Set property "PodCidr":
 	if typedInput.PodCidr != nil {
 		podCidr := *typedInput.PodCidr
 		profile.PodCidr = &podCidr
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if typedInput.ServiceCidr != nil {
 		serviceCidr := *typedInput.ServiceCidr
 		profile.ServiceCidr = &serviceCidr
@@ -3414,19 +3414,19 @@ func (profile *ContainerServiceNetworkProfile_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceNetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if typedInput.DnsServiceIP != nil {
 		dnsServiceIP := *typedInput.DnsServiceIP
 		profile.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if typedInput.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *typedInput.DockerBridgeCidr
 		profile.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘LoadBalancerProfile’:
+	// Set property "LoadBalancerProfile":
 	if typedInput.LoadBalancerProfile != nil {
 		var loadBalancerProfile1 ManagedClusterLoadBalancerProfile_STATUS
 		err := loadBalancerProfile1.PopulateFromARM(owner, *typedInput.LoadBalancerProfile)
@@ -3437,43 +3437,43 @@ func (profile *ContainerServiceNetworkProfile_STATUS) PopulateFromARM(owner genr
 		profile.LoadBalancerProfile = &loadBalancerProfile
 	}
 
-	// Set property ‘LoadBalancerSku’:
+	// Set property "LoadBalancerSku":
 	if typedInput.LoadBalancerSku != nil {
 		loadBalancerSku := *typedInput.LoadBalancerSku
 		profile.LoadBalancerSku = &loadBalancerSku
 	}
 
-	// Set property ‘NetworkMode’:
+	// Set property "NetworkMode":
 	if typedInput.NetworkMode != nil {
 		networkMode := *typedInput.NetworkMode
 		profile.NetworkMode = &networkMode
 	}
 
-	// Set property ‘NetworkPlugin’:
+	// Set property "NetworkPlugin":
 	if typedInput.NetworkPlugin != nil {
 		networkPlugin := *typedInput.NetworkPlugin
 		profile.NetworkPlugin = &networkPlugin
 	}
 
-	// Set property ‘NetworkPolicy’:
+	// Set property "NetworkPolicy":
 	if typedInput.NetworkPolicy != nil {
 		networkPolicy := *typedInput.NetworkPolicy
 		profile.NetworkPolicy = &networkPolicy
 	}
 
-	// Set property ‘OutboundType’:
+	// Set property "OutboundType":
 	if typedInput.OutboundType != nil {
 		outboundType := *typedInput.OutboundType
 		profile.OutboundType = &outboundType
 	}
 
-	// Set property ‘PodCidr’:
+	// Set property "PodCidr":
 	if typedInput.PodCidr != nil {
 		podCidr := *typedInput.PodCidr
 		profile.PodCidr = &podCidr
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if typedInput.ServiceCidr != nil {
 		serviceCidr := *typedInput.ServiceCidr
 		profile.ServiceCidr = &serviceCidr
@@ -3649,13 +3649,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -3675,13 +3675,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -3756,13 +3756,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -3837,42 +3837,42 @@ func (profile *ManagedClusterAADProfile) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &ManagedClusterAADProfile_ARM{}
 
-	// Set property ‘AdminGroupObjectIDs’:
+	// Set property "AdminGroupObjectIDs":
 	for _, item := range profile.AdminGroupObjectIDs {
 		result.AdminGroupObjectIDs = append(result.AdminGroupObjectIDs, item)
 	}
 
-	// Set property ‘ClientAppID’:
+	// Set property "ClientAppID":
 	if profile.ClientAppID != nil {
 		clientAppID := *profile.ClientAppID
 		result.ClientAppID = &clientAppID
 	}
 
-	// Set property ‘EnableAzureRBAC’:
+	// Set property "EnableAzureRBAC":
 	if profile.EnableAzureRBAC != nil {
 		enableAzureRBAC := *profile.EnableAzureRBAC
 		result.EnableAzureRBAC = &enableAzureRBAC
 	}
 
-	// Set property ‘Managed’:
+	// Set property "Managed":
 	if profile.Managed != nil {
 		managed := *profile.Managed
 		result.Managed = &managed
 	}
 
-	// Set property ‘ServerAppID’:
+	// Set property "ServerAppID":
 	if profile.ServerAppID != nil {
 		serverAppID := *profile.ServerAppID
 		result.ServerAppID = &serverAppID
 	}
 
-	// Set property ‘ServerAppSecret’:
+	// Set property "ServerAppSecret":
 	if profile.ServerAppSecret != nil {
 		serverAppSecret := *profile.ServerAppSecret
 		result.ServerAppSecret = &serverAppSecret
 	}
 
-	// Set property ‘TenantID’:
+	// Set property "TenantID":
 	if profile.TenantID != nil {
 		tenantID := *profile.TenantID
 		result.TenantID = &tenantID
@@ -3892,42 +3892,42 @@ func (profile *ManagedClusterAADProfile) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAADProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminGroupObjectIDs’:
+	// Set property "AdminGroupObjectIDs":
 	for _, item := range typedInput.AdminGroupObjectIDs {
 		profile.AdminGroupObjectIDs = append(profile.AdminGroupObjectIDs, item)
 	}
 
-	// Set property ‘ClientAppID’:
+	// Set property "ClientAppID":
 	if typedInput.ClientAppID != nil {
 		clientAppID := *typedInput.ClientAppID
 		profile.ClientAppID = &clientAppID
 	}
 
-	// Set property ‘EnableAzureRBAC’:
+	// Set property "EnableAzureRBAC":
 	if typedInput.EnableAzureRBAC != nil {
 		enableAzureRBAC := *typedInput.EnableAzureRBAC
 		profile.EnableAzureRBAC = &enableAzureRBAC
 	}
 
-	// Set property ‘Managed’:
+	// Set property "Managed":
 	if typedInput.Managed != nil {
 		managed := *typedInput.Managed
 		profile.Managed = &managed
 	}
 
-	// Set property ‘ServerAppID’:
+	// Set property "ServerAppID":
 	if typedInput.ServerAppID != nil {
 		serverAppID := *typedInput.ServerAppID
 		profile.ServerAppID = &serverAppID
 	}
 
-	// Set property ‘ServerAppSecret’:
+	// Set property "ServerAppSecret":
 	if typedInput.ServerAppSecret != nil {
 		serverAppSecret := *typedInput.ServerAppSecret
 		profile.ServerAppSecret = &serverAppSecret
 	}
 
-	// Set property ‘TenantID’:
+	// Set property "TenantID":
 	if typedInput.TenantID != nil {
 		tenantID := *typedInput.TenantID
 		profile.TenantID = &tenantID
@@ -4047,42 +4047,42 @@ func (profile *ManagedClusterAADProfile_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAADProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminGroupObjectIDs’:
+	// Set property "AdminGroupObjectIDs":
 	for _, item := range typedInput.AdminGroupObjectIDs {
 		profile.AdminGroupObjectIDs = append(profile.AdminGroupObjectIDs, item)
 	}
 
-	// Set property ‘ClientAppID’:
+	// Set property "ClientAppID":
 	if typedInput.ClientAppID != nil {
 		clientAppID := *typedInput.ClientAppID
 		profile.ClientAppID = &clientAppID
 	}
 
-	// Set property ‘EnableAzureRBAC’:
+	// Set property "EnableAzureRBAC":
 	if typedInput.EnableAzureRBAC != nil {
 		enableAzureRBAC := *typedInput.EnableAzureRBAC
 		profile.EnableAzureRBAC = &enableAzureRBAC
 	}
 
-	// Set property ‘Managed’:
+	// Set property "Managed":
 	if typedInput.Managed != nil {
 		managed := *typedInput.Managed
 		profile.Managed = &managed
 	}
 
-	// Set property ‘ServerAppID’:
+	// Set property "ServerAppID":
 	if typedInput.ServerAppID != nil {
 		serverAppID := *typedInput.ServerAppID
 		profile.ServerAppID = &serverAppID
 	}
 
-	// Set property ‘ServerAppSecret’:
+	// Set property "ServerAppSecret":
 	if typedInput.ServerAppSecret != nil {
 		serverAppSecret := *typedInput.ServerAppSecret
 		profile.ServerAppSecret = &serverAppSecret
 	}
 
-	// Set property ‘TenantID’:
+	// Set property "TenantID":
 	if typedInput.TenantID != nil {
 		tenantID := *typedInput.TenantID
 		profile.TenantID = &tenantID
@@ -4194,7 +4194,7 @@ func (profile *ManagedClusterAddonProfile) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ManagedClusterAddonProfile_ARM{}
 
-	// Set property ‘Config’:
+	// Set property "Config":
 	if profile.Config != nil {
 		result.Config = make(map[string]string, len(profile.Config))
 		for key, value := range profile.Config {
@@ -4202,7 +4202,7 @@ func (profile *ManagedClusterAddonProfile) ConvertToARM(resolved genruntime.Conv
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if profile.Enabled != nil {
 		enabled := *profile.Enabled
 		result.Enabled = &enabled
@@ -4222,7 +4222,7 @@ func (profile *ManagedClusterAddonProfile) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAddonProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Config’:
+	// Set property "Config":
 	if typedInput.Config != nil {
 		profile.Config = make(map[string]string, len(typedInput.Config))
 		for key, value := range typedInput.Config {
@@ -4230,7 +4230,7 @@ func (profile *ManagedClusterAddonProfile) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
@@ -4306,7 +4306,7 @@ func (profile *ManagedClusterAddonProfile_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAddonProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Config’:
+	// Set property "Config":
 	if typedInput.Config != nil {
 		profile.Config = make(map[string]string, len(typedInput.Config))
 		for key, value := range typedInput.Config {
@@ -4314,13 +4314,13 @@ func (profile *ManagedClusterAddonProfile_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 UserAssignedIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -4453,54 +4453,54 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 	}
 	result := &ManagedClusterAgentPoolProfile_ARM{}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	for _, item := range profile.AvailabilityZones {
 		result.AvailabilityZones = append(result.AvailabilityZones, item)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if profile.Count != nil {
 		count := *profile.Count
 		result.Count = &count
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	if profile.EnableAutoScaling != nil {
 		enableAutoScaling := *profile.EnableAutoScaling
 		result.EnableAutoScaling = &enableAutoScaling
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	if profile.EnableEncryptionAtHost != nil {
 		enableEncryptionAtHost := *profile.EnableEncryptionAtHost
 		result.EnableEncryptionAtHost = &enableEncryptionAtHost
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	if profile.EnableFIPS != nil {
 		enableFIPS := *profile.EnableFIPS
 		result.EnableFIPS = &enableFIPS
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	if profile.EnableNodePublicIP != nil {
 		enableNodePublicIP := *profile.EnableNodePublicIP
 		result.EnableNodePublicIP = &enableNodePublicIP
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	if profile.EnableUltraSSD != nil {
 		enableUltraSSD := *profile.EnableUltraSSD
 		result.EnableUltraSSD = &enableUltraSSD
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	if profile.GpuInstanceProfile != nil {
 		gpuInstanceProfile := *profile.GpuInstanceProfile
 		result.GpuInstanceProfile = &gpuInstanceProfile
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	if profile.KubeletConfig != nil {
 		kubeletConfig_ARM, err := (*profile.KubeletConfig).ConvertToARM(resolved)
 		if err != nil {
@@ -4510,13 +4510,13 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.KubeletConfig = &kubeletConfig
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	if profile.KubeletDiskType != nil {
 		kubeletDiskType := *profile.KubeletDiskType
 		result.KubeletDiskType = &kubeletDiskType
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	if profile.LinuxOSConfig != nil {
 		linuxOSConfig_ARM, err := (*profile.LinuxOSConfig).ConvertToARM(resolved)
 		if err != nil {
@@ -4526,37 +4526,37 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.LinuxOSConfig = &linuxOSConfig
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	if profile.MaxCount != nil {
 		maxCount := *profile.MaxCount
 		result.MaxCount = &maxCount
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	if profile.MaxPods != nil {
 		maxPods := *profile.MaxPods
 		result.MaxPods = &maxPods
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	if profile.MinCount != nil {
 		minCount := *profile.MinCount
 		result.MinCount = &minCount
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if profile.Mode != nil {
 		mode := *profile.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if profile.Name != nil {
 		name := *profile.Name
 		result.Name = &name
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	if profile.NodeLabels != nil {
 		result.NodeLabels = make(map[string]string, len(profile.NodeLabels))
 		for key, value := range profile.NodeLabels {
@@ -4564,7 +4564,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		}
 	}
 
-	// Set property ‘NodePublicIPPrefixID’:
+	// Set property "NodePublicIPPrefixID":
 	if profile.NodePublicIPPrefixIDReference != nil {
 		nodePublicIPPrefixIDReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.NodePublicIPPrefixIDReference)
 		if err != nil {
@@ -4574,42 +4574,42 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.NodePublicIPPrefixID = &nodePublicIPPrefixIDReference
 	}
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	for _, item := range profile.NodeTaints {
 		result.NodeTaints = append(result.NodeTaints, item)
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	if profile.OrchestratorVersion != nil {
 		orchestratorVersion := *profile.OrchestratorVersion
 		result.OrchestratorVersion = &orchestratorVersion
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	if profile.OsDiskSizeGB != nil {
 		osDiskSizeGB := *profile.OsDiskSizeGB
 		result.OsDiskSizeGB = &osDiskSizeGB
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	if profile.OsDiskType != nil {
 		osDiskType := *profile.OsDiskType
 		result.OsDiskType = &osDiskType
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	if profile.OsSKU != nil {
 		osSKU := *profile.OsSKU
 		result.OsSKU = &osSKU
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if profile.OsType != nil {
 		osType := *profile.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘PodSubnetID’:
+	// Set property "PodSubnetID":
 	if profile.PodSubnetIDReference != nil {
 		podSubnetIDReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.PodSubnetIDReference)
 		if err != nil {
@@ -4619,31 +4619,31 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.PodSubnetID = &podSubnetIDReference
 	}
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	if profile.ProximityPlacementGroupID != nil {
 		proximityPlacementGroupID := *profile.ProximityPlacementGroupID
 		result.ProximityPlacementGroupID = &proximityPlacementGroupID
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	if profile.ScaleSetEvictionPolicy != nil {
 		scaleSetEvictionPolicy := *profile.ScaleSetEvictionPolicy
 		result.ScaleSetEvictionPolicy = &scaleSetEvictionPolicy
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	if profile.ScaleSetPriority != nil {
 		scaleSetPriority := *profile.ScaleSetPriority
 		result.ScaleSetPriority = &scaleSetPriority
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	if profile.SpotMaxPrice != nil {
 		spotMaxPrice := *profile.SpotMaxPrice
 		result.SpotMaxPrice = &spotMaxPrice
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if profile.Tags != nil {
 		result.Tags = make(map[string]string, len(profile.Tags))
 		for key, value := range profile.Tags {
@@ -4651,13 +4651,13 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if profile.Type != nil {
 		typeVar := *profile.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	if profile.UpgradeSettings != nil {
 		upgradeSettings_ARM, err := (*profile.UpgradeSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -4667,13 +4667,13 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		result.UpgradeSettings = &upgradeSettings
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if profile.VmSize != nil {
 		vmSize := *profile.VmSize
 		result.VmSize = &vmSize
 	}
 
-	// Set property ‘VnetSubnetID’:
+	// Set property "VnetSubnetID":
 	if profile.VnetSubnetIDReference != nil {
 		vnetSubnetIDReferenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.VnetSubnetIDReference)
 		if err != nil {
@@ -4697,54 +4697,54 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAgentPoolProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	for _, item := range typedInput.AvailabilityZones {
 		profile.AvailabilityZones = append(profile.AvailabilityZones, item)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		profile.Count = &count
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	if typedInput.EnableAutoScaling != nil {
 		enableAutoScaling := *typedInput.EnableAutoScaling
 		profile.EnableAutoScaling = &enableAutoScaling
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	if typedInput.EnableEncryptionAtHost != nil {
 		enableEncryptionAtHost := *typedInput.EnableEncryptionAtHost
 		profile.EnableEncryptionAtHost = &enableEncryptionAtHost
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	if typedInput.EnableFIPS != nil {
 		enableFIPS := *typedInput.EnableFIPS
 		profile.EnableFIPS = &enableFIPS
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	if typedInput.EnableNodePublicIP != nil {
 		enableNodePublicIP := *typedInput.EnableNodePublicIP
 		profile.EnableNodePublicIP = &enableNodePublicIP
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	if typedInput.EnableUltraSSD != nil {
 		enableUltraSSD := *typedInput.EnableUltraSSD
 		profile.EnableUltraSSD = &enableUltraSSD
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	if typedInput.GpuInstanceProfile != nil {
 		gpuInstanceProfile := *typedInput.GpuInstanceProfile
 		profile.GpuInstanceProfile = &gpuInstanceProfile
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	if typedInput.KubeletConfig != nil {
 		var kubeletConfig1 KubeletConfig
 		err := kubeletConfig1.PopulateFromARM(owner, *typedInput.KubeletConfig)
@@ -4755,13 +4755,13 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.KubeletConfig = &kubeletConfig
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	if typedInput.KubeletDiskType != nil {
 		kubeletDiskType := *typedInput.KubeletDiskType
 		profile.KubeletDiskType = &kubeletDiskType
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	if typedInput.LinuxOSConfig != nil {
 		var linuxOSConfig1 LinuxOSConfig
 		err := linuxOSConfig1.PopulateFromARM(owner, *typedInput.LinuxOSConfig)
@@ -4772,37 +4772,37 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.LinuxOSConfig = &linuxOSConfig
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	if typedInput.MaxCount != nil {
 		maxCount := *typedInput.MaxCount
 		profile.MaxCount = &maxCount
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	if typedInput.MaxPods != nil {
 		maxPods := *typedInput.MaxPods
 		profile.MaxPods = &maxPods
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	if typedInput.MinCount != nil {
 		minCount := *typedInput.MinCount
 		profile.MinCount = &minCount
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		profile.Mode = &mode
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	if typedInput.NodeLabels != nil {
 		profile.NodeLabels = make(map[string]string, len(typedInput.NodeLabels))
 		for key, value := range typedInput.NodeLabels {
@@ -4810,70 +4810,70 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// no assignment for property ‘NodePublicIPPrefixIDReference’
+	// no assignment for property "NodePublicIPPrefixIDReference"
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	for _, item := range typedInput.NodeTaints {
 		profile.NodeTaints = append(profile.NodeTaints, item)
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	if typedInput.OrchestratorVersion != nil {
 		orchestratorVersion := *typedInput.OrchestratorVersion
 		profile.OrchestratorVersion = &orchestratorVersion
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
 		osDiskSizeGB := *typedInput.OsDiskSizeGB
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	if typedInput.OsDiskType != nil {
 		osDiskType := *typedInput.OsDiskType
 		profile.OsDiskType = &osDiskType
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	if typedInput.OsSKU != nil {
 		osSKU := *typedInput.OsSKU
 		profile.OsSKU = &osSKU
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		profile.OsType = &osType
 	}
 
-	// no assignment for property ‘PodSubnetIDReference’
+	// no assignment for property "PodSubnetIDReference"
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	if typedInput.ProximityPlacementGroupID != nil {
 		proximityPlacementGroupID := *typedInput.ProximityPlacementGroupID
 		profile.ProximityPlacementGroupID = &proximityPlacementGroupID
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	if typedInput.ScaleSetEvictionPolicy != nil {
 		scaleSetEvictionPolicy := *typedInput.ScaleSetEvictionPolicy
 		profile.ScaleSetEvictionPolicy = &scaleSetEvictionPolicy
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	if typedInput.ScaleSetPriority != nil {
 		scaleSetPriority := *typedInput.ScaleSetPriority
 		profile.ScaleSetPriority = &scaleSetPriority
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	if typedInput.SpotMaxPrice != nil {
 		spotMaxPrice := *typedInput.SpotMaxPrice
 		profile.SpotMaxPrice = &spotMaxPrice
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		profile.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -4881,13 +4881,13 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	if typedInput.UpgradeSettings != nil {
 		var upgradeSettings1 AgentPoolUpgradeSettings
 		err := upgradeSettings1.PopulateFromARM(owner, *typedInput.UpgradeSettings)
@@ -4898,13 +4898,13 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 		profile.UpgradeSettings = &upgradeSettings
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
 	}
 
-	// no assignment for property ‘VnetSubnetIDReference’
+	// no assignment for property "VnetSubnetIDReference"
 
 	// No error
 	return nil
@@ -5446,54 +5446,54 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAgentPoolProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	for _, item := range typedInput.AvailabilityZones {
 		profile.AvailabilityZones = append(profile.AvailabilityZones, item)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		profile.Count = &count
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	if typedInput.EnableAutoScaling != nil {
 		enableAutoScaling := *typedInput.EnableAutoScaling
 		profile.EnableAutoScaling = &enableAutoScaling
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	if typedInput.EnableEncryptionAtHost != nil {
 		enableEncryptionAtHost := *typedInput.EnableEncryptionAtHost
 		profile.EnableEncryptionAtHost = &enableEncryptionAtHost
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	if typedInput.EnableFIPS != nil {
 		enableFIPS := *typedInput.EnableFIPS
 		profile.EnableFIPS = &enableFIPS
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	if typedInput.EnableNodePublicIP != nil {
 		enableNodePublicIP := *typedInput.EnableNodePublicIP
 		profile.EnableNodePublicIP = &enableNodePublicIP
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	if typedInput.EnableUltraSSD != nil {
 		enableUltraSSD := *typedInput.EnableUltraSSD
 		profile.EnableUltraSSD = &enableUltraSSD
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	if typedInput.GpuInstanceProfile != nil {
 		gpuInstanceProfile := *typedInput.GpuInstanceProfile
 		profile.GpuInstanceProfile = &gpuInstanceProfile
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	if typedInput.KubeletConfig != nil {
 		var kubeletConfig1 KubeletConfig_STATUS
 		err := kubeletConfig1.PopulateFromARM(owner, *typedInput.KubeletConfig)
@@ -5504,13 +5504,13 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.KubeletConfig = &kubeletConfig
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	if typedInput.KubeletDiskType != nil {
 		kubeletDiskType := *typedInput.KubeletDiskType
 		profile.KubeletDiskType = &kubeletDiskType
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	if typedInput.LinuxOSConfig != nil {
 		var linuxOSConfig1 LinuxOSConfig_STATUS
 		err := linuxOSConfig1.PopulateFromARM(owner, *typedInput.LinuxOSConfig)
@@ -5521,43 +5521,43 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.LinuxOSConfig = &linuxOSConfig
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	if typedInput.MaxCount != nil {
 		maxCount := *typedInput.MaxCount
 		profile.MaxCount = &maxCount
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	if typedInput.MaxPods != nil {
 		maxPods := *typedInput.MaxPods
 		profile.MaxPods = &maxPods
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	if typedInput.MinCount != nil {
 		minCount := *typedInput.MinCount
 		profile.MinCount = &minCount
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		profile.Mode = &mode
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘NodeImageVersion’:
+	// Set property "NodeImageVersion":
 	if typedInput.NodeImageVersion != nil {
 		nodeImageVersion := *typedInput.NodeImageVersion
 		profile.NodeImageVersion = &nodeImageVersion
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	if typedInput.NodeLabels != nil {
 		profile.NodeLabels = make(map[string]string, len(typedInput.NodeLabels))
 		for key, value := range typedInput.NodeLabels {
@@ -5565,54 +5565,54 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘NodePublicIPPrefixID’:
+	// Set property "NodePublicIPPrefixID":
 	if typedInput.NodePublicIPPrefixID != nil {
 		nodePublicIPPrefixID := *typedInput.NodePublicIPPrefixID
 		profile.NodePublicIPPrefixID = &nodePublicIPPrefixID
 	}
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	for _, item := range typedInput.NodeTaints {
 		profile.NodeTaints = append(profile.NodeTaints, item)
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	if typedInput.OrchestratorVersion != nil {
 		orchestratorVersion := *typedInput.OrchestratorVersion
 		profile.OrchestratorVersion = &orchestratorVersion
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
 		osDiskSizeGB := *typedInput.OsDiskSizeGB
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	if typedInput.OsDiskType != nil {
 		osDiskType := *typedInput.OsDiskType
 		profile.OsDiskType = &osDiskType
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	if typedInput.OsSKU != nil {
 		osSKU := *typedInput.OsSKU
 		profile.OsSKU = &osSKU
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		profile.OsType = &osType
 	}
 
-	// Set property ‘PodSubnetID’:
+	// Set property "PodSubnetID":
 	if typedInput.PodSubnetID != nil {
 		podSubnetID := *typedInput.PodSubnetID
 		profile.PodSubnetID = &podSubnetID
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	if typedInput.PowerState != nil {
 		var powerState1 PowerState_STATUS
 		err := powerState1.PopulateFromARM(owner, *typedInput.PowerState)
@@ -5623,37 +5623,37 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.PowerState = &powerState
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		profile.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	if typedInput.ProximityPlacementGroupID != nil {
 		proximityPlacementGroupID := *typedInput.ProximityPlacementGroupID
 		profile.ProximityPlacementGroupID = &proximityPlacementGroupID
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	if typedInput.ScaleSetEvictionPolicy != nil {
 		scaleSetEvictionPolicy := *typedInput.ScaleSetEvictionPolicy
 		profile.ScaleSetEvictionPolicy = &scaleSetEvictionPolicy
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	if typedInput.ScaleSetPriority != nil {
 		scaleSetPriority := *typedInput.ScaleSetPriority
 		profile.ScaleSetPriority = &scaleSetPriority
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	if typedInput.SpotMaxPrice != nil {
 		spotMaxPrice := *typedInput.SpotMaxPrice
 		profile.SpotMaxPrice = &spotMaxPrice
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		profile.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -5661,13 +5661,13 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	if typedInput.UpgradeSettings != nil {
 		var upgradeSettings1 AgentPoolUpgradeSettings_STATUS
 		err := upgradeSettings1.PopulateFromARM(owner, *typedInput.UpgradeSettings)
@@ -5678,13 +5678,13 @@ func (profile *ManagedClusterAgentPoolProfile_STATUS) PopulateFromARM(owner genr
 		profile.UpgradeSettings = &upgradeSettings
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		profile.VmSize = &vmSize
 	}
 
-	// Set property ‘VnetSubnetID’:
+	// Set property "VnetSubnetID":
 	if typedInput.VnetSubnetID != nil {
 		vnetSubnetID := *typedInput.VnetSubnetID
 		profile.VnetSubnetID = &vnetSubnetID
@@ -6178,24 +6178,24 @@ func (profile *ManagedClusterAPIServerAccessProfile) ConvertToARM(resolved genru
 	}
 	result := &ManagedClusterAPIServerAccessProfile_ARM{}
 
-	// Set property ‘AuthorizedIPRanges’:
+	// Set property "AuthorizedIPRanges":
 	for _, item := range profile.AuthorizedIPRanges {
 		result.AuthorizedIPRanges = append(result.AuthorizedIPRanges, item)
 	}
 
-	// Set property ‘EnablePrivateCluster’:
+	// Set property "EnablePrivateCluster":
 	if profile.EnablePrivateCluster != nil {
 		enablePrivateCluster := *profile.EnablePrivateCluster
 		result.EnablePrivateCluster = &enablePrivateCluster
 	}
 
-	// Set property ‘EnablePrivateClusterPublicFQDN’:
+	// Set property "EnablePrivateClusterPublicFQDN":
 	if profile.EnablePrivateClusterPublicFQDN != nil {
 		enablePrivateClusterPublicFQDN := *profile.EnablePrivateClusterPublicFQDN
 		result.EnablePrivateClusterPublicFQDN = &enablePrivateClusterPublicFQDN
 	}
 
-	// Set property ‘PrivateDNSZone’:
+	// Set property "PrivateDNSZone":
 	if profile.PrivateDNSZone != nil {
 		privateDNSZone := *profile.PrivateDNSZone
 		result.PrivateDNSZone = &privateDNSZone
@@ -6215,24 +6215,24 @@ func (profile *ManagedClusterAPIServerAccessProfile) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAPIServerAccessProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthorizedIPRanges’:
+	// Set property "AuthorizedIPRanges":
 	for _, item := range typedInput.AuthorizedIPRanges {
 		profile.AuthorizedIPRanges = append(profile.AuthorizedIPRanges, item)
 	}
 
-	// Set property ‘EnablePrivateCluster’:
+	// Set property "EnablePrivateCluster":
 	if typedInput.EnablePrivateCluster != nil {
 		enablePrivateCluster := *typedInput.EnablePrivateCluster
 		profile.EnablePrivateCluster = &enablePrivateCluster
 	}
 
-	// Set property ‘EnablePrivateClusterPublicFQDN’:
+	// Set property "EnablePrivateClusterPublicFQDN":
 	if typedInput.EnablePrivateClusterPublicFQDN != nil {
 		enablePrivateClusterPublicFQDN := *typedInput.EnablePrivateClusterPublicFQDN
 		profile.EnablePrivateClusterPublicFQDN = &enablePrivateClusterPublicFQDN
 	}
 
-	// Set property ‘PrivateDNSZone’:
+	// Set property "PrivateDNSZone":
 	if typedInput.PrivateDNSZone != nil {
 		privateDNSZone := *typedInput.PrivateDNSZone
 		profile.PrivateDNSZone = &privateDNSZone
@@ -6331,24 +6331,24 @@ func (profile *ManagedClusterAPIServerAccessProfile_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAPIServerAccessProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthorizedIPRanges’:
+	// Set property "AuthorizedIPRanges":
 	for _, item := range typedInput.AuthorizedIPRanges {
 		profile.AuthorizedIPRanges = append(profile.AuthorizedIPRanges, item)
 	}
 
-	// Set property ‘EnablePrivateCluster’:
+	// Set property "EnablePrivateCluster":
 	if typedInput.EnablePrivateCluster != nil {
 		enablePrivateCluster := *typedInput.EnablePrivateCluster
 		profile.EnablePrivateCluster = &enablePrivateCluster
 	}
 
-	// Set property ‘EnablePrivateClusterPublicFQDN’:
+	// Set property "EnablePrivateClusterPublicFQDN":
 	if typedInput.EnablePrivateClusterPublicFQDN != nil {
 		enablePrivateClusterPublicFQDN := *typedInput.EnablePrivateClusterPublicFQDN
 		profile.EnablePrivateClusterPublicFQDN = &enablePrivateClusterPublicFQDN
 	}
 
-	// Set property ‘PrivateDNSZone’:
+	// Set property "PrivateDNSZone":
 	if typedInput.PrivateDNSZone != nil {
 		privateDNSZone := *typedInput.PrivateDNSZone
 		profile.PrivateDNSZone = &privateDNSZone
@@ -6439,7 +6439,7 @@ func (profile *ManagedClusterAutoUpgradeProfile) ConvertToARM(resolved genruntim
 	}
 	result := &ManagedClusterAutoUpgradeProfile_ARM{}
 
-	// Set property ‘UpgradeChannel’:
+	// Set property "UpgradeChannel":
 	if profile.UpgradeChannel != nil {
 		upgradeChannel := *profile.UpgradeChannel
 		result.UpgradeChannel = &upgradeChannel
@@ -6459,7 +6459,7 @@ func (profile *ManagedClusterAutoUpgradeProfile) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAutoUpgradeProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UpgradeChannel’:
+	// Set property "UpgradeChannel":
 	if typedInput.UpgradeChannel != nil {
 		upgradeChannel := *typedInput.UpgradeChannel
 		profile.UpgradeChannel = &upgradeChannel
@@ -6527,7 +6527,7 @@ func (profile *ManagedClusterAutoUpgradeProfile_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterAutoUpgradeProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UpgradeChannel’:
+	// Set property "UpgradeChannel":
 	if typedInput.UpgradeChannel != nil {
 		upgradeChannel := *typedInput.UpgradeChannel
 		profile.UpgradeChannel = &upgradeChannel
@@ -6593,24 +6593,24 @@ func (config *ManagedClusterHTTPProxyConfig) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ManagedClusterHTTPProxyConfig_ARM{}
 
-	// Set property ‘HttpProxy’:
+	// Set property "HttpProxy":
 	if config.HttpProxy != nil {
 		httpProxy := *config.HttpProxy
 		result.HttpProxy = &httpProxy
 	}
 
-	// Set property ‘HttpsProxy’:
+	// Set property "HttpsProxy":
 	if config.HttpsProxy != nil {
 		httpsProxy := *config.HttpsProxy
 		result.HttpsProxy = &httpsProxy
 	}
 
-	// Set property ‘NoProxy’:
+	// Set property "NoProxy":
 	for _, item := range config.NoProxy {
 		result.NoProxy = append(result.NoProxy, item)
 	}
 
-	// Set property ‘TrustedCa’:
+	// Set property "TrustedCa":
 	if config.TrustedCa != nil {
 		trustedCa := *config.TrustedCa
 		result.TrustedCa = &trustedCa
@@ -6630,24 +6630,24 @@ func (config *ManagedClusterHTTPProxyConfig) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterHTTPProxyConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpProxy’:
+	// Set property "HttpProxy":
 	if typedInput.HttpProxy != nil {
 		httpProxy := *typedInput.HttpProxy
 		config.HttpProxy = &httpProxy
 	}
 
-	// Set property ‘HttpsProxy’:
+	// Set property "HttpsProxy":
 	if typedInput.HttpsProxy != nil {
 		httpsProxy := *typedInput.HttpsProxy
 		config.HttpsProxy = &httpsProxy
 	}
 
-	// Set property ‘NoProxy’:
+	// Set property "NoProxy":
 	for _, item := range typedInput.NoProxy {
 		config.NoProxy = append(config.NoProxy, item)
 	}
 
-	// Set property ‘TrustedCa’:
+	// Set property "TrustedCa":
 	if typedInput.TrustedCa != nil {
 		trustedCa := *typedInput.TrustedCa
 		config.TrustedCa = &trustedCa
@@ -6726,24 +6726,24 @@ func (config *ManagedClusterHTTPProxyConfig_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterHTTPProxyConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HttpProxy’:
+	// Set property "HttpProxy":
 	if typedInput.HttpProxy != nil {
 		httpProxy := *typedInput.HttpProxy
 		config.HttpProxy = &httpProxy
 	}
 
-	// Set property ‘HttpsProxy’:
+	// Set property "HttpsProxy":
 	if typedInput.HttpsProxy != nil {
 		httpsProxy := *typedInput.HttpsProxy
 		config.HttpsProxy = &httpsProxy
 	}
 
-	// Set property ‘NoProxy’:
+	// Set property "NoProxy":
 	for _, item := range typedInput.NoProxy {
 		config.NoProxy = append(config.NoProxy, item)
 	}
 
-	// Set property ‘TrustedCa’:
+	// Set property "TrustedCa":
 	if typedInput.TrustedCa != nil {
 		trustedCa := *typedInput.TrustedCa
 		config.TrustedCa = &trustedCa
@@ -6815,13 +6815,13 @@ func (identity *ManagedClusterIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ManagedClusterIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -6846,13 +6846,13 @@ func (identity *ManagedClusterIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -6955,25 +6955,25 @@ func (identity *ManagedClusterIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]ManagedClusterIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -7147,19 +7147,19 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 	}
 	result := &ManagedClusterPodIdentityProfile_ARM{}
 
-	// Set property ‘AllowNetworkPluginKubenet’:
+	// Set property "AllowNetworkPluginKubenet":
 	if profile.AllowNetworkPluginKubenet != nil {
 		allowNetworkPluginKubenet := *profile.AllowNetworkPluginKubenet
 		result.AllowNetworkPluginKubenet = &allowNetworkPluginKubenet
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if profile.Enabled != nil {
 		enabled := *profile.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	for _, item := range profile.UserAssignedIdentities {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -7168,7 +7168,7 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 		result.UserAssignedIdentities = append(result.UserAssignedIdentities, *item_ARM.(*ManagedClusterPodIdentity_ARM))
 	}
 
-	// Set property ‘UserAssignedIdentityExceptions’:
+	// Set property "UserAssignedIdentityExceptions":
 	for _, item := range profile.UserAssignedIdentityExceptions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -7191,19 +7191,19 @@ func (profile *ManagedClusterPodIdentityProfile) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowNetworkPluginKubenet’:
+	// Set property "AllowNetworkPluginKubenet":
 	if typedInput.AllowNetworkPluginKubenet != nil {
 		allowNetworkPluginKubenet := *typedInput.AllowNetworkPluginKubenet
 		profile.AllowNetworkPluginKubenet = &allowNetworkPluginKubenet
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	for _, item := range typedInput.UserAssignedIdentities {
 		var item1 ManagedClusterPodIdentity
 		err := item1.PopulateFromARM(owner, item)
@@ -7213,7 +7213,7 @@ func (profile *ManagedClusterPodIdentityProfile) PopulateFromARM(owner genruntim
 		profile.UserAssignedIdentities = append(profile.UserAssignedIdentities, item1)
 	}
 
-	// Set property ‘UserAssignedIdentityExceptions’:
+	// Set property "UserAssignedIdentityExceptions":
 	for _, item := range typedInput.UserAssignedIdentityExceptions {
 		var item1 ManagedClusterPodIdentityException
 		err := item1.PopulateFromARM(owner, item)
@@ -7376,19 +7376,19 @@ func (profile *ManagedClusterPodIdentityProfile_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowNetworkPluginKubenet’:
+	// Set property "AllowNetworkPluginKubenet":
 	if typedInput.AllowNetworkPluginKubenet != nil {
 		allowNetworkPluginKubenet := *typedInput.AllowNetworkPluginKubenet
 		profile.AllowNetworkPluginKubenet = &allowNetworkPluginKubenet
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		profile.Enabled = &enabled
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	for _, item := range typedInput.UserAssignedIdentities {
 		var item1 ManagedClusterPodIdentity_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7398,7 +7398,7 @@ func (profile *ManagedClusterPodIdentityProfile_STATUS) PopulateFromARM(owner ge
 		profile.UserAssignedIdentities = append(profile.UserAssignedIdentities, item1)
 	}
 
-	// Set property ‘UserAssignedIdentityExceptions’:
+	// Set property "UserAssignedIdentityExceptions":
 	for _, item := range typedInput.UserAssignedIdentityExceptions {
 		var item1 ManagedClusterPodIdentityException_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7569,103 +7569,103 @@ func (profile *ManagedClusterProperties_AutoScalerProfile) ConvertToARM(resolved
 	}
 	result := &ManagedClusterProperties_AutoScalerProfile_ARM{}
 
-	// Set property ‘BalanceSimilarNodeGroups’:
+	// Set property "BalanceSimilarNodeGroups":
 	if profile.BalanceSimilarNodeGroups != nil {
 		balanceSimilarNodeGroups := *profile.BalanceSimilarNodeGroups
 		result.BalanceSimilarNodeGroups = &balanceSimilarNodeGroups
 	}
 
-	// Set property ‘Expander’:
+	// Set property "Expander":
 	if profile.Expander != nil {
 		expander := *profile.Expander
 		result.Expander = &expander
 	}
 
-	// Set property ‘MaxEmptyBulkDelete’:
+	// Set property "MaxEmptyBulkDelete":
 	if profile.MaxEmptyBulkDelete != nil {
 		maxEmptyBulkDelete := *profile.MaxEmptyBulkDelete
 		result.MaxEmptyBulkDelete = &maxEmptyBulkDelete
 	}
 
-	// Set property ‘MaxGracefulTerminationSec’:
+	// Set property "MaxGracefulTerminationSec":
 	if profile.MaxGracefulTerminationSec != nil {
 		maxGracefulTerminationSec := *profile.MaxGracefulTerminationSec
 		result.MaxGracefulTerminationSec = &maxGracefulTerminationSec
 	}
 
-	// Set property ‘MaxNodeProvisionTime’:
+	// Set property "MaxNodeProvisionTime":
 	if profile.MaxNodeProvisionTime != nil {
 		maxNodeProvisionTime := *profile.MaxNodeProvisionTime
 		result.MaxNodeProvisionTime = &maxNodeProvisionTime
 	}
 
-	// Set property ‘MaxTotalUnreadyPercentage’:
+	// Set property "MaxTotalUnreadyPercentage":
 	if profile.MaxTotalUnreadyPercentage != nil {
 		maxTotalUnreadyPercentage := *profile.MaxTotalUnreadyPercentage
 		result.MaxTotalUnreadyPercentage = &maxTotalUnreadyPercentage
 	}
 
-	// Set property ‘NewPodScaleUpDelay’:
+	// Set property "NewPodScaleUpDelay":
 	if profile.NewPodScaleUpDelay != nil {
 		newPodScaleUpDelay := *profile.NewPodScaleUpDelay
 		result.NewPodScaleUpDelay = &newPodScaleUpDelay
 	}
 
-	// Set property ‘OkTotalUnreadyCount’:
+	// Set property "OkTotalUnreadyCount":
 	if profile.OkTotalUnreadyCount != nil {
 		okTotalUnreadyCount := *profile.OkTotalUnreadyCount
 		result.OkTotalUnreadyCount = &okTotalUnreadyCount
 	}
 
-	// Set property ‘ScaleDownDelayAfterAdd’:
+	// Set property "ScaleDownDelayAfterAdd":
 	if profile.ScaleDownDelayAfterAdd != nil {
 		scaleDownDelayAfterAdd := *profile.ScaleDownDelayAfterAdd
 		result.ScaleDownDelayAfterAdd = &scaleDownDelayAfterAdd
 	}
 
-	// Set property ‘ScaleDownDelayAfterDelete’:
+	// Set property "ScaleDownDelayAfterDelete":
 	if profile.ScaleDownDelayAfterDelete != nil {
 		scaleDownDelayAfterDelete := *profile.ScaleDownDelayAfterDelete
 		result.ScaleDownDelayAfterDelete = &scaleDownDelayAfterDelete
 	}
 
-	// Set property ‘ScaleDownDelayAfterFailure’:
+	// Set property "ScaleDownDelayAfterFailure":
 	if profile.ScaleDownDelayAfterFailure != nil {
 		scaleDownDelayAfterFailure := *profile.ScaleDownDelayAfterFailure
 		result.ScaleDownDelayAfterFailure = &scaleDownDelayAfterFailure
 	}
 
-	// Set property ‘ScaleDownUnneededTime’:
+	// Set property "ScaleDownUnneededTime":
 	if profile.ScaleDownUnneededTime != nil {
 		scaleDownUnneededTime := *profile.ScaleDownUnneededTime
 		result.ScaleDownUnneededTime = &scaleDownUnneededTime
 	}
 
-	// Set property ‘ScaleDownUnreadyTime’:
+	// Set property "ScaleDownUnreadyTime":
 	if profile.ScaleDownUnreadyTime != nil {
 		scaleDownUnreadyTime := *profile.ScaleDownUnreadyTime
 		result.ScaleDownUnreadyTime = &scaleDownUnreadyTime
 	}
 
-	// Set property ‘ScaleDownUtilizationThreshold’:
+	// Set property "ScaleDownUtilizationThreshold":
 	if profile.ScaleDownUtilizationThreshold != nil {
 		scaleDownUtilizationThreshold := *profile.ScaleDownUtilizationThreshold
 		result.ScaleDownUtilizationThreshold = &scaleDownUtilizationThreshold
 	}
 
-	// Set property ‘ScanInterval’:
+	// Set property "ScanInterval":
 	if profile.ScanInterval != nil {
 		scanInterval := *profile.ScanInterval
 		result.ScanInterval = &scanInterval
 	}
 
-	// Set property ‘SkipNodesWithLocalStorage’:
+	// Set property "SkipNodesWithLocalStorage":
 	if profile.SkipNodesWithLocalStorage != nil {
 		skipNodesWithLocalStorage := *profile.SkipNodesWithLocalStorage
 		result.SkipNodesWithLocalStorage = &skipNodesWithLocalStorage
 	}
 
-	// Set property ‘SkipNodesWithSystemPods’:
+	// Set property "SkipNodesWithSystemPods":
 	if profile.SkipNodesWithSystemPods != nil {
 		skipNodesWithSystemPods := *profile.SkipNodesWithSystemPods
 		result.SkipNodesWithSystemPods = &skipNodesWithSystemPods
@@ -7685,103 +7685,103 @@ func (profile *ManagedClusterProperties_AutoScalerProfile) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterProperties_AutoScalerProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BalanceSimilarNodeGroups’:
+	// Set property "BalanceSimilarNodeGroups":
 	if typedInput.BalanceSimilarNodeGroups != nil {
 		balanceSimilarNodeGroups := *typedInput.BalanceSimilarNodeGroups
 		profile.BalanceSimilarNodeGroups = &balanceSimilarNodeGroups
 	}
 
-	// Set property ‘Expander’:
+	// Set property "Expander":
 	if typedInput.Expander != nil {
 		expander := *typedInput.Expander
 		profile.Expander = &expander
 	}
 
-	// Set property ‘MaxEmptyBulkDelete’:
+	// Set property "MaxEmptyBulkDelete":
 	if typedInput.MaxEmptyBulkDelete != nil {
 		maxEmptyBulkDelete := *typedInput.MaxEmptyBulkDelete
 		profile.MaxEmptyBulkDelete = &maxEmptyBulkDelete
 	}
 
-	// Set property ‘MaxGracefulTerminationSec’:
+	// Set property "MaxGracefulTerminationSec":
 	if typedInput.MaxGracefulTerminationSec != nil {
 		maxGracefulTerminationSec := *typedInput.MaxGracefulTerminationSec
 		profile.MaxGracefulTerminationSec = &maxGracefulTerminationSec
 	}
 
-	// Set property ‘MaxNodeProvisionTime’:
+	// Set property "MaxNodeProvisionTime":
 	if typedInput.MaxNodeProvisionTime != nil {
 		maxNodeProvisionTime := *typedInput.MaxNodeProvisionTime
 		profile.MaxNodeProvisionTime = &maxNodeProvisionTime
 	}
 
-	// Set property ‘MaxTotalUnreadyPercentage’:
+	// Set property "MaxTotalUnreadyPercentage":
 	if typedInput.MaxTotalUnreadyPercentage != nil {
 		maxTotalUnreadyPercentage := *typedInput.MaxTotalUnreadyPercentage
 		profile.MaxTotalUnreadyPercentage = &maxTotalUnreadyPercentage
 	}
 
-	// Set property ‘NewPodScaleUpDelay’:
+	// Set property "NewPodScaleUpDelay":
 	if typedInput.NewPodScaleUpDelay != nil {
 		newPodScaleUpDelay := *typedInput.NewPodScaleUpDelay
 		profile.NewPodScaleUpDelay = &newPodScaleUpDelay
 	}
 
-	// Set property ‘OkTotalUnreadyCount’:
+	// Set property "OkTotalUnreadyCount":
 	if typedInput.OkTotalUnreadyCount != nil {
 		okTotalUnreadyCount := *typedInput.OkTotalUnreadyCount
 		profile.OkTotalUnreadyCount = &okTotalUnreadyCount
 	}
 
-	// Set property ‘ScaleDownDelayAfterAdd’:
+	// Set property "ScaleDownDelayAfterAdd":
 	if typedInput.ScaleDownDelayAfterAdd != nil {
 		scaleDownDelayAfterAdd := *typedInput.ScaleDownDelayAfterAdd
 		profile.ScaleDownDelayAfterAdd = &scaleDownDelayAfterAdd
 	}
 
-	// Set property ‘ScaleDownDelayAfterDelete’:
+	// Set property "ScaleDownDelayAfterDelete":
 	if typedInput.ScaleDownDelayAfterDelete != nil {
 		scaleDownDelayAfterDelete := *typedInput.ScaleDownDelayAfterDelete
 		profile.ScaleDownDelayAfterDelete = &scaleDownDelayAfterDelete
 	}
 
-	// Set property ‘ScaleDownDelayAfterFailure’:
+	// Set property "ScaleDownDelayAfterFailure":
 	if typedInput.ScaleDownDelayAfterFailure != nil {
 		scaleDownDelayAfterFailure := *typedInput.ScaleDownDelayAfterFailure
 		profile.ScaleDownDelayAfterFailure = &scaleDownDelayAfterFailure
 	}
 
-	// Set property ‘ScaleDownUnneededTime’:
+	// Set property "ScaleDownUnneededTime":
 	if typedInput.ScaleDownUnneededTime != nil {
 		scaleDownUnneededTime := *typedInput.ScaleDownUnneededTime
 		profile.ScaleDownUnneededTime = &scaleDownUnneededTime
 	}
 
-	// Set property ‘ScaleDownUnreadyTime’:
+	// Set property "ScaleDownUnreadyTime":
 	if typedInput.ScaleDownUnreadyTime != nil {
 		scaleDownUnreadyTime := *typedInput.ScaleDownUnreadyTime
 		profile.ScaleDownUnreadyTime = &scaleDownUnreadyTime
 	}
 
-	// Set property ‘ScaleDownUtilizationThreshold’:
+	// Set property "ScaleDownUtilizationThreshold":
 	if typedInput.ScaleDownUtilizationThreshold != nil {
 		scaleDownUtilizationThreshold := *typedInput.ScaleDownUtilizationThreshold
 		profile.ScaleDownUtilizationThreshold = &scaleDownUtilizationThreshold
 	}
 
-	// Set property ‘ScanInterval’:
+	// Set property "ScanInterval":
 	if typedInput.ScanInterval != nil {
 		scanInterval := *typedInput.ScanInterval
 		profile.ScanInterval = &scanInterval
 	}
 
-	// Set property ‘SkipNodesWithLocalStorage’:
+	// Set property "SkipNodesWithLocalStorage":
 	if typedInput.SkipNodesWithLocalStorage != nil {
 		skipNodesWithLocalStorage := *typedInput.SkipNodesWithLocalStorage
 		profile.SkipNodesWithLocalStorage = &skipNodesWithLocalStorage
 	}
 
-	// Set property ‘SkipNodesWithSystemPods’:
+	// Set property "SkipNodesWithSystemPods":
 	if typedInput.SkipNodesWithSystemPods != nil {
 		skipNodesWithSystemPods := *typedInput.SkipNodesWithSystemPods
 		profile.SkipNodesWithSystemPods = &skipNodesWithSystemPods
@@ -7961,103 +7961,103 @@ func (profile *ManagedClusterProperties_AutoScalerProfile_STATUS) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterProperties_AutoScalerProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BalanceSimilarNodeGroups’:
+	// Set property "BalanceSimilarNodeGroups":
 	if typedInput.BalanceSimilarNodeGroups != nil {
 		balanceSimilarNodeGroups := *typedInput.BalanceSimilarNodeGroups
 		profile.BalanceSimilarNodeGroups = &balanceSimilarNodeGroups
 	}
 
-	// Set property ‘Expander’:
+	// Set property "Expander":
 	if typedInput.Expander != nil {
 		expander := *typedInput.Expander
 		profile.Expander = &expander
 	}
 
-	// Set property ‘MaxEmptyBulkDelete’:
+	// Set property "MaxEmptyBulkDelete":
 	if typedInput.MaxEmptyBulkDelete != nil {
 		maxEmptyBulkDelete := *typedInput.MaxEmptyBulkDelete
 		profile.MaxEmptyBulkDelete = &maxEmptyBulkDelete
 	}
 
-	// Set property ‘MaxGracefulTerminationSec’:
+	// Set property "MaxGracefulTerminationSec":
 	if typedInput.MaxGracefulTerminationSec != nil {
 		maxGracefulTerminationSec := *typedInput.MaxGracefulTerminationSec
 		profile.MaxGracefulTerminationSec = &maxGracefulTerminationSec
 	}
 
-	// Set property ‘MaxNodeProvisionTime’:
+	// Set property "MaxNodeProvisionTime":
 	if typedInput.MaxNodeProvisionTime != nil {
 		maxNodeProvisionTime := *typedInput.MaxNodeProvisionTime
 		profile.MaxNodeProvisionTime = &maxNodeProvisionTime
 	}
 
-	// Set property ‘MaxTotalUnreadyPercentage’:
+	// Set property "MaxTotalUnreadyPercentage":
 	if typedInput.MaxTotalUnreadyPercentage != nil {
 		maxTotalUnreadyPercentage := *typedInput.MaxTotalUnreadyPercentage
 		profile.MaxTotalUnreadyPercentage = &maxTotalUnreadyPercentage
 	}
 
-	// Set property ‘NewPodScaleUpDelay’:
+	// Set property "NewPodScaleUpDelay":
 	if typedInput.NewPodScaleUpDelay != nil {
 		newPodScaleUpDelay := *typedInput.NewPodScaleUpDelay
 		profile.NewPodScaleUpDelay = &newPodScaleUpDelay
 	}
 
-	// Set property ‘OkTotalUnreadyCount’:
+	// Set property "OkTotalUnreadyCount":
 	if typedInput.OkTotalUnreadyCount != nil {
 		okTotalUnreadyCount := *typedInput.OkTotalUnreadyCount
 		profile.OkTotalUnreadyCount = &okTotalUnreadyCount
 	}
 
-	// Set property ‘ScaleDownDelayAfterAdd’:
+	// Set property "ScaleDownDelayAfterAdd":
 	if typedInput.ScaleDownDelayAfterAdd != nil {
 		scaleDownDelayAfterAdd := *typedInput.ScaleDownDelayAfterAdd
 		profile.ScaleDownDelayAfterAdd = &scaleDownDelayAfterAdd
 	}
 
-	// Set property ‘ScaleDownDelayAfterDelete’:
+	// Set property "ScaleDownDelayAfterDelete":
 	if typedInput.ScaleDownDelayAfterDelete != nil {
 		scaleDownDelayAfterDelete := *typedInput.ScaleDownDelayAfterDelete
 		profile.ScaleDownDelayAfterDelete = &scaleDownDelayAfterDelete
 	}
 
-	// Set property ‘ScaleDownDelayAfterFailure’:
+	// Set property "ScaleDownDelayAfterFailure":
 	if typedInput.ScaleDownDelayAfterFailure != nil {
 		scaleDownDelayAfterFailure := *typedInput.ScaleDownDelayAfterFailure
 		profile.ScaleDownDelayAfterFailure = &scaleDownDelayAfterFailure
 	}
 
-	// Set property ‘ScaleDownUnneededTime’:
+	// Set property "ScaleDownUnneededTime":
 	if typedInput.ScaleDownUnneededTime != nil {
 		scaleDownUnneededTime := *typedInput.ScaleDownUnneededTime
 		profile.ScaleDownUnneededTime = &scaleDownUnneededTime
 	}
 
-	// Set property ‘ScaleDownUnreadyTime’:
+	// Set property "ScaleDownUnreadyTime":
 	if typedInput.ScaleDownUnreadyTime != nil {
 		scaleDownUnreadyTime := *typedInput.ScaleDownUnreadyTime
 		profile.ScaleDownUnreadyTime = &scaleDownUnreadyTime
 	}
 
-	// Set property ‘ScaleDownUtilizationThreshold’:
+	// Set property "ScaleDownUtilizationThreshold":
 	if typedInput.ScaleDownUtilizationThreshold != nil {
 		scaleDownUtilizationThreshold := *typedInput.ScaleDownUtilizationThreshold
 		profile.ScaleDownUtilizationThreshold = &scaleDownUtilizationThreshold
 	}
 
-	// Set property ‘ScanInterval’:
+	// Set property "ScanInterval":
 	if typedInput.ScanInterval != nil {
 		scanInterval := *typedInput.ScanInterval
 		profile.ScanInterval = &scanInterval
 	}
 
-	// Set property ‘SkipNodesWithLocalStorage’:
+	// Set property "SkipNodesWithLocalStorage":
 	if typedInput.SkipNodesWithLocalStorage != nil {
 		skipNodesWithLocalStorage := *typedInput.SkipNodesWithLocalStorage
 		profile.SkipNodesWithLocalStorage = &skipNodesWithLocalStorage
 	}
 
-	// Set property ‘SkipNodesWithSystemPods’:
+	// Set property "SkipNodesWithSystemPods":
 	if typedInput.SkipNodesWithSystemPods != nil {
 		skipNodesWithSystemPods := *typedInput.SkipNodesWithSystemPods
 		profile.SkipNodesWithSystemPods = &skipNodesWithSystemPods
@@ -8218,13 +8218,13 @@ func (profile *ManagedClusterServicePrincipalProfile) ConvertToARM(resolved genr
 	}
 	result := &ManagedClusterServicePrincipalProfile_ARM{}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if profile.ClientId != nil {
 		clientId := *profile.ClientId
 		result.ClientId = &clientId
 	}
 
-	// Set property ‘Secret’:
+	// Set property "Secret":
 	if profile.Secret != nil {
 		secretSecret, err := resolved.ResolvedSecrets.Lookup(*profile.Secret)
 		if err != nil {
@@ -8248,13 +8248,13 @@ func (profile *ManagedClusterServicePrincipalProfile) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterServicePrincipalProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		profile.ClientId = &clientId
 	}
 
-	// no assignment for property ‘Secret’
+	// no assignment for property "Secret"
 
 	// No error
 	return nil
@@ -8324,7 +8324,7 @@ func (profile *ManagedClusterServicePrincipalProfile_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterServicePrincipalProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		profile.ClientId = &clientId
@@ -8378,13 +8378,13 @@ func (clusterSKU *ManagedClusterSKU) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &ManagedClusterSKU_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if clusterSKU.Name != nil {
 		name := *clusterSKU.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if clusterSKU.Tier != nil {
 		tier := *clusterSKU.Tier
 		result.Tier = &tier
@@ -8404,13 +8404,13 @@ func (clusterSKU *ManagedClusterSKU) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSKU_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		clusterSKU.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		clusterSKU.Tier = &tier
@@ -8495,13 +8495,13 @@ func (clusterSKU *ManagedClusterSKU_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterSKU_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		clusterSKU.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		clusterSKU.Tier = &tier
@@ -8585,25 +8585,25 @@ func (profile *ManagedClusterWindowsProfile) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ManagedClusterWindowsProfile_ARM{}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if profile.AdminPassword != nil {
 		adminPassword := *profile.AdminPassword
 		result.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if profile.AdminUsername != nil {
 		adminUsername := *profile.AdminUsername
 		result.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘EnableCSIProxy’:
+	// Set property "EnableCSIProxy":
 	if profile.EnableCSIProxy != nil {
 		enableCSIProxy := *profile.EnableCSIProxy
 		result.EnableCSIProxy = &enableCSIProxy
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if profile.LicenseType != nil {
 		licenseType := *profile.LicenseType
 		result.LicenseType = &licenseType
@@ -8623,25 +8623,25 @@ func (profile *ManagedClusterWindowsProfile) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWindowsProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if typedInput.AdminPassword != nil {
 		adminPassword := *typedInput.AdminPassword
 		profile.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘EnableCSIProxy’:
+	// Set property "EnableCSIProxy":
 	if typedInput.EnableCSIProxy != nil {
 		enableCSIProxy := *typedInput.EnableCSIProxy
 		profile.EnableCSIProxy = &enableCSIProxy
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
@@ -8740,25 +8740,25 @@ func (profile *ManagedClusterWindowsProfile_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterWindowsProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminPassword’:
+	// Set property "AdminPassword":
 	if typedInput.AdminPassword != nil {
 		adminPassword := *typedInput.AdminPassword
 		profile.AdminPassword = &adminPassword
 	}
 
-	// Set property ‘AdminUsername’:
+	// Set property "AdminUsername":
 	if typedInput.AdminUsername != nil {
 		adminUsername := *typedInput.AdminUsername
 		profile.AdminUsername = &adminUsername
 	}
 
-	// Set property ‘EnableCSIProxy’:
+	// Set property "EnableCSIProxy":
 	if typedInput.EnableCSIProxy != nil {
 		enableCSIProxy := *typedInput.EnableCSIProxy
 		profile.EnableCSIProxy = &enableCSIProxy
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	if typedInput.LicenseType != nil {
 		licenseType := *typedInput.LicenseType
 		profile.LicenseType = &licenseType
@@ -8854,7 +8854,7 @@ func (state *PowerState_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PowerState_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		state.Code = &code
@@ -8921,13 +8921,13 @@ func (resource *PrivateLinkResource) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &PrivateLinkResource_ARM{}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if resource.GroupId != nil {
 		groupId := *resource.GroupId
 		result.GroupId = &groupId
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -8937,18 +8937,18 @@ func (resource *PrivateLinkResource) ConvertToARM(resolved genruntime.ConvertToA
 		result.Id = &reference
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if resource.Name != nil {
 		name := *resource.Name
 		result.Name = &name
 	}
 
-	// Set property ‘RequiredMembers’:
+	// Set property "RequiredMembers":
 	for _, item := range resource.RequiredMembers {
 		result.RequiredMembers = append(result.RequiredMembers, item)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if resource.Type != nil {
 		typeVar := *resource.Type
 		result.Type = &typeVar
@@ -8968,26 +8968,26 @@ func (resource *PrivateLinkResource) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if typedInput.GroupId != nil {
 		groupId := *typedInput.GroupId
 		resource.GroupId = &groupId
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resource.Name = &name
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘RequiredMembers’:
+	// Set property "RequiredMembers":
 	for _, item := range typedInput.RequiredMembers {
 		resource.RequiredMembers = append(resource.RequiredMembers, item)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		resource.Type = &typeVar
@@ -9084,36 +9084,36 @@ func (resource *PrivateLinkResource_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if typedInput.GroupId != nil {
 		groupId := *typedInput.GroupId
 		resource.GroupId = &groupId
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resource.Name = &name
 	}
 
-	// Set property ‘PrivateLinkServiceID’:
+	// Set property "PrivateLinkServiceID":
 	if typedInput.PrivateLinkServiceID != nil {
 		privateLinkServiceID := *typedInput.PrivateLinkServiceID
 		resource.PrivateLinkServiceID = &privateLinkServiceID
 	}
 
-	// Set property ‘RequiredMembers’:
+	// Set property "RequiredMembers":
 	for _, item := range typedInput.RequiredMembers {
 		resource.RequiredMembers = append(resource.RequiredMembers, item)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		resource.Type = &typeVar
@@ -9198,19 +9198,19 @@ func (identity *UserAssignedIdentity) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &UserAssignedIdentity_ARM{}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if identity.ClientId != nil {
 		clientId := *identity.ClientId
 		result.ClientId = &clientId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if identity.ObjectId != nil {
 		objectId := *identity.ObjectId
 		result.ObjectId = &objectId
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if identity.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*identity.ResourceReference)
 		if err != nil {
@@ -9234,19 +9234,19 @@ func (identity *UserAssignedIdentity) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		identity.ObjectId = &objectId
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -9324,19 +9324,19 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		identity.ObjectId = &objectId
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		identity.ResourceId = &resourceId
@@ -9497,7 +9497,7 @@ func (configuration *ContainerServiceSshConfiguration) ConvertToARM(resolved gen
 	}
 	result := &ContainerServiceSshConfiguration_ARM{}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range configuration.PublicKeys {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -9520,7 +9520,7 @@ func (configuration *ContainerServiceSshConfiguration) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 ContainerServiceSshPublicKey
 		err := item1.PopulateFromARM(owner, item)
@@ -9612,7 +9612,7 @@ func (configuration *ContainerServiceSshConfiguration_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicKeys’:
+	// Set property "PublicKeys":
 	for _, item := range typedInput.PublicKeys {
 		var item1 ContainerServiceSshPublicKey_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -9730,13 +9730,13 @@ func (identities *ManagedClusterIdentity_UserAssignedIdentities_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -9805,13 +9805,13 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 	}
 	result := &ManagedClusterLoadBalancerProfile_ARM{}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	if profile.AllocatedOutboundPorts != nil {
 		allocatedOutboundPorts := *profile.AllocatedOutboundPorts
 		result.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range profile.EffectiveOutboundIPs {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -9820,13 +9820,13 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		result.EffectiveOutboundIPs = append(result.EffectiveOutboundIPs, *item_ARM.(*ResourceReference_ARM))
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if profile.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *profile.IdleTimeoutInMinutes
 		result.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPs’:
+	// Set property "ManagedOutboundIPs":
 	if profile.ManagedOutboundIPs != nil {
 		managedOutboundIPs_ARM, err := (*profile.ManagedOutboundIPs).ConvertToARM(resolved)
 		if err != nil {
@@ -9836,7 +9836,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		result.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
-	// Set property ‘OutboundIPPrefixes’:
+	// Set property "OutboundIPPrefixes":
 	if profile.OutboundIPPrefixes != nil {
 		outboundIPPrefixes_ARM, err := (*profile.OutboundIPPrefixes).ConvertToARM(resolved)
 		if err != nil {
@@ -9846,7 +9846,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		result.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
-	// Set property ‘OutboundIPs’:
+	// Set property "OutboundIPs":
 	if profile.OutboundIPs != nil {
 		outboundIPs_ARM, err := (*profile.OutboundIPs).ConvertToARM(resolved)
 		if err != nil {
@@ -9870,13 +9870,13 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	if typedInput.AllocatedOutboundPorts != nil {
 		allocatedOutboundPorts := *typedInput.AllocatedOutboundPorts
 		profile.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range typedInput.EffectiveOutboundIPs {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -9886,13 +9886,13 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		profile.EffectiveOutboundIPs = append(profile.EffectiveOutboundIPs, item1)
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if typedInput.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *typedInput.IdleTimeoutInMinutes
 		profile.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPs’:
+	// Set property "ManagedOutboundIPs":
 	if typedInput.ManagedOutboundIPs != nil {
 		var managedOutboundIPs1 ManagedClusterLoadBalancerProfile_ManagedOutboundIPs
 		err := managedOutboundIPs1.PopulateFromARM(owner, *typedInput.ManagedOutboundIPs)
@@ -9903,7 +9903,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		profile.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
-	// Set property ‘OutboundIPPrefixes’:
+	// Set property "OutboundIPPrefixes":
 	if typedInput.OutboundIPPrefixes != nil {
 		var outboundIPPrefixes1 ManagedClusterLoadBalancerProfile_OutboundIPPrefixes
 		err := outboundIPPrefixes1.PopulateFromARM(owner, *typedInput.OutboundIPPrefixes)
@@ -9914,7 +9914,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 		profile.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
-	// Set property ‘OutboundIPs’:
+	// Set property "OutboundIPs":
 	if typedInput.OutboundIPs != nil {
 		var outboundIPs1 ManagedClusterLoadBalancerProfile_OutboundIPs
 		err := outboundIPs1.PopulateFromARM(owner, *typedInput.OutboundIPs)
@@ -10116,13 +10116,13 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	if typedInput.AllocatedOutboundPorts != nil {
 		allocatedOutboundPorts := *typedInput.AllocatedOutboundPorts
 		profile.AllocatedOutboundPorts = &allocatedOutboundPorts
 	}
 
-	// Set property ‘EffectiveOutboundIPs’:
+	// Set property "EffectiveOutboundIPs":
 	for _, item := range typedInput.EffectiveOutboundIPs {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10132,13 +10132,13 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		profile.EffectiveOutboundIPs = append(profile.EffectiveOutboundIPs, item1)
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	if typedInput.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *typedInput.IdleTimeoutInMinutes
 		profile.IdleTimeoutInMinutes = &idleTimeoutInMinutes
 	}
 
-	// Set property ‘ManagedOutboundIPs’:
+	// Set property "ManagedOutboundIPs":
 	if typedInput.ManagedOutboundIPs != nil {
 		var managedOutboundIPs1 ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS
 		err := managedOutboundIPs1.PopulateFromARM(owner, *typedInput.ManagedOutboundIPs)
@@ -10149,7 +10149,7 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		profile.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
-	// Set property ‘OutboundIPPrefixes’:
+	// Set property "OutboundIPPrefixes":
 	if typedInput.OutboundIPPrefixes != nil {
 		var outboundIPPrefixes1 ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS
 		err := outboundIPPrefixes1.PopulateFromARM(owner, *typedInput.OutboundIPPrefixes)
@@ -10160,7 +10160,7 @@ func (profile *ManagedClusterLoadBalancerProfile_STATUS) PopulateFromARM(owner g
 		profile.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
-	// Set property ‘OutboundIPs’:
+	// Set property "OutboundIPs":
 	if typedInput.OutboundIPs != nil {
 		var outboundIPs1 ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS
 		err := outboundIPs1.PopulateFromARM(owner, *typedInput.OutboundIPs)
@@ -10406,13 +10406,13 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ManagedClusterPodIdentity_ARM{}
 
-	// Set property ‘BindingSelector’:
+	// Set property "BindingSelector":
 	if identity.BindingSelector != nil {
 		bindingSelector := *identity.BindingSelector
 		result.BindingSelector = &bindingSelector
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if identity.Identity != nil {
 		identity_ARM, err := (*identity.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -10422,13 +10422,13 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 		result.Identity = &identity1
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if identity.Name != nil {
 		name := *identity.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if identity.Namespace != nil {
 		namespace := *identity.Namespace
 		result.Namespace = &namespace
@@ -10448,13 +10448,13 @@ func (identity *ManagedClusterPodIdentity) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BindingSelector’:
+	// Set property "BindingSelector":
 	if typedInput.BindingSelector != nil {
 		bindingSelector := *typedInput.BindingSelector
 		identity.BindingSelector = &bindingSelector
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity2 UserAssignedIdentity
 		err := identity2.PopulateFromARM(owner, *typedInput.Identity)
@@ -10465,13 +10465,13 @@ func (identity *ManagedClusterPodIdentity) PopulateFromARM(owner genruntime.Arbi
 		identity.Identity = &identity1
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		identity.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		identity.Namespace = &namespace
@@ -10570,13 +10570,13 @@ func (identity *ManagedClusterPodIdentity_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BindingSelector’:
+	// Set property "BindingSelector":
 	if typedInput.BindingSelector != nil {
 		bindingSelector := *typedInput.BindingSelector
 		identity.BindingSelector = &bindingSelector
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity2 UserAssignedIdentity_STATUS
 		err := identity2.PopulateFromARM(owner, *typedInput.Identity)
@@ -10587,19 +10587,19 @@ func (identity *ManagedClusterPodIdentity_STATUS) PopulateFromARM(owner genrunti
 		identity.Identity = &identity1
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		identity.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		identity.Namespace = &namespace
 	}
 
-	// Set property ‘ProvisioningInfo’:
+	// Set property "ProvisioningInfo":
 	if typedInput.ProvisioningInfo != nil {
 		var provisioningInfo1 ManagedClusterPodIdentity_ProvisioningInfo_STATUS
 		err := provisioningInfo1.PopulateFromARM(owner, *typedInput.ProvisioningInfo)
@@ -10610,7 +10610,7 @@ func (identity *ManagedClusterPodIdentity_STATUS) PopulateFromARM(owner genrunti
 		identity.ProvisioningInfo = &provisioningInfo
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		identity.ProvisioningState = &provisioningState
@@ -10746,19 +10746,19 @@ func (exception *ManagedClusterPodIdentityException) ConvertToARM(resolved genru
 	}
 	result := &ManagedClusterPodIdentityException_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if exception.Name != nil {
 		name := *exception.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if exception.Namespace != nil {
 		namespace := *exception.Namespace
 		result.Namespace = &namespace
 	}
 
-	// Set property ‘PodLabels’:
+	// Set property "PodLabels":
 	if exception.PodLabels != nil {
 		result.PodLabels = make(map[string]string, len(exception.PodLabels))
 		for key, value := range exception.PodLabels {
@@ -10780,19 +10780,19 @@ func (exception *ManagedClusterPodIdentityException) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityException_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		exception.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		exception.Namespace = &namespace
 	}
 
-	// Set property ‘PodLabels’:
+	// Set property "PodLabels":
 	if typedInput.PodLabels != nil {
 		exception.PodLabels = make(map[string]string, len(typedInput.PodLabels))
 		for key, value := range typedInput.PodLabels {
@@ -10866,19 +10866,19 @@ func (exception *ManagedClusterPodIdentityException_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityException_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		exception.Name = &name
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		exception.Namespace = &namespace
 	}
 
-	// Set property ‘PodLabels’:
+	// Set property "PodLabels":
 	if typedInput.PodLabels != nil {
 		exception.PodLabels = make(map[string]string, len(typedInput.PodLabels))
 		for key, value := range typedInput.PodLabels {
@@ -11030,7 +11030,7 @@ func (publicKey *ContainerServiceSshPublicKey) ConvertToARM(resolved genruntime.
 	}
 	result := &ContainerServiceSshPublicKey_ARM{}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if publicKey.KeyData != nil {
 		keyData := *publicKey.KeyData
 		result.KeyData = &keyData
@@ -11050,7 +11050,7 @@ func (publicKey *ContainerServiceSshPublicKey) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshPublicKey_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
@@ -11108,7 +11108,7 @@ func (publicKey *ContainerServiceSshPublicKey_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerServiceSshPublicKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyData’:
+	// Set property "KeyData":
 	if typedInput.KeyData != nil {
 		keyData := *typedInput.KeyData
 		publicKey.KeyData = &keyData
@@ -11163,7 +11163,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) ConvertToARM(re
 	}
 	result := &ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if iPs.Count != nil {
 		count := *iPs.Count
 		result.Count = &count
@@ -11183,7 +11183,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		iPs.Count = &count
@@ -11251,7 +11251,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		iPs.Count = &count
@@ -11304,7 +11304,7 @@ func (prefixes *ManagedClusterLoadBalancerProfile_OutboundIPPrefixes) ConvertToA
 	}
 	result := &ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_ARM{}
 
-	// Set property ‘PublicIPPrefixes’:
+	// Set property "PublicIPPrefixes":
 	for _, item := range prefixes.PublicIPPrefixes {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -11327,7 +11327,7 @@ func (prefixes *ManagedClusterLoadBalancerProfile_OutboundIPPrefixes) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPPrefixes’:
+	// Set property "PublicIPPrefixes":
 	for _, item := range typedInput.PublicIPPrefixes {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -11419,7 +11419,7 @@ func (prefixes *ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPPrefixes_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPPrefixes’:
+	// Set property "PublicIPPrefixes":
 	for _, item := range typedInput.PublicIPPrefixes {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11506,7 +11506,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_OutboundIPs) ConvertToARM(resolved 
 	}
 	result := &ManagedClusterLoadBalancerProfile_OutboundIPs_ARM{}
 
-	// Set property ‘PublicIPs’:
+	// Set property "PublicIPs":
 	for _, item := range iPs.PublicIPs {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -11529,7 +11529,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_OutboundIPs) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPs_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPs’:
+	// Set property "PublicIPs":
 	for _, item := range typedInput.PublicIPs {
 		var item1 ResourceReference
 		err := item1.PopulateFromARM(owner, item)
@@ -11621,7 +11621,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterLoadBalancerProfile_OutboundIPs_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIPs’:
+	// Set property "PublicIPs":
 	for _, item := range typedInput.PublicIPs {
 		var item1 ResourceReference_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11713,7 +11713,7 @@ func (info *ManagedClusterPodIdentity_ProvisioningInfo_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentity_ProvisioningInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ManagedClusterPodIdentityProvisioningError_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -11800,7 +11800,7 @@ func (reference *ResourceReference) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &ResourceReference_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if reference.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*reference.Reference)
 		if err != nil {
@@ -11824,7 +11824,7 @@ func (reference *ResourceReference) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceReference_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -11888,7 +11888,7 @@ func (reference *ResourceReference_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		reference.Id = &id
@@ -11946,7 +11946,7 @@ func (error *ManagedClusterPodIdentityProvisioningError_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProvisioningError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error2 ManagedClusterPodIdentityProvisioningErrorBody_STATUS
 		err := error2.PopulateFromARM(owner, *typedInput.Error)
@@ -12030,13 +12030,13 @@ func (body *ManagedClusterPodIdentityProvisioningErrorBody_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProvisioningErrorBody_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		body.Code = &code
 	}
 
-	// Set property ‘Details’:
+	// Set property "Details":
 	for _, item := range typedInput.Details {
 		var item1 ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled
 		err := item1.PopulateFromARM(owner, item)
@@ -12046,13 +12046,13 @@ func (body *ManagedClusterPodIdentityProvisioningErrorBody_STATUS) PopulateFromA
 		body.Details = append(body.Details, item1)
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		body.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		body.Target = &target
@@ -12160,19 +12160,19 @@ func (unrolled *ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusterPodIdentityProvisioningErrorBody_STATUS_Unrolled_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		unrolled.Code = &code
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		unrolled.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		unrolled.Target = &target

--- a/v2/api/containerservice/v1beta20210501/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1beta20210501/managed_clusters_agent_pool_types_gen.go
@@ -364,10 +364,10 @@ func (pool *ManagedClusters_AgentPool_Spec) ConvertToARM(resolved genruntime.Con
 	}
 	result := &ManagedClusters_AgentPool_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if pool.AvailabilityZones != nil ||
 		pool.Count != nil ||
 		pool.EnableAutoScaling != nil ||
@@ -576,7 +576,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusters_AgentPool_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AvailabilityZones {
@@ -584,10 +584,10 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	pool.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Count != nil {
@@ -596,7 +596,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutoScaling != nil {
@@ -605,7 +605,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableEncryptionAtHost != nil {
@@ -614,7 +614,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFIPS != nil {
@@ -623,7 +623,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNodePublicIP != nil {
@@ -632,7 +632,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableUltraSSD != nil {
@@ -641,7 +641,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GpuInstanceProfile != nil {
@@ -650,7 +650,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletConfig != nil {
@@ -664,7 +664,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletDiskType != nil {
@@ -673,7 +673,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxOSConfig != nil {
@@ -687,7 +687,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxCount != nil {
@@ -696,7 +696,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxPods != nil {
@@ -705,7 +705,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinCount != nil {
@@ -714,7 +714,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Mode != nil {
@@ -723,7 +723,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeLabels != nil {
@@ -734,9 +734,9 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘NodePublicIPPrefixIDReference’
+	// no assignment for property "NodePublicIPPrefixIDReference"
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NodeTaints {
@@ -744,7 +744,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestratorVersion != nil {
@@ -753,7 +753,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
@@ -762,7 +762,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskType != nil {
@@ -771,7 +771,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsSKU != nil {
@@ -780,7 +780,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -789,12 +789,12 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	pool.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// no assignment for property ‘PodSubnetIDReference’
+	// no assignment for property "PodSubnetIDReference"
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroupID != nil {
@@ -803,7 +803,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetEvictionPolicy != nil {
@@ -812,7 +812,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetPriority != nil {
@@ -821,7 +821,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotMaxPrice != nil {
@@ -830,7 +830,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tags != nil {
@@ -841,7 +841,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -850,7 +850,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradeSettings != nil {
@@ -864,7 +864,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VmSize != nil {
@@ -873,7 +873,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘VnetSubnetIDReference’
+	// no assignment for property "VnetSubnetIDReference"
 
 	// No error
 	return nil
@@ -1539,7 +1539,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedClusters_AgentPool_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityZones’:
+	// Set property "AvailabilityZones":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AvailabilityZones {
@@ -1547,9 +1547,9 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Count != nil {
@@ -1558,7 +1558,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableAutoScaling’:
+	// Set property "EnableAutoScaling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutoScaling != nil {
@@ -1567,7 +1567,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableEncryptionAtHost’:
+	// Set property "EnableEncryptionAtHost":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableEncryptionAtHost != nil {
@@ -1576,7 +1576,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableFIPS’:
+	// Set property "EnableFIPS":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFIPS != nil {
@@ -1585,7 +1585,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableNodePublicIP’:
+	// Set property "EnableNodePublicIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNodePublicIP != nil {
@@ -1594,7 +1594,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EnableUltraSSD’:
+	// Set property "EnableUltraSSD":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableUltraSSD != nil {
@@ -1603,7 +1603,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘GpuInstanceProfile’:
+	// Set property "GpuInstanceProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GpuInstanceProfile != nil {
@@ -1612,13 +1612,13 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		pool.Id = &id
 	}
 
-	// Set property ‘KubeletConfig’:
+	// Set property "KubeletConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletConfig != nil {
@@ -1632,7 +1632,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘KubeletDiskType’:
+	// Set property "KubeletDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeletDiskType != nil {
@@ -1641,7 +1641,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘LinuxOSConfig’:
+	// Set property "LinuxOSConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinuxOSConfig != nil {
@@ -1655,7 +1655,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘MaxCount’:
+	// Set property "MaxCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxCount != nil {
@@ -1664,7 +1664,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘MaxPods’:
+	// Set property "MaxPods":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxPods != nil {
@@ -1673,7 +1673,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘MinCount’:
+	// Set property "MinCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinCount != nil {
@@ -1682,7 +1682,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Mode != nil {
@@ -1691,13 +1691,13 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pool.Name = &name
 	}
 
-	// Set property ‘NodeImageVersion’:
+	// Set property "NodeImageVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeImageVersion != nil {
@@ -1706,7 +1706,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘NodeLabels’:
+	// Set property "NodeLabels":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeLabels != nil {
@@ -1717,7 +1717,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘NodePublicIPPrefixID’:
+	// Set property "NodePublicIPPrefixID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodePublicIPPrefixID != nil {
@@ -1726,7 +1726,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘NodeTaints’:
+	// Set property "NodeTaints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NodeTaints {
@@ -1734,7 +1734,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OrchestratorVersion’:
+	// Set property "OrchestratorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OrchestratorVersion != nil {
@@ -1743,7 +1743,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsDiskSizeGB’:
+	// Set property "OsDiskSizeGB":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
@@ -1752,7 +1752,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsDiskType’:
+	// Set property "OsDiskType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskType != nil {
@@ -1761,7 +1761,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsSKU’:
+	// Set property "OsSKU":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsSKU != nil {
@@ -1770,7 +1770,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsType != nil {
@@ -1779,7 +1779,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘PodSubnetID’:
+	// Set property "PodSubnetID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PodSubnetID != nil {
@@ -1788,7 +1788,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘PowerState’:
+	// Set property "PowerState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PowerState != nil {
@@ -1802,7 +1802,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘PropertiesType’:
+	// Set property "PropertiesType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Type != nil {
@@ -1811,7 +1811,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1820,7 +1820,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ProximityPlacementGroupID’:
+	// Set property "ProximityPlacementGroupID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProximityPlacementGroupID != nil {
@@ -1829,7 +1829,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ScaleSetEvictionPolicy’:
+	// Set property "ScaleSetEvictionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetEvictionPolicy != nil {
@@ -1838,7 +1838,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ScaleSetPriority’:
+	// Set property "ScaleSetPriority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleSetPriority != nil {
@@ -1847,7 +1847,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘SpotMaxPrice’:
+	// Set property "SpotMaxPrice":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotMaxPrice != nil {
@@ -1856,7 +1856,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tags != nil {
@@ -1867,13 +1867,13 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		pool.Type = &typeVar
 	}
 
-	// Set property ‘UpgradeSettings’:
+	// Set property "UpgradeSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpgradeSettings != nil {
@@ -1887,7 +1887,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VmSize != nil {
@@ -1896,7 +1896,7 @@ func (pool *ManagedClusters_AgentPool_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘VnetSubnetID’:
+	// Set property "VnetSubnetID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetSubnetID != nil {
@@ -2442,7 +2442,7 @@ func (settings *AgentPoolUpgradeSettings) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &AgentPoolUpgradeSettings_ARM{}
 
-	// Set property ‘MaxSurge’:
+	// Set property "MaxSurge":
 	if settings.MaxSurge != nil {
 		maxSurge := *settings.MaxSurge
 		result.MaxSurge = &maxSurge
@@ -2462,7 +2462,7 @@ func (settings *AgentPoolUpgradeSettings) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AgentPoolUpgradeSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxSurge’:
+	// Set property "MaxSurge":
 	if typedInput.MaxSurge != nil {
 		maxSurge := *typedInput.MaxSurge
 		settings.MaxSurge = &maxSurge
@@ -2520,7 +2520,7 @@ func (settings *AgentPoolUpgradeSettings_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AgentPoolUpgradeSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxSurge’:
+	// Set property "MaxSurge":
 	if typedInput.MaxSurge != nil {
 		maxSurge := *typedInput.MaxSurge
 		settings.MaxSurge = &maxSurge
@@ -2613,66 +2613,66 @@ func (config *KubeletConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &KubeletConfig_ARM{}
 
-	// Set property ‘AllowedUnsafeSysctls’:
+	// Set property "AllowedUnsafeSysctls":
 	for _, item := range config.AllowedUnsafeSysctls {
 		result.AllowedUnsafeSysctls = append(result.AllowedUnsafeSysctls, item)
 	}
 
-	// Set property ‘ContainerLogMaxFiles’:
+	// Set property "ContainerLogMaxFiles":
 	if config.ContainerLogMaxFiles != nil {
 		containerLogMaxFiles := *config.ContainerLogMaxFiles
 		result.ContainerLogMaxFiles = &containerLogMaxFiles
 	}
 
-	// Set property ‘ContainerLogMaxSizeMB’:
+	// Set property "ContainerLogMaxSizeMB":
 	if config.ContainerLogMaxSizeMB != nil {
 		containerLogMaxSizeMB := *config.ContainerLogMaxSizeMB
 		result.ContainerLogMaxSizeMB = &containerLogMaxSizeMB
 	}
 
-	// Set property ‘CpuCfsQuota’:
+	// Set property "CpuCfsQuota":
 	if config.CpuCfsQuota != nil {
 		cpuCfsQuota := *config.CpuCfsQuota
 		result.CpuCfsQuota = &cpuCfsQuota
 	}
 
-	// Set property ‘CpuCfsQuotaPeriod’:
+	// Set property "CpuCfsQuotaPeriod":
 	if config.CpuCfsQuotaPeriod != nil {
 		cpuCfsQuotaPeriod := *config.CpuCfsQuotaPeriod
 		result.CpuCfsQuotaPeriod = &cpuCfsQuotaPeriod
 	}
 
-	// Set property ‘CpuManagerPolicy’:
+	// Set property "CpuManagerPolicy":
 	if config.CpuManagerPolicy != nil {
 		cpuManagerPolicy := *config.CpuManagerPolicy
 		result.CpuManagerPolicy = &cpuManagerPolicy
 	}
 
-	// Set property ‘FailSwapOn’:
+	// Set property "FailSwapOn":
 	if config.FailSwapOn != nil {
 		failSwapOn := *config.FailSwapOn
 		result.FailSwapOn = &failSwapOn
 	}
 
-	// Set property ‘ImageGcHighThreshold’:
+	// Set property "ImageGcHighThreshold":
 	if config.ImageGcHighThreshold != nil {
 		imageGcHighThreshold := *config.ImageGcHighThreshold
 		result.ImageGcHighThreshold = &imageGcHighThreshold
 	}
 
-	// Set property ‘ImageGcLowThreshold’:
+	// Set property "ImageGcLowThreshold":
 	if config.ImageGcLowThreshold != nil {
 		imageGcLowThreshold := *config.ImageGcLowThreshold
 		result.ImageGcLowThreshold = &imageGcLowThreshold
 	}
 
-	// Set property ‘PodMaxPids’:
+	// Set property "PodMaxPids":
 	if config.PodMaxPids != nil {
 		podMaxPids := *config.PodMaxPids
 		result.PodMaxPids = &podMaxPids
 	}
 
-	// Set property ‘TopologyManagerPolicy’:
+	// Set property "TopologyManagerPolicy":
 	if config.TopologyManagerPolicy != nil {
 		topologyManagerPolicy := *config.TopologyManagerPolicy
 		result.TopologyManagerPolicy = &topologyManagerPolicy
@@ -2692,66 +2692,66 @@ func (config *KubeletConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubeletConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedUnsafeSysctls’:
+	// Set property "AllowedUnsafeSysctls":
 	for _, item := range typedInput.AllowedUnsafeSysctls {
 		config.AllowedUnsafeSysctls = append(config.AllowedUnsafeSysctls, item)
 	}
 
-	// Set property ‘ContainerLogMaxFiles’:
+	// Set property "ContainerLogMaxFiles":
 	if typedInput.ContainerLogMaxFiles != nil {
 		containerLogMaxFiles := *typedInput.ContainerLogMaxFiles
 		config.ContainerLogMaxFiles = &containerLogMaxFiles
 	}
 
-	// Set property ‘ContainerLogMaxSizeMB’:
+	// Set property "ContainerLogMaxSizeMB":
 	if typedInput.ContainerLogMaxSizeMB != nil {
 		containerLogMaxSizeMB := *typedInput.ContainerLogMaxSizeMB
 		config.ContainerLogMaxSizeMB = &containerLogMaxSizeMB
 	}
 
-	// Set property ‘CpuCfsQuota’:
+	// Set property "CpuCfsQuota":
 	if typedInput.CpuCfsQuota != nil {
 		cpuCfsQuota := *typedInput.CpuCfsQuota
 		config.CpuCfsQuota = &cpuCfsQuota
 	}
 
-	// Set property ‘CpuCfsQuotaPeriod’:
+	// Set property "CpuCfsQuotaPeriod":
 	if typedInput.CpuCfsQuotaPeriod != nil {
 		cpuCfsQuotaPeriod := *typedInput.CpuCfsQuotaPeriod
 		config.CpuCfsQuotaPeriod = &cpuCfsQuotaPeriod
 	}
 
-	// Set property ‘CpuManagerPolicy’:
+	// Set property "CpuManagerPolicy":
 	if typedInput.CpuManagerPolicy != nil {
 		cpuManagerPolicy := *typedInput.CpuManagerPolicy
 		config.CpuManagerPolicy = &cpuManagerPolicy
 	}
 
-	// Set property ‘FailSwapOn’:
+	// Set property "FailSwapOn":
 	if typedInput.FailSwapOn != nil {
 		failSwapOn := *typedInput.FailSwapOn
 		config.FailSwapOn = &failSwapOn
 	}
 
-	// Set property ‘ImageGcHighThreshold’:
+	// Set property "ImageGcHighThreshold":
 	if typedInput.ImageGcHighThreshold != nil {
 		imageGcHighThreshold := *typedInput.ImageGcHighThreshold
 		config.ImageGcHighThreshold = &imageGcHighThreshold
 	}
 
-	// Set property ‘ImageGcLowThreshold’:
+	// Set property "ImageGcLowThreshold":
 	if typedInput.ImageGcLowThreshold != nil {
 		imageGcLowThreshold := *typedInput.ImageGcLowThreshold
 		config.ImageGcLowThreshold = &imageGcLowThreshold
 	}
 
-	// Set property ‘PodMaxPids’:
+	// Set property "PodMaxPids":
 	if typedInput.PodMaxPids != nil {
 		podMaxPids := *typedInput.PodMaxPids
 		config.PodMaxPids = &podMaxPids
 	}
 
-	// Set property ‘TopologyManagerPolicy’:
+	// Set property "TopologyManagerPolicy":
 	if typedInput.TopologyManagerPolicy != nil {
 		topologyManagerPolicy := *typedInput.TopologyManagerPolicy
 		config.TopologyManagerPolicy = &topologyManagerPolicy
@@ -2909,66 +2909,66 @@ func (config *KubeletConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubeletConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedUnsafeSysctls’:
+	// Set property "AllowedUnsafeSysctls":
 	for _, item := range typedInput.AllowedUnsafeSysctls {
 		config.AllowedUnsafeSysctls = append(config.AllowedUnsafeSysctls, item)
 	}
 
-	// Set property ‘ContainerLogMaxFiles’:
+	// Set property "ContainerLogMaxFiles":
 	if typedInput.ContainerLogMaxFiles != nil {
 		containerLogMaxFiles := *typedInput.ContainerLogMaxFiles
 		config.ContainerLogMaxFiles = &containerLogMaxFiles
 	}
 
-	// Set property ‘ContainerLogMaxSizeMB’:
+	// Set property "ContainerLogMaxSizeMB":
 	if typedInput.ContainerLogMaxSizeMB != nil {
 		containerLogMaxSizeMB := *typedInput.ContainerLogMaxSizeMB
 		config.ContainerLogMaxSizeMB = &containerLogMaxSizeMB
 	}
 
-	// Set property ‘CpuCfsQuota’:
+	// Set property "CpuCfsQuota":
 	if typedInput.CpuCfsQuota != nil {
 		cpuCfsQuota := *typedInput.CpuCfsQuota
 		config.CpuCfsQuota = &cpuCfsQuota
 	}
 
-	// Set property ‘CpuCfsQuotaPeriod’:
+	// Set property "CpuCfsQuotaPeriod":
 	if typedInput.CpuCfsQuotaPeriod != nil {
 		cpuCfsQuotaPeriod := *typedInput.CpuCfsQuotaPeriod
 		config.CpuCfsQuotaPeriod = &cpuCfsQuotaPeriod
 	}
 
-	// Set property ‘CpuManagerPolicy’:
+	// Set property "CpuManagerPolicy":
 	if typedInput.CpuManagerPolicy != nil {
 		cpuManagerPolicy := *typedInput.CpuManagerPolicy
 		config.CpuManagerPolicy = &cpuManagerPolicy
 	}
 
-	// Set property ‘FailSwapOn’:
+	// Set property "FailSwapOn":
 	if typedInput.FailSwapOn != nil {
 		failSwapOn := *typedInput.FailSwapOn
 		config.FailSwapOn = &failSwapOn
 	}
 
-	// Set property ‘ImageGcHighThreshold’:
+	// Set property "ImageGcHighThreshold":
 	if typedInput.ImageGcHighThreshold != nil {
 		imageGcHighThreshold := *typedInput.ImageGcHighThreshold
 		config.ImageGcHighThreshold = &imageGcHighThreshold
 	}
 
-	// Set property ‘ImageGcLowThreshold’:
+	// Set property "ImageGcLowThreshold":
 	if typedInput.ImageGcLowThreshold != nil {
 		imageGcLowThreshold := *typedInput.ImageGcLowThreshold
 		config.ImageGcLowThreshold = &imageGcLowThreshold
 	}
 
-	// Set property ‘PodMaxPids’:
+	// Set property "PodMaxPids":
 	if typedInput.PodMaxPids != nil {
 		podMaxPids := *typedInput.PodMaxPids
 		config.PodMaxPids = &podMaxPids
 	}
 
-	// Set property ‘TopologyManagerPolicy’:
+	// Set property "TopologyManagerPolicy":
 	if typedInput.TopologyManagerPolicy != nil {
 		topologyManagerPolicy := *typedInput.TopologyManagerPolicy
 		config.TopologyManagerPolicy = &topologyManagerPolicy
@@ -3121,13 +3121,13 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &LinuxOSConfig_ARM{}
 
-	// Set property ‘SwapFileSizeMB’:
+	// Set property "SwapFileSizeMB":
 	if config.SwapFileSizeMB != nil {
 		swapFileSizeMB := *config.SwapFileSizeMB
 		result.SwapFileSizeMB = &swapFileSizeMB
 	}
 
-	// Set property ‘Sysctls’:
+	// Set property "Sysctls":
 	if config.Sysctls != nil {
 		sysctls_ARM, err := (*config.Sysctls).ConvertToARM(resolved)
 		if err != nil {
@@ -3137,13 +3137,13 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Sysctls = &sysctls
 	}
 
-	// Set property ‘TransparentHugePageDefrag’:
+	// Set property "TransparentHugePageDefrag":
 	if config.TransparentHugePageDefrag != nil {
 		transparentHugePageDefrag := *config.TransparentHugePageDefrag
 		result.TransparentHugePageDefrag = &transparentHugePageDefrag
 	}
 
-	// Set property ‘TransparentHugePageEnabled’:
+	// Set property "TransparentHugePageEnabled":
 	if config.TransparentHugePageEnabled != nil {
 		transparentHugePageEnabled := *config.TransparentHugePageEnabled
 		result.TransparentHugePageEnabled = &transparentHugePageEnabled
@@ -3163,13 +3163,13 @@ func (config *LinuxOSConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxOSConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SwapFileSizeMB’:
+	// Set property "SwapFileSizeMB":
 	if typedInput.SwapFileSizeMB != nil {
 		swapFileSizeMB := *typedInput.SwapFileSizeMB
 		config.SwapFileSizeMB = &swapFileSizeMB
 	}
 
-	// Set property ‘Sysctls’:
+	// Set property "Sysctls":
 	if typedInput.Sysctls != nil {
 		var sysctls1 SysctlConfig
 		err := sysctls1.PopulateFromARM(owner, *typedInput.Sysctls)
@@ -3180,13 +3180,13 @@ func (config *LinuxOSConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		config.Sysctls = &sysctls
 	}
 
-	// Set property ‘TransparentHugePageDefrag’:
+	// Set property "TransparentHugePageDefrag":
 	if typedInput.TransparentHugePageDefrag != nil {
 		transparentHugePageDefrag := *typedInput.TransparentHugePageDefrag
 		config.TransparentHugePageDefrag = &transparentHugePageDefrag
 	}
 
-	// Set property ‘TransparentHugePageEnabled’:
+	// Set property "TransparentHugePageEnabled":
 	if typedInput.TransparentHugePageEnabled != nil {
 		transparentHugePageEnabled := *typedInput.TransparentHugePageEnabled
 		config.TransparentHugePageEnabled = &transparentHugePageEnabled
@@ -3283,13 +3283,13 @@ func (config *LinuxOSConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LinuxOSConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SwapFileSizeMB’:
+	// Set property "SwapFileSizeMB":
 	if typedInput.SwapFileSizeMB != nil {
 		swapFileSizeMB := *typedInput.SwapFileSizeMB
 		config.SwapFileSizeMB = &swapFileSizeMB
 	}
 
-	// Set property ‘Sysctls’:
+	// Set property "Sysctls":
 	if typedInput.Sysctls != nil {
 		var sysctls1 SysctlConfig_STATUS
 		err := sysctls1.PopulateFromARM(owner, *typedInput.Sysctls)
@@ -3300,13 +3300,13 @@ func (config *LinuxOSConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		config.Sysctls = &sysctls
 	}
 
-	// Set property ‘TransparentHugePageDefrag’:
+	// Set property "TransparentHugePageDefrag":
 	if typedInput.TransparentHugePageDefrag != nil {
 		transparentHugePageDefrag := *typedInput.TransparentHugePageDefrag
 		config.TransparentHugePageDefrag = &transparentHugePageDefrag
 	}
 
-	// Set property ‘TransparentHugePageEnabled’:
+	// Set property "TransparentHugePageEnabled":
 	if typedInput.TransparentHugePageEnabled != nil {
 		transparentHugePageEnabled := *typedInput.TransparentHugePageEnabled
 		config.TransparentHugePageEnabled = &transparentHugePageEnabled
@@ -3507,169 +3507,169 @@ func (config *SysctlConfig) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &SysctlConfig_ARM{}
 
-	// Set property ‘FsAioMaxNr’:
+	// Set property "FsAioMaxNr":
 	if config.FsAioMaxNr != nil {
 		fsAioMaxNr := *config.FsAioMaxNr
 		result.FsAioMaxNr = &fsAioMaxNr
 	}
 
-	// Set property ‘FsFileMax’:
+	// Set property "FsFileMax":
 	if config.FsFileMax != nil {
 		fsFileMax := *config.FsFileMax
 		result.FsFileMax = &fsFileMax
 	}
 
-	// Set property ‘FsInotifyMaxUserWatches’:
+	// Set property "FsInotifyMaxUserWatches":
 	if config.FsInotifyMaxUserWatches != nil {
 		fsInotifyMaxUserWatches := *config.FsInotifyMaxUserWatches
 		result.FsInotifyMaxUserWatches = &fsInotifyMaxUserWatches
 	}
 
-	// Set property ‘FsNrOpen’:
+	// Set property "FsNrOpen":
 	if config.FsNrOpen != nil {
 		fsNrOpen := *config.FsNrOpen
 		result.FsNrOpen = &fsNrOpen
 	}
 
-	// Set property ‘KernelThreadsMax’:
+	// Set property "KernelThreadsMax":
 	if config.KernelThreadsMax != nil {
 		kernelThreadsMax := *config.KernelThreadsMax
 		result.KernelThreadsMax = &kernelThreadsMax
 	}
 
-	// Set property ‘NetCoreNetdevMaxBacklog’:
+	// Set property "NetCoreNetdevMaxBacklog":
 	if config.NetCoreNetdevMaxBacklog != nil {
 		netCoreNetdevMaxBacklog := *config.NetCoreNetdevMaxBacklog
 		result.NetCoreNetdevMaxBacklog = &netCoreNetdevMaxBacklog
 	}
 
-	// Set property ‘NetCoreOptmemMax’:
+	// Set property "NetCoreOptmemMax":
 	if config.NetCoreOptmemMax != nil {
 		netCoreOptmemMax := *config.NetCoreOptmemMax
 		result.NetCoreOptmemMax = &netCoreOptmemMax
 	}
 
-	// Set property ‘NetCoreRmemDefault’:
+	// Set property "NetCoreRmemDefault":
 	if config.NetCoreRmemDefault != nil {
 		netCoreRmemDefault := *config.NetCoreRmemDefault
 		result.NetCoreRmemDefault = &netCoreRmemDefault
 	}
 
-	// Set property ‘NetCoreRmemMax’:
+	// Set property "NetCoreRmemMax":
 	if config.NetCoreRmemMax != nil {
 		netCoreRmemMax := *config.NetCoreRmemMax
 		result.NetCoreRmemMax = &netCoreRmemMax
 	}
 
-	// Set property ‘NetCoreSomaxconn’:
+	// Set property "NetCoreSomaxconn":
 	if config.NetCoreSomaxconn != nil {
 		netCoreSomaxconn := *config.NetCoreSomaxconn
 		result.NetCoreSomaxconn = &netCoreSomaxconn
 	}
 
-	// Set property ‘NetCoreWmemDefault’:
+	// Set property "NetCoreWmemDefault":
 	if config.NetCoreWmemDefault != nil {
 		netCoreWmemDefault := *config.NetCoreWmemDefault
 		result.NetCoreWmemDefault = &netCoreWmemDefault
 	}
 
-	// Set property ‘NetCoreWmemMax’:
+	// Set property "NetCoreWmemMax":
 	if config.NetCoreWmemMax != nil {
 		netCoreWmemMax := *config.NetCoreWmemMax
 		result.NetCoreWmemMax = &netCoreWmemMax
 	}
 
-	// Set property ‘NetIpv4IpLocalPortRange’:
+	// Set property "NetIpv4IpLocalPortRange":
 	if config.NetIpv4IpLocalPortRange != nil {
 		netIpv4IpLocalPortRange := *config.NetIpv4IpLocalPortRange
 		result.NetIpv4IpLocalPortRange = &netIpv4IpLocalPortRange
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh1’:
+	// Set property "NetIpv4NeighDefaultGcThresh1":
 	if config.NetIpv4NeighDefaultGcThresh1 != nil {
 		netIpv4NeighDefaultGcThresh1 := *config.NetIpv4NeighDefaultGcThresh1
 		result.NetIpv4NeighDefaultGcThresh1 = &netIpv4NeighDefaultGcThresh1
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh2’:
+	// Set property "NetIpv4NeighDefaultGcThresh2":
 	if config.NetIpv4NeighDefaultGcThresh2 != nil {
 		netIpv4NeighDefaultGcThresh2 := *config.NetIpv4NeighDefaultGcThresh2
 		result.NetIpv4NeighDefaultGcThresh2 = &netIpv4NeighDefaultGcThresh2
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh3’:
+	// Set property "NetIpv4NeighDefaultGcThresh3":
 	if config.NetIpv4NeighDefaultGcThresh3 != nil {
 		netIpv4NeighDefaultGcThresh3 := *config.NetIpv4NeighDefaultGcThresh3
 		result.NetIpv4NeighDefaultGcThresh3 = &netIpv4NeighDefaultGcThresh3
 	}
 
-	// Set property ‘NetIpv4TcpFinTimeout’:
+	// Set property "NetIpv4TcpFinTimeout":
 	if config.NetIpv4TcpFinTimeout != nil {
 		netIpv4TcpFinTimeout := *config.NetIpv4TcpFinTimeout
 		result.NetIpv4TcpFinTimeout = &netIpv4TcpFinTimeout
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveProbes’:
+	// Set property "NetIpv4TcpKeepaliveProbes":
 	if config.NetIpv4TcpKeepaliveProbes != nil {
 		netIpv4TcpKeepaliveProbes := *config.NetIpv4TcpKeepaliveProbes
 		result.NetIpv4TcpKeepaliveProbes = &netIpv4TcpKeepaliveProbes
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveTime’:
+	// Set property "NetIpv4TcpKeepaliveTime":
 	if config.NetIpv4TcpKeepaliveTime != nil {
 		netIpv4TcpKeepaliveTime := *config.NetIpv4TcpKeepaliveTime
 		result.NetIpv4TcpKeepaliveTime = &netIpv4TcpKeepaliveTime
 	}
 
-	// Set property ‘NetIpv4TcpMaxSynBacklog’:
+	// Set property "NetIpv4TcpMaxSynBacklog":
 	if config.NetIpv4TcpMaxSynBacklog != nil {
 		netIpv4TcpMaxSynBacklog := *config.NetIpv4TcpMaxSynBacklog
 		result.NetIpv4TcpMaxSynBacklog = &netIpv4TcpMaxSynBacklog
 	}
 
-	// Set property ‘NetIpv4TcpMaxTwBuckets’:
+	// Set property "NetIpv4TcpMaxTwBuckets":
 	if config.NetIpv4TcpMaxTwBuckets != nil {
 		netIpv4TcpMaxTwBuckets := *config.NetIpv4TcpMaxTwBuckets
 		result.NetIpv4TcpMaxTwBuckets = &netIpv4TcpMaxTwBuckets
 	}
 
-	// Set property ‘NetIpv4TcpTwReuse’:
+	// Set property "NetIpv4TcpTwReuse":
 	if config.NetIpv4TcpTwReuse != nil {
 		netIpv4TcpTwReuse := *config.NetIpv4TcpTwReuse
 		result.NetIpv4TcpTwReuse = &netIpv4TcpTwReuse
 	}
 
-	// Set property ‘NetIpv4TcpkeepaliveIntvl’:
+	// Set property "NetIpv4TcpkeepaliveIntvl":
 	if config.NetIpv4TcpkeepaliveIntvl != nil {
 		netIpv4TcpkeepaliveIntvl := *config.NetIpv4TcpkeepaliveIntvl
 		result.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
 	}
 
-	// Set property ‘NetNetfilterNfConntrackBuckets’:
+	// Set property "NetNetfilterNfConntrackBuckets":
 	if config.NetNetfilterNfConntrackBuckets != nil {
 		netNetfilterNfConntrackBuckets := *config.NetNetfilterNfConntrackBuckets
 		result.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBuckets
 	}
 
-	// Set property ‘NetNetfilterNfConntrackMax’:
+	// Set property "NetNetfilterNfConntrackMax":
 	if config.NetNetfilterNfConntrackMax != nil {
 		netNetfilterNfConntrackMax := *config.NetNetfilterNfConntrackMax
 		result.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
 	}
 
-	// Set property ‘VmMaxMapCount’:
+	// Set property "VmMaxMapCount":
 	if config.VmMaxMapCount != nil {
 		vmMaxMapCount := *config.VmMaxMapCount
 		result.VmMaxMapCount = &vmMaxMapCount
 	}
 
-	// Set property ‘VmSwappiness’:
+	// Set property "VmSwappiness":
 	if config.VmSwappiness != nil {
 		vmSwappiness := *config.VmSwappiness
 		result.VmSwappiness = &vmSwappiness
 	}
 
-	// Set property ‘VmVfsCachePressure’:
+	// Set property "VmVfsCachePressure":
 	if config.VmVfsCachePressure != nil {
 		vmVfsCachePressure := *config.VmVfsCachePressure
 		result.VmVfsCachePressure = &vmVfsCachePressure
@@ -3689,169 +3689,169 @@ func (config *SysctlConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SysctlConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FsAioMaxNr’:
+	// Set property "FsAioMaxNr":
 	if typedInput.FsAioMaxNr != nil {
 		fsAioMaxNr := *typedInput.FsAioMaxNr
 		config.FsAioMaxNr = &fsAioMaxNr
 	}
 
-	// Set property ‘FsFileMax’:
+	// Set property "FsFileMax":
 	if typedInput.FsFileMax != nil {
 		fsFileMax := *typedInput.FsFileMax
 		config.FsFileMax = &fsFileMax
 	}
 
-	// Set property ‘FsInotifyMaxUserWatches’:
+	// Set property "FsInotifyMaxUserWatches":
 	if typedInput.FsInotifyMaxUserWatches != nil {
 		fsInotifyMaxUserWatches := *typedInput.FsInotifyMaxUserWatches
 		config.FsInotifyMaxUserWatches = &fsInotifyMaxUserWatches
 	}
 
-	// Set property ‘FsNrOpen’:
+	// Set property "FsNrOpen":
 	if typedInput.FsNrOpen != nil {
 		fsNrOpen := *typedInput.FsNrOpen
 		config.FsNrOpen = &fsNrOpen
 	}
 
-	// Set property ‘KernelThreadsMax’:
+	// Set property "KernelThreadsMax":
 	if typedInput.KernelThreadsMax != nil {
 		kernelThreadsMax := *typedInput.KernelThreadsMax
 		config.KernelThreadsMax = &kernelThreadsMax
 	}
 
-	// Set property ‘NetCoreNetdevMaxBacklog’:
+	// Set property "NetCoreNetdevMaxBacklog":
 	if typedInput.NetCoreNetdevMaxBacklog != nil {
 		netCoreNetdevMaxBacklog := *typedInput.NetCoreNetdevMaxBacklog
 		config.NetCoreNetdevMaxBacklog = &netCoreNetdevMaxBacklog
 	}
 
-	// Set property ‘NetCoreOptmemMax’:
+	// Set property "NetCoreOptmemMax":
 	if typedInput.NetCoreOptmemMax != nil {
 		netCoreOptmemMax := *typedInput.NetCoreOptmemMax
 		config.NetCoreOptmemMax = &netCoreOptmemMax
 	}
 
-	// Set property ‘NetCoreRmemDefault’:
+	// Set property "NetCoreRmemDefault":
 	if typedInput.NetCoreRmemDefault != nil {
 		netCoreRmemDefault := *typedInput.NetCoreRmemDefault
 		config.NetCoreRmemDefault = &netCoreRmemDefault
 	}
 
-	// Set property ‘NetCoreRmemMax’:
+	// Set property "NetCoreRmemMax":
 	if typedInput.NetCoreRmemMax != nil {
 		netCoreRmemMax := *typedInput.NetCoreRmemMax
 		config.NetCoreRmemMax = &netCoreRmemMax
 	}
 
-	// Set property ‘NetCoreSomaxconn’:
+	// Set property "NetCoreSomaxconn":
 	if typedInput.NetCoreSomaxconn != nil {
 		netCoreSomaxconn := *typedInput.NetCoreSomaxconn
 		config.NetCoreSomaxconn = &netCoreSomaxconn
 	}
 
-	// Set property ‘NetCoreWmemDefault’:
+	// Set property "NetCoreWmemDefault":
 	if typedInput.NetCoreWmemDefault != nil {
 		netCoreWmemDefault := *typedInput.NetCoreWmemDefault
 		config.NetCoreWmemDefault = &netCoreWmemDefault
 	}
 
-	// Set property ‘NetCoreWmemMax’:
+	// Set property "NetCoreWmemMax":
 	if typedInput.NetCoreWmemMax != nil {
 		netCoreWmemMax := *typedInput.NetCoreWmemMax
 		config.NetCoreWmemMax = &netCoreWmemMax
 	}
 
-	// Set property ‘NetIpv4IpLocalPortRange’:
+	// Set property "NetIpv4IpLocalPortRange":
 	if typedInput.NetIpv4IpLocalPortRange != nil {
 		netIpv4IpLocalPortRange := *typedInput.NetIpv4IpLocalPortRange
 		config.NetIpv4IpLocalPortRange = &netIpv4IpLocalPortRange
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh1’:
+	// Set property "NetIpv4NeighDefaultGcThresh1":
 	if typedInput.NetIpv4NeighDefaultGcThresh1 != nil {
 		netIpv4NeighDefaultGcThresh1 := *typedInput.NetIpv4NeighDefaultGcThresh1
 		config.NetIpv4NeighDefaultGcThresh1 = &netIpv4NeighDefaultGcThresh1
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh2’:
+	// Set property "NetIpv4NeighDefaultGcThresh2":
 	if typedInput.NetIpv4NeighDefaultGcThresh2 != nil {
 		netIpv4NeighDefaultGcThresh2 := *typedInput.NetIpv4NeighDefaultGcThresh2
 		config.NetIpv4NeighDefaultGcThresh2 = &netIpv4NeighDefaultGcThresh2
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh3’:
+	// Set property "NetIpv4NeighDefaultGcThresh3":
 	if typedInput.NetIpv4NeighDefaultGcThresh3 != nil {
 		netIpv4NeighDefaultGcThresh3 := *typedInput.NetIpv4NeighDefaultGcThresh3
 		config.NetIpv4NeighDefaultGcThresh3 = &netIpv4NeighDefaultGcThresh3
 	}
 
-	// Set property ‘NetIpv4TcpFinTimeout’:
+	// Set property "NetIpv4TcpFinTimeout":
 	if typedInput.NetIpv4TcpFinTimeout != nil {
 		netIpv4TcpFinTimeout := *typedInput.NetIpv4TcpFinTimeout
 		config.NetIpv4TcpFinTimeout = &netIpv4TcpFinTimeout
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveProbes’:
+	// Set property "NetIpv4TcpKeepaliveProbes":
 	if typedInput.NetIpv4TcpKeepaliveProbes != nil {
 		netIpv4TcpKeepaliveProbes := *typedInput.NetIpv4TcpKeepaliveProbes
 		config.NetIpv4TcpKeepaliveProbes = &netIpv4TcpKeepaliveProbes
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveTime’:
+	// Set property "NetIpv4TcpKeepaliveTime":
 	if typedInput.NetIpv4TcpKeepaliveTime != nil {
 		netIpv4TcpKeepaliveTime := *typedInput.NetIpv4TcpKeepaliveTime
 		config.NetIpv4TcpKeepaliveTime = &netIpv4TcpKeepaliveTime
 	}
 
-	// Set property ‘NetIpv4TcpMaxSynBacklog’:
+	// Set property "NetIpv4TcpMaxSynBacklog":
 	if typedInput.NetIpv4TcpMaxSynBacklog != nil {
 		netIpv4TcpMaxSynBacklog := *typedInput.NetIpv4TcpMaxSynBacklog
 		config.NetIpv4TcpMaxSynBacklog = &netIpv4TcpMaxSynBacklog
 	}
 
-	// Set property ‘NetIpv4TcpMaxTwBuckets’:
+	// Set property "NetIpv4TcpMaxTwBuckets":
 	if typedInput.NetIpv4TcpMaxTwBuckets != nil {
 		netIpv4TcpMaxTwBuckets := *typedInput.NetIpv4TcpMaxTwBuckets
 		config.NetIpv4TcpMaxTwBuckets = &netIpv4TcpMaxTwBuckets
 	}
 
-	// Set property ‘NetIpv4TcpTwReuse’:
+	// Set property "NetIpv4TcpTwReuse":
 	if typedInput.NetIpv4TcpTwReuse != nil {
 		netIpv4TcpTwReuse := *typedInput.NetIpv4TcpTwReuse
 		config.NetIpv4TcpTwReuse = &netIpv4TcpTwReuse
 	}
 
-	// Set property ‘NetIpv4TcpkeepaliveIntvl’:
+	// Set property "NetIpv4TcpkeepaliveIntvl":
 	if typedInput.NetIpv4TcpkeepaliveIntvl != nil {
 		netIpv4TcpkeepaliveIntvl := *typedInput.NetIpv4TcpkeepaliveIntvl
 		config.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
 	}
 
-	// Set property ‘NetNetfilterNfConntrackBuckets’:
+	// Set property "NetNetfilterNfConntrackBuckets":
 	if typedInput.NetNetfilterNfConntrackBuckets != nil {
 		netNetfilterNfConntrackBuckets := *typedInput.NetNetfilterNfConntrackBuckets
 		config.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBuckets
 	}
 
-	// Set property ‘NetNetfilterNfConntrackMax’:
+	// Set property "NetNetfilterNfConntrackMax":
 	if typedInput.NetNetfilterNfConntrackMax != nil {
 		netNetfilterNfConntrackMax := *typedInput.NetNetfilterNfConntrackMax
 		config.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
 	}
 
-	// Set property ‘VmMaxMapCount’:
+	// Set property "VmMaxMapCount":
 	if typedInput.VmMaxMapCount != nil {
 		vmMaxMapCount := *typedInput.VmMaxMapCount
 		config.VmMaxMapCount = &vmMaxMapCount
 	}
 
-	// Set property ‘VmSwappiness’:
+	// Set property "VmSwappiness":
 	if typedInput.VmSwappiness != nil {
 		vmSwappiness := *typedInput.VmSwappiness
 		config.VmSwappiness = &vmSwappiness
 	}
 
-	// Set property ‘VmVfsCachePressure’:
+	// Set property "VmVfsCachePressure":
 	if typedInput.VmVfsCachePressure != nil {
 		vmVfsCachePressure := *typedInput.VmVfsCachePressure
 		config.VmVfsCachePressure = &vmVfsCachePressure
@@ -4108,169 +4108,169 @@ func (config *SysctlConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SysctlConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FsAioMaxNr’:
+	// Set property "FsAioMaxNr":
 	if typedInput.FsAioMaxNr != nil {
 		fsAioMaxNr := *typedInput.FsAioMaxNr
 		config.FsAioMaxNr = &fsAioMaxNr
 	}
 
-	// Set property ‘FsFileMax’:
+	// Set property "FsFileMax":
 	if typedInput.FsFileMax != nil {
 		fsFileMax := *typedInput.FsFileMax
 		config.FsFileMax = &fsFileMax
 	}
 
-	// Set property ‘FsInotifyMaxUserWatches’:
+	// Set property "FsInotifyMaxUserWatches":
 	if typedInput.FsInotifyMaxUserWatches != nil {
 		fsInotifyMaxUserWatches := *typedInput.FsInotifyMaxUserWatches
 		config.FsInotifyMaxUserWatches = &fsInotifyMaxUserWatches
 	}
 
-	// Set property ‘FsNrOpen’:
+	// Set property "FsNrOpen":
 	if typedInput.FsNrOpen != nil {
 		fsNrOpen := *typedInput.FsNrOpen
 		config.FsNrOpen = &fsNrOpen
 	}
 
-	// Set property ‘KernelThreadsMax’:
+	// Set property "KernelThreadsMax":
 	if typedInput.KernelThreadsMax != nil {
 		kernelThreadsMax := *typedInput.KernelThreadsMax
 		config.KernelThreadsMax = &kernelThreadsMax
 	}
 
-	// Set property ‘NetCoreNetdevMaxBacklog’:
+	// Set property "NetCoreNetdevMaxBacklog":
 	if typedInput.NetCoreNetdevMaxBacklog != nil {
 		netCoreNetdevMaxBacklog := *typedInput.NetCoreNetdevMaxBacklog
 		config.NetCoreNetdevMaxBacklog = &netCoreNetdevMaxBacklog
 	}
 
-	// Set property ‘NetCoreOptmemMax’:
+	// Set property "NetCoreOptmemMax":
 	if typedInput.NetCoreOptmemMax != nil {
 		netCoreOptmemMax := *typedInput.NetCoreOptmemMax
 		config.NetCoreOptmemMax = &netCoreOptmemMax
 	}
 
-	// Set property ‘NetCoreRmemDefault’:
+	// Set property "NetCoreRmemDefault":
 	if typedInput.NetCoreRmemDefault != nil {
 		netCoreRmemDefault := *typedInput.NetCoreRmemDefault
 		config.NetCoreRmemDefault = &netCoreRmemDefault
 	}
 
-	// Set property ‘NetCoreRmemMax’:
+	// Set property "NetCoreRmemMax":
 	if typedInput.NetCoreRmemMax != nil {
 		netCoreRmemMax := *typedInput.NetCoreRmemMax
 		config.NetCoreRmemMax = &netCoreRmemMax
 	}
 
-	// Set property ‘NetCoreSomaxconn’:
+	// Set property "NetCoreSomaxconn":
 	if typedInput.NetCoreSomaxconn != nil {
 		netCoreSomaxconn := *typedInput.NetCoreSomaxconn
 		config.NetCoreSomaxconn = &netCoreSomaxconn
 	}
 
-	// Set property ‘NetCoreWmemDefault’:
+	// Set property "NetCoreWmemDefault":
 	if typedInput.NetCoreWmemDefault != nil {
 		netCoreWmemDefault := *typedInput.NetCoreWmemDefault
 		config.NetCoreWmemDefault = &netCoreWmemDefault
 	}
 
-	// Set property ‘NetCoreWmemMax’:
+	// Set property "NetCoreWmemMax":
 	if typedInput.NetCoreWmemMax != nil {
 		netCoreWmemMax := *typedInput.NetCoreWmemMax
 		config.NetCoreWmemMax = &netCoreWmemMax
 	}
 
-	// Set property ‘NetIpv4IpLocalPortRange’:
+	// Set property "NetIpv4IpLocalPortRange":
 	if typedInput.NetIpv4IpLocalPortRange != nil {
 		netIpv4IpLocalPortRange := *typedInput.NetIpv4IpLocalPortRange
 		config.NetIpv4IpLocalPortRange = &netIpv4IpLocalPortRange
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh1’:
+	// Set property "NetIpv4NeighDefaultGcThresh1":
 	if typedInput.NetIpv4NeighDefaultGcThresh1 != nil {
 		netIpv4NeighDefaultGcThresh1 := *typedInput.NetIpv4NeighDefaultGcThresh1
 		config.NetIpv4NeighDefaultGcThresh1 = &netIpv4NeighDefaultGcThresh1
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh2’:
+	// Set property "NetIpv4NeighDefaultGcThresh2":
 	if typedInput.NetIpv4NeighDefaultGcThresh2 != nil {
 		netIpv4NeighDefaultGcThresh2 := *typedInput.NetIpv4NeighDefaultGcThresh2
 		config.NetIpv4NeighDefaultGcThresh2 = &netIpv4NeighDefaultGcThresh2
 	}
 
-	// Set property ‘NetIpv4NeighDefaultGcThresh3’:
+	// Set property "NetIpv4NeighDefaultGcThresh3":
 	if typedInput.NetIpv4NeighDefaultGcThresh3 != nil {
 		netIpv4NeighDefaultGcThresh3 := *typedInput.NetIpv4NeighDefaultGcThresh3
 		config.NetIpv4NeighDefaultGcThresh3 = &netIpv4NeighDefaultGcThresh3
 	}
 
-	// Set property ‘NetIpv4TcpFinTimeout’:
+	// Set property "NetIpv4TcpFinTimeout":
 	if typedInput.NetIpv4TcpFinTimeout != nil {
 		netIpv4TcpFinTimeout := *typedInput.NetIpv4TcpFinTimeout
 		config.NetIpv4TcpFinTimeout = &netIpv4TcpFinTimeout
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveProbes’:
+	// Set property "NetIpv4TcpKeepaliveProbes":
 	if typedInput.NetIpv4TcpKeepaliveProbes != nil {
 		netIpv4TcpKeepaliveProbes := *typedInput.NetIpv4TcpKeepaliveProbes
 		config.NetIpv4TcpKeepaliveProbes = &netIpv4TcpKeepaliveProbes
 	}
 
-	// Set property ‘NetIpv4TcpKeepaliveTime’:
+	// Set property "NetIpv4TcpKeepaliveTime":
 	if typedInput.NetIpv4TcpKeepaliveTime != nil {
 		netIpv4TcpKeepaliveTime := *typedInput.NetIpv4TcpKeepaliveTime
 		config.NetIpv4TcpKeepaliveTime = &netIpv4TcpKeepaliveTime
 	}
 
-	// Set property ‘NetIpv4TcpMaxSynBacklog’:
+	// Set property "NetIpv4TcpMaxSynBacklog":
 	if typedInput.NetIpv4TcpMaxSynBacklog != nil {
 		netIpv4TcpMaxSynBacklog := *typedInput.NetIpv4TcpMaxSynBacklog
 		config.NetIpv4TcpMaxSynBacklog = &netIpv4TcpMaxSynBacklog
 	}
 
-	// Set property ‘NetIpv4TcpMaxTwBuckets’:
+	// Set property "NetIpv4TcpMaxTwBuckets":
 	if typedInput.NetIpv4TcpMaxTwBuckets != nil {
 		netIpv4TcpMaxTwBuckets := *typedInput.NetIpv4TcpMaxTwBuckets
 		config.NetIpv4TcpMaxTwBuckets = &netIpv4TcpMaxTwBuckets
 	}
 
-	// Set property ‘NetIpv4TcpTwReuse’:
+	// Set property "NetIpv4TcpTwReuse":
 	if typedInput.NetIpv4TcpTwReuse != nil {
 		netIpv4TcpTwReuse := *typedInput.NetIpv4TcpTwReuse
 		config.NetIpv4TcpTwReuse = &netIpv4TcpTwReuse
 	}
 
-	// Set property ‘NetIpv4TcpkeepaliveIntvl’:
+	// Set property "NetIpv4TcpkeepaliveIntvl":
 	if typedInput.NetIpv4TcpkeepaliveIntvl != nil {
 		netIpv4TcpkeepaliveIntvl := *typedInput.NetIpv4TcpkeepaliveIntvl
 		config.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
 	}
 
-	// Set property ‘NetNetfilterNfConntrackBuckets’:
+	// Set property "NetNetfilterNfConntrackBuckets":
 	if typedInput.NetNetfilterNfConntrackBuckets != nil {
 		netNetfilterNfConntrackBuckets := *typedInput.NetNetfilterNfConntrackBuckets
 		config.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBuckets
 	}
 
-	// Set property ‘NetNetfilterNfConntrackMax’:
+	// Set property "NetNetfilterNfConntrackMax":
 	if typedInput.NetNetfilterNfConntrackMax != nil {
 		netNetfilterNfConntrackMax := *typedInput.NetNetfilterNfConntrackMax
 		config.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
 	}
 
-	// Set property ‘VmMaxMapCount’:
+	// Set property "VmMaxMapCount":
 	if typedInput.VmMaxMapCount != nil {
 		vmMaxMapCount := *typedInput.VmMaxMapCount
 		config.VmMaxMapCount = &vmMaxMapCount
 	}
 
-	// Set property ‘VmSwappiness’:
+	// Set property "VmSwappiness":
 	if typedInput.VmSwappiness != nil {
 		vmSwappiness := *typedInput.VmSwappiness
 		config.VmSwappiness = &vmSwappiness
 	}
 
-	// Set property ‘VmVfsCachePressure’:
+	// Set property "VmVfsCachePressure":
 	if typedInput.VmVfsCachePressure != nil {
 		vmVfsCachePressure := *typedInput.VmVfsCachePressure
 		config.VmVfsCachePressure = &vmVfsCachePressure

--- a/v2/api/datafactory/v1api20180601/factory_types_gen.go
+++ b/v2/api/datafactory/v1api20180601/factory_types_gen.go
@@ -366,7 +366,7 @@ func (factory *Factory_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &Factory_Spec_ARM{}
 
-	// Set property ‘AdditionalProperties’:
+	// Set property "AdditionalProperties":
 	if factory.AdditionalProperties != nil {
 		result.AdditionalProperties = make(map[string]v1.JSON, len(factory.AdditionalProperties))
 		for key, value := range factory.AdditionalProperties {
@@ -374,7 +374,7 @@ func (factory *Factory_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if factory.Identity != nil {
 		identity_ARM, err := (*factory.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -384,16 +384,16 @@ func (factory *Factory_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if factory.Location != nil {
 		location := *factory.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if factory.Encryption != nil ||
 		factory.GlobalParameters != nil ||
 		factory.PublicNetworkAccess != nil ||
@@ -440,7 +440,7 @@ func (factory *Factory_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.RepoConfiguration = &repoConfiguration
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if factory.Tags != nil {
 		result.Tags = make(map[string]string, len(factory.Tags))
 		for key, value := range factory.Tags {
@@ -462,7 +462,7 @@ func (factory *Factory_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Factory_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalProperties’:
+	// Set property "AdditionalProperties":
 	if typedInput.AdditionalProperties != nil {
 		factory.AdditionalProperties = make(map[string]v1.JSON, len(typedInput.AdditionalProperties))
 		for key, value := range typedInput.AdditionalProperties {
@@ -470,10 +470,10 @@ func (factory *Factory_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	factory.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -487,7 +487,7 @@ func (factory *Factory_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘GlobalParameters’:
+	// Set property "GlobalParameters":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GlobalParameters != nil {
@@ -503,7 +503,7 @@ func (factory *Factory_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 FactoryIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -514,16 +514,16 @@ func (factory *Factory_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		factory.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		factory.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	factory.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -532,7 +532,7 @@ func (factory *Factory_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘PurviewConfiguration’:
+	// Set property "PurviewConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PurviewConfiguration != nil {
@@ -546,7 +546,7 @@ func (factory *Factory_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘RepoConfiguration’:
+	// Set property "RepoConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RepoConfiguration != nil {
@@ -560,7 +560,7 @@ func (factory *Factory_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		factory.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1081,7 +1081,7 @@ func (factory *Factory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Factory_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalProperties’:
+	// Set property "AdditionalProperties":
 	if typedInput.AdditionalProperties != nil {
 		factory.AdditionalProperties = make(map[string]v1.JSON, len(typedInput.AdditionalProperties))
 		for key, value := range typedInput.AdditionalProperties {
@@ -1089,9 +1089,9 @@ func (factory *Factory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreateTime’:
+	// Set property "CreateTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateTime != nil {
@@ -1100,13 +1100,13 @@ func (factory *Factory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ETag’:
+	// Set property "ETag":
 	if typedInput.ETag != nil {
 		eTag := *typedInput.ETag
 		factory.ETag = &eTag
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1120,7 +1120,7 @@ func (factory *Factory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘GlobalParameters’:
+	// Set property "GlobalParameters":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GlobalParameters != nil {
@@ -1136,13 +1136,13 @@ func (factory *Factory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		factory.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 FactoryIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1153,19 +1153,19 @@ func (factory *Factory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		factory.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		factory.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		factory.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1174,7 +1174,7 @@ func (factory *Factory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1183,7 +1183,7 @@ func (factory *Factory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘PurviewConfiguration’:
+	// Set property "PurviewConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PurviewConfiguration != nil {
@@ -1197,7 +1197,7 @@ func (factory *Factory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘RepoConfiguration’:
+	// Set property "RepoConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RepoConfiguration != nil {
@@ -1211,7 +1211,7 @@ func (factory *Factory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		factory.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1219,13 +1219,13 @@ func (factory *Factory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		factory.Type = &typeVar
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1522,7 +1522,7 @@ func (configuration *EncryptionConfiguration) ConvertToARM(resolved genruntime.C
 	}
 	result := &EncryptionConfiguration_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if configuration.Identity != nil {
 		identity_ARM, err := (*configuration.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -1532,19 +1532,19 @@ func (configuration *EncryptionConfiguration) ConvertToARM(resolved genruntime.C
 		result.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if configuration.KeyName != nil {
 		keyName := *configuration.KeyName
 		result.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if configuration.KeyVersion != nil {
 		keyVersion := *configuration.KeyVersion
 		result.KeyVersion = &keyVersion
 	}
 
-	// Set property ‘VaultBaseUrl’:
+	// Set property "VaultBaseUrl":
 	if configuration.VaultBaseUrl != nil {
 		vaultBaseUrl := *configuration.VaultBaseUrl
 		result.VaultBaseUrl = &vaultBaseUrl
@@ -1564,7 +1564,7 @@ func (configuration *EncryptionConfiguration) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 CMKIdentityDefinition
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1575,19 +1575,19 @@ func (configuration *EncryptionConfiguration) PopulateFromARM(owner genruntime.A
 		configuration.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		configuration.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		configuration.KeyVersion = &keyVersion
 	}
 
-	// Set property ‘VaultBaseUrl’:
+	// Set property "VaultBaseUrl":
 	if typedInput.VaultBaseUrl != nil {
 		vaultBaseUrl := *typedInput.VaultBaseUrl
 		configuration.VaultBaseUrl = &vaultBaseUrl
@@ -1720,7 +1720,7 @@ func (configuration *EncryptionConfiguration_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 CMKIdentityDefinition_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1731,19 +1731,19 @@ func (configuration *EncryptionConfiguration_STATUS) PopulateFromARM(owner genru
 		configuration.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		configuration.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		configuration.KeyVersion = &keyVersion
 	}
 
-	// Set property ‘VaultBaseUrl’:
+	// Set property "VaultBaseUrl":
 	if typedInput.VaultBaseUrl != nil {
 		vaultBaseUrl := *typedInput.VaultBaseUrl
 		configuration.VaultBaseUrl = &vaultBaseUrl
@@ -1837,13 +1837,13 @@ func (identity *FactoryIdentity) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &FactoryIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -1868,13 +1868,13 @@ func (identity *FactoryIdentity) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FactoryIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -2011,25 +2011,25 @@ func (identity *FactoryIdentity_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FactoryIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]v1.JSON, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2150,7 +2150,7 @@ func (configuration *FactoryRepoConfiguration) ConvertToARM(resolved genruntime.
 	}
 	result := &FactoryRepoConfiguration_ARM{}
 
-	// Set property ‘FactoryGitHub’:
+	// Set property "FactoryGitHub":
 	if configuration.FactoryGitHub != nil {
 		factoryGitHub_ARM, err := (*configuration.FactoryGitHub).ConvertToARM(resolved)
 		if err != nil {
@@ -2160,7 +2160,7 @@ func (configuration *FactoryRepoConfiguration) ConvertToARM(resolved genruntime.
 		result.FactoryGitHub = &factoryGitHub
 	}
 
-	// Set property ‘FactoryVSTS’:
+	// Set property "FactoryVSTS":
 	if configuration.FactoryVSTS != nil {
 		factoryVSTS_ARM, err := (*configuration.FactoryVSTS).ConvertToARM(resolved)
 		if err != nil {
@@ -2184,7 +2184,7 @@ func (configuration *FactoryRepoConfiguration) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FactoryRepoConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FactoryGitHub’:
+	// Set property "FactoryGitHub":
 	if typedInput.FactoryGitHub != nil {
 		var factoryGitHub1 FactoryGitHubConfiguration
 		err := factoryGitHub1.PopulateFromARM(owner, *typedInput.FactoryGitHub)
@@ -2195,7 +2195,7 @@ func (configuration *FactoryRepoConfiguration) PopulateFromARM(owner genruntime.
 		configuration.FactoryGitHub = &factoryGitHub
 	}
 
-	// Set property ‘FactoryVSTS’:
+	// Set property "FactoryVSTS":
 	if typedInput.FactoryVSTS != nil {
 		var factoryVSTS1 FactoryVSTSConfiguration
 		err := factoryVSTS1.PopulateFromARM(owner, *typedInput.FactoryVSTS)
@@ -2334,7 +2334,7 @@ func (configuration *FactoryRepoConfiguration_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FactoryRepoConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FactoryGitHub’:
+	// Set property "FactoryGitHub":
 	if typedInput.FactoryGitHub != nil {
 		var factoryGitHub1 FactoryGitHubConfiguration_STATUS
 		err := factoryGitHub1.PopulateFromARM(owner, *typedInput.FactoryGitHub)
@@ -2345,7 +2345,7 @@ func (configuration *FactoryRepoConfiguration_STATUS) PopulateFromARM(owner genr
 		configuration.FactoryGitHub = &factoryGitHub
 	}
 
-	// Set property ‘FactoryVSTS’:
+	// Set property "FactoryVSTS":
 	if typedInput.FactoryVSTS != nil {
 		var factoryVSTS1 FactoryVSTSConfiguration_STATUS
 		err := factoryVSTS1.PopulateFromARM(owner, *typedInput.FactoryVSTS)
@@ -2451,13 +2451,13 @@ func (specification *GlobalParameterSpecification) ConvertToARM(resolved genrunt
 	}
 	result := &GlobalParameterSpecification_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if specification.Type != nil {
 		typeVar := *specification.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if specification.Value != nil {
 		result.Value = make(map[string]v1.JSON, len(specification.Value))
 		for key, value := range specification.Value {
@@ -2479,13 +2479,13 @@ func (specification *GlobalParameterSpecification) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GlobalParameterSpecification_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		specification.Type = &typeVar
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		specification.Value = make(map[string]v1.JSON, len(typedInput.Value))
 		for key, value := range typedInput.Value {
@@ -2613,13 +2613,13 @@ func (specification *GlobalParameterSpecification_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GlobalParameterSpecification_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		specification.Type = &typeVar
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		specification.Value = make(map[string]v1.JSON, len(typedInput.Value))
 		for key, value := range typedInput.Value {
@@ -2711,7 +2711,7 @@ func (configuration *PurviewConfiguration) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &PurviewConfiguration_ARM{}
 
-	// Set property ‘PurviewResourceId’:
+	// Set property "PurviewResourceId":
 	if configuration.PurviewResourceReference != nil {
 		purviewResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*configuration.PurviewResourceReference)
 		if err != nil {
@@ -2735,7 +2735,7 @@ func (configuration *PurviewConfiguration) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PurviewConfiguration_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘PurviewResourceReference’
+	// no assignment for property "PurviewResourceReference"
 
 	// No error
 	return nil
@@ -2815,7 +2815,7 @@ func (configuration *PurviewConfiguration_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PurviewConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PurviewResourceId’:
+	// Set property "PurviewResourceId":
 	if typedInput.PurviewResourceId != nil {
 		purviewResourceId := *typedInput.PurviewResourceId
 		configuration.PurviewResourceId = &purviewResourceId
@@ -2869,7 +2869,7 @@ func (definition *CMKIdentityDefinition) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &CMKIdentityDefinition_ARM{}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if definition.UserAssignedIdentityReference != nil {
 		userAssignedIdentityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*definition.UserAssignedIdentityReference)
 		if err != nil {
@@ -2893,7 +2893,7 @@ func (definition *CMKIdentityDefinition) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CMKIdentityDefinition_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘UserAssignedIdentityReference’
+	// no assignment for property "UserAssignedIdentityReference"
 
 	// No error
 	return nil
@@ -2965,7 +2965,7 @@ func (definition *CMKIdentityDefinition_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CMKIdentityDefinition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		definition.UserAssignedIdentity = &userAssignedIdentity
@@ -3050,19 +3050,19 @@ func (configuration *FactoryGitHubConfiguration) ConvertToARM(resolved genruntim
 	}
 	result := &FactoryGitHubConfiguration_ARM{}
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if configuration.AccountName != nil {
 		accountName := *configuration.AccountName
 		result.AccountName = &accountName
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if configuration.ClientId != nil {
 		clientId := *configuration.ClientId
 		result.ClientId = &clientId
 	}
 
-	// Set property ‘ClientSecret’:
+	// Set property "ClientSecret":
 	if configuration.ClientSecret != nil {
 		clientSecret_ARM, err := (*configuration.ClientSecret).ConvertToARM(resolved)
 		if err != nil {
@@ -3072,43 +3072,43 @@ func (configuration *FactoryGitHubConfiguration) ConvertToARM(resolved genruntim
 		result.ClientSecret = &clientSecret
 	}
 
-	// Set property ‘CollaborationBranch’:
+	// Set property "CollaborationBranch":
 	if configuration.CollaborationBranch != nil {
 		collaborationBranch := *configuration.CollaborationBranch
 		result.CollaborationBranch = &collaborationBranch
 	}
 
-	// Set property ‘DisablePublish’:
+	// Set property "DisablePublish":
 	if configuration.DisablePublish != nil {
 		disablePublish := *configuration.DisablePublish
 		result.DisablePublish = &disablePublish
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	if configuration.HostName != nil {
 		hostName := *configuration.HostName
 		result.HostName = &hostName
 	}
 
-	// Set property ‘LastCommitId’:
+	// Set property "LastCommitId":
 	if configuration.LastCommitId != nil {
 		lastCommitId := *configuration.LastCommitId
 		result.LastCommitId = &lastCommitId
 	}
 
-	// Set property ‘RepositoryName’:
+	// Set property "RepositoryName":
 	if configuration.RepositoryName != nil {
 		repositoryName := *configuration.RepositoryName
 		result.RepositoryName = &repositoryName
 	}
 
-	// Set property ‘RootFolder’:
+	// Set property "RootFolder":
 	if configuration.RootFolder != nil {
 		rootFolder := *configuration.RootFolder
 		result.RootFolder = &rootFolder
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if configuration.Type != nil {
 		result.Type = *configuration.Type
 	}
@@ -3127,19 +3127,19 @@ func (configuration *FactoryGitHubConfiguration) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FactoryGitHubConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if typedInput.AccountName != nil {
 		accountName := *typedInput.AccountName
 		configuration.AccountName = &accountName
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		configuration.ClientId = &clientId
 	}
 
-	// Set property ‘ClientSecret’:
+	// Set property "ClientSecret":
 	if typedInput.ClientSecret != nil {
 		var clientSecret1 GitHubClientSecret
 		err := clientSecret1.PopulateFromARM(owner, *typedInput.ClientSecret)
@@ -3150,43 +3150,43 @@ func (configuration *FactoryGitHubConfiguration) PopulateFromARM(owner genruntim
 		configuration.ClientSecret = &clientSecret
 	}
 
-	// Set property ‘CollaborationBranch’:
+	// Set property "CollaborationBranch":
 	if typedInput.CollaborationBranch != nil {
 		collaborationBranch := *typedInput.CollaborationBranch
 		configuration.CollaborationBranch = &collaborationBranch
 	}
 
-	// Set property ‘DisablePublish’:
+	// Set property "DisablePublish":
 	if typedInput.DisablePublish != nil {
 		disablePublish := *typedInput.DisablePublish
 		configuration.DisablePublish = &disablePublish
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	if typedInput.HostName != nil {
 		hostName := *typedInput.HostName
 		configuration.HostName = &hostName
 	}
 
-	// Set property ‘LastCommitId’:
+	// Set property "LastCommitId":
 	if typedInput.LastCommitId != nil {
 		lastCommitId := *typedInput.LastCommitId
 		configuration.LastCommitId = &lastCommitId
 	}
 
-	// Set property ‘RepositoryName’:
+	// Set property "RepositoryName":
 	if typedInput.RepositoryName != nil {
 		repositoryName := *typedInput.RepositoryName
 		configuration.RepositoryName = &repositoryName
 	}
 
-	// Set property ‘RootFolder’:
+	// Set property "RootFolder":
 	if typedInput.RootFolder != nil {
 		rootFolder := *typedInput.RootFolder
 		configuration.RootFolder = &rootFolder
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	configuration.Type = &typedInput.Type
 
 	// No error
@@ -3416,19 +3416,19 @@ func (configuration *FactoryGitHubConfiguration_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FactoryGitHubConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if typedInput.AccountName != nil {
 		accountName := *typedInput.AccountName
 		configuration.AccountName = &accountName
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		configuration.ClientId = &clientId
 	}
 
-	// Set property ‘ClientSecret’:
+	// Set property "ClientSecret":
 	if typedInput.ClientSecret != nil {
 		var clientSecret1 GitHubClientSecret_STATUS
 		err := clientSecret1.PopulateFromARM(owner, *typedInput.ClientSecret)
@@ -3439,43 +3439,43 @@ func (configuration *FactoryGitHubConfiguration_STATUS) PopulateFromARM(owner ge
 		configuration.ClientSecret = &clientSecret
 	}
 
-	// Set property ‘CollaborationBranch’:
+	// Set property "CollaborationBranch":
 	if typedInput.CollaborationBranch != nil {
 		collaborationBranch := *typedInput.CollaborationBranch
 		configuration.CollaborationBranch = &collaborationBranch
 	}
 
-	// Set property ‘DisablePublish’:
+	// Set property "DisablePublish":
 	if typedInput.DisablePublish != nil {
 		disablePublish := *typedInput.DisablePublish
 		configuration.DisablePublish = &disablePublish
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	if typedInput.HostName != nil {
 		hostName := *typedInput.HostName
 		configuration.HostName = &hostName
 	}
 
-	// Set property ‘LastCommitId’:
+	// Set property "LastCommitId":
 	if typedInput.LastCommitId != nil {
 		lastCommitId := *typedInput.LastCommitId
 		configuration.LastCommitId = &lastCommitId
 	}
 
-	// Set property ‘RepositoryName’:
+	// Set property "RepositoryName":
 	if typedInput.RepositoryName != nil {
 		repositoryName := *typedInput.RepositoryName
 		configuration.RepositoryName = &repositoryName
 	}
 
-	// Set property ‘RootFolder’:
+	// Set property "RootFolder":
 	if typedInput.RootFolder != nil {
 		rootFolder := *typedInput.RootFolder
 		configuration.RootFolder = &rootFolder
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	configuration.Type = &typedInput.Type
 
 	// No error
@@ -3647,55 +3647,55 @@ func (configuration *FactoryVSTSConfiguration) ConvertToARM(resolved genruntime.
 	}
 	result := &FactoryVSTSConfiguration_ARM{}
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if configuration.AccountName != nil {
 		accountName := *configuration.AccountName
 		result.AccountName = &accountName
 	}
 
-	// Set property ‘CollaborationBranch’:
+	// Set property "CollaborationBranch":
 	if configuration.CollaborationBranch != nil {
 		collaborationBranch := *configuration.CollaborationBranch
 		result.CollaborationBranch = &collaborationBranch
 	}
 
-	// Set property ‘DisablePublish’:
+	// Set property "DisablePublish":
 	if configuration.DisablePublish != nil {
 		disablePublish := *configuration.DisablePublish
 		result.DisablePublish = &disablePublish
 	}
 
-	// Set property ‘LastCommitId’:
+	// Set property "LastCommitId":
 	if configuration.LastCommitId != nil {
 		lastCommitId := *configuration.LastCommitId
 		result.LastCommitId = &lastCommitId
 	}
 
-	// Set property ‘ProjectName’:
+	// Set property "ProjectName":
 	if configuration.ProjectName != nil {
 		projectName := *configuration.ProjectName
 		result.ProjectName = &projectName
 	}
 
-	// Set property ‘RepositoryName’:
+	// Set property "RepositoryName":
 	if configuration.RepositoryName != nil {
 		repositoryName := *configuration.RepositoryName
 		result.RepositoryName = &repositoryName
 	}
 
-	// Set property ‘RootFolder’:
+	// Set property "RootFolder":
 	if configuration.RootFolder != nil {
 		rootFolder := *configuration.RootFolder
 		result.RootFolder = &rootFolder
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if configuration.TenantId != nil {
 		tenantId := *configuration.TenantId
 		result.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if configuration.Type != nil {
 		result.Type = *configuration.Type
 	}
@@ -3714,55 +3714,55 @@ func (configuration *FactoryVSTSConfiguration) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FactoryVSTSConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if typedInput.AccountName != nil {
 		accountName := *typedInput.AccountName
 		configuration.AccountName = &accountName
 	}
 
-	// Set property ‘CollaborationBranch’:
+	// Set property "CollaborationBranch":
 	if typedInput.CollaborationBranch != nil {
 		collaborationBranch := *typedInput.CollaborationBranch
 		configuration.CollaborationBranch = &collaborationBranch
 	}
 
-	// Set property ‘DisablePublish’:
+	// Set property "DisablePublish":
 	if typedInput.DisablePublish != nil {
 		disablePublish := *typedInput.DisablePublish
 		configuration.DisablePublish = &disablePublish
 	}
 
-	// Set property ‘LastCommitId’:
+	// Set property "LastCommitId":
 	if typedInput.LastCommitId != nil {
 		lastCommitId := *typedInput.LastCommitId
 		configuration.LastCommitId = &lastCommitId
 	}
 
-	// Set property ‘ProjectName’:
+	// Set property "ProjectName":
 	if typedInput.ProjectName != nil {
 		projectName := *typedInput.ProjectName
 		configuration.ProjectName = &projectName
 	}
 
-	// Set property ‘RepositoryName’:
+	// Set property "RepositoryName":
 	if typedInput.RepositoryName != nil {
 		repositoryName := *typedInput.RepositoryName
 		configuration.RepositoryName = &repositoryName
 	}
 
-	// Set property ‘RootFolder’:
+	// Set property "RootFolder":
 	if typedInput.RootFolder != nil {
 		rootFolder := *typedInput.RootFolder
 		configuration.RootFolder = &rootFolder
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		configuration.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	configuration.Type = &typedInput.Type
 
 	// No error
@@ -3953,55 +3953,55 @@ func (configuration *FactoryVSTSConfiguration_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FactoryVSTSConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if typedInput.AccountName != nil {
 		accountName := *typedInput.AccountName
 		configuration.AccountName = &accountName
 	}
 
-	// Set property ‘CollaborationBranch’:
+	// Set property "CollaborationBranch":
 	if typedInput.CollaborationBranch != nil {
 		collaborationBranch := *typedInput.CollaborationBranch
 		configuration.CollaborationBranch = &collaborationBranch
 	}
 
-	// Set property ‘DisablePublish’:
+	// Set property "DisablePublish":
 	if typedInput.DisablePublish != nil {
 		disablePublish := *typedInput.DisablePublish
 		configuration.DisablePublish = &disablePublish
 	}
 
-	// Set property ‘LastCommitId’:
+	// Set property "LastCommitId":
 	if typedInput.LastCommitId != nil {
 		lastCommitId := *typedInput.LastCommitId
 		configuration.LastCommitId = &lastCommitId
 	}
 
-	// Set property ‘ProjectName’:
+	// Set property "ProjectName":
 	if typedInput.ProjectName != nil {
 		projectName := *typedInput.ProjectName
 		configuration.ProjectName = &projectName
 	}
 
-	// Set property ‘RepositoryName’:
+	// Set property "RepositoryName":
 	if typedInput.RepositoryName != nil {
 		repositoryName := *typedInput.RepositoryName
 		configuration.RepositoryName = &repositoryName
 	}
 
-	// Set property ‘RootFolder’:
+	// Set property "RootFolder":
 	if typedInput.RootFolder != nil {
 		rootFolder := *typedInput.RootFolder
 		configuration.RootFolder = &rootFolder
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		configuration.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	configuration.Type = &typedInput.Type
 
 	// No error
@@ -4198,13 +4198,13 @@ func (secret *GitHubClientSecret) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &GitHubClientSecret_ARM{}
 
-	// Set property ‘ByoaSecretAkvUrl’:
+	// Set property "ByoaSecretAkvUrl":
 	if secret.ByoaSecretAkvUrl != nil {
 		byoaSecretAkvUrl := *secret.ByoaSecretAkvUrl
 		result.ByoaSecretAkvUrl = &byoaSecretAkvUrl
 	}
 
-	// Set property ‘ByoaSecretName’:
+	// Set property "ByoaSecretName":
 	if secret.ByoaSecretName != nil {
 		byoaSecretName := *secret.ByoaSecretName
 		result.ByoaSecretName = &byoaSecretName
@@ -4224,13 +4224,13 @@ func (secret *GitHubClientSecret) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GitHubClientSecret_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ByoaSecretAkvUrl’:
+	// Set property "ByoaSecretAkvUrl":
 	if typedInput.ByoaSecretAkvUrl != nil {
 		byoaSecretAkvUrl := *typedInput.ByoaSecretAkvUrl
 		secret.ByoaSecretAkvUrl = &byoaSecretAkvUrl
 	}
 
-	// Set property ‘ByoaSecretName’:
+	// Set property "ByoaSecretName":
 	if typedInput.ByoaSecretName != nil {
 		byoaSecretName := *typedInput.ByoaSecretName
 		secret.ByoaSecretName = &byoaSecretName
@@ -4311,13 +4311,13 @@ func (secret *GitHubClientSecret_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GitHubClientSecret_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ByoaSecretAkvUrl’:
+	// Set property "ByoaSecretAkvUrl":
 	if typedInput.ByoaSecretAkvUrl != nil {
 		byoaSecretAkvUrl := *typedInput.ByoaSecretAkvUrl
 		secret.ByoaSecretAkvUrl = &byoaSecretAkvUrl
 	}
 
-	// Set property ‘ByoaSecretName’:
+	// Set property "ByoaSecretName":
 	if typedInput.ByoaSecretName != nil {
 		byoaSecretName := *typedInput.ByoaSecretName
 		secret.ByoaSecretName = &byoaSecretName

--- a/v2/api/dataprotection/v1api20230101/backup_vault_types_gen.go
+++ b/v2/api/dataprotection/v1api20230101/backup_vault_types_gen.go
@@ -349,7 +349,7 @@ func (vault *BackupVault_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &BackupVault_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if vault.Identity != nil {
 		identity_ARM, err := (*vault.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -359,16 +359,16 @@ func (vault *BackupVault_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if vault.Location != nil {
 		location := *vault.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if vault.Properties != nil {
 		properties_ARM, err := (*vault.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -378,7 +378,7 @@ func (vault *BackupVault_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties = &properties
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if vault.Tags != nil {
 		result.Tags = make(map[string]string, len(vault.Tags))
 		for key, value := range vault.Tags {
@@ -400,10 +400,10 @@ func (vault *BackupVault_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupVault_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	vault.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 DppIdentityDetails
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -414,16 +414,16 @@ func (vault *BackupVault_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		vault.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		vault.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	vault.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 BackupVaultSpec
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -434,7 +434,7 @@ func (vault *BackupVault_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		vault.Properties = &properties
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		vault.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -746,21 +746,21 @@ func (resource *BackupVaultResource_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupVaultResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ETag’:
+	// Set property "ETag":
 	if typedInput.ETag != nil {
 		eTag := *typedInput.ETag
 		resource.ETag = &eTag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 DppIdentityDetails_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -771,19 +771,19 @@ func (resource *BackupVaultResource_STATUS) PopulateFromARM(owner genruntime.Arb
 		resource.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		resource.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resource.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 BackupVault_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -794,7 +794,7 @@ func (resource *BackupVaultResource_STATUS) PopulateFromARM(owner genruntime.Arb
 		resource.Properties = &properties
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -805,7 +805,7 @@ func (resource *BackupVaultResource_STATUS) PopulateFromARM(owner genruntime.Arb
 		resource.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		resource.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -813,7 +813,7 @@ func (resource *BackupVaultResource_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		resource.Type = &typeVar
@@ -1001,7 +1001,7 @@ func (vault *BackupVault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupVault_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FeatureSettings’:
+	// Set property "FeatureSettings":
 	if typedInput.FeatureSettings != nil {
 		var featureSettings1 FeatureSettings_STATUS
 		err := featureSettings1.PopulateFromARM(owner, *typedInput.FeatureSettings)
@@ -1012,13 +1012,13 @@ func (vault *BackupVault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		vault.FeatureSettings = &featureSettings
 	}
 
-	// Set property ‘IsVaultProtectedByResourceGuard’:
+	// Set property "IsVaultProtectedByResourceGuard":
 	if typedInput.IsVaultProtectedByResourceGuard != nil {
 		isVaultProtectedByResourceGuard := *typedInput.IsVaultProtectedByResourceGuard
 		vault.IsVaultProtectedByResourceGuard = &isVaultProtectedByResourceGuard
 	}
 
-	// Set property ‘MonitoringSettings’:
+	// Set property "MonitoringSettings":
 	if typedInput.MonitoringSettings != nil {
 		var monitoringSettings1 MonitoringSettings_STATUS
 		err := monitoringSettings1.PopulateFromARM(owner, *typedInput.MonitoringSettings)
@@ -1029,13 +1029,13 @@ func (vault *BackupVault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		vault.MonitoringSettings = &monitoringSettings
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		vault.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceMoveDetails’:
+	// Set property "ResourceMoveDetails":
 	if typedInput.ResourceMoveDetails != nil {
 		var resourceMoveDetails1 ResourceMoveDetails_STATUS
 		err := resourceMoveDetails1.PopulateFromARM(owner, *typedInput.ResourceMoveDetails)
@@ -1046,13 +1046,13 @@ func (vault *BackupVault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		vault.ResourceMoveDetails = &resourceMoveDetails
 	}
 
-	// Set property ‘ResourceMoveState’:
+	// Set property "ResourceMoveState":
 	if typedInput.ResourceMoveState != nil {
 		resourceMoveState := *typedInput.ResourceMoveState
 		vault.ResourceMoveState = &resourceMoveState
 	}
 
-	// Set property ‘SecuritySettings’:
+	// Set property "SecuritySettings":
 	if typedInput.SecuritySettings != nil {
 		var securitySettings1 SecuritySettings_STATUS
 		err := securitySettings1.PopulateFromARM(owner, *typedInput.SecuritySettings)
@@ -1063,7 +1063,7 @@ func (vault *BackupVault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		vault.SecuritySettings = &securitySettings
 	}
 
-	// Set property ‘StorageSettings’:
+	// Set property "StorageSettings":
 	for _, item := range typedInput.StorageSettings {
 		var item1 StorageSetting_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1305,7 +1305,7 @@ func (vault *BackupVaultSpec) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &BackupVaultSpec_ARM{}
 
-	// Set property ‘FeatureSettings’:
+	// Set property "FeatureSettings":
 	if vault.FeatureSettings != nil {
 		featureSettings_ARM, err := (*vault.FeatureSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -1315,7 +1315,7 @@ func (vault *BackupVaultSpec) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.FeatureSettings = &featureSettings
 	}
 
-	// Set property ‘MonitoringSettings’:
+	// Set property "MonitoringSettings":
 	if vault.MonitoringSettings != nil {
 		monitoringSettings_ARM, err := (*vault.MonitoringSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -1325,7 +1325,7 @@ func (vault *BackupVaultSpec) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.MonitoringSettings = &monitoringSettings
 	}
 
-	// Set property ‘SecuritySettings’:
+	// Set property "SecuritySettings":
 	if vault.SecuritySettings != nil {
 		securitySettings_ARM, err := (*vault.SecuritySettings).ConvertToARM(resolved)
 		if err != nil {
@@ -1335,7 +1335,7 @@ func (vault *BackupVaultSpec) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.SecuritySettings = &securitySettings
 	}
 
-	// Set property ‘StorageSettings’:
+	// Set property "StorageSettings":
 	for _, item := range vault.StorageSettings {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1358,7 +1358,7 @@ func (vault *BackupVaultSpec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupVaultSpec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FeatureSettings’:
+	// Set property "FeatureSettings":
 	if typedInput.FeatureSettings != nil {
 		var featureSettings1 FeatureSettings
 		err := featureSettings1.PopulateFromARM(owner, *typedInput.FeatureSettings)
@@ -1369,7 +1369,7 @@ func (vault *BackupVaultSpec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		vault.FeatureSettings = &featureSettings
 	}
 
-	// Set property ‘MonitoringSettings’:
+	// Set property "MonitoringSettings":
 	if typedInput.MonitoringSettings != nil {
 		var monitoringSettings1 MonitoringSettings
 		err := monitoringSettings1.PopulateFromARM(owner, *typedInput.MonitoringSettings)
@@ -1380,7 +1380,7 @@ func (vault *BackupVaultSpec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		vault.MonitoringSettings = &monitoringSettings
 	}
 
-	// Set property ‘SecuritySettings’:
+	// Set property "SecuritySettings":
 	if typedInput.SecuritySettings != nil {
 		var securitySettings1 SecuritySettings
 		err := securitySettings1.PopulateFromARM(owner, *typedInput.SecuritySettings)
@@ -1391,7 +1391,7 @@ func (vault *BackupVaultSpec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		vault.SecuritySettings = &securitySettings
 	}
 
-	// Set property ‘StorageSettings’:
+	// Set property "StorageSettings":
 	for _, item := range typedInput.StorageSettings {
 		var item1 StorageSetting
 		err := item1.PopulateFromARM(owner, item)
@@ -1612,7 +1612,7 @@ func (details *DppIdentityDetails) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &DppIdentityDetails_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if details.Type != nil {
 		typeVar := *details.Type
 		result.Type = &typeVar
@@ -1632,7 +1632,7 @@ func (details *DppIdentityDetails) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DppIdentityDetails_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		details.Type = &typeVar
@@ -1708,19 +1708,19 @@ func (details *DppIdentityDetails_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DppIdentityDetails_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		details.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		details.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		details.Type = &typeVar
@@ -1806,37 +1806,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -1940,7 +1940,7 @@ func (settings *FeatureSettings) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &FeatureSettings_ARM{}
 
-	// Set property ‘CrossSubscriptionRestoreSettings’:
+	// Set property "CrossSubscriptionRestoreSettings":
 	if settings.CrossSubscriptionRestoreSettings != nil {
 		crossSubscriptionRestoreSettings_ARM, err := (*settings.CrossSubscriptionRestoreSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -1964,7 +1964,7 @@ func (settings *FeatureSettings) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FeatureSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CrossSubscriptionRestoreSettings’:
+	// Set property "CrossSubscriptionRestoreSettings":
 	if typedInput.CrossSubscriptionRestoreSettings != nil {
 		var crossSubscriptionRestoreSettings1 CrossSubscriptionRestoreSettings
 		err := crossSubscriptionRestoreSettings1.PopulateFromARM(owner, *typedInput.CrossSubscriptionRestoreSettings)
@@ -2065,7 +2065,7 @@ func (settings *FeatureSettings_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FeatureSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CrossSubscriptionRestoreSettings’:
+	// Set property "CrossSubscriptionRestoreSettings":
 	if typedInput.CrossSubscriptionRestoreSettings != nil {
 		var crossSubscriptionRestoreSettings1 CrossSubscriptionRestoreSettings_STATUS
 		err := crossSubscriptionRestoreSettings1.PopulateFromARM(owner, *typedInput.CrossSubscriptionRestoreSettings)
@@ -2142,7 +2142,7 @@ func (settings *MonitoringSettings) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &MonitoringSettings_ARM{}
 
-	// Set property ‘AzureMonitorAlertSettings’:
+	// Set property "AzureMonitorAlertSettings":
 	if settings.AzureMonitorAlertSettings != nil {
 		azureMonitorAlertSettings_ARM, err := (*settings.AzureMonitorAlertSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -2166,7 +2166,7 @@ func (settings *MonitoringSettings) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MonitoringSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureMonitorAlertSettings’:
+	// Set property "AzureMonitorAlertSettings":
 	if typedInput.AzureMonitorAlertSettings != nil {
 		var azureMonitorAlertSettings1 AzureMonitorAlertSettings
 		err := azureMonitorAlertSettings1.PopulateFromARM(owner, *typedInput.AzureMonitorAlertSettings)
@@ -2267,7 +2267,7 @@ func (settings *MonitoringSettings_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MonitoringSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureMonitorAlertSettings’:
+	// Set property "AzureMonitorAlertSettings":
 	if typedInput.AzureMonitorAlertSettings != nil {
 		var azureMonitorAlertSettings1 AzureMonitorAlertSettings_STATUS
 		err := azureMonitorAlertSettings1.PopulateFromARM(owner, *typedInput.AzureMonitorAlertSettings)
@@ -2361,31 +2361,31 @@ func (details *ResourceMoveDetails_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceMoveDetails_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CompletionTimeUtc’:
+	// Set property "CompletionTimeUtc":
 	if typedInput.CompletionTimeUtc != nil {
 		completionTimeUtc := *typedInput.CompletionTimeUtc
 		details.CompletionTimeUtc = &completionTimeUtc
 	}
 
-	// Set property ‘OperationId’:
+	// Set property "OperationId":
 	if typedInput.OperationId != nil {
 		operationId := *typedInput.OperationId
 		details.OperationId = &operationId
 	}
 
-	// Set property ‘SourceResourcePath’:
+	// Set property "SourceResourcePath":
 	if typedInput.SourceResourcePath != nil {
 		sourceResourcePath := *typedInput.SourceResourcePath
 		details.SourceResourcePath = &sourceResourcePath
 	}
 
-	// Set property ‘StartTimeUtc’:
+	// Set property "StartTimeUtc":
 	if typedInput.StartTimeUtc != nil {
 		startTimeUtc := *typedInput.StartTimeUtc
 		details.StartTimeUtc = &startTimeUtc
 	}
 
-	// Set property ‘TargetResourcePath’:
+	// Set property "TargetResourcePath":
 	if typedInput.TargetResourcePath != nil {
 		targetResourcePath := *typedInput.TargetResourcePath
 		details.TargetResourcePath = &targetResourcePath
@@ -2466,7 +2466,7 @@ func (settings *SecuritySettings) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &SecuritySettings_ARM{}
 
-	// Set property ‘ImmutabilitySettings’:
+	// Set property "ImmutabilitySettings":
 	if settings.ImmutabilitySettings != nil {
 		immutabilitySettings_ARM, err := (*settings.ImmutabilitySettings).ConvertToARM(resolved)
 		if err != nil {
@@ -2476,7 +2476,7 @@ func (settings *SecuritySettings) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.ImmutabilitySettings = &immutabilitySettings
 	}
 
-	// Set property ‘SoftDeleteSettings’:
+	// Set property "SoftDeleteSettings":
 	if settings.SoftDeleteSettings != nil {
 		softDeleteSettings_ARM, err := (*settings.SoftDeleteSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -2500,7 +2500,7 @@ func (settings *SecuritySettings) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SecuritySettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ImmutabilitySettings’:
+	// Set property "ImmutabilitySettings":
 	if typedInput.ImmutabilitySettings != nil {
 		var immutabilitySettings1 ImmutabilitySettings
 		err := immutabilitySettings1.PopulateFromARM(owner, *typedInput.ImmutabilitySettings)
@@ -2511,7 +2511,7 @@ func (settings *SecuritySettings) PopulateFromARM(owner genruntime.ArbitraryOwne
 		settings.ImmutabilitySettings = &immutabilitySettings
 	}
 
-	// Set property ‘SoftDeleteSettings’:
+	// Set property "SoftDeleteSettings":
 	if typedInput.SoftDeleteSettings != nil {
 		var softDeleteSettings1 SoftDeleteSettings
 		err := softDeleteSettings1.PopulateFromARM(owner, *typedInput.SoftDeleteSettings)
@@ -2651,7 +2651,7 @@ func (settings *SecuritySettings_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SecuritySettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ImmutabilitySettings’:
+	// Set property "ImmutabilitySettings":
 	if typedInput.ImmutabilitySettings != nil {
 		var immutabilitySettings1 ImmutabilitySettings_STATUS
 		err := immutabilitySettings1.PopulateFromARM(owner, *typedInput.ImmutabilitySettings)
@@ -2662,7 +2662,7 @@ func (settings *SecuritySettings_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		settings.ImmutabilitySettings = &immutabilitySettings
 	}
 
-	// Set property ‘SoftDeleteSettings’:
+	// Set property "SoftDeleteSettings":
 	if typedInput.SoftDeleteSettings != nil {
 		var softDeleteSettings1 SoftDeleteSettings_STATUS
 		err := softDeleteSettings1.PopulateFromARM(owner, *typedInput.SoftDeleteSettings)
@@ -2766,13 +2766,13 @@ func (setting *StorageSetting) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &StorageSetting_ARM{}
 
-	// Set property ‘DatastoreType’:
+	// Set property "DatastoreType":
 	if setting.DatastoreType != nil {
 		datastoreType := *setting.DatastoreType
 		result.DatastoreType = &datastoreType
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if setting.Type != nil {
 		typeVar := *setting.Type
 		result.Type = &typeVar
@@ -2792,13 +2792,13 @@ func (setting *StorageSetting) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageSetting_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DatastoreType’:
+	// Set property "DatastoreType":
 	if typedInput.DatastoreType != nil {
 		datastoreType := *typedInput.DatastoreType
 		setting.DatastoreType = &datastoreType
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar
@@ -2909,13 +2909,13 @@ func (setting *StorageSetting_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DatastoreType’:
+	// Set property "DatastoreType":
 	if typedInput.DatastoreType != nil {
 		datastoreType := *typedInput.DatastoreType
 		setting.DatastoreType = &datastoreType
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar
@@ -2994,7 +2994,7 @@ func (settings *AzureMonitorAlertSettings) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &AzureMonitorAlertSettings_ARM{}
 
-	// Set property ‘AlertsForAllJobFailures’:
+	// Set property "AlertsForAllJobFailures":
 	if settings.AlertsForAllJobFailures != nil {
 		alertsForAllJobFailures := *settings.AlertsForAllJobFailures
 		result.AlertsForAllJobFailures = &alertsForAllJobFailures
@@ -3014,7 +3014,7 @@ func (settings *AzureMonitorAlertSettings) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureMonitorAlertSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AlertsForAllJobFailures’:
+	// Set property "AlertsForAllJobFailures":
 	if typedInput.AlertsForAllJobFailures != nil {
 		alertsForAllJobFailures := *typedInput.AlertsForAllJobFailures
 		settings.AlertsForAllJobFailures = &alertsForAllJobFailures
@@ -3097,7 +3097,7 @@ func (settings *AzureMonitorAlertSettings_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureMonitorAlertSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AlertsForAllJobFailures’:
+	// Set property "AlertsForAllJobFailures":
 	if typedInput.AlertsForAllJobFailures != nil {
 		alertsForAllJobFailures := *typedInput.AlertsForAllJobFailures
 		settings.AlertsForAllJobFailures = &alertsForAllJobFailures
@@ -3161,7 +3161,7 @@ func (settings *CrossSubscriptionRestoreSettings) ConvertToARM(resolved genrunti
 	}
 	result := &CrossSubscriptionRestoreSettings_ARM{}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if settings.State != nil {
 		state := *settings.State
 		result.State = &state
@@ -3181,7 +3181,7 @@ func (settings *CrossSubscriptionRestoreSettings) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CrossSubscriptionRestoreSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		settings.State = &state
@@ -3265,7 +3265,7 @@ func (settings *CrossSubscriptionRestoreSettings_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CrossSubscriptionRestoreSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		settings.State = &state
@@ -3329,7 +3329,7 @@ func (settings *ImmutabilitySettings) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ImmutabilitySettings_ARM{}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if settings.State != nil {
 		state := *settings.State
 		result.State = &state
@@ -3349,7 +3349,7 @@ func (settings *ImmutabilitySettings) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmutabilitySettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		settings.State = &state
@@ -3433,7 +3433,7 @@ func (settings *ImmutabilitySettings_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmutabilitySettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		settings.State = &state
@@ -3500,13 +3500,13 @@ func (settings *SoftDeleteSettings) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &SoftDeleteSettings_ARM{}
 
-	// Set property ‘RetentionDurationInDays’:
+	// Set property "RetentionDurationInDays":
 	if settings.RetentionDurationInDays != nil {
 		retentionDurationInDays := *settings.RetentionDurationInDays
 		result.RetentionDurationInDays = &retentionDurationInDays
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if settings.State != nil {
 		state := *settings.State
 		result.State = &state
@@ -3526,13 +3526,13 @@ func (settings *SoftDeleteSettings) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SoftDeleteSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RetentionDurationInDays’:
+	// Set property "RetentionDurationInDays":
 	if typedInput.RetentionDurationInDays != nil {
 		retentionDurationInDays := *typedInput.RetentionDurationInDays
 		settings.RetentionDurationInDays = &retentionDurationInDays
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		settings.State = &state
@@ -3643,13 +3643,13 @@ func (settings *SoftDeleteSettings_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SoftDeleteSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RetentionDurationInDays’:
+	// Set property "RetentionDurationInDays":
 	if typedInput.RetentionDurationInDays != nil {
 		retentionDurationInDays := *typedInput.RetentionDurationInDays
 		settings.RetentionDurationInDays = &retentionDurationInDays
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		settings.State = &state

--- a/v2/api/dataprotection/v1api20230101/backup_vaults_backup_policy_types_gen.go
+++ b/v2/api/dataprotection/v1api20230101/backup_vaults_backup_policy_types_gen.go
@@ -334,10 +334,10 @@ func (policy *BackupVaults_BackupPolicy_Spec) ConvertToARM(resolved genruntime.C
 	}
 	result := &BackupVaults_BackupPolicy_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if policy.Properties != nil {
 		properties_ARM, err := (*policy.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -361,13 +361,13 @@ func (policy *BackupVaults_BackupPolicy_Spec) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupVaults_BackupPolicy_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	policy.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	policy.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 BaseBackupPolicy
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -617,21 +617,21 @@ func (policy *BackupVaults_BackupPolicy_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupVaults_BackupPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		policy.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 BaseBackupPolicy_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -642,7 +642,7 @@ func (policy *BackupVaults_BackupPolicy_STATUS) PopulateFromARM(owner genruntime
 		policy.Properties = &properties
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -653,7 +653,7 @@ func (policy *BackupVaults_BackupPolicy_STATUS) PopulateFromARM(owner genruntime
 		policy.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		policy.Type = &typeVar
@@ -772,7 +772,7 @@ func (policy *BaseBackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &BaseBackupPolicy_ARM{}
 
-	// Set property ‘BackupPolicy’:
+	// Set property "BackupPolicy":
 	if policy.BackupPolicy != nil {
 		backupPolicy_ARM, err := (*policy.BackupPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -796,7 +796,7 @@ func (policy *BaseBackupPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BaseBackupPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupPolicy’:
+	// Set property "BackupPolicy":
 	if typedInput.BackupPolicy != nil {
 		var backupPolicy1 BackupPolicy
 		err := backupPolicy1.PopulateFromARM(owner, *typedInput.BackupPolicy)
@@ -896,7 +896,7 @@ func (policy *BaseBackupPolicy_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BaseBackupPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupPolicy’:
+	// Set property "BackupPolicy":
 	if typedInput.BackupPolicy != nil {
 		var backupPolicy1 BackupPolicy_STATUS
 		err := backupPolicy1.PopulateFromARM(owner, *typedInput.BackupPolicy)
@@ -980,17 +980,17 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &BackupPolicy_ARM{}
 
-	// Set property ‘DatasourceTypes’:
+	// Set property "DatasourceTypes":
 	for _, item := range policy.DatasourceTypes {
 		result.DatasourceTypes = append(result.DatasourceTypes, item)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if policy.ObjectType != nil {
 		result.ObjectType = *policy.ObjectType
 	}
 
-	// Set property ‘PolicyRules’:
+	// Set property "PolicyRules":
 	for _, item := range policy.PolicyRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1013,15 +1013,15 @@ func (policy *BackupPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DatasourceTypes’:
+	// Set property "DatasourceTypes":
 	for _, item := range typedInput.DatasourceTypes {
 		policy.DatasourceTypes = append(policy.DatasourceTypes, item)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	policy.ObjectType = &typedInput.ObjectType
 
-	// Set property ‘PolicyRules’:
+	// Set property "PolicyRules":
 	for _, item := range typedInput.PolicyRules {
 		var item1 BasePolicyRule
 		err := item1.PopulateFromARM(owner, item)
@@ -1175,15 +1175,15 @@ func (policy *BackupPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DatasourceTypes’:
+	// Set property "DatasourceTypes":
 	for _, item := range typedInput.DatasourceTypes {
 		policy.DatasourceTypes = append(policy.DatasourceTypes, item)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	policy.ObjectType = &typedInput.ObjectType
 
-	// Set property ‘PolicyRules’:
+	// Set property "PolicyRules":
 	for _, item := range typedInput.PolicyRules {
 		var item1 BasePolicyRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1295,7 +1295,7 @@ func (rule *BasePolicyRule) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &BasePolicyRule_ARM{}
 
-	// Set property ‘AzureBackup’:
+	// Set property "AzureBackup":
 	if rule.AzureBackup != nil {
 		azureBackup_ARM, err := (*rule.AzureBackup).ConvertToARM(resolved)
 		if err != nil {
@@ -1305,7 +1305,7 @@ func (rule *BasePolicyRule) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		result.AzureBackup = &azureBackup
 	}
 
-	// Set property ‘AzureRetention’:
+	// Set property "AzureRetention":
 	if rule.AzureRetention != nil {
 		azureRetention_ARM, err := (*rule.AzureRetention).ConvertToARM(resolved)
 		if err != nil {
@@ -1329,7 +1329,7 @@ func (rule *BasePolicyRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BasePolicyRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureBackup’:
+	// Set property "AzureBackup":
 	if typedInput.AzureBackup != nil {
 		var azureBackup1 AzureBackupRule
 		err := azureBackup1.PopulateFromARM(owner, *typedInput.AzureBackup)
@@ -1340,7 +1340,7 @@ func (rule *BasePolicyRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		rule.AzureBackup = &azureBackup
 	}
 
-	// Set property ‘AzureRetention’:
+	// Set property "AzureRetention":
 	if typedInput.AzureRetention != nil {
 		var azureRetention1 AzureRetentionRule
 		err := azureRetention1.PopulateFromARM(owner, *typedInput.AzureRetention)
@@ -1479,7 +1479,7 @@ func (rule *BasePolicyRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BasePolicyRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureBackup’:
+	// Set property "AzureBackup":
 	if typedInput.AzureBackup != nil {
 		var azureBackup1 AzureBackupRule_STATUS
 		err := azureBackup1.PopulateFromARM(owner, *typedInput.AzureBackup)
@@ -1490,7 +1490,7 @@ func (rule *BasePolicyRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		rule.AzureBackup = &azureBackup
 	}
 
-	// Set property ‘AzureRetention’:
+	// Set property "AzureRetention":
 	if typedInput.AzureRetention != nil {
 		var azureRetention1 AzureRetentionRule_STATUS
 		err := azureRetention1.PopulateFromARM(owner, *typedInput.AzureRetention)
@@ -1602,7 +1602,7 @@ func (rule *AzureBackupRule) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &AzureBackupRule_ARM{}
 
-	// Set property ‘BackupParameters’:
+	// Set property "BackupParameters":
 	if rule.BackupParameters != nil {
 		backupParameters_ARM, err := (*rule.BackupParameters).ConvertToARM(resolved)
 		if err != nil {
@@ -1612,7 +1612,7 @@ func (rule *AzureBackupRule) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.BackupParameters = &backupParameters
 	}
 
-	// Set property ‘DataStore’:
+	// Set property "DataStore":
 	if rule.DataStore != nil {
 		dataStore_ARM, err := (*rule.DataStore).ConvertToARM(resolved)
 		if err != nil {
@@ -1622,18 +1622,18 @@ func (rule *AzureBackupRule) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.DataStore = &dataStore
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if rule.Name != nil {
 		name := *rule.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if rule.ObjectType != nil {
 		result.ObjectType = *rule.ObjectType
 	}
 
-	// Set property ‘Trigger’:
+	// Set property "Trigger":
 	if rule.Trigger != nil {
 		trigger_ARM, err := (*rule.Trigger).ConvertToARM(resolved)
 		if err != nil {
@@ -1657,7 +1657,7 @@ func (rule *AzureBackupRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureBackupRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupParameters’:
+	// Set property "BackupParameters":
 	if typedInput.BackupParameters != nil {
 		var backupParameters1 BackupParameters
 		err := backupParameters1.PopulateFromARM(owner, *typedInput.BackupParameters)
@@ -1668,7 +1668,7 @@ func (rule *AzureBackupRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		rule.BackupParameters = &backupParameters
 	}
 
-	// Set property ‘DataStore’:
+	// Set property "DataStore":
 	if typedInput.DataStore != nil {
 		var dataStore1 DataStoreInfoBase
 		err := dataStore1.PopulateFromARM(owner, *typedInput.DataStore)
@@ -1679,16 +1679,16 @@ func (rule *AzureBackupRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		rule.DataStore = &dataStore
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	rule.ObjectType = &typedInput.ObjectType
 
-	// Set property ‘Trigger’:
+	// Set property "Trigger":
 	if typedInput.Trigger != nil {
 		var trigger1 TriggerContext
 		err := trigger1.PopulateFromARM(owner, *typedInput.Trigger)
@@ -1898,7 +1898,7 @@ func (rule *AzureBackupRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureBackupRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupParameters’:
+	// Set property "BackupParameters":
 	if typedInput.BackupParameters != nil {
 		var backupParameters1 BackupParameters_STATUS
 		err := backupParameters1.PopulateFromARM(owner, *typedInput.BackupParameters)
@@ -1909,7 +1909,7 @@ func (rule *AzureBackupRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		rule.BackupParameters = &backupParameters
 	}
 
-	// Set property ‘DataStore’:
+	// Set property "DataStore":
 	if typedInput.DataStore != nil {
 		var dataStore1 DataStoreInfoBase_STATUS
 		err := dataStore1.PopulateFromARM(owner, *typedInput.DataStore)
@@ -1920,16 +1920,16 @@ func (rule *AzureBackupRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		rule.DataStore = &dataStore
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	rule.ObjectType = &typedInput.ObjectType
 
-	// Set property ‘Trigger’:
+	// Set property "Trigger":
 	if typedInput.Trigger != nil {
 		var trigger1 TriggerContext_STATUS
 		err := trigger1.PopulateFromARM(owner, *typedInput.Trigger)
@@ -2083,13 +2083,13 @@ func (rule *AzureRetentionRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &AzureRetentionRule_ARM{}
 
-	// Set property ‘IsDefault’:
+	// Set property "IsDefault":
 	if rule.IsDefault != nil {
 		isDefault := *rule.IsDefault
 		result.IsDefault = &isDefault
 	}
 
-	// Set property ‘Lifecycles’:
+	// Set property "Lifecycles":
 	for _, item := range rule.Lifecycles {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2098,13 +2098,13 @@ func (rule *AzureRetentionRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.Lifecycles = append(result.Lifecycles, *item_ARM.(*SourceLifeCycle_ARM))
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if rule.Name != nil {
 		name := *rule.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if rule.ObjectType != nil {
 		result.ObjectType = *rule.ObjectType
 	}
@@ -2123,13 +2123,13 @@ func (rule *AzureRetentionRule) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureRetentionRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IsDefault’:
+	// Set property "IsDefault":
 	if typedInput.IsDefault != nil {
 		isDefault := *typedInput.IsDefault
 		rule.IsDefault = &isDefault
 	}
 
-	// Set property ‘Lifecycles’:
+	// Set property "Lifecycles":
 	for _, item := range typedInput.Lifecycles {
 		var item1 SourceLifeCycle
 		err := item1.PopulateFromARM(owner, item)
@@ -2139,13 +2139,13 @@ func (rule *AzureRetentionRule) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		rule.Lifecycles = append(rule.Lifecycles, item1)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	rule.ObjectType = &typedInput.ObjectType
 
 	// No error
@@ -2314,13 +2314,13 @@ func (rule *AzureRetentionRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureRetentionRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IsDefault’:
+	// Set property "IsDefault":
 	if typedInput.IsDefault != nil {
 		isDefault := *typedInput.IsDefault
 		rule.IsDefault = &isDefault
 	}
 
-	// Set property ‘Lifecycles’:
+	// Set property "Lifecycles":
 	for _, item := range typedInput.Lifecycles {
 		var item1 SourceLifeCycle_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2330,13 +2330,13 @@ func (rule *AzureRetentionRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		rule.Lifecycles = append(rule.Lifecycles, item1)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	rule.ObjectType = &typedInput.ObjectType
 
 	// No error
@@ -2454,7 +2454,7 @@ func (parameters *BackupParameters) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &BackupParameters_ARM{}
 
-	// Set property ‘AzureBackupParams’:
+	// Set property "AzureBackupParams":
 	if parameters.AzureBackupParams != nil {
 		azureBackupParams_ARM, err := (*parameters.AzureBackupParams).ConvertToARM(resolved)
 		if err != nil {
@@ -2478,7 +2478,7 @@ func (parameters *BackupParameters) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupParameters_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureBackupParams’:
+	// Set property "AzureBackupParams":
 	if typedInput.AzureBackupParams != nil {
 		var azureBackupParams1 AzureBackupParams
 		err := azureBackupParams1.PopulateFromARM(owner, *typedInput.AzureBackupParams)
@@ -2578,7 +2578,7 @@ func (parameters *BackupParameters_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureBackupParams’:
+	// Set property "AzureBackupParams":
 	if typedInput.AzureBackupParams != nil {
 		var azureBackupParams1 AzureBackupParams_STATUS
 		err := azureBackupParams1.PopulateFromARM(owner, *typedInput.AzureBackupParams)
@@ -2660,13 +2660,13 @@ func (base *DataStoreInfoBase) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &DataStoreInfoBase_ARM{}
 
-	// Set property ‘DataStoreType’:
+	// Set property "DataStoreType":
 	if base.DataStoreType != nil {
 		dataStoreType := *base.DataStoreType
 		result.DataStoreType = &dataStoreType
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if base.ObjectType != nil {
 		objectType := *base.ObjectType
 		result.ObjectType = &objectType
@@ -2686,13 +2686,13 @@ func (base *DataStoreInfoBase) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataStoreInfoBase_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataStoreType’:
+	// Set property "DataStoreType":
 	if typedInput.DataStoreType != nil {
 		dataStoreType := *typedInput.DataStoreType
 		base.DataStoreType = &dataStoreType
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if typedInput.ObjectType != nil {
 		objectType := *typedInput.ObjectType
 		base.ObjectType = &objectType
@@ -2788,13 +2788,13 @@ func (base *DataStoreInfoBase_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataStoreInfoBase_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataStoreType’:
+	// Set property "DataStoreType":
 	if typedInput.DataStoreType != nil {
 		dataStoreType := *typedInput.DataStoreType
 		base.DataStoreType = &dataStoreType
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if typedInput.ObjectType != nil {
 		objectType := *typedInput.ObjectType
 		base.ObjectType = &objectType
@@ -2869,7 +2869,7 @@ func (cycle *SourceLifeCycle) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &SourceLifeCycle_ARM{}
 
-	// Set property ‘DeleteAfter’:
+	// Set property "DeleteAfter":
 	if cycle.DeleteAfter != nil {
 		deleteAfter_ARM, err := (*cycle.DeleteAfter).ConvertToARM(resolved)
 		if err != nil {
@@ -2879,7 +2879,7 @@ func (cycle *SourceLifeCycle) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.DeleteAfter = &deleteAfter
 	}
 
-	// Set property ‘SourceDataStore’:
+	// Set property "SourceDataStore":
 	if cycle.SourceDataStore != nil {
 		sourceDataStore_ARM, err := (*cycle.SourceDataStore).ConvertToARM(resolved)
 		if err != nil {
@@ -2889,7 +2889,7 @@ func (cycle *SourceLifeCycle) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.SourceDataStore = &sourceDataStore
 	}
 
-	// Set property ‘TargetDataStoreCopySettings’:
+	// Set property "TargetDataStoreCopySettings":
 	for _, item := range cycle.TargetDataStoreCopySettings {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2912,7 +2912,7 @@ func (cycle *SourceLifeCycle) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SourceLifeCycle_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteAfter’:
+	// Set property "DeleteAfter":
 	if typedInput.DeleteAfter != nil {
 		var deleteAfter1 DeleteOption
 		err := deleteAfter1.PopulateFromARM(owner, *typedInput.DeleteAfter)
@@ -2923,7 +2923,7 @@ func (cycle *SourceLifeCycle) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		cycle.DeleteAfter = &deleteAfter
 	}
 
-	// Set property ‘SourceDataStore’:
+	// Set property "SourceDataStore":
 	if typedInput.SourceDataStore != nil {
 		var sourceDataStore1 DataStoreInfoBase
 		err := sourceDataStore1.PopulateFromARM(owner, *typedInput.SourceDataStore)
@@ -2934,7 +2934,7 @@ func (cycle *SourceLifeCycle) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		cycle.SourceDataStore = &sourceDataStore
 	}
 
-	// Set property ‘TargetDataStoreCopySettings’:
+	// Set property "TargetDataStoreCopySettings":
 	for _, item := range typedInput.TargetDataStoreCopySettings {
 		var item1 TargetCopySetting
 		err := item1.PopulateFromARM(owner, item)
@@ -3127,7 +3127,7 @@ func (cycle *SourceLifeCycle_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SourceLifeCycle_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DeleteAfter’:
+	// Set property "DeleteAfter":
 	if typedInput.DeleteAfter != nil {
 		var deleteAfter1 DeleteOption_STATUS
 		err := deleteAfter1.PopulateFromARM(owner, *typedInput.DeleteAfter)
@@ -3138,7 +3138,7 @@ func (cycle *SourceLifeCycle_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		cycle.DeleteAfter = &deleteAfter
 	}
 
-	// Set property ‘SourceDataStore’:
+	// Set property "SourceDataStore":
 	if typedInput.SourceDataStore != nil {
 		var sourceDataStore1 DataStoreInfoBase_STATUS
 		err := sourceDataStore1.PopulateFromARM(owner, *typedInput.SourceDataStore)
@@ -3149,7 +3149,7 @@ func (cycle *SourceLifeCycle_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		cycle.SourceDataStore = &sourceDataStore
 	}
 
-	// Set property ‘TargetDataStoreCopySettings’:
+	// Set property "TargetDataStoreCopySettings":
 	for _, item := range typedInput.TargetDataStoreCopySettings {
 		var item1 TargetCopySetting_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3287,7 +3287,7 @@ func (context *TriggerContext) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &TriggerContext_ARM{}
 
-	// Set property ‘Adhoc’:
+	// Set property "Adhoc":
 	if context.Adhoc != nil {
 		adhoc_ARM, err := (*context.Adhoc).ConvertToARM(resolved)
 		if err != nil {
@@ -3297,7 +3297,7 @@ func (context *TriggerContext) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Adhoc = &adhoc
 	}
 
-	// Set property ‘Schedule’:
+	// Set property "Schedule":
 	if context.Schedule != nil {
 		schedule_ARM, err := (*context.Schedule).ConvertToARM(resolved)
 		if err != nil {
@@ -3321,7 +3321,7 @@ func (context *TriggerContext) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TriggerContext_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Adhoc’:
+	// Set property "Adhoc":
 	if typedInput.Adhoc != nil {
 		var adhoc1 AdhocBasedTriggerContext
 		err := adhoc1.PopulateFromARM(owner, *typedInput.Adhoc)
@@ -3332,7 +3332,7 @@ func (context *TriggerContext) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		context.Adhoc = &adhoc
 	}
 
-	// Set property ‘Schedule’:
+	// Set property "Schedule":
 	if typedInput.Schedule != nil {
 		var schedule1 ScheduleBasedTriggerContext
 		err := schedule1.PopulateFromARM(owner, *typedInput.Schedule)
@@ -3471,7 +3471,7 @@ func (context *TriggerContext_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TriggerContext_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Adhoc’:
+	// Set property "Adhoc":
 	if typedInput.Adhoc != nil {
 		var adhoc1 AdhocBasedTriggerContext_STATUS
 		err := adhoc1.PopulateFromARM(owner, *typedInput.Adhoc)
@@ -3482,7 +3482,7 @@ func (context *TriggerContext_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		context.Adhoc = &adhoc
 	}
 
-	// Set property ‘Schedule’:
+	// Set property "Schedule":
 	if typedInput.Schedule != nil {
 		var schedule1 ScheduleBasedTriggerContext_STATUS
 		err := schedule1.PopulateFromARM(owner, *typedInput.Schedule)
@@ -3587,12 +3587,12 @@ func (context *AdhocBasedTriggerContext) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &AdhocBasedTriggerContext_ARM{}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if context.ObjectType != nil {
 		result.ObjectType = *context.ObjectType
 	}
 
-	// Set property ‘TaggingCriteria’:
+	// Set property "TaggingCriteria":
 	if context.TaggingCriteria != nil {
 		taggingCriteria_ARM, err := (*context.TaggingCriteria).ConvertToARM(resolved)
 		if err != nil {
@@ -3616,10 +3616,10 @@ func (context *AdhocBasedTriggerContext) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdhocBasedTriggerContext_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	context.ObjectType = &typedInput.ObjectType
 
-	// Set property ‘TaggingCriteria’:
+	// Set property "TaggingCriteria":
 	if typedInput.TaggingCriteria != nil {
 		var taggingCriteria1 AdhocBasedTaggingCriteria
 		err := taggingCriteria1.PopulateFromARM(owner, *typedInput.TaggingCriteria)
@@ -3746,10 +3746,10 @@ func (context *AdhocBasedTriggerContext_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdhocBasedTriggerContext_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	context.ObjectType = &typedInput.ObjectType
 
-	// Set property ‘TaggingCriteria’:
+	// Set property "TaggingCriteria":
 	if typedInput.TaggingCriteria != nil {
 		var taggingCriteria1 AdhocBasedTaggingCriteria_STATUS
 		err := taggingCriteria1.PopulateFromARM(owner, *typedInput.TaggingCriteria)
@@ -3846,13 +3846,13 @@ func (params *AzureBackupParams) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &AzureBackupParams_ARM{}
 
-	// Set property ‘BackupType’:
+	// Set property "BackupType":
 	if params.BackupType != nil {
 		backupType := *params.BackupType
 		result.BackupType = &backupType
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if params.ObjectType != nil {
 		result.ObjectType = *params.ObjectType
 	}
@@ -3871,13 +3871,13 @@ func (params *AzureBackupParams) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureBackupParams_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupType’:
+	// Set property "BackupType":
 	if typedInput.BackupType != nil {
 		backupType := *typedInput.BackupType
 		params.BackupType = &backupType
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	params.ObjectType = &typedInput.ObjectType
 
 	// No error
@@ -3969,13 +3969,13 @@ func (params *AzureBackupParams_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureBackupParams_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupType’:
+	// Set property "BackupType":
 	if typedInput.BackupType != nil {
 		backupType := *typedInput.BackupType
 		params.BackupType = &backupType
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	params.ObjectType = &typedInput.ObjectType
 
 	// No error
@@ -4041,7 +4041,7 @@ func (option *DeleteOption) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &DeleteOption_ARM{}
 
-	// Set property ‘AbsoluteDeleteOption’:
+	// Set property "AbsoluteDeleteOption":
 	if option.AbsoluteDeleteOption != nil {
 		absoluteDeleteOption_ARM, err := (*option.AbsoluteDeleteOption).ConvertToARM(resolved)
 		if err != nil {
@@ -4065,7 +4065,7 @@ func (option *DeleteOption) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeleteOption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AbsoluteDeleteOption’:
+	// Set property "AbsoluteDeleteOption":
 	if typedInput.AbsoluteDeleteOption != nil {
 		var absoluteDeleteOption1 AbsoluteDeleteOption
 		err := absoluteDeleteOption1.PopulateFromARM(owner, *typedInput.AbsoluteDeleteOption)
@@ -4165,7 +4165,7 @@ func (option *DeleteOption_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeleteOption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AbsoluteDeleteOption’:
+	// Set property "AbsoluteDeleteOption":
 	if typedInput.AbsoluteDeleteOption != nil {
 		var absoluteDeleteOption1 AbsoluteDeleteOption_STATUS
 		err := absoluteDeleteOption1.PopulateFromARM(owner, *typedInput.AbsoluteDeleteOption)
@@ -4250,12 +4250,12 @@ func (context *ScheduleBasedTriggerContext) ConvertToARM(resolved genruntime.Con
 	}
 	result := &ScheduleBasedTriggerContext_ARM{}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if context.ObjectType != nil {
 		result.ObjectType = *context.ObjectType
 	}
 
-	// Set property ‘Schedule’:
+	// Set property "Schedule":
 	if context.Schedule != nil {
 		schedule_ARM, err := (*context.Schedule).ConvertToARM(resolved)
 		if err != nil {
@@ -4265,7 +4265,7 @@ func (context *ScheduleBasedTriggerContext) ConvertToARM(resolved genruntime.Con
 		result.Schedule = &schedule
 	}
 
-	// Set property ‘TaggingCriteria’:
+	// Set property "TaggingCriteria":
 	for _, item := range context.TaggingCriteria {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4288,10 +4288,10 @@ func (context *ScheduleBasedTriggerContext) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduleBasedTriggerContext_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	context.ObjectType = &typedInput.ObjectType
 
-	// Set property ‘Schedule’:
+	// Set property "Schedule":
 	if typedInput.Schedule != nil {
 		var schedule1 BackupSchedule
 		err := schedule1.PopulateFromARM(owner, *typedInput.Schedule)
@@ -4302,7 +4302,7 @@ func (context *ScheduleBasedTriggerContext) PopulateFromARM(owner genruntime.Arb
 		context.Schedule = &schedule
 	}
 
-	// Set property ‘TaggingCriteria’:
+	// Set property "TaggingCriteria":
 	for _, item := range typedInput.TaggingCriteria {
 		var item1 TaggingCriteria
 		err := item1.PopulateFromARM(owner, item)
@@ -4485,10 +4485,10 @@ func (context *ScheduleBasedTriggerContext_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduleBasedTriggerContext_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	context.ObjectType = &typedInput.ObjectType
 
-	// Set property ‘Schedule’:
+	// Set property "Schedule":
 	if typedInput.Schedule != nil {
 		var schedule1 BackupSchedule_STATUS
 		err := schedule1.PopulateFromARM(owner, *typedInput.Schedule)
@@ -4499,7 +4499,7 @@ func (context *ScheduleBasedTriggerContext_STATUS) PopulateFromARM(owner genrunt
 		context.Schedule = &schedule
 	}
 
-	// Set property ‘TaggingCriteria’:
+	// Set property "TaggingCriteria":
 	for _, item := range typedInput.TaggingCriteria {
 		var item1 TaggingCriteria_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4632,7 +4632,7 @@ func (setting *TargetCopySetting) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &TargetCopySetting_ARM{}
 
-	// Set property ‘CopyAfter’:
+	// Set property "CopyAfter":
 	if setting.CopyAfter != nil {
 		copyAfter_ARM, err := (*setting.CopyAfter).ConvertToARM(resolved)
 		if err != nil {
@@ -4642,7 +4642,7 @@ func (setting *TargetCopySetting) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.CopyAfter = &copyAfter
 	}
 
-	// Set property ‘DataStore’:
+	// Set property "DataStore":
 	if setting.DataStore != nil {
 		dataStore_ARM, err := (*setting.DataStore).ConvertToARM(resolved)
 		if err != nil {
@@ -4666,7 +4666,7 @@ func (setting *TargetCopySetting) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TargetCopySetting_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CopyAfter’:
+	// Set property "CopyAfter":
 	if typedInput.CopyAfter != nil {
 		var copyAfter1 CopyOption
 		err := copyAfter1.PopulateFromARM(owner, *typedInput.CopyAfter)
@@ -4677,7 +4677,7 @@ func (setting *TargetCopySetting) PopulateFromARM(owner genruntime.ArbitraryOwne
 		setting.CopyAfter = &copyAfter
 	}
 
-	// Set property ‘DataStore’:
+	// Set property "DataStore":
 	if typedInput.DataStore != nil {
 		var dataStore1 DataStoreInfoBase
 		err := dataStore1.PopulateFromARM(owner, *typedInput.DataStore)
@@ -4817,7 +4817,7 @@ func (setting *TargetCopySetting_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TargetCopySetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CopyAfter’:
+	// Set property "CopyAfter":
 	if typedInput.CopyAfter != nil {
 		var copyAfter1 CopyOption_STATUS
 		err := copyAfter1.PopulateFromARM(owner, *typedInput.CopyAfter)
@@ -4828,7 +4828,7 @@ func (setting *TargetCopySetting_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		setting.CopyAfter = &copyAfter
 	}
 
-	// Set property ‘DataStore’:
+	// Set property "DataStore":
 	if typedInput.DataStore != nil {
 		var dataStore1 DataStoreInfoBase_STATUS
 		err := dataStore1.PopulateFromARM(owner, *typedInput.DataStore)
@@ -4933,13 +4933,13 @@ func (option *AbsoluteDeleteOption) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &AbsoluteDeleteOption_ARM{}
 
-	// Set property ‘Duration’:
+	// Set property "Duration":
 	if option.Duration != nil {
 		duration := *option.Duration
 		result.Duration = &duration
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if option.ObjectType != nil {
 		result.ObjectType = *option.ObjectType
 	}
@@ -4958,13 +4958,13 @@ func (option *AbsoluteDeleteOption) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AbsoluteDeleteOption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Duration’:
+	// Set property "Duration":
 	if typedInput.Duration != nil {
 		duration := *typedInput.Duration
 		option.Duration = &duration
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	option.ObjectType = &typedInput.ObjectType
 
 	// No error
@@ -5056,13 +5056,13 @@ func (option *AbsoluteDeleteOption_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AbsoluteDeleteOption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Duration’:
+	// Set property "Duration":
 	if typedInput.Duration != nil {
 		duration := *typedInput.Duration
 		option.Duration = &duration
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	option.ObjectType = &typedInput.ObjectType
 
 	// No error
@@ -5129,7 +5129,7 @@ func (criteria *AdhocBasedTaggingCriteria) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &AdhocBasedTaggingCriteria_ARM{}
 
-	// Set property ‘TagInfo’:
+	// Set property "TagInfo":
 	if criteria.TagInfo != nil {
 		tagInfo_ARM, err := (*criteria.TagInfo).ConvertToARM(resolved)
 		if err != nil {
@@ -5153,7 +5153,7 @@ func (criteria *AdhocBasedTaggingCriteria) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdhocBasedTaggingCriteria_ARM, got %T", armInput)
 	}
 
-	// Set property ‘TagInfo’:
+	// Set property "TagInfo":
 	if typedInput.TagInfo != nil {
 		var tagInfo1 RetentionTag
 		err := tagInfo1.PopulateFromARM(owner, *typedInput.TagInfo)
@@ -5254,7 +5254,7 @@ func (criteria *AdhocBasedTaggingCriteria_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdhocBasedTaggingCriteria_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘TagInfo’:
+	// Set property "TagInfo":
 	if typedInput.TagInfo != nil {
 		var tagInfo1 RetentionTag_STATUS
 		err := tagInfo1.PopulateFromARM(owner, *typedInput.TagInfo)
@@ -5335,12 +5335,12 @@ func (schedule *BackupSchedule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &BackupSchedule_ARM{}
 
-	// Set property ‘RepeatingTimeIntervals’:
+	// Set property "RepeatingTimeIntervals":
 	for _, item := range schedule.RepeatingTimeIntervals {
 		result.RepeatingTimeIntervals = append(result.RepeatingTimeIntervals, item)
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if schedule.TimeZone != nil {
 		timeZone := *schedule.TimeZone
 		result.TimeZone = &timeZone
@@ -5360,12 +5360,12 @@ func (schedule *BackupSchedule) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupSchedule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RepeatingTimeIntervals’:
+	// Set property "RepeatingTimeIntervals":
 	for _, item := range typedInput.RepeatingTimeIntervals {
 		schedule.RepeatingTimeIntervals = append(schedule.RepeatingTimeIntervals, item)
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if typedInput.TimeZone != nil {
 		timeZone := *typedInput.TimeZone
 		schedule.TimeZone = &timeZone
@@ -5446,12 +5446,12 @@ func (schedule *BackupSchedule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupSchedule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RepeatingTimeIntervals’:
+	// Set property "RepeatingTimeIntervals":
 	for _, item := range typedInput.RepeatingTimeIntervals {
 		schedule.RepeatingTimeIntervals = append(schedule.RepeatingTimeIntervals, item)
 	}
 
-	// Set property ‘TimeZone’:
+	// Set property "TimeZone":
 	if typedInput.TimeZone != nil {
 		timeZone := *typedInput.TimeZone
 		schedule.TimeZone = &timeZone
@@ -5516,7 +5516,7 @@ func (option *CopyOption) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &CopyOption_ARM{}
 
-	// Set property ‘CopyOnExpiry’:
+	// Set property "CopyOnExpiry":
 	if option.CopyOnExpiry != nil {
 		copyOnExpiry_ARM, err := (*option.CopyOnExpiry).ConvertToARM(resolved)
 		if err != nil {
@@ -5526,7 +5526,7 @@ func (option *CopyOption) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.CopyOnExpiry = &copyOnExpiry
 	}
 
-	// Set property ‘CustomCopy’:
+	// Set property "CustomCopy":
 	if option.CustomCopy != nil {
 		customCopy_ARM, err := (*option.CustomCopy).ConvertToARM(resolved)
 		if err != nil {
@@ -5536,7 +5536,7 @@ func (option *CopyOption) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.CustomCopy = &customCopy
 	}
 
-	// Set property ‘ImmediateCopy’:
+	// Set property "ImmediateCopy":
 	if option.ImmediateCopy != nil {
 		immediateCopy_ARM, err := (*option.ImmediateCopy).ConvertToARM(resolved)
 		if err != nil {
@@ -5560,7 +5560,7 @@ func (option *CopyOption) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CopyOption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CopyOnExpiry’:
+	// Set property "CopyOnExpiry":
 	if typedInput.CopyOnExpiry != nil {
 		var copyOnExpiry1 CopyOnExpiryOption
 		err := copyOnExpiry1.PopulateFromARM(owner, *typedInput.CopyOnExpiry)
@@ -5571,7 +5571,7 @@ func (option *CopyOption) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		option.CopyOnExpiry = &copyOnExpiry
 	}
 
-	// Set property ‘CustomCopy’:
+	// Set property "CustomCopy":
 	if typedInput.CustomCopy != nil {
 		var customCopy1 CustomCopyOption
 		err := customCopy1.PopulateFromARM(owner, *typedInput.CustomCopy)
@@ -5582,7 +5582,7 @@ func (option *CopyOption) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		option.CustomCopy = &customCopy
 	}
 
-	// Set property ‘ImmediateCopy’:
+	// Set property "ImmediateCopy":
 	if typedInput.ImmediateCopy != nil {
 		var immediateCopy1 ImmediateCopyOption
 		err := immediateCopy1.PopulateFromARM(owner, *typedInput.ImmediateCopy)
@@ -5760,7 +5760,7 @@ func (option *CopyOption_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CopyOption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CopyOnExpiry’:
+	// Set property "CopyOnExpiry":
 	if typedInput.CopyOnExpiry != nil {
 		var copyOnExpiry1 CopyOnExpiryOption_STATUS
 		err := copyOnExpiry1.PopulateFromARM(owner, *typedInput.CopyOnExpiry)
@@ -5771,7 +5771,7 @@ func (option *CopyOption_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		option.CopyOnExpiry = &copyOnExpiry
 	}
 
-	// Set property ‘CustomCopy’:
+	// Set property "CustomCopy":
 	if typedInput.CustomCopy != nil {
 		var customCopy1 CustomCopyOption_STATUS
 		err := customCopy1.PopulateFromARM(owner, *typedInput.CustomCopy)
@@ -5782,7 +5782,7 @@ func (option *CopyOption_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		option.CustomCopy = &customCopy
 	}
 
-	// Set property ‘ImmediateCopy’:
+	// Set property "ImmediateCopy":
 	if typedInput.ImmediateCopy != nil {
 		var immediateCopy1 ImmediateCopyOption_STATUS
 		err := immediateCopy1.PopulateFromARM(owner, *typedInput.ImmediateCopy)
@@ -5919,7 +5919,7 @@ func (criteria *TaggingCriteria) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &TaggingCriteria_ARM{}
 
-	// Set property ‘Criteria’:
+	// Set property "Criteria":
 	for _, item := range criteria.Criteria {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5928,13 +5928,13 @@ func (criteria *TaggingCriteria) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Criteria = append(result.Criteria, *item_ARM.(*BackupCriteria_ARM))
 	}
 
-	// Set property ‘IsDefault’:
+	// Set property "IsDefault":
 	if criteria.IsDefault != nil {
 		isDefault := *criteria.IsDefault
 		result.IsDefault = &isDefault
 	}
 
-	// Set property ‘TagInfo’:
+	// Set property "TagInfo":
 	if criteria.TagInfo != nil {
 		tagInfo_ARM, err := (*criteria.TagInfo).ConvertToARM(resolved)
 		if err != nil {
@@ -5944,7 +5944,7 @@ func (criteria *TaggingCriteria) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.TagInfo = &tagInfo
 	}
 
-	// Set property ‘TaggingPriority’:
+	// Set property "TaggingPriority":
 	if criteria.TaggingPriority != nil {
 		taggingPriority := *criteria.TaggingPriority
 		result.TaggingPriority = &taggingPriority
@@ -5964,7 +5964,7 @@ func (criteria *TaggingCriteria) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TaggingCriteria_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Criteria’:
+	// Set property "Criteria":
 	for _, item := range typedInput.Criteria {
 		var item1 BackupCriteria
 		err := item1.PopulateFromARM(owner, item)
@@ -5974,13 +5974,13 @@ func (criteria *TaggingCriteria) PopulateFromARM(owner genruntime.ArbitraryOwner
 		criteria.Criteria = append(criteria.Criteria, item1)
 	}
 
-	// Set property ‘IsDefault’:
+	// Set property "IsDefault":
 	if typedInput.IsDefault != nil {
 		isDefault := *typedInput.IsDefault
 		criteria.IsDefault = &isDefault
 	}
 
-	// Set property ‘TagInfo’:
+	// Set property "TagInfo":
 	if typedInput.TagInfo != nil {
 		var tagInfo1 RetentionTag
 		err := tagInfo1.PopulateFromARM(owner, *typedInput.TagInfo)
@@ -5991,7 +5991,7 @@ func (criteria *TaggingCriteria) PopulateFromARM(owner genruntime.ArbitraryOwner
 		criteria.TagInfo = &tagInfo
 	}
 
-	// Set property ‘TaggingPriority’:
+	// Set property "TaggingPriority":
 	if typedInput.TaggingPriority != nil {
 		taggingPriority := *typedInput.TaggingPriority
 		criteria.TaggingPriority = &taggingPriority
@@ -6183,7 +6183,7 @@ func (criteria *TaggingCriteria_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TaggingCriteria_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Criteria’:
+	// Set property "Criteria":
 	for _, item := range typedInput.Criteria {
 		var item1 BackupCriteria_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6193,13 +6193,13 @@ func (criteria *TaggingCriteria_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		criteria.Criteria = append(criteria.Criteria, item1)
 	}
 
-	// Set property ‘IsDefault’:
+	// Set property "IsDefault":
 	if typedInput.IsDefault != nil {
 		isDefault := *typedInput.IsDefault
 		criteria.IsDefault = &isDefault
 	}
 
-	// Set property ‘TagInfo’:
+	// Set property "TagInfo":
 	if typedInput.TagInfo != nil {
 		var tagInfo1 RetentionTag_STATUS
 		err := tagInfo1.PopulateFromARM(owner, *typedInput.TagInfo)
@@ -6210,7 +6210,7 @@ func (criteria *TaggingCriteria_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		criteria.TagInfo = &tagInfo
 	}
 
-	// Set property ‘TaggingPriority’:
+	// Set property "TaggingPriority":
 	if typedInput.TaggingPriority != nil {
 		taggingPriority := *typedInput.TaggingPriority
 		criteria.TaggingPriority = &taggingPriority
@@ -6339,7 +6339,7 @@ func (criteria *BackupCriteria) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &BackupCriteria_ARM{}
 
-	// Set property ‘ScheduleBasedBackupCriteria’:
+	// Set property "ScheduleBasedBackupCriteria":
 	if criteria.ScheduleBasedBackupCriteria != nil {
 		scheduleBasedBackupCriteria_ARM, err := (*criteria.ScheduleBasedBackupCriteria).ConvertToARM(resolved)
 		if err != nil {
@@ -6363,7 +6363,7 @@ func (criteria *BackupCriteria) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupCriteria_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ScheduleBasedBackupCriteria’:
+	// Set property "ScheduleBasedBackupCriteria":
 	if typedInput.ScheduleBasedBackupCriteria != nil {
 		var scheduleBasedBackupCriteria1 ScheduleBasedBackupCriteria
 		err := scheduleBasedBackupCriteria1.PopulateFromARM(owner, *typedInput.ScheduleBasedBackupCriteria)
@@ -6463,7 +6463,7 @@ func (criteria *BackupCriteria_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupCriteria_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ScheduleBasedBackupCriteria’:
+	// Set property "ScheduleBasedBackupCriteria":
 	if typedInput.ScheduleBasedBackupCriteria != nil {
 		var scheduleBasedBackupCriteria1 ScheduleBasedBackupCriteria_STATUS
 		err := scheduleBasedBackupCriteria1.PopulateFromARM(owner, *typedInput.ScheduleBasedBackupCriteria)
@@ -6540,7 +6540,7 @@ func (option *CopyOnExpiryOption) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &CopyOnExpiryOption_ARM{}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if option.ObjectType != nil {
 		result.ObjectType = *option.ObjectType
 	}
@@ -6559,7 +6559,7 @@ func (option *CopyOnExpiryOption) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CopyOnExpiryOption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	option.ObjectType = &typedInput.ObjectType
 
 	// No error
@@ -6639,7 +6639,7 @@ func (option *CopyOnExpiryOption_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CopyOnExpiryOption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	option.ObjectType = &typedInput.ObjectType
 
 	// No error
@@ -6703,13 +6703,13 @@ func (option *CustomCopyOption) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &CustomCopyOption_ARM{}
 
-	// Set property ‘Duration’:
+	// Set property "Duration":
 	if option.Duration != nil {
 		duration := *option.Duration
 		result.Duration = &duration
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if option.ObjectType != nil {
 		result.ObjectType = *option.ObjectType
 	}
@@ -6728,13 +6728,13 @@ func (option *CustomCopyOption) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CustomCopyOption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Duration’:
+	// Set property "Duration":
 	if typedInput.Duration != nil {
 		duration := *typedInput.Duration
 		option.Duration = &duration
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	option.ObjectType = &typedInput.ObjectType
 
 	// No error
@@ -6826,13 +6826,13 @@ func (option *CustomCopyOption_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CustomCopyOption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Duration’:
+	// Set property "Duration":
 	if typedInput.Duration != nil {
 		duration := *typedInput.Duration
 		option.Duration = &duration
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	option.ObjectType = &typedInput.ObjectType
 
 	// No error
@@ -6899,7 +6899,7 @@ func (option *ImmediateCopyOption) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &ImmediateCopyOption_ARM{}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if option.ObjectType != nil {
 		result.ObjectType = *option.ObjectType
 	}
@@ -6918,7 +6918,7 @@ func (option *ImmediateCopyOption) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmediateCopyOption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	option.ObjectType = &typedInput.ObjectType
 
 	// No error
@@ -6998,7 +6998,7 @@ func (option *ImmediateCopyOption_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmediateCopyOption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	option.ObjectType = &typedInput.ObjectType
 
 	// No error
@@ -7060,7 +7060,7 @@ func (retentionTag *RetentionTag) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &RetentionTag_ARM{}
 
-	// Set property ‘TagName’:
+	// Set property "TagName":
 	if retentionTag.TagName != nil {
 		tagName := *retentionTag.TagName
 		result.TagName = &tagName
@@ -7080,7 +7080,7 @@ func (retentionTag *RetentionTag) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RetentionTag_ARM, got %T", armInput)
 	}
 
-	// Set property ‘TagName’:
+	// Set property "TagName":
 	if typedInput.TagName != nil {
 		tagName := *typedInput.TagName
 		retentionTag.TagName = &tagName
@@ -7155,19 +7155,19 @@ func (retentionTag *RetentionTag_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RetentionTag_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ETag’:
+	// Set property "ETag":
 	if typedInput.ETag != nil {
 		eTag := *typedInput.ETag
 		retentionTag.ETag = &eTag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		retentionTag.Id = &id
 	}
 
-	// Set property ‘TagName’:
+	// Set property "TagName":
 	if typedInput.TagName != nil {
 		tagName := *typedInput.TagName
 		retentionTag.TagName = &tagName
@@ -7252,12 +7252,12 @@ func (criteria *ScheduleBasedBackupCriteria) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ScheduleBasedBackupCriteria_ARM{}
 
-	// Set property ‘AbsoluteCriteria’:
+	// Set property "AbsoluteCriteria":
 	for _, item := range criteria.AbsoluteCriteria {
 		result.AbsoluteCriteria = append(result.AbsoluteCriteria, item)
 	}
 
-	// Set property ‘DaysOfMonth’:
+	// Set property "DaysOfMonth":
 	for _, item := range criteria.DaysOfMonth {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -7266,27 +7266,27 @@ func (criteria *ScheduleBasedBackupCriteria) ConvertToARM(resolved genruntime.Co
 		result.DaysOfMonth = append(result.DaysOfMonth, *item_ARM.(*Day_ARM))
 	}
 
-	// Set property ‘DaysOfTheWeek’:
+	// Set property "DaysOfTheWeek":
 	for _, item := range criteria.DaysOfTheWeek {
 		result.DaysOfTheWeek = append(result.DaysOfTheWeek, item)
 	}
 
-	// Set property ‘MonthsOfYear’:
+	// Set property "MonthsOfYear":
 	for _, item := range criteria.MonthsOfYear {
 		result.MonthsOfYear = append(result.MonthsOfYear, item)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	if criteria.ObjectType != nil {
 		result.ObjectType = *criteria.ObjectType
 	}
 
-	// Set property ‘ScheduleTimes’:
+	// Set property "ScheduleTimes":
 	for _, item := range criteria.ScheduleTimes {
 		result.ScheduleTimes = append(result.ScheduleTimes, item)
 	}
 
-	// Set property ‘WeeksOfTheMonth’:
+	// Set property "WeeksOfTheMonth":
 	for _, item := range criteria.WeeksOfTheMonth {
 		result.WeeksOfTheMonth = append(result.WeeksOfTheMonth, item)
 	}
@@ -7305,12 +7305,12 @@ func (criteria *ScheduleBasedBackupCriteria) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduleBasedBackupCriteria_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AbsoluteCriteria’:
+	// Set property "AbsoluteCriteria":
 	for _, item := range typedInput.AbsoluteCriteria {
 		criteria.AbsoluteCriteria = append(criteria.AbsoluteCriteria, item)
 	}
 
-	// Set property ‘DaysOfMonth’:
+	// Set property "DaysOfMonth":
 	for _, item := range typedInput.DaysOfMonth {
 		var item1 Day
 		err := item1.PopulateFromARM(owner, item)
@@ -7320,25 +7320,25 @@ func (criteria *ScheduleBasedBackupCriteria) PopulateFromARM(owner genruntime.Ar
 		criteria.DaysOfMonth = append(criteria.DaysOfMonth, item1)
 	}
 
-	// Set property ‘DaysOfTheWeek’:
+	// Set property "DaysOfTheWeek":
 	for _, item := range typedInput.DaysOfTheWeek {
 		criteria.DaysOfTheWeek = append(criteria.DaysOfTheWeek, item)
 	}
 
-	// Set property ‘MonthsOfYear’:
+	// Set property "MonthsOfYear":
 	for _, item := range typedInput.MonthsOfYear {
 		criteria.MonthsOfYear = append(criteria.MonthsOfYear, item)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	criteria.ObjectType = &typedInput.ObjectType
 
-	// Set property ‘ScheduleTimes’:
+	// Set property "ScheduleTimes":
 	for _, item := range typedInput.ScheduleTimes {
 		criteria.ScheduleTimes = append(criteria.ScheduleTimes, item)
 	}
 
-	// Set property ‘WeeksOfTheMonth’:
+	// Set property "WeeksOfTheMonth":
 	for _, item := range typedInput.WeeksOfTheMonth {
 		criteria.WeeksOfTheMonth = append(criteria.WeeksOfTheMonth, item)
 	}
@@ -7662,12 +7662,12 @@ func (criteria *ScheduleBasedBackupCriteria_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScheduleBasedBackupCriteria_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AbsoluteCriteria’:
+	// Set property "AbsoluteCriteria":
 	for _, item := range typedInput.AbsoluteCriteria {
 		criteria.AbsoluteCriteria = append(criteria.AbsoluteCriteria, item)
 	}
 
-	// Set property ‘DaysOfMonth’:
+	// Set property "DaysOfMonth":
 	for _, item := range typedInput.DaysOfMonth {
 		var item1 Day_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7677,25 +7677,25 @@ func (criteria *ScheduleBasedBackupCriteria_STATUS) PopulateFromARM(owner genrun
 		criteria.DaysOfMonth = append(criteria.DaysOfMonth, item1)
 	}
 
-	// Set property ‘DaysOfTheWeek’:
+	// Set property "DaysOfTheWeek":
 	for _, item := range typedInput.DaysOfTheWeek {
 		criteria.DaysOfTheWeek = append(criteria.DaysOfTheWeek, item)
 	}
 
-	// Set property ‘MonthsOfYear’:
+	// Set property "MonthsOfYear":
 	for _, item := range typedInput.MonthsOfYear {
 		criteria.MonthsOfYear = append(criteria.MonthsOfYear, item)
 	}
 
-	// Set property ‘ObjectType’:
+	// Set property "ObjectType":
 	criteria.ObjectType = &typedInput.ObjectType
 
-	// Set property ‘ScheduleTimes’:
+	// Set property "ScheduleTimes":
 	for _, item := range typedInput.ScheduleTimes {
 		criteria.ScheduleTimes = append(criteria.ScheduleTimes, item)
 	}
 
-	// Set property ‘WeeksOfTheMonth’:
+	// Set property "WeeksOfTheMonth":
 	for _, item := range typedInput.WeeksOfTheMonth {
 		criteria.WeeksOfTheMonth = append(criteria.WeeksOfTheMonth, item)
 	}
@@ -7907,13 +7907,13 @@ func (day *Day) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Day_ARM{}
 
-	// Set property ‘Date’:
+	// Set property "Date":
 	if day.Date != nil {
 		date := *day.Date
 		result.Date = &date
 	}
 
-	// Set property ‘IsLast’:
+	// Set property "IsLast":
 	if day.IsLast != nil {
 		isLast := *day.IsLast
 		result.IsLast = &isLast
@@ -7933,13 +7933,13 @@ func (day *Day) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Day_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Date’:
+	// Set property "Date":
 	if typedInput.Date != nil {
 		date := *typedInput.Date
 		day.Date = &date
 	}
 
-	// Set property ‘IsLast’:
+	// Set property "IsLast":
 	if typedInput.IsLast != nil {
 		isLast := *typedInput.IsLast
 		day.IsLast = &isLast
@@ -8035,13 +8035,13 @@ func (day *Day_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Day_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Date’:
+	// Set property "Date":
 	if typedInput.Date != nil {
 		date := *typedInput.Date
 		day.Date = &date
 	}
 
-	// Set property ‘IsLast’:
+	// Set property "IsLast":
 	if typedInput.IsLast != nil {
 		isLast := *typedInput.IsLast
 		day.IsLast = &isLast

--- a/v2/api/dbformariadb/v1api20180601/configuration_types_gen.go
+++ b/v2/api/dbformariadb/v1api20180601/configuration_types_gen.go
@@ -342,10 +342,10 @@ func (configuration *Servers_Configuration_Spec) ConvertToARM(resolved genruntim
 	}
 	result := &Servers_Configuration_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.Source != nil || configuration.Value != nil {
 		result.Properties = &ConfigurationProperties_ARM{}
 	}
@@ -372,13 +372,13 @@ func (configuration *Servers_Configuration_Spec) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Configuration_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	configuration.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	configuration.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -387,7 +387,7 @@ func (configuration *Servers_Configuration_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {
@@ -630,7 +630,7 @@ func (configuration *Servers_Configuration_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Configuration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedValues’:
+	// Set property "AllowedValues":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowedValues != nil {
@@ -639,9 +639,9 @@ func (configuration *Servers_Configuration_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DataType’:
+	// Set property "DataType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataType != nil {
@@ -650,7 +650,7 @@ func (configuration *Servers_Configuration_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘DefaultValue’:
+	// Set property "DefaultValue":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultValue != nil {
@@ -659,7 +659,7 @@ func (configuration *Servers_Configuration_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -668,19 +668,19 @@ func (configuration *Servers_Configuration_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -689,13 +689,13 @@ func (configuration *Servers_Configuration_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		configuration.Type = &typeVar
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {

--- a/v2/api/dbformariadb/v1api20180601/database_types_gen.go
+++ b/v2/api/dbformariadb/v1api20180601/database_types_gen.go
@@ -337,10 +337,10 @@ func (database *Servers_Database_Spec) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &Servers_Database_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.Charset != nil || database.Collation != nil {
 		result.Properties = &DatabaseProperties_ARM{}
 	}
@@ -367,10 +367,10 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Database_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -379,7 +379,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -388,7 +388,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -611,7 +611,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Database_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -620,7 +620,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -629,21 +629,21 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar

--- a/v2/api/dbformariadb/v1api20180601/server_types_gen.go
+++ b/v2/api/dbformariadb/v1api20180601/server_types_gen.go
@@ -367,16 +367,16 @@ func (server *Server_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &Server_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if server.Location != nil {
 		location := *server.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if server.Properties != nil {
 		properties_ARM, err := (*server.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -386,7 +386,7 @@ func (server *Server_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Properties = &properties
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if server.Sku != nil {
 		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -396,7 +396,7 @@ func (server *Server_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if server.Tags != nil {
 		result.Tags = make(map[string]string, len(server.Tags))
 		for key, value := range server.Tags {
@@ -418,21 +418,21 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Server_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	server.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 ServerPropertiesForCreate
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -443,7 +443,7 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		server.Properties = &properties
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -454,7 +454,7 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		server.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -811,7 +811,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Server_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -820,9 +820,9 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EarliestRestoreDate’:
+	// Set property "EarliestRestoreDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EarliestRestoreDate != nil {
@@ -831,7 +831,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘FullyQualifiedDomainName’:
+	// Set property "FullyQualifiedDomainName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FullyQualifiedDomainName != nil {
@@ -840,19 +840,19 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		server.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MasterServerId’:
+	// Set property "MasterServerId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MasterServerId != nil {
@@ -861,7 +861,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimalTlsVersion != nil {
@@ -870,13 +870,13 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		server.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -889,7 +889,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -898,7 +898,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘ReplicaCapacity’:
+	// Set property "ReplicaCapacity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicaCapacity != nil {
@@ -907,7 +907,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘ReplicationRole’:
+	// Set property "ReplicationRole":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicationRole != nil {
@@ -916,7 +916,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -927,7 +927,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		server.Sku = &sku
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SslEnforcement != nil {
@@ -936,7 +936,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -950,7 +950,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -958,13 +958,13 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		server.Type = &typeVar
 	}
 
-	// Set property ‘UserVisibleState’:
+	// Set property "UserVisibleState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UserVisibleState != nil {
@@ -973,7 +973,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1340,13 +1340,13 @@ func (connection *ServerPrivateEndpointConnection_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 ServerPrivateEndpointConnectionProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -1445,7 +1445,7 @@ func (create *ServerPropertiesForCreate) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &ServerPropertiesForCreate_ARM{}
 
-	// Set property ‘Default’:
+	// Set property "Default":
 	if create.Default != nil {
 		default_ARM, err := (*create.Default).ConvertToARM(resolved)
 		if err != nil {
@@ -1455,7 +1455,7 @@ func (create *ServerPropertiesForCreate) ConvertToARM(resolved genruntime.Conver
 		result.Default = &def
 	}
 
-	// Set property ‘GeoRestore’:
+	// Set property "GeoRestore":
 	if create.GeoRestore != nil {
 		geoRestore_ARM, err := (*create.GeoRestore).ConvertToARM(resolved)
 		if err != nil {
@@ -1465,7 +1465,7 @@ func (create *ServerPropertiesForCreate) ConvertToARM(resolved genruntime.Conver
 		result.GeoRestore = &geoRestore
 	}
 
-	// Set property ‘PointInTimeRestore’:
+	// Set property "PointInTimeRestore":
 	if create.PointInTimeRestore != nil {
 		pointInTimeRestore_ARM, err := (*create.PointInTimeRestore).ConvertToARM(resolved)
 		if err != nil {
@@ -1475,7 +1475,7 @@ func (create *ServerPropertiesForCreate) ConvertToARM(resolved genruntime.Conver
 		result.PointInTimeRestore = &pointInTimeRestore
 	}
 
-	// Set property ‘Replica’:
+	// Set property "Replica":
 	if create.Replica != nil {
 		replica_ARM, err := (*create.Replica).ConvertToARM(resolved)
 		if err != nil {
@@ -1499,7 +1499,7 @@ func (create *ServerPropertiesForCreate) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPropertiesForCreate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Default’:
+	// Set property "Default":
 	if typedInput.Default != nil {
 		var default1 ServerPropertiesForDefaultCreate
 		err := default1.PopulateFromARM(owner, *typedInput.Default)
@@ -1510,7 +1510,7 @@ func (create *ServerPropertiesForCreate) PopulateFromARM(owner genruntime.Arbitr
 		create.Default = &def
 	}
 
-	// Set property ‘GeoRestore’:
+	// Set property "GeoRestore":
 	if typedInput.GeoRestore != nil {
 		var geoRestore1 ServerPropertiesForGeoRestore
 		err := geoRestore1.PopulateFromARM(owner, *typedInput.GeoRestore)
@@ -1521,7 +1521,7 @@ func (create *ServerPropertiesForCreate) PopulateFromARM(owner genruntime.Arbitr
 		create.GeoRestore = &geoRestore
 	}
 
-	// Set property ‘PointInTimeRestore’:
+	// Set property "PointInTimeRestore":
 	if typedInput.PointInTimeRestore != nil {
 		var pointInTimeRestore1 ServerPropertiesForRestore
 		err := pointInTimeRestore1.PopulateFromARM(owner, *typedInput.PointInTimeRestore)
@@ -1532,7 +1532,7 @@ func (create *ServerPropertiesForCreate) PopulateFromARM(owner genruntime.Arbitr
 		create.PointInTimeRestore = &pointInTimeRestore
 	}
 
-	// Set property ‘Replica’:
+	// Set property "Replica":
 	if typedInput.Replica != nil {
 		var replica1 ServerPropertiesForReplica
 		err := replica1.PopulateFromARM(owner, *typedInput.Replica)
@@ -1703,31 +1703,31 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sku.Capacity != nil {
 		capacity := *sku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if sku.Family != nil {
 		family := *sku.Family
 		result.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if sku.Size != nil {
 		size := *sku.Size
 		result.Size = &size
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -1747,31 +1747,31 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if typedInput.Size != nil {
 		size := *typedInput.Size
 		sku.Size = &size
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -1918,31 +1918,31 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if typedInput.Size != nil {
 		size := *typedInput.Size
 		sku.Size = &size
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2052,25 +2052,25 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		profile.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		profile.GeoRedundantBackup = &geoRedundantBackup
 	}
 
-	// Set property ‘StorageAutogrow’:
+	// Set property "StorageAutogrow":
 	if typedInput.StorageAutogrow != nil {
 		storageAutogrow := *typedInput.StorageAutogrow
 		profile.StorageAutogrow = &storageAutogrow
 	}
 
-	// Set property ‘StorageMB’:
+	// Set property "StorageMB":
 	if typedInput.StorageMB != nil {
 		storageMB := *typedInput.StorageMB
 		profile.StorageMB = &storageMB
@@ -2218,7 +2218,7 @@ func (properties *ServerPrivateEndpointConnectionProperties_STATUS) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPrivateEndpointConnectionProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrivateEndpoint’:
+	// Set property "PrivateEndpoint":
 	if typedInput.PrivateEndpoint != nil {
 		var privateEndpoint1 PrivateEndpointProperty_STATUS
 		err := privateEndpoint1.PopulateFromARM(owner, *typedInput.PrivateEndpoint)
@@ -2229,7 +2229,7 @@ func (properties *ServerPrivateEndpointConnectionProperties_STATUS) PopulateFrom
 		properties.PrivateEndpoint = &privateEndpoint
 	}
 
-	// Set property ‘PrivateLinkServiceConnectionState’:
+	// Set property "PrivateLinkServiceConnectionState":
 	if typedInput.PrivateLinkServiceConnectionState != nil {
 		var privateLinkServiceConnectionState1 ServerPrivateLinkServiceConnectionStateProperty_STATUS
 		err := privateLinkServiceConnectionState1.PopulateFromARM(owner, *typedInput.PrivateLinkServiceConnectionState)
@@ -2240,7 +2240,7 @@ func (properties *ServerPrivateEndpointConnectionProperties_STATUS) PopulateFrom
 		properties.PrivateLinkServiceConnectionState = &privateLinkServiceConnectionState
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		properties.ProvisioningState = &provisioningState
@@ -2377,43 +2377,43 @@ func (create *ServerPropertiesForDefaultCreate) ConvertToARM(resolved genruntime
 	}
 	result := &ServerPropertiesForDefaultCreate_ARM{}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	if create.AdministratorLogin != nil {
 		administratorLogin := *create.AdministratorLogin
 		result.AdministratorLogin = &administratorLogin
 	}
 
-	// Set property ‘AdministratorLoginPassword’:
+	// Set property "AdministratorLoginPassword":
 	administratorLoginPasswordSecret, err := resolved.ResolvedSecrets.Lookup(create.AdministratorLoginPassword)
 	if err != nil {
 		return nil, errors.Wrap(err, "looking up secret for property AdministratorLoginPassword")
 	}
 	result.AdministratorLoginPassword = administratorLoginPasswordSecret
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if create.CreateMode != nil {
 		result.CreateMode = *create.CreateMode
 	}
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if create.MinimalTlsVersion != nil {
 		minimalTlsVersion := *create.MinimalTlsVersion
 		result.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if create.PublicNetworkAccess != nil {
 		publicNetworkAccess := *create.PublicNetworkAccess
 		result.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if create.SslEnforcement != nil {
 		sslEnforcement := *create.SslEnforcement
 		result.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if create.StorageProfile != nil {
 		storageProfile_ARM, err := (*create.StorageProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -2423,7 +2423,7 @@ func (create *ServerPropertiesForDefaultCreate) ConvertToARM(resolved genruntime
 		result.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if create.Version != nil {
 		version := *create.Version
 		result.Version = &version
@@ -2443,36 +2443,36 @@ func (create *ServerPropertiesForDefaultCreate) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPropertiesForDefaultCreate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	if typedInput.AdministratorLogin != nil {
 		administratorLogin := *typedInput.AdministratorLogin
 		create.AdministratorLogin = &administratorLogin
 	}
 
-	// no assignment for property ‘AdministratorLoginPassword’
+	// no assignment for property "AdministratorLoginPassword"
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	create.CreateMode = &typedInput.CreateMode
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if typedInput.MinimalTlsVersion != nil {
 		minimalTlsVersion := *typedInput.MinimalTlsVersion
 		create.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		create.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if typedInput.SslEnforcement != nil {
 		sslEnforcement := *typedInput.SslEnforcement
 		create.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 StorageProfile
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -2483,7 +2483,7 @@ func (create *ServerPropertiesForDefaultCreate) PopulateFromARM(owner genruntime
 		create.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		create.Version = &version
@@ -2672,36 +2672,36 @@ func (restore *ServerPropertiesForGeoRestore) ConvertToARM(resolved genruntime.C
 	}
 	result := &ServerPropertiesForGeoRestore_ARM{}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if restore.CreateMode != nil {
 		result.CreateMode = *restore.CreateMode
 	}
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if restore.MinimalTlsVersion != nil {
 		minimalTlsVersion := *restore.MinimalTlsVersion
 		result.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if restore.PublicNetworkAccess != nil {
 		publicNetworkAccess := *restore.PublicNetworkAccess
 		result.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘SourceServerId’:
+	// Set property "SourceServerId":
 	if restore.SourceServerId != nil {
 		sourceServerId := *restore.SourceServerId
 		result.SourceServerId = &sourceServerId
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if restore.SslEnforcement != nil {
 		sslEnforcement := *restore.SslEnforcement
 		result.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if restore.StorageProfile != nil {
 		storageProfile_ARM, err := (*restore.StorageProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -2711,7 +2711,7 @@ func (restore *ServerPropertiesForGeoRestore) ConvertToARM(resolved genruntime.C
 		result.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if restore.Version != nil {
 		version := *restore.Version
 		result.Version = &version
@@ -2731,34 +2731,34 @@ func (restore *ServerPropertiesForGeoRestore) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPropertiesForGeoRestore_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	restore.CreateMode = &typedInput.CreateMode
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if typedInput.MinimalTlsVersion != nil {
 		minimalTlsVersion := *typedInput.MinimalTlsVersion
 		restore.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		restore.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘SourceServerId’:
+	// Set property "SourceServerId":
 	if typedInput.SourceServerId != nil {
 		sourceServerId := *typedInput.SourceServerId
 		restore.SourceServerId = &sourceServerId
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if typedInput.SslEnforcement != nil {
 		sslEnforcement := *typedInput.SslEnforcement
 		restore.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 StorageProfile
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -2769,7 +2769,7 @@ func (restore *ServerPropertiesForGeoRestore) PopulateFromARM(owner genruntime.A
 		restore.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		restore.Version = &version
@@ -2947,36 +2947,36 @@ func (replica *ServerPropertiesForReplica) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ServerPropertiesForReplica_ARM{}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if replica.CreateMode != nil {
 		result.CreateMode = *replica.CreateMode
 	}
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if replica.MinimalTlsVersion != nil {
 		minimalTlsVersion := *replica.MinimalTlsVersion
 		result.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if replica.PublicNetworkAccess != nil {
 		publicNetworkAccess := *replica.PublicNetworkAccess
 		result.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘SourceServerId’:
+	// Set property "SourceServerId":
 	if replica.SourceServerId != nil {
 		sourceServerId := *replica.SourceServerId
 		result.SourceServerId = &sourceServerId
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if replica.SslEnforcement != nil {
 		sslEnforcement := *replica.SslEnforcement
 		result.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if replica.StorageProfile != nil {
 		storageProfile_ARM, err := (*replica.StorageProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -2986,7 +2986,7 @@ func (replica *ServerPropertiesForReplica) ConvertToARM(resolved genruntime.Conv
 		result.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if replica.Version != nil {
 		version := *replica.Version
 		result.Version = &version
@@ -3006,34 +3006,34 @@ func (replica *ServerPropertiesForReplica) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPropertiesForReplica_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	replica.CreateMode = &typedInput.CreateMode
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if typedInput.MinimalTlsVersion != nil {
 		minimalTlsVersion := *typedInput.MinimalTlsVersion
 		replica.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		replica.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘SourceServerId’:
+	// Set property "SourceServerId":
 	if typedInput.SourceServerId != nil {
 		sourceServerId := *typedInput.SourceServerId
 		replica.SourceServerId = &sourceServerId
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if typedInput.SslEnforcement != nil {
 		sslEnforcement := *typedInput.SslEnforcement
 		replica.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 StorageProfile
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -3044,7 +3044,7 @@ func (replica *ServerPropertiesForReplica) PopulateFromARM(owner genruntime.Arbi
 		replica.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		replica.Version = &version
@@ -3226,42 +3226,42 @@ func (restore *ServerPropertiesForRestore) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ServerPropertiesForRestore_ARM{}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if restore.CreateMode != nil {
 		result.CreateMode = *restore.CreateMode
 	}
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if restore.MinimalTlsVersion != nil {
 		minimalTlsVersion := *restore.MinimalTlsVersion
 		result.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if restore.PublicNetworkAccess != nil {
 		publicNetworkAccess := *restore.PublicNetworkAccess
 		result.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘RestorePointInTime’:
+	// Set property "RestorePointInTime":
 	if restore.RestorePointInTime != nil {
 		restorePointInTime := *restore.RestorePointInTime
 		result.RestorePointInTime = &restorePointInTime
 	}
 
-	// Set property ‘SourceServerId’:
+	// Set property "SourceServerId":
 	if restore.SourceServerId != nil {
 		sourceServerId := *restore.SourceServerId
 		result.SourceServerId = &sourceServerId
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if restore.SslEnforcement != nil {
 		sslEnforcement := *restore.SslEnforcement
 		result.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if restore.StorageProfile != nil {
 		storageProfile_ARM, err := (*restore.StorageProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3271,7 +3271,7 @@ func (restore *ServerPropertiesForRestore) ConvertToARM(resolved genruntime.Conv
 		result.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if restore.Version != nil {
 		version := *restore.Version
 		result.Version = &version
@@ -3291,40 +3291,40 @@ func (restore *ServerPropertiesForRestore) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPropertiesForRestore_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	restore.CreateMode = &typedInput.CreateMode
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if typedInput.MinimalTlsVersion != nil {
 		minimalTlsVersion := *typedInput.MinimalTlsVersion
 		restore.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		restore.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘RestorePointInTime’:
+	// Set property "RestorePointInTime":
 	if typedInput.RestorePointInTime != nil {
 		restorePointInTime := *typedInput.RestorePointInTime
 		restore.RestorePointInTime = &restorePointInTime
 	}
 
-	// Set property ‘SourceServerId’:
+	// Set property "SourceServerId":
 	if typedInput.SourceServerId != nil {
 		sourceServerId := *typedInput.SourceServerId
 		restore.SourceServerId = &sourceServerId
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if typedInput.SslEnforcement != nil {
 		sslEnforcement := *typedInput.SslEnforcement
 		restore.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 StorageProfile
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -3335,7 +3335,7 @@ func (restore *ServerPropertiesForRestore) PopulateFromARM(owner genruntime.Arbi
 		restore.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		restore.Version = &version
@@ -3517,7 +3517,7 @@ func (property *PrivateEndpointProperty_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		property.Id = &id
@@ -3591,19 +3591,19 @@ func (property *ServerPrivateLinkServiceConnectionStateProperty_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPrivateLinkServiceConnectionStateProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionsRequired’:
+	// Set property "ActionsRequired":
 	if typedInput.ActionsRequired != nil {
 		actionsRequired := *typedInput.ActionsRequired
 		property.ActionsRequired = &actionsRequired
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		property.Description = &description
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		property.Status = &status
@@ -3698,25 +3698,25 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &StorageProfile_ARM{}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if profile.BackupRetentionDays != nil {
 		backupRetentionDays := *profile.BackupRetentionDays
 		result.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if profile.GeoRedundantBackup != nil {
 		geoRedundantBackup := *profile.GeoRedundantBackup
 		result.GeoRedundantBackup = &geoRedundantBackup
 	}
 
-	// Set property ‘StorageAutogrow’:
+	// Set property "StorageAutogrow":
 	if profile.StorageAutogrow != nil {
 		storageAutogrow := *profile.StorageAutogrow
 		result.StorageAutogrow = &storageAutogrow
 	}
 
-	// Set property ‘StorageMB’:
+	// Set property "StorageMB":
 	if profile.StorageMB != nil {
 		storageMB := *profile.StorageMB
 		result.StorageMB = &storageMB
@@ -3736,25 +3736,25 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		profile.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		profile.GeoRedundantBackup = &geoRedundantBackup
 	}
 
-	// Set property ‘StorageAutogrow’:
+	// Set property "StorageAutogrow":
 	if typedInput.StorageAutogrow != nil {
 		storageAutogrow := *typedInput.StorageAutogrow
 		profile.StorageAutogrow = &storageAutogrow
 	}
 
-	// Set property ‘StorageMB’:
+	// Set property "StorageMB":
 	if typedInput.StorageMB != nil {
 		storageMB := *typedInput.StorageMB
 		profile.StorageMB = &storageMB

--- a/v2/api/dbformariadb/v1beta20180601/configuration_types_gen.go
+++ b/v2/api/dbformariadb/v1beta20180601/configuration_types_gen.go
@@ -338,10 +338,10 @@ func (configuration *Servers_Configuration_Spec) ConvertToARM(resolved genruntim
 	}
 	result := &Servers_Configuration_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.Source != nil || configuration.Value != nil {
 		result.Properties = &ConfigurationProperties_ARM{}
 	}
@@ -368,13 +368,13 @@ func (configuration *Servers_Configuration_Spec) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Configuration_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	configuration.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	configuration.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -383,7 +383,7 @@ func (configuration *Servers_Configuration_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {
@@ -596,7 +596,7 @@ func (configuration *Servers_Configuration_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Configuration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedValues’:
+	// Set property "AllowedValues":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowedValues != nil {
@@ -605,9 +605,9 @@ func (configuration *Servers_Configuration_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DataType’:
+	// Set property "DataType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataType != nil {
@@ -616,7 +616,7 @@ func (configuration *Servers_Configuration_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘DefaultValue’:
+	// Set property "DefaultValue":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultValue != nil {
@@ -625,7 +625,7 @@ func (configuration *Servers_Configuration_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -634,19 +634,19 @@ func (configuration *Servers_Configuration_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -655,13 +655,13 @@ func (configuration *Servers_Configuration_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		configuration.Type = &typeVar
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {

--- a/v2/api/dbformariadb/v1beta20180601/database_types_gen.go
+++ b/v2/api/dbformariadb/v1beta20180601/database_types_gen.go
@@ -332,10 +332,10 @@ func (database *Servers_Database_Spec) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &Servers_Database_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.Charset != nil || database.Collation != nil {
 		result.Properties = &DatabaseProperties_ARM{}
 	}
@@ -362,10 +362,10 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Database_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -374,7 +374,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -383,7 +383,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -584,7 +584,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Database_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -593,7 +593,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -602,21 +602,21 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar

--- a/v2/api/dbformariadb/v1beta20180601/server_types_gen.go
+++ b/v2/api/dbformariadb/v1beta20180601/server_types_gen.go
@@ -360,16 +360,16 @@ func (server *Server_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &Server_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if server.Location != nil {
 		location := *server.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if server.Properties != nil {
 		properties_ARM, err := (*server.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -379,7 +379,7 @@ func (server *Server_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Properties = &properties
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if server.Sku != nil {
 		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -389,7 +389,7 @@ func (server *Server_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if server.Tags != nil {
 		result.Tags = make(map[string]string, len(server.Tags))
 		for key, value := range server.Tags {
@@ -411,21 +411,21 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Server_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	server.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 ServerPropertiesForCreate
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -436,7 +436,7 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		server.Properties = &properties
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -447,7 +447,7 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		server.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -739,7 +739,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Server_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -748,9 +748,9 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EarliestRestoreDate’:
+	// Set property "EarliestRestoreDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EarliestRestoreDate != nil {
@@ -759,7 +759,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘FullyQualifiedDomainName’:
+	// Set property "FullyQualifiedDomainName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FullyQualifiedDomainName != nil {
@@ -768,19 +768,19 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		server.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MasterServerId’:
+	// Set property "MasterServerId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MasterServerId != nil {
@@ -789,7 +789,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimalTlsVersion != nil {
@@ -798,13 +798,13 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		server.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -817,7 +817,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -826,7 +826,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘ReplicaCapacity’:
+	// Set property "ReplicaCapacity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicaCapacity != nil {
@@ -835,7 +835,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘ReplicationRole’:
+	// Set property "ReplicationRole":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicationRole != nil {
@@ -844,7 +844,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -855,7 +855,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		server.Sku = &sku
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SslEnforcement != nil {
@@ -864,7 +864,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageProfile != nil {
@@ -878,7 +878,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -886,13 +886,13 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		server.Type = &typeVar
 	}
 
-	// Set property ‘UserVisibleState’:
+	// Set property "UserVisibleState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UserVisibleState != nil {
@@ -901,7 +901,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1264,13 +1264,13 @@ func (connection *ServerPrivateEndpointConnection_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 ServerPrivateEndpointConnectionProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -1365,7 +1365,7 @@ func (create *ServerPropertiesForCreate) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &ServerPropertiesForCreate_ARM{}
 
-	// Set property ‘Default’:
+	// Set property "Default":
 	if create.Default != nil {
 		default_ARM, err := (*create.Default).ConvertToARM(resolved)
 		if err != nil {
@@ -1375,7 +1375,7 @@ func (create *ServerPropertiesForCreate) ConvertToARM(resolved genruntime.Conver
 		result.Default = &def
 	}
 
-	// Set property ‘GeoRestore’:
+	// Set property "GeoRestore":
 	if create.GeoRestore != nil {
 		geoRestore_ARM, err := (*create.GeoRestore).ConvertToARM(resolved)
 		if err != nil {
@@ -1385,7 +1385,7 @@ func (create *ServerPropertiesForCreate) ConvertToARM(resolved genruntime.Conver
 		result.GeoRestore = &geoRestore
 	}
 
-	// Set property ‘PointInTimeRestore’:
+	// Set property "PointInTimeRestore":
 	if create.PointInTimeRestore != nil {
 		pointInTimeRestore_ARM, err := (*create.PointInTimeRestore).ConvertToARM(resolved)
 		if err != nil {
@@ -1395,7 +1395,7 @@ func (create *ServerPropertiesForCreate) ConvertToARM(resolved genruntime.Conver
 		result.PointInTimeRestore = &pointInTimeRestore
 	}
 
-	// Set property ‘Replica’:
+	// Set property "Replica":
 	if create.Replica != nil {
 		replica_ARM, err := (*create.Replica).ConvertToARM(resolved)
 		if err != nil {
@@ -1419,7 +1419,7 @@ func (create *ServerPropertiesForCreate) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPropertiesForCreate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Default’:
+	// Set property "Default":
 	if typedInput.Default != nil {
 		var default1 ServerPropertiesForDefaultCreate
 		err := default1.PopulateFromARM(owner, *typedInput.Default)
@@ -1430,7 +1430,7 @@ func (create *ServerPropertiesForCreate) PopulateFromARM(owner genruntime.Arbitr
 		create.Default = &def
 	}
 
-	// Set property ‘GeoRestore’:
+	// Set property "GeoRestore":
 	if typedInput.GeoRestore != nil {
 		var geoRestore1 ServerPropertiesForGeoRestore
 		err := geoRestore1.PopulateFromARM(owner, *typedInput.GeoRestore)
@@ -1441,7 +1441,7 @@ func (create *ServerPropertiesForCreate) PopulateFromARM(owner genruntime.Arbitr
 		create.GeoRestore = &geoRestore
 	}
 
-	// Set property ‘PointInTimeRestore’:
+	// Set property "PointInTimeRestore":
 	if typedInput.PointInTimeRestore != nil {
 		var pointInTimeRestore1 ServerPropertiesForRestore
 		err := pointInTimeRestore1.PopulateFromARM(owner, *typedInput.PointInTimeRestore)
@@ -1452,7 +1452,7 @@ func (create *ServerPropertiesForCreate) PopulateFromARM(owner genruntime.Arbitr
 		create.PointInTimeRestore = &pointInTimeRestore
 	}
 
-	// Set property ‘Replica’:
+	// Set property "Replica":
 	if typedInput.Replica != nil {
 		var replica1 ServerPropertiesForReplica
 		err := replica1.PopulateFromARM(owner, *typedInput.Replica)
@@ -1615,31 +1615,31 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sku.Capacity != nil {
 		capacity := *sku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if sku.Family != nil {
 		family := *sku.Family
 		result.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if sku.Size != nil {
 		size := *sku.Size
 		result.Size = &size
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -1659,31 +1659,31 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if typedInput.Size != nil {
 		size := *typedInput.Size
 		sku.Size = &size
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -1789,31 +1789,31 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if typedInput.Size != nil {
 		size := *typedInput.Size
 		sku.Size = &size
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -1916,25 +1916,25 @@ func (profile *StorageProfile_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		profile.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		profile.GeoRedundantBackup = &geoRedundantBackup
 	}
 
-	// Set property ‘StorageAutogrow’:
+	// Set property "StorageAutogrow":
 	if typedInput.StorageAutogrow != nil {
 		storageAutogrow := *typedInput.StorageAutogrow
 		profile.StorageAutogrow = &storageAutogrow
 	}
 
-	// Set property ‘StorageMB’:
+	// Set property "StorageMB":
 	if typedInput.StorageMB != nil {
 		storageMB := *typedInput.StorageMB
 		profile.StorageMB = &storageMB
@@ -2077,7 +2077,7 @@ func (properties *ServerPrivateEndpointConnectionProperties_STATUS) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPrivateEndpointConnectionProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrivateEndpoint’:
+	// Set property "PrivateEndpoint":
 	if typedInput.PrivateEndpoint != nil {
 		var privateEndpoint1 PrivateEndpointProperty_STATUS
 		err := privateEndpoint1.PopulateFromARM(owner, *typedInput.PrivateEndpoint)
@@ -2088,7 +2088,7 @@ func (properties *ServerPrivateEndpointConnectionProperties_STATUS) PopulateFrom
 		properties.PrivateEndpoint = &privateEndpoint
 	}
 
-	// Set property ‘PrivateLinkServiceConnectionState’:
+	// Set property "PrivateLinkServiceConnectionState":
 	if typedInput.PrivateLinkServiceConnectionState != nil {
 		var privateLinkServiceConnectionState1 ServerPrivateLinkServiceConnectionStateProperty_STATUS
 		err := privateLinkServiceConnectionState1.PopulateFromARM(owner, *typedInput.PrivateLinkServiceConnectionState)
@@ -2099,7 +2099,7 @@ func (properties *ServerPrivateEndpointConnectionProperties_STATUS) PopulateFrom
 		properties.PrivateLinkServiceConnectionState = &privateLinkServiceConnectionState
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		properties.ProvisioningState = &provisioningState
@@ -2222,43 +2222,43 @@ func (create *ServerPropertiesForDefaultCreate) ConvertToARM(resolved genruntime
 	}
 	result := &ServerPropertiesForDefaultCreate_ARM{}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	if create.AdministratorLogin != nil {
 		administratorLogin := *create.AdministratorLogin
 		result.AdministratorLogin = &administratorLogin
 	}
 
-	// Set property ‘AdministratorLoginPassword’:
+	// Set property "AdministratorLoginPassword":
 	administratorLoginPasswordSecret, err := resolved.ResolvedSecrets.Lookup(create.AdministratorLoginPassword)
 	if err != nil {
 		return nil, errors.Wrap(err, "looking up secret for property AdministratorLoginPassword")
 	}
 	result.AdministratorLoginPassword = administratorLoginPasswordSecret
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if create.CreateMode != nil {
 		result.CreateMode = *create.CreateMode
 	}
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if create.MinimalTlsVersion != nil {
 		minimalTlsVersion := *create.MinimalTlsVersion
 		result.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if create.PublicNetworkAccess != nil {
 		publicNetworkAccess := *create.PublicNetworkAccess
 		result.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if create.SslEnforcement != nil {
 		sslEnforcement := *create.SslEnforcement
 		result.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if create.StorageProfile != nil {
 		storageProfile_ARM, err := (*create.StorageProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -2268,7 +2268,7 @@ func (create *ServerPropertiesForDefaultCreate) ConvertToARM(resolved genruntime
 		result.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if create.Version != nil {
 		version := *create.Version
 		result.Version = &version
@@ -2288,36 +2288,36 @@ func (create *ServerPropertiesForDefaultCreate) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPropertiesForDefaultCreate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	if typedInput.AdministratorLogin != nil {
 		administratorLogin := *typedInput.AdministratorLogin
 		create.AdministratorLogin = &administratorLogin
 	}
 
-	// no assignment for property ‘AdministratorLoginPassword’
+	// no assignment for property "AdministratorLoginPassword"
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	create.CreateMode = &typedInput.CreateMode
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if typedInput.MinimalTlsVersion != nil {
 		minimalTlsVersion := *typedInput.MinimalTlsVersion
 		create.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		create.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if typedInput.SslEnforcement != nil {
 		sslEnforcement := *typedInput.SslEnforcement
 		create.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 StorageProfile
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -2328,7 +2328,7 @@ func (create *ServerPropertiesForDefaultCreate) PopulateFromARM(owner genruntime
 		create.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		create.Version = &version
@@ -2505,36 +2505,36 @@ func (restore *ServerPropertiesForGeoRestore) ConvertToARM(resolved genruntime.C
 	}
 	result := &ServerPropertiesForGeoRestore_ARM{}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if restore.CreateMode != nil {
 		result.CreateMode = *restore.CreateMode
 	}
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if restore.MinimalTlsVersion != nil {
 		minimalTlsVersion := *restore.MinimalTlsVersion
 		result.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if restore.PublicNetworkAccess != nil {
 		publicNetworkAccess := *restore.PublicNetworkAccess
 		result.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘SourceServerId’:
+	// Set property "SourceServerId":
 	if restore.SourceServerId != nil {
 		sourceServerId := *restore.SourceServerId
 		result.SourceServerId = &sourceServerId
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if restore.SslEnforcement != nil {
 		sslEnforcement := *restore.SslEnforcement
 		result.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if restore.StorageProfile != nil {
 		storageProfile_ARM, err := (*restore.StorageProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -2544,7 +2544,7 @@ func (restore *ServerPropertiesForGeoRestore) ConvertToARM(resolved genruntime.C
 		result.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if restore.Version != nil {
 		version := *restore.Version
 		result.Version = &version
@@ -2564,34 +2564,34 @@ func (restore *ServerPropertiesForGeoRestore) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPropertiesForGeoRestore_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	restore.CreateMode = &typedInput.CreateMode
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if typedInput.MinimalTlsVersion != nil {
 		minimalTlsVersion := *typedInput.MinimalTlsVersion
 		restore.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		restore.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘SourceServerId’:
+	// Set property "SourceServerId":
 	if typedInput.SourceServerId != nil {
 		sourceServerId := *typedInput.SourceServerId
 		restore.SourceServerId = &sourceServerId
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if typedInput.SslEnforcement != nil {
 		sslEnforcement := *typedInput.SslEnforcement
 		restore.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 StorageProfile
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -2602,7 +2602,7 @@ func (restore *ServerPropertiesForGeoRestore) PopulateFromARM(owner genruntime.A
 		restore.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		restore.Version = &version
@@ -2768,36 +2768,36 @@ func (replica *ServerPropertiesForReplica) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ServerPropertiesForReplica_ARM{}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if replica.CreateMode != nil {
 		result.CreateMode = *replica.CreateMode
 	}
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if replica.MinimalTlsVersion != nil {
 		minimalTlsVersion := *replica.MinimalTlsVersion
 		result.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if replica.PublicNetworkAccess != nil {
 		publicNetworkAccess := *replica.PublicNetworkAccess
 		result.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘SourceServerId’:
+	// Set property "SourceServerId":
 	if replica.SourceServerId != nil {
 		sourceServerId := *replica.SourceServerId
 		result.SourceServerId = &sourceServerId
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if replica.SslEnforcement != nil {
 		sslEnforcement := *replica.SslEnforcement
 		result.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if replica.StorageProfile != nil {
 		storageProfile_ARM, err := (*replica.StorageProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -2807,7 +2807,7 @@ func (replica *ServerPropertiesForReplica) ConvertToARM(resolved genruntime.Conv
 		result.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if replica.Version != nil {
 		version := *replica.Version
 		result.Version = &version
@@ -2827,34 +2827,34 @@ func (replica *ServerPropertiesForReplica) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPropertiesForReplica_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	replica.CreateMode = &typedInput.CreateMode
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if typedInput.MinimalTlsVersion != nil {
 		minimalTlsVersion := *typedInput.MinimalTlsVersion
 		replica.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		replica.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘SourceServerId’:
+	// Set property "SourceServerId":
 	if typedInput.SourceServerId != nil {
 		sourceServerId := *typedInput.SourceServerId
 		replica.SourceServerId = &sourceServerId
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if typedInput.SslEnforcement != nil {
 		sslEnforcement := *typedInput.SslEnforcement
 		replica.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 StorageProfile
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -2865,7 +2865,7 @@ func (replica *ServerPropertiesForReplica) PopulateFromARM(owner genruntime.Arbi
 		replica.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		replica.Version = &version
@@ -3034,42 +3034,42 @@ func (restore *ServerPropertiesForRestore) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ServerPropertiesForRestore_ARM{}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if restore.CreateMode != nil {
 		result.CreateMode = *restore.CreateMode
 	}
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if restore.MinimalTlsVersion != nil {
 		minimalTlsVersion := *restore.MinimalTlsVersion
 		result.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if restore.PublicNetworkAccess != nil {
 		publicNetworkAccess := *restore.PublicNetworkAccess
 		result.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘RestorePointInTime’:
+	// Set property "RestorePointInTime":
 	if restore.RestorePointInTime != nil {
 		restorePointInTime := *restore.RestorePointInTime
 		result.RestorePointInTime = &restorePointInTime
 	}
 
-	// Set property ‘SourceServerId’:
+	// Set property "SourceServerId":
 	if restore.SourceServerId != nil {
 		sourceServerId := *restore.SourceServerId
 		result.SourceServerId = &sourceServerId
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if restore.SslEnforcement != nil {
 		sslEnforcement := *restore.SslEnforcement
 		result.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if restore.StorageProfile != nil {
 		storageProfile_ARM, err := (*restore.StorageProfile).ConvertToARM(resolved)
 		if err != nil {
@@ -3079,7 +3079,7 @@ func (restore *ServerPropertiesForRestore) ConvertToARM(resolved genruntime.Conv
 		result.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if restore.Version != nil {
 		version := *restore.Version
 		result.Version = &version
@@ -3099,40 +3099,40 @@ func (restore *ServerPropertiesForRestore) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPropertiesForRestore_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	restore.CreateMode = &typedInput.CreateMode
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	if typedInput.MinimalTlsVersion != nil {
 		minimalTlsVersion := *typedInput.MinimalTlsVersion
 		restore.MinimalTlsVersion = &minimalTlsVersion
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		restore.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘RestorePointInTime’:
+	// Set property "RestorePointInTime":
 	if typedInput.RestorePointInTime != nil {
 		restorePointInTime := *typedInput.RestorePointInTime
 		restore.RestorePointInTime = &restorePointInTime
 	}
 
-	// Set property ‘SourceServerId’:
+	// Set property "SourceServerId":
 	if typedInput.SourceServerId != nil {
 		sourceServerId := *typedInput.SourceServerId
 		restore.SourceServerId = &sourceServerId
 	}
 
-	// Set property ‘SslEnforcement’:
+	// Set property "SslEnforcement":
 	if typedInput.SslEnforcement != nil {
 		sslEnforcement := *typedInput.SslEnforcement
 		restore.SslEnforcement = &sslEnforcement
 	}
 
-	// Set property ‘StorageProfile’:
+	// Set property "StorageProfile":
 	if typedInput.StorageProfile != nil {
 		var storageProfile1 StorageProfile
 		err := storageProfile1.PopulateFromARM(owner, *typedInput.StorageProfile)
@@ -3143,7 +3143,7 @@ func (restore *ServerPropertiesForRestore) PopulateFromARM(owner genruntime.Arbi
 		restore.StorageProfile = &storageProfile
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		restore.Version = &version
@@ -3329,7 +3329,7 @@ func (property *PrivateEndpointProperty_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		property.Id = &id
@@ -3401,19 +3401,19 @@ func (property *ServerPrivateLinkServiceConnectionStateProperty_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPrivateLinkServiceConnectionStateProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionsRequired’:
+	// Set property "ActionsRequired":
 	if typedInput.ActionsRequired != nil {
 		actionsRequired := *typedInput.ActionsRequired
 		property.ActionsRequired = &actionsRequired
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		property.Description = &description
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		property.Status = &status
@@ -3501,25 +3501,25 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &StorageProfile_ARM{}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if profile.BackupRetentionDays != nil {
 		backupRetentionDays := *profile.BackupRetentionDays
 		result.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if profile.GeoRedundantBackup != nil {
 		geoRedundantBackup := *profile.GeoRedundantBackup
 		result.GeoRedundantBackup = &geoRedundantBackup
 	}
 
-	// Set property ‘StorageAutogrow’:
+	// Set property "StorageAutogrow":
 	if profile.StorageAutogrow != nil {
 		storageAutogrow := *profile.StorageAutogrow
 		result.StorageAutogrow = &storageAutogrow
 	}
 
-	// Set property ‘StorageMB’:
+	// Set property "StorageMB":
 	if profile.StorageMB != nil {
 		storageMB := *profile.StorageMB
 		result.StorageMB = &storageMB
@@ -3539,25 +3539,25 @@ func (profile *StorageProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		profile.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		profile.GeoRedundantBackup = &geoRedundantBackup
 	}
 
-	// Set property ‘StorageAutogrow’:
+	// Set property "StorageAutogrow":
 	if typedInput.StorageAutogrow != nil {
 		storageAutogrow := *typedInput.StorageAutogrow
 		profile.StorageAutogrow = &storageAutogrow
 	}
 
-	// Set property ‘StorageMB’:
+	// Set property "StorageMB":
 	if typedInput.StorageMB != nil {
 		storageMB := *typedInput.StorageMB
 		profile.StorageMB = &storageMB

--- a/v2/api/dbformysql/v1api20210501/flexible_server_types_gen.go
+++ b/v2/api/dbformysql/v1api20210501/flexible_server_types_gen.go
@@ -415,7 +415,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FlexibleServer_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if server.Identity != nil {
 		identity_ARM, err := (*server.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -425,16 +425,16 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if server.Location != nil {
 		location := *server.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if server.AdministratorLogin != nil ||
 		server.AdministratorLoginPassword != nil ||
 		server.AvailabilityZone != nil ||
@@ -536,7 +536,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.Version = &version
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if server.Sku != nil {
 		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -546,7 +546,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if server.Tags != nil {
 		result.Tags = make(map[string]string, len(server.Tags))
 		for key, value := range server.Tags {
@@ -568,7 +568,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServer_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -577,9 +577,9 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘AdministratorLoginPassword’
+	// no assignment for property "AdministratorLoginPassword"
 
-	// Set property ‘AvailabilityZone’:
+	// Set property "AvailabilityZone":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityZone != nil {
@@ -588,10 +588,10 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	server.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Backup’:
+	// Set property "Backup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Backup != nil {
@@ -605,7 +605,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -614,7 +614,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘DataEncryption’:
+	// Set property "DataEncryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataEncryption != nil {
@@ -628,7 +628,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HighAvailability’:
+	// Set property "HighAvailability":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailability != nil {
@@ -642,7 +642,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -653,13 +653,13 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		server.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceWindow != nil {
@@ -673,7 +673,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Network’:
+	// Set property "Network":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Network != nil {
@@ -687,12 +687,12 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ReplicationRole’:
+	// Set property "ReplicationRole":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicationRole != nil {
@@ -701,7 +701,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘RestorePointInTime’:
+	// Set property "RestorePointInTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestorePointInTime != nil {
@@ -710,7 +710,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -721,7 +721,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		server.Sku = &sku
 	}
 
-	// Set property ‘SourceServerResourceId’:
+	// Set property "SourceServerResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceServerResourceId != nil {
@@ -730,7 +730,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Storage != nil {
@@ -744,7 +744,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -752,7 +752,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1475,7 +1475,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServer_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -1484,7 +1484,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘AvailabilityZone’:
+	// Set property "AvailabilityZone":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityZone != nil {
@@ -1493,7 +1493,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Backup’:
+	// Set property "Backup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Backup != nil {
@@ -1507,9 +1507,9 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -1518,7 +1518,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘DataEncryption’:
+	// Set property "DataEncryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataEncryption != nil {
@@ -1532,7 +1532,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘FullyQualifiedDomainName’:
+	// Set property "FullyQualifiedDomainName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FullyQualifiedDomainName != nil {
@@ -1541,7 +1541,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘HighAvailability’:
+	// Set property "HighAvailability":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailability != nil {
@@ -1555,13 +1555,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		server.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1572,13 +1572,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceWindow != nil {
@@ -1592,13 +1592,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		server.Name = &name
 	}
 
-	// Set property ‘Network’:
+	// Set property "Network":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Network != nil {
@@ -1612,7 +1612,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ReplicaCapacity’:
+	// Set property "ReplicaCapacity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicaCapacity != nil {
@@ -1621,7 +1621,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ReplicationRole’:
+	// Set property "ReplicationRole":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicationRole != nil {
@@ -1630,7 +1630,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘RestorePointInTime’:
+	// Set property "RestorePointInTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestorePointInTime != nil {
@@ -1639,7 +1639,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1650,7 +1650,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.Sku = &sku
 	}
 
-	// Set property ‘SourceServerResourceId’:
+	// Set property "SourceServerResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceServerResourceId != nil {
@@ -1659,7 +1659,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1668,7 +1668,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Storage != nil {
@@ -1682,7 +1682,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1693,7 +1693,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1701,13 +1701,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		server.Type = &typeVar
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -2113,13 +2113,13 @@ func (backup *Backup) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &Backup_ARM{}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if backup.BackupRetentionDays != nil {
 		backupRetentionDays := *backup.BackupRetentionDays
 		result.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if backup.GeoRedundantBackup != nil {
 		geoRedundantBackup := *backup.GeoRedundantBackup
 		result.GeoRedundantBackup = &geoRedundantBackup
@@ -2139,13 +2139,13 @@ func (backup *Backup) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Backup_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		backup.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		backup.GeoRedundantBackup = &geoRedundantBackup
@@ -2244,19 +2244,19 @@ func (backup *Backup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Backup_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		backup.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘EarliestRestoreDate’:
+	// Set property "EarliestRestoreDate":
 	if typedInput.EarliestRestoreDate != nil {
 		earliestRestoreDate := *typedInput.EarliestRestoreDate
 		backup.EarliestRestoreDate = &earliestRestoreDate
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		backup.GeoRedundantBackup = &geoRedundantBackup
@@ -2345,13 +2345,13 @@ func (encryption *DataEncryption) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &DataEncryption_ARM{}
 
-	// Set property ‘GeoBackupKeyURI’:
+	// Set property "GeoBackupKeyURI":
 	if encryption.GeoBackupKeyURI != nil {
 		geoBackupKeyURI := *encryption.GeoBackupKeyURI
 		result.GeoBackupKeyURI = &geoBackupKeyURI
 	}
 
-	// Set property ‘GeoBackupUserAssignedIdentityId’:
+	// Set property "GeoBackupUserAssignedIdentityId":
 	if encryption.GeoBackupUserAssignedIdentityReference != nil {
 		geoBackupUserAssignedIdentityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*encryption.GeoBackupUserAssignedIdentityReference)
 		if err != nil {
@@ -2361,13 +2361,13 @@ func (encryption *DataEncryption) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.GeoBackupUserAssignedIdentityId = &geoBackupUserAssignedIdentityReference
 	}
 
-	// Set property ‘PrimaryKeyURI’:
+	// Set property "PrimaryKeyURI":
 	if encryption.PrimaryKeyURI != nil {
 		primaryKeyURI := *encryption.PrimaryKeyURI
 		result.PrimaryKeyURI = &primaryKeyURI
 	}
 
-	// Set property ‘PrimaryUserAssignedIdentityId’:
+	// Set property "PrimaryUserAssignedIdentityId":
 	if encryption.PrimaryUserAssignedIdentityReference != nil {
 		primaryUserAssignedIdentityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*encryption.PrimaryUserAssignedIdentityReference)
 		if err != nil {
@@ -2377,7 +2377,7 @@ func (encryption *DataEncryption) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.PrimaryUserAssignedIdentityId = &primaryUserAssignedIdentityReference
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if encryption.Type != nil {
 		typeVar := *encryption.Type
 		result.Type = &typeVar
@@ -2397,23 +2397,23 @@ func (encryption *DataEncryption) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataEncryption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GeoBackupKeyURI’:
+	// Set property "GeoBackupKeyURI":
 	if typedInput.GeoBackupKeyURI != nil {
 		geoBackupKeyURI := *typedInput.GeoBackupKeyURI
 		encryption.GeoBackupKeyURI = &geoBackupKeyURI
 	}
 
-	// no assignment for property ‘GeoBackupUserAssignedIdentityReference’
+	// no assignment for property "GeoBackupUserAssignedIdentityReference"
 
-	// Set property ‘PrimaryKeyURI’:
+	// Set property "PrimaryKeyURI":
 	if typedInput.PrimaryKeyURI != nil {
 		primaryKeyURI := *typedInput.PrimaryKeyURI
 		encryption.PrimaryKeyURI = &primaryKeyURI
 	}
 
-	// no assignment for property ‘PrimaryUserAssignedIdentityReference’
+	// no assignment for property "PrimaryUserAssignedIdentityReference"
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		encryption.Type = &typeVar
@@ -2576,31 +2576,31 @@ func (encryption *DataEncryption_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataEncryption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GeoBackupKeyURI’:
+	// Set property "GeoBackupKeyURI":
 	if typedInput.GeoBackupKeyURI != nil {
 		geoBackupKeyURI := *typedInput.GeoBackupKeyURI
 		encryption.GeoBackupKeyURI = &geoBackupKeyURI
 	}
 
-	// Set property ‘GeoBackupUserAssignedIdentityId’:
+	// Set property "GeoBackupUserAssignedIdentityId":
 	if typedInput.GeoBackupUserAssignedIdentityId != nil {
 		geoBackupUserAssignedIdentityId := *typedInput.GeoBackupUserAssignedIdentityId
 		encryption.GeoBackupUserAssignedIdentityId = &geoBackupUserAssignedIdentityId
 	}
 
-	// Set property ‘PrimaryKeyURI’:
+	// Set property "PrimaryKeyURI":
 	if typedInput.PrimaryKeyURI != nil {
 		primaryKeyURI := *typedInput.PrimaryKeyURI
 		encryption.PrimaryKeyURI = &primaryKeyURI
 	}
 
-	// Set property ‘PrimaryUserAssignedIdentityId’:
+	// Set property "PrimaryUserAssignedIdentityId":
 	if typedInput.PrimaryUserAssignedIdentityId != nil {
 		primaryUserAssignedIdentityId := *typedInput.PrimaryUserAssignedIdentityId
 		encryption.PrimaryUserAssignedIdentityId = &primaryUserAssignedIdentityId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		encryption.Type = &typeVar
@@ -2744,13 +2744,13 @@ func (availability *HighAvailability) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &HighAvailability_ARM{}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if availability.Mode != nil {
 		mode := *availability.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if availability.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *availability.StandbyAvailabilityZone
 		result.StandbyAvailabilityZone = &standbyAvailabilityZone
@@ -2770,13 +2770,13 @@ func (availability *HighAvailability) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HighAvailability_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		availability.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if typedInput.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *typedInput.StandbyAvailabilityZone
 		availability.StandbyAvailabilityZone = &standbyAvailabilityZone
@@ -2875,19 +2875,19 @@ func (availability *HighAvailability_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HighAvailability_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		availability.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if typedInput.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *typedInput.StandbyAvailabilityZone
 		availability.StandbyAvailabilityZone = &standbyAvailabilityZone
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		availability.State = &state
@@ -2976,13 +2976,13 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Identity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -3007,13 +3007,13 @@ func (identity *Identity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -3150,25 +3150,25 @@ func (identity *Identity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]v1.JSON, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -3281,25 +3281,25 @@ func (window *MaintenanceWindow) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &MaintenanceWindow_ARM{}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if window.CustomWindow != nil {
 		customWindow := *window.CustomWindow
 		result.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if window.DayOfWeek != nil {
 		dayOfWeek := *window.DayOfWeek
 		result.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if window.StartHour != nil {
 		startHour := *window.StartHour
 		result.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if window.StartMinute != nil {
 		startMinute := *window.StartMinute
 		result.StartMinute = &startMinute
@@ -3319,25 +3319,25 @@ func (window *MaintenanceWindow) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceWindow_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if typedInput.CustomWindow != nil {
 		customWindow := *typedInput.CustomWindow
 		window.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		window.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if typedInput.StartHour != nil {
 		startHour := *typedInput.StartHour
 		window.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if typedInput.StartMinute != nil {
 		startMinute := *typedInput.StartMinute
 		window.StartMinute = &startMinute
@@ -3442,25 +3442,25 @@ func (window *MaintenanceWindow_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceWindow_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if typedInput.CustomWindow != nil {
 		customWindow := *typedInput.CustomWindow
 		window.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		window.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if typedInput.StartHour != nil {
 		startHour := *typedInput.StartHour
 		window.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if typedInput.StartMinute != nil {
 		startMinute := *typedInput.StartMinute
 		window.StartMinute = &startMinute
@@ -3535,7 +3535,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Network_ARM{}
 
-	// Set property ‘DelegatedSubnetResourceId’:
+	// Set property "DelegatedSubnetResourceId":
 	if network.DelegatedSubnetResourceReference != nil {
 		delegatedSubnetResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*network.DelegatedSubnetResourceReference)
 		if err != nil {
@@ -3545,7 +3545,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.DelegatedSubnetResourceId = &delegatedSubnetResourceReference
 	}
 
-	// Set property ‘PrivateDnsZoneResourceId’:
+	// Set property "PrivateDnsZoneResourceId":
 	if network.PrivateDnsZoneResourceReference != nil {
 		privateDnsZoneResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*network.PrivateDnsZoneResourceReference)
 		if err != nil {
@@ -3569,9 +3569,9 @@ func (network *Network) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Network_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘DelegatedSubnetResourceReference’
+	// no assignment for property "DelegatedSubnetResourceReference"
 
-	// no assignment for property ‘PrivateDnsZoneResourceReference’
+	// no assignment for property "PrivateDnsZoneResourceReference"
 
 	// No error
 	return nil
@@ -3682,19 +3682,19 @@ func (network *Network_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Network_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DelegatedSubnetResourceId’:
+	// Set property "DelegatedSubnetResourceId":
 	if typedInput.DelegatedSubnetResourceId != nil {
 		delegatedSubnetResourceId := *typedInput.DelegatedSubnetResourceId
 		network.DelegatedSubnetResourceId = &delegatedSubnetResourceId
 	}
 
-	// Set property ‘PrivateDnsZoneResourceId’:
+	// Set property "PrivateDnsZoneResourceId":
 	if typedInput.PrivateDnsZoneResourceId != nil {
 		privateDnsZoneResourceId := *typedInput.PrivateDnsZoneResourceId
 		network.PrivateDnsZoneResourceId = &privateDnsZoneResourceId
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		network.PublicNetworkAccess = &publicNetworkAccess
@@ -3842,13 +3842,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -3868,13 +3868,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3970,13 +3970,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -4052,19 +4052,19 @@ func (storage *Storage) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Storage_ARM{}
 
-	// Set property ‘AutoGrow’:
+	// Set property "AutoGrow":
 	if storage.AutoGrow != nil {
 		autoGrow := *storage.AutoGrow
 		result.AutoGrow = &autoGrow
 	}
 
-	// Set property ‘Iops’:
+	// Set property "Iops":
 	if storage.Iops != nil {
 		iops := *storage.Iops
 		result.Iops = &iops
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if storage.StorageSizeGB != nil {
 		storageSizeGB := *storage.StorageSizeGB
 		result.StorageSizeGB = &storageSizeGB
@@ -4084,19 +4084,19 @@ func (storage *Storage) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Storage_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoGrow’:
+	// Set property "AutoGrow":
 	if typedInput.AutoGrow != nil {
 		autoGrow := *typedInput.AutoGrow
 		storage.AutoGrow = &autoGrow
 	}
 
-	// Set property ‘Iops’:
+	// Set property "Iops":
 	if typedInput.Iops != nil {
 		iops := *typedInput.Iops
 		storage.Iops = &iops
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if typedInput.StorageSizeGB != nil {
 		storageSizeGB := *typedInput.StorageSizeGB
 		storage.StorageSizeGB = &storageSizeGB
@@ -4207,25 +4207,25 @@ func (storage *Storage_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Storage_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoGrow’:
+	// Set property "AutoGrow":
 	if typedInput.AutoGrow != nil {
 		autoGrow := *typedInput.AutoGrow
 		storage.AutoGrow = &autoGrow
 	}
 
-	// Set property ‘Iops’:
+	// Set property "Iops":
 	if typedInput.Iops != nil {
 		iops := *typedInput.Iops
 		storage.Iops = &iops
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if typedInput.StorageSizeGB != nil {
 		storageSizeGB := *typedInput.StorageSizeGB
 		storage.StorageSizeGB = &storageSizeGB
 	}
 
-	// Set property ‘StorageSku’:
+	// Set property "StorageSku":
 	if typedInput.StorageSku != nil {
 		storageSku := *typedInput.StorageSku
 		storage.StorageSku = &storageSku
@@ -4327,37 +4327,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType

--- a/v2/api/dbformysql/v1api20210501/flexible_servers_database_types_gen.go
+++ b/v2/api/dbformysql/v1api20210501/flexible_servers_database_types_gen.go
@@ -337,10 +337,10 @@ func (database *FlexibleServers_Database_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &FlexibleServers_Database_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.Charset != nil || database.Collation != nil {
 		result.Properties = &DatabaseProperties_ARM{}
 	}
@@ -367,10 +367,10 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Database_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -379,7 +379,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -388,7 +388,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -616,7 +616,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Database_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -625,7 +625,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -634,21 +634,21 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -659,7 +659,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		database.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar

--- a/v2/api/dbformysql/v1api20210501/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbformysql/v1api20210501/flexible_servers_firewall_rule_types_gen.go
@@ -341,10 +341,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &FlexibleServers_FirewallRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.EndIpAddress != nil || rule.StartIpAddress != nil {
 		result.Properties = &FirewallRuleProperties_ARM{}
 	}
@@ -371,10 +371,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_FirewallRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -383,10 +383,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -650,9 +650,9 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_FirewallRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -661,19 +661,19 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -682,7 +682,7 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -693,7 +693,7 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/dbformysql/v1api20220101/flexible_servers_administrator_types_gen.go
+++ b/v2/api/dbformysql/v1api20220101/flexible_servers_administrator_types_gen.go
@@ -359,10 +359,10 @@ func (administrator *FlexibleServers_Administrator_Spec) ConvertToARM(resolved g
 	}
 	result := &FlexibleServers_Administrator_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if administrator.AdministratorType != nil ||
 		administrator.IdentityResourceReference != nil ||
 		administrator.Login != nil ||
@@ -427,7 +427,7 @@ func (administrator *FlexibleServers_Administrator_Spec) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Administrator_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorType’:
+	// Set property "AdministratorType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorType != nil {
@@ -436,9 +436,9 @@ func (administrator *FlexibleServers_Administrator_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// no assignment for property ‘IdentityResourceReference’
+	// no assignment for property "IdentityResourceReference"
 
-	// Set property ‘Login’:
+	// Set property "Login":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Login != nil {
@@ -447,10 +447,10 @@ func (administrator *FlexibleServers_Administrator_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	administrator.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Sid’:
+	// Set property "Sid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sid != nil {
@@ -459,9 +459,9 @@ func (administrator *FlexibleServers_Administrator_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// no assignment for property ‘SidFromConfig’
+	// no assignment for property "SidFromConfig"
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantId != nil {
@@ -470,7 +470,7 @@ func (administrator *FlexibleServers_Administrator_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// no assignment for property ‘TenantIdFromConfig’
+	// no assignment for property "TenantIdFromConfig"
 
 	// No error
 	return nil
@@ -784,7 +784,7 @@ func (administrator *FlexibleServers_Administrator_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Administrator_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorType’:
+	// Set property "AdministratorType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorType != nil {
@@ -793,15 +793,15 @@ func (administrator *FlexibleServers_Administrator_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		administrator.Id = &id
 	}
 
-	// Set property ‘IdentityResourceId’:
+	// Set property "IdentityResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdentityResourceId != nil {
@@ -810,7 +810,7 @@ func (administrator *FlexibleServers_Administrator_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Login’:
+	// Set property "Login":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Login != nil {
@@ -819,13 +819,13 @@ func (administrator *FlexibleServers_Administrator_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		administrator.Name = &name
 	}
 
-	// Set property ‘Sid’:
+	// Set property "Sid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sid != nil {
@@ -834,7 +834,7 @@ func (administrator *FlexibleServers_Administrator_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -845,7 +845,7 @@ func (administrator *FlexibleServers_Administrator_STATUS) PopulateFromARM(owner
 		administrator.SystemData = &systemData
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantId != nil {
@@ -854,7 +854,7 @@ func (administrator *FlexibleServers_Administrator_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		administrator.Type = &typeVar
@@ -1019,37 +1019,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType

--- a/v2/api/dbformysql/v1api20220101/flexible_servers_configuration_types_gen.go
+++ b/v2/api/dbformysql/v1api20220101/flexible_servers_configuration_types_gen.go
@@ -341,10 +341,10 @@ func (configuration *FlexibleServers_Configuration_Spec) ConvertToARM(resolved g
 	}
 	result := &FlexibleServers_Configuration_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.CurrentValue != nil ||
 		configuration.Source != nil ||
 		configuration.Value != nil {
@@ -377,10 +377,10 @@ func (configuration *FlexibleServers_Configuration_Spec) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Configuration_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	configuration.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CurrentValue’:
+	// Set property "CurrentValue":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CurrentValue != nil {
@@ -389,10 +389,10 @@ func (configuration *FlexibleServers_Configuration_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	configuration.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -401,7 +401,7 @@ func (configuration *FlexibleServers_Configuration_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {
@@ -686,7 +686,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Configuration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedValues’:
+	// Set property "AllowedValues":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowedValues != nil {
@@ -695,9 +695,9 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CurrentValue’:
+	// Set property "CurrentValue":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CurrentValue != nil {
@@ -706,7 +706,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DataType’:
+	// Set property "DataType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataType != nil {
@@ -715,7 +715,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DefaultValue’:
+	// Set property "DefaultValue":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultValue != nil {
@@ -724,7 +724,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -733,7 +733,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DocumentationLink’:
+	// Set property "DocumentationLink":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DocumentationLink != nil {
@@ -742,13 +742,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘IsConfigPendingRestart’:
+	// Set property "IsConfigPendingRestart":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsConfigPendingRestart != nil {
@@ -757,7 +757,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘IsDynamicConfig’:
+	// Set property "IsDynamicConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsDynamicConfig != nil {
@@ -766,7 +766,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘IsReadOnly’:
+	// Set property "IsReadOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsReadOnly != nil {
@@ -775,13 +775,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -790,7 +790,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -801,13 +801,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		configuration.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		configuration.Type = &typeVar
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {

--- a/v2/api/dbformysql/v1beta20210501/flexible_server_types_gen.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_server_types_gen.go
@@ -380,7 +380,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FlexibleServer_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if server.Identity != nil {
 		identity_ARM, err := (*server.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -390,16 +390,16 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if server.Location != nil {
 		location := *server.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if server.AdministratorLogin != nil ||
 		server.AdministratorLoginPassword != nil ||
 		server.AvailabilityZone != nil ||
@@ -501,7 +501,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.Version = &version
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if server.Sku != nil {
 		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -511,7 +511,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if server.Tags != nil {
 		result.Tags = make(map[string]string, len(server.Tags))
 		for key, value := range server.Tags {
@@ -533,7 +533,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServer_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -542,9 +542,9 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘AdministratorLoginPassword’
+	// no assignment for property "AdministratorLoginPassword"
 
-	// Set property ‘AvailabilityZone’:
+	// Set property "AvailabilityZone":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityZone != nil {
@@ -553,10 +553,10 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	server.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Backup’:
+	// Set property "Backup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Backup != nil {
@@ -570,7 +570,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -579,7 +579,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘DataEncryption’:
+	// Set property "DataEncryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataEncryption != nil {
@@ -593,7 +593,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HighAvailability’:
+	// Set property "HighAvailability":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailability != nil {
@@ -607,7 +607,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -618,13 +618,13 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		server.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceWindow != nil {
@@ -638,7 +638,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Network’:
+	// Set property "Network":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Network != nil {
@@ -652,12 +652,12 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ReplicationRole’:
+	// Set property "ReplicationRole":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicationRole != nil {
@@ -666,7 +666,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘RestorePointInTime’:
+	// Set property "RestorePointInTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestorePointInTime != nil {
@@ -675,7 +675,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -686,7 +686,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		server.Sku = &sku
 	}
 
-	// Set property ‘SourceServerResourceId’:
+	// Set property "SourceServerResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceServerResourceId != nil {
@@ -695,7 +695,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Storage != nil {
@@ -709,7 +709,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -717,7 +717,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1247,7 +1247,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServer_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -1256,7 +1256,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘AvailabilityZone’:
+	// Set property "AvailabilityZone":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityZone != nil {
@@ -1265,7 +1265,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Backup’:
+	// Set property "Backup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Backup != nil {
@@ -1279,9 +1279,9 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -1290,7 +1290,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘DataEncryption’:
+	// Set property "DataEncryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataEncryption != nil {
@@ -1304,7 +1304,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘FullyQualifiedDomainName’:
+	// Set property "FullyQualifiedDomainName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FullyQualifiedDomainName != nil {
@@ -1313,7 +1313,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘HighAvailability’:
+	// Set property "HighAvailability":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailability != nil {
@@ -1327,13 +1327,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		server.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1344,13 +1344,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceWindow != nil {
@@ -1364,13 +1364,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		server.Name = &name
 	}
 
-	// Set property ‘Network’:
+	// Set property "Network":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Network != nil {
@@ -1384,7 +1384,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ReplicaCapacity’:
+	// Set property "ReplicaCapacity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicaCapacity != nil {
@@ -1393,7 +1393,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ReplicationRole’:
+	// Set property "ReplicationRole":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicationRole != nil {
@@ -1402,7 +1402,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘RestorePointInTime’:
+	// Set property "RestorePointInTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestorePointInTime != nil {
@@ -1411,7 +1411,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1422,7 +1422,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.Sku = &sku
 	}
 
-	// Set property ‘SourceServerResourceId’:
+	// Set property "SourceServerResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceServerResourceId != nil {
@@ -1431,7 +1431,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1440,7 +1440,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Storage != nil {
@@ -1454,7 +1454,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1465,7 +1465,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1473,13 +1473,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		server.Type = &typeVar
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1882,13 +1882,13 @@ func (backup *Backup) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &Backup_ARM{}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if backup.BackupRetentionDays != nil {
 		backupRetentionDays := *backup.BackupRetentionDays
 		result.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if backup.GeoRedundantBackup != nil {
 		geoRedundantBackup := *backup.GeoRedundantBackup
 		result.GeoRedundantBackup = &geoRedundantBackup
@@ -1908,13 +1908,13 @@ func (backup *Backup) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Backup_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		backup.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		backup.GeoRedundantBackup = &geoRedundantBackup
@@ -1990,19 +1990,19 @@ func (backup *Backup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Backup_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		backup.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘EarliestRestoreDate’:
+	// Set property "EarliestRestoreDate":
 	if typedInput.EarliestRestoreDate != nil {
 		earliestRestoreDate := *typedInput.EarliestRestoreDate
 		backup.EarliestRestoreDate = &earliestRestoreDate
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		backup.GeoRedundantBackup = &geoRedundantBackup
@@ -2081,13 +2081,13 @@ func (encryption *DataEncryption) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &DataEncryption_ARM{}
 
-	// Set property ‘GeoBackupKeyURI’:
+	// Set property "GeoBackupKeyURI":
 	if encryption.GeoBackupKeyURI != nil {
 		geoBackupKeyURI := *encryption.GeoBackupKeyURI
 		result.GeoBackupKeyURI = &geoBackupKeyURI
 	}
 
-	// Set property ‘GeoBackupUserAssignedIdentityId’:
+	// Set property "GeoBackupUserAssignedIdentityId":
 	if encryption.GeoBackupUserAssignedIdentityReference != nil {
 		geoBackupUserAssignedIdentityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*encryption.GeoBackupUserAssignedIdentityReference)
 		if err != nil {
@@ -2097,13 +2097,13 @@ func (encryption *DataEncryption) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.GeoBackupUserAssignedIdentityId = &geoBackupUserAssignedIdentityReference
 	}
 
-	// Set property ‘PrimaryKeyURI’:
+	// Set property "PrimaryKeyURI":
 	if encryption.PrimaryKeyURI != nil {
 		primaryKeyURI := *encryption.PrimaryKeyURI
 		result.PrimaryKeyURI = &primaryKeyURI
 	}
 
-	// Set property ‘PrimaryUserAssignedIdentityId’:
+	// Set property "PrimaryUserAssignedIdentityId":
 	if encryption.PrimaryUserAssignedIdentityReference != nil {
 		primaryUserAssignedIdentityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*encryption.PrimaryUserAssignedIdentityReference)
 		if err != nil {
@@ -2113,7 +2113,7 @@ func (encryption *DataEncryption) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.PrimaryUserAssignedIdentityId = &primaryUserAssignedIdentityReference
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if encryption.Type != nil {
 		typeVar := *encryption.Type
 		result.Type = &typeVar
@@ -2133,23 +2133,23 @@ func (encryption *DataEncryption) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataEncryption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GeoBackupKeyURI’:
+	// Set property "GeoBackupKeyURI":
 	if typedInput.GeoBackupKeyURI != nil {
 		geoBackupKeyURI := *typedInput.GeoBackupKeyURI
 		encryption.GeoBackupKeyURI = &geoBackupKeyURI
 	}
 
-	// no assignment for property ‘GeoBackupUserAssignedIdentityReference’
+	// no assignment for property "GeoBackupUserAssignedIdentityReference"
 
-	// Set property ‘PrimaryKeyURI’:
+	// Set property "PrimaryKeyURI":
 	if typedInput.PrimaryKeyURI != nil {
 		primaryKeyURI := *typedInput.PrimaryKeyURI
 		encryption.PrimaryKeyURI = &primaryKeyURI
 	}
 
-	// no assignment for property ‘PrimaryUserAssignedIdentityReference’
+	// no assignment for property "PrimaryUserAssignedIdentityReference"
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		encryption.Type = &typeVar
@@ -2265,31 +2265,31 @@ func (encryption *DataEncryption_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataEncryption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GeoBackupKeyURI’:
+	// Set property "GeoBackupKeyURI":
 	if typedInput.GeoBackupKeyURI != nil {
 		geoBackupKeyURI := *typedInput.GeoBackupKeyURI
 		encryption.GeoBackupKeyURI = &geoBackupKeyURI
 	}
 
-	// Set property ‘GeoBackupUserAssignedIdentityId’:
+	// Set property "GeoBackupUserAssignedIdentityId":
 	if typedInput.GeoBackupUserAssignedIdentityId != nil {
 		geoBackupUserAssignedIdentityId := *typedInput.GeoBackupUserAssignedIdentityId
 		encryption.GeoBackupUserAssignedIdentityId = &geoBackupUserAssignedIdentityId
 	}
 
-	// Set property ‘PrimaryKeyURI’:
+	// Set property "PrimaryKeyURI":
 	if typedInput.PrimaryKeyURI != nil {
 		primaryKeyURI := *typedInput.PrimaryKeyURI
 		encryption.PrimaryKeyURI = &primaryKeyURI
 	}
 
-	// Set property ‘PrimaryUserAssignedIdentityId’:
+	// Set property "PrimaryUserAssignedIdentityId":
 	if typedInput.PrimaryUserAssignedIdentityId != nil {
 		primaryUserAssignedIdentityId := *typedInput.PrimaryUserAssignedIdentityId
 		encryption.PrimaryUserAssignedIdentityId = &primaryUserAssignedIdentityId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		encryption.Type = &typeVar
@@ -2430,13 +2430,13 @@ func (availability *HighAvailability) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &HighAvailability_ARM{}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if availability.Mode != nil {
 		mode := *availability.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if availability.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *availability.StandbyAvailabilityZone
 		result.StandbyAvailabilityZone = &standbyAvailabilityZone
@@ -2456,13 +2456,13 @@ func (availability *HighAvailability) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HighAvailability_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		availability.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if typedInput.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *typedInput.StandbyAvailabilityZone
 		availability.StandbyAvailabilityZone = &standbyAvailabilityZone
@@ -2538,19 +2538,19 @@ func (availability *HighAvailability_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HighAvailability_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		availability.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if typedInput.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *typedInput.StandbyAvailabilityZone
 		availability.StandbyAvailabilityZone = &standbyAvailabilityZone
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		availability.State = &state
@@ -2636,13 +2636,13 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Identity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -2667,13 +2667,13 @@ func (identity *Identity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -2776,25 +2776,25 @@ func (identity *Identity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]v1.JSON, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2900,25 +2900,25 @@ func (window *MaintenanceWindow) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &MaintenanceWindow_ARM{}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if window.CustomWindow != nil {
 		customWindow := *window.CustomWindow
 		result.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if window.DayOfWeek != nil {
 		dayOfWeek := *window.DayOfWeek
 		result.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if window.StartHour != nil {
 		startHour := *window.StartHour
 		result.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if window.StartMinute != nil {
 		startMinute := *window.StartMinute
 		result.StartMinute = &startMinute
@@ -2938,25 +2938,25 @@ func (window *MaintenanceWindow) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceWindow_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if typedInput.CustomWindow != nil {
 		customWindow := *typedInput.CustomWindow
 		window.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		window.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if typedInput.StartHour != nil {
 		startHour := *typedInput.StartHour
 		window.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if typedInput.StartMinute != nil {
 		startMinute := *typedInput.StartMinute
 		window.StartMinute = &startMinute
@@ -3035,25 +3035,25 @@ func (window *MaintenanceWindow_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceWindow_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if typedInput.CustomWindow != nil {
 		customWindow := *typedInput.CustomWindow
 		window.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		window.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if typedInput.StartHour != nil {
 		startHour := *typedInput.StartHour
 		window.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if typedInput.StartMinute != nil {
 		startMinute := *typedInput.StartMinute
 		window.StartMinute = &startMinute
@@ -3125,7 +3125,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Network_ARM{}
 
-	// Set property ‘DelegatedSubnetResourceId’:
+	// Set property "DelegatedSubnetResourceId":
 	if network.DelegatedSubnetResourceReference != nil {
 		delegatedSubnetResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*network.DelegatedSubnetResourceReference)
 		if err != nil {
@@ -3135,7 +3135,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.DelegatedSubnetResourceId = &delegatedSubnetResourceReference
 	}
 
-	// Set property ‘PrivateDnsZoneResourceId’:
+	// Set property "PrivateDnsZoneResourceId":
 	if network.PrivateDnsZoneResourceReference != nil {
 		privateDnsZoneResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*network.PrivateDnsZoneResourceReference)
 		if err != nil {
@@ -3159,9 +3159,9 @@ func (network *Network) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Network_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘DelegatedSubnetResourceReference’
+	// no assignment for property "DelegatedSubnetResourceReference"
 
-	// no assignment for property ‘PrivateDnsZoneResourceReference’
+	// no assignment for property "PrivateDnsZoneResourceReference"
 
 	// No error
 	return nil
@@ -3243,19 +3243,19 @@ func (network *Network_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Network_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DelegatedSubnetResourceId’:
+	// Set property "DelegatedSubnetResourceId":
 	if typedInput.DelegatedSubnetResourceId != nil {
 		delegatedSubnetResourceId := *typedInput.DelegatedSubnetResourceId
 		network.DelegatedSubnetResourceId = &delegatedSubnetResourceId
 	}
 
-	// Set property ‘PrivateDnsZoneResourceId’:
+	// Set property "PrivateDnsZoneResourceId":
 	if typedInput.PrivateDnsZoneResourceId != nil {
 		privateDnsZoneResourceId := *typedInput.PrivateDnsZoneResourceId
 		network.PrivateDnsZoneResourceId = &privateDnsZoneResourceId
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		network.PublicNetworkAccess = &publicNetworkAccess
@@ -3404,13 +3404,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -3430,13 +3430,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3511,13 +3511,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3588,19 +3588,19 @@ func (storage *Storage) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Storage_ARM{}
 
-	// Set property ‘AutoGrow’:
+	// Set property "AutoGrow":
 	if storage.AutoGrow != nil {
 		autoGrow := *storage.AutoGrow
 		result.AutoGrow = &autoGrow
 	}
 
-	// Set property ‘Iops’:
+	// Set property "Iops":
 	if storage.Iops != nil {
 		iops := *storage.Iops
 		result.Iops = &iops
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if storage.StorageSizeGB != nil {
 		storageSizeGB := *storage.StorageSizeGB
 		result.StorageSizeGB = &storageSizeGB
@@ -3620,19 +3620,19 @@ func (storage *Storage) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Storage_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoGrow’:
+	// Set property "AutoGrow":
 	if typedInput.AutoGrow != nil {
 		autoGrow := *typedInput.AutoGrow
 		storage.AutoGrow = &autoGrow
 	}
 
-	// Set property ‘Iops’:
+	// Set property "Iops":
 	if typedInput.Iops != nil {
 		iops := *typedInput.Iops
 		storage.Iops = &iops
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if typedInput.StorageSizeGB != nil {
 		storageSizeGB := *typedInput.StorageSizeGB
 		storage.StorageSizeGB = &storageSizeGB
@@ -3715,25 +3715,25 @@ func (storage *Storage_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Storage_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoGrow’:
+	// Set property "AutoGrow":
 	if typedInput.AutoGrow != nil {
 		autoGrow := *typedInput.AutoGrow
 		storage.AutoGrow = &autoGrow
 	}
 
-	// Set property ‘Iops’:
+	// Set property "Iops":
 	if typedInput.Iops != nil {
 		iops := *typedInput.Iops
 		storage.Iops = &iops
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if typedInput.StorageSizeGB != nil {
 		storageSizeGB := *typedInput.StorageSizeGB
 		storage.StorageSizeGB = &storageSizeGB
 	}
 
-	// Set property ‘StorageSku’:
+	// Set property "StorageSku":
 	if typedInput.StorageSku != nil {
 		storageSku := *typedInput.StorageSku
 		storage.StorageSku = &storageSku
@@ -3824,37 +3824,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType

--- a/v2/api/dbformysql/v1beta20210501/flexible_servers_database_types_gen.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_servers_database_types_gen.go
@@ -332,10 +332,10 @@ func (database *FlexibleServers_Database_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &FlexibleServers_Database_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.Charset != nil || database.Collation != nil {
 		result.Properties = &DatabaseProperties_ARM{}
 	}
@@ -362,10 +362,10 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Database_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -374,7 +374,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -383,7 +383,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -587,7 +587,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Database_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -596,7 +596,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -605,21 +605,21 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -630,7 +630,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		database.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar

--- a/v2/api/dbformysql/v1beta20210501/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_servers_firewall_rule_types_gen.go
@@ -338,10 +338,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &FlexibleServers_FirewallRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.EndIpAddress != nil || rule.StartIpAddress != nil {
 		result.Properties = &FirewallRuleProperties_ARM{}
 	}
@@ -368,10 +368,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_FirewallRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -380,10 +380,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -612,9 +612,9 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_FirewallRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -623,19 +623,19 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -644,7 +644,7 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -655,7 +655,7 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/dbforpostgresql/v1api20210601/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20210601/flexible_server_types_gen.go
@@ -407,16 +407,16 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FlexibleServer_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if server.Location != nil {
 		location := *server.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if server.AdministratorLogin != nil ||
 		server.AdministratorLoginPassword != nil ||
 		server.AvailabilityZone != nil ||
@@ -508,7 +508,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.Version = &version
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if server.Sku != nil {
 		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -518,7 +518,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if server.Tags != nil {
 		result.Tags = make(map[string]string, len(server.Tags))
 		for key, value := range server.Tags {
@@ -540,7 +540,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServer_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -549,9 +549,9 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘AdministratorLoginPassword’
+	// no assignment for property "AdministratorLoginPassword"
 
-	// Set property ‘AvailabilityZone’:
+	// Set property "AvailabilityZone":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityZone != nil {
@@ -560,10 +560,10 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	server.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Backup’:
+	// Set property "Backup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Backup != nil {
@@ -577,7 +577,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -586,7 +586,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HighAvailability’:
+	// Set property "HighAvailability":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailability != nil {
@@ -600,13 +600,13 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceWindow != nil {
@@ -620,7 +620,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Network’:
+	// Set property "Network":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Network != nil {
@@ -634,12 +634,12 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PointInTimeUTC’:
+	// Set property "PointInTimeUTC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PointInTimeUTC != nil {
@@ -648,7 +648,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -659,9 +659,9 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		server.Sku = &sku
 	}
 
-	// no assignment for property ‘SourceServerResourceReference’
+	// no assignment for property "SourceServerResourceReference"
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Storage != nil {
@@ -675,7 +675,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -683,7 +683,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1318,7 +1318,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServer_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -1327,7 +1327,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘AvailabilityZone’:
+	// Set property "AvailabilityZone":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityZone != nil {
@@ -1336,7 +1336,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Backup’:
+	// Set property "Backup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Backup != nil {
@@ -1350,9 +1350,9 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -1361,7 +1361,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘FullyQualifiedDomainName’:
+	// Set property "FullyQualifiedDomainName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FullyQualifiedDomainName != nil {
@@ -1370,7 +1370,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘HighAvailability’:
+	// Set property "HighAvailability":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailability != nil {
@@ -1384,19 +1384,19 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		server.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceWindow != nil {
@@ -1410,7 +1410,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘MinorVersion’:
+	// Set property "MinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinorVersion != nil {
@@ -1419,13 +1419,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		server.Name = &name
 	}
 
-	// Set property ‘Network’:
+	// Set property "Network":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Network != nil {
@@ -1439,7 +1439,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PointInTimeUTC’:
+	// Set property "PointInTimeUTC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PointInTimeUTC != nil {
@@ -1448,7 +1448,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1459,7 +1459,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.Sku = &sku
 	}
 
-	// Set property ‘SourceServerResourceId’:
+	// Set property "SourceServerResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceServerResourceId != nil {
@@ -1468,7 +1468,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1477,7 +1477,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Storage != nil {
@@ -1491,7 +1491,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1502,7 +1502,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1510,13 +1510,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		server.Type = &typeVar
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1858,13 +1858,13 @@ func (backup *Backup) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &Backup_ARM{}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if backup.BackupRetentionDays != nil {
 		backupRetentionDays := *backup.BackupRetentionDays
 		result.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if backup.GeoRedundantBackup != nil {
 		geoRedundantBackup := *backup.GeoRedundantBackup
 		result.GeoRedundantBackup = &geoRedundantBackup
@@ -1884,13 +1884,13 @@ func (backup *Backup) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Backup_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		backup.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		backup.GeoRedundantBackup = &geoRedundantBackup
@@ -1989,19 +1989,19 @@ func (backup *Backup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Backup_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		backup.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘EarliestRestoreDate’:
+	// Set property "EarliestRestoreDate":
 	if typedInput.EarliestRestoreDate != nil {
 		earliestRestoreDate := *typedInput.EarliestRestoreDate
 		backup.EarliestRestoreDate = &earliestRestoreDate
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		backup.GeoRedundantBackup = &geoRedundantBackup
@@ -2133,13 +2133,13 @@ func (availability *HighAvailability) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &HighAvailability_ARM{}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if availability.Mode != nil {
 		mode := *availability.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if availability.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *availability.StandbyAvailabilityZone
 		result.StandbyAvailabilityZone = &standbyAvailabilityZone
@@ -2159,13 +2159,13 @@ func (availability *HighAvailability) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HighAvailability_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		availability.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if typedInput.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *typedInput.StandbyAvailabilityZone
 		availability.StandbyAvailabilityZone = &standbyAvailabilityZone
@@ -2264,19 +2264,19 @@ func (availability *HighAvailability_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HighAvailability_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		availability.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if typedInput.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *typedInput.StandbyAvailabilityZone
 		availability.StandbyAvailabilityZone = &standbyAvailabilityZone
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		availability.State = &state
@@ -2371,25 +2371,25 @@ func (window *MaintenanceWindow) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &MaintenanceWindow_ARM{}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if window.CustomWindow != nil {
 		customWindow := *window.CustomWindow
 		result.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if window.DayOfWeek != nil {
 		dayOfWeek := *window.DayOfWeek
 		result.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if window.StartHour != nil {
 		startHour := *window.StartHour
 		result.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if window.StartMinute != nil {
 		startMinute := *window.StartMinute
 		result.StartMinute = &startMinute
@@ -2409,25 +2409,25 @@ func (window *MaintenanceWindow) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceWindow_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if typedInput.CustomWindow != nil {
 		customWindow := *typedInput.CustomWindow
 		window.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		window.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if typedInput.StartHour != nil {
 		startHour := *typedInput.StartHour
 		window.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if typedInput.StartMinute != nil {
 		startMinute := *typedInput.StartMinute
 		window.StartMinute = &startMinute
@@ -2532,25 +2532,25 @@ func (window *MaintenanceWindow_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceWindow_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if typedInput.CustomWindow != nil {
 		customWindow := *typedInput.CustomWindow
 		window.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		window.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if typedInput.StartHour != nil {
 		startHour := *typedInput.StartHour
 		window.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if typedInput.StartMinute != nil {
 		startMinute := *typedInput.StartMinute
 		window.StartMinute = &startMinute
@@ -2625,7 +2625,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Network_ARM{}
 
-	// Set property ‘DelegatedSubnetResourceId’:
+	// Set property "DelegatedSubnetResourceId":
 	if network.DelegatedSubnetResourceReference != nil {
 		delegatedSubnetResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*network.DelegatedSubnetResourceReference)
 		if err != nil {
@@ -2635,7 +2635,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.DelegatedSubnetResourceId = &delegatedSubnetResourceReference
 	}
 
-	// Set property ‘PrivateDnsZoneArmResourceId’:
+	// Set property "PrivateDnsZoneArmResourceId":
 	if network.PrivateDnsZoneArmResourceReference != nil {
 		privateDnsZoneArmResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*network.PrivateDnsZoneArmResourceReference)
 		if err != nil {
@@ -2659,9 +2659,9 @@ func (network *Network) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Network_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘DelegatedSubnetResourceReference’
+	// no assignment for property "DelegatedSubnetResourceReference"
 
-	// no assignment for property ‘PrivateDnsZoneArmResourceReference’
+	// no assignment for property "PrivateDnsZoneArmResourceReference"
 
 	// No error
 	return nil
@@ -2771,19 +2771,19 @@ func (network *Network_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Network_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DelegatedSubnetResourceId’:
+	// Set property "DelegatedSubnetResourceId":
 	if typedInput.DelegatedSubnetResourceId != nil {
 		delegatedSubnetResourceId := *typedInput.DelegatedSubnetResourceId
 		network.DelegatedSubnetResourceId = &delegatedSubnetResourceId
 	}
 
-	// Set property ‘PrivateDnsZoneArmResourceId’:
+	// Set property "PrivateDnsZoneArmResourceId":
 	if typedInput.PrivateDnsZoneArmResourceId != nil {
 		privateDnsZoneArmResourceId := *typedInput.PrivateDnsZoneArmResourceId
 		network.PrivateDnsZoneArmResourceId = &privateDnsZoneArmResourceId
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		network.PublicNetworkAccess = &publicNetworkAccess
@@ -2916,13 +2916,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -2942,13 +2942,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3044,13 +3044,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3120,7 +3120,7 @@ func (storage *Storage) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Storage_ARM{}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if storage.StorageSizeGB != nil {
 		storageSizeGB := *storage.StorageSizeGB
 		result.StorageSizeGB = &storageSizeGB
@@ -3140,7 +3140,7 @@ func (storage *Storage) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Storage_ARM, got %T", armInput)
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if typedInput.StorageSizeGB != nil {
 		storageSizeGB := *typedInput.StorageSizeGB
 		storage.StorageSizeGB = &storageSizeGB
@@ -3209,7 +3209,7 @@ func (storage *Storage_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Storage_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if typedInput.StorageSizeGB != nil {
 		storageSizeGB := *typedInput.StorageSizeGB
 		storage.StorageSizeGB = &storageSizeGB
@@ -3283,37 +3283,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType

--- a/v2/api/dbforpostgresql/v1api20210601/flexible_servers_configuration_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20210601/flexible_servers_configuration_types_gen.go
@@ -337,10 +337,10 @@ func (configuration *FlexibleServers_Configuration_Spec) ConvertToARM(resolved g
 	}
 	result := &FlexibleServers_Configuration_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.Source != nil || configuration.Value != nil {
 		result.Properties = &ConfigurationProperties_ARM{}
 	}
@@ -367,13 +367,13 @@ func (configuration *FlexibleServers_Configuration_Spec) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Configuration_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	configuration.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	configuration.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -382,7 +382,7 @@ func (configuration *FlexibleServers_Configuration_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {
@@ -643,7 +643,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Configuration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedValues’:
+	// Set property "AllowedValues":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowedValues != nil {
@@ -652,9 +652,9 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DataType’:
+	// Set property "DataType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataType != nil {
@@ -663,7 +663,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DefaultValue’:
+	// Set property "DefaultValue":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultValue != nil {
@@ -672,7 +672,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -681,7 +681,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DocumentationLink’:
+	// Set property "DocumentationLink":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DocumentationLink != nil {
@@ -690,13 +690,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘IsConfigPendingRestart’:
+	// Set property "IsConfigPendingRestart":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsConfigPendingRestart != nil {
@@ -705,7 +705,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘IsDynamicConfig’:
+	// Set property "IsDynamicConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsDynamicConfig != nil {
@@ -714,7 +714,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘IsReadOnly’:
+	// Set property "IsReadOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsReadOnly != nil {
@@ -723,13 +723,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -738,7 +738,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -749,13 +749,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		configuration.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		configuration.Type = &typeVar
 	}
 
-	// Set property ‘Unit’:
+	// Set property "Unit":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Unit != nil {
@@ -764,7 +764,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {

--- a/v2/api/dbforpostgresql/v1api20210601/flexible_servers_database_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20210601/flexible_servers_database_types_gen.go
@@ -337,10 +337,10 @@ func (database *FlexibleServers_Database_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &FlexibleServers_Database_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.Charset != nil || database.Collation != nil {
 		result.Properties = &DatabaseProperties_ARM{}
 	}
@@ -367,10 +367,10 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Database_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -379,7 +379,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -388,7 +388,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -616,7 +616,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Database_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -625,7 +625,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -634,21 +634,21 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -659,7 +659,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		database.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar

--- a/v2/api/dbforpostgresql/v1api20210601/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20210601/flexible_servers_firewall_rule_types_gen.go
@@ -341,10 +341,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &FlexibleServers_FirewallRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.EndIpAddress != nil || rule.StartIpAddress != nil {
 		result.Properties = &FirewallRuleProperties_ARM{}
 	}
@@ -371,10 +371,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_FirewallRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -383,10 +383,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -650,9 +650,9 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_FirewallRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -661,19 +661,19 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -682,7 +682,7 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -693,7 +693,7 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/dbforpostgresql/v1api20220120preview/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20220120preview/flexible_server_types_gen.go
@@ -432,16 +432,16 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FlexibleServer_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if server.Location != nil {
 		location := *server.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if server.AdministratorLogin != nil ||
 		server.AdministratorLoginPassword != nil ||
 		server.AvailabilityZone != nil ||
@@ -533,7 +533,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.Version = &version
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if server.Sku != nil {
 		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -543,7 +543,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if server.Tags != nil {
 		result.Tags = make(map[string]string, len(server.Tags))
 		for key, value := range server.Tags {
@@ -565,7 +565,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServer_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -574,9 +574,9 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘AdministratorLoginPassword’
+	// no assignment for property "AdministratorLoginPassword"
 
-	// Set property ‘AvailabilityZone’:
+	// Set property "AvailabilityZone":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityZone != nil {
@@ -585,10 +585,10 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	server.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Backup’:
+	// Set property "Backup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Backup != nil {
@@ -602,7 +602,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -611,7 +611,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HighAvailability’:
+	// Set property "HighAvailability":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailability != nil {
@@ -625,13 +625,13 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceWindow != nil {
@@ -645,7 +645,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Network’:
+	// Set property "Network":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Network != nil {
@@ -659,12 +659,12 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PointInTimeUTC’:
+	// Set property "PointInTimeUTC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PointInTimeUTC != nil {
@@ -673,7 +673,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -684,9 +684,9 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		server.Sku = &sku
 	}
 
-	// no assignment for property ‘SourceServerResourceReference’
+	// no assignment for property "SourceServerResourceReference"
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Storage != nil {
@@ -700,7 +700,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -708,7 +708,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1225,7 +1225,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServer_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -1234,7 +1234,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘AvailabilityZone’:
+	// Set property "AvailabilityZone":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityZone != nil {
@@ -1243,7 +1243,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Backup’:
+	// Set property "Backup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Backup != nil {
@@ -1257,9 +1257,9 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -1268,7 +1268,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘FullyQualifiedDomainName’:
+	// Set property "FullyQualifiedDomainName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FullyQualifiedDomainName != nil {
@@ -1277,7 +1277,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘HighAvailability’:
+	// Set property "HighAvailability":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailability != nil {
@@ -1291,19 +1291,19 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		server.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceWindow != nil {
@@ -1317,7 +1317,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘MinorVersion’:
+	// Set property "MinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinorVersion != nil {
@@ -1326,13 +1326,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		server.Name = &name
 	}
 
-	// Set property ‘Network’:
+	// Set property "Network":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Network != nil {
@@ -1346,7 +1346,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PointInTimeUTC’:
+	// Set property "PointInTimeUTC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PointInTimeUTC != nil {
@@ -1355,7 +1355,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1366,7 +1366,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.Sku = &sku
 	}
 
-	// Set property ‘SourceServerResourceId’:
+	// Set property "SourceServerResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceServerResourceId != nil {
@@ -1375,7 +1375,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1384,7 +1384,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Storage != nil {
@@ -1398,7 +1398,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1409,7 +1409,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1417,13 +1417,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		server.Type = &typeVar
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1765,13 +1765,13 @@ func (backup *Backup) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &Backup_ARM{}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if backup.BackupRetentionDays != nil {
 		backupRetentionDays := *backup.BackupRetentionDays
 		result.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if backup.GeoRedundantBackup != nil {
 		geoRedundantBackup := *backup.GeoRedundantBackup
 		result.GeoRedundantBackup = &geoRedundantBackup
@@ -1791,13 +1791,13 @@ func (backup *Backup) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Backup_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		backup.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		backup.GeoRedundantBackup = &geoRedundantBackup
@@ -1878,19 +1878,19 @@ func (backup *Backup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Backup_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		backup.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘EarliestRestoreDate’:
+	// Set property "EarliestRestoreDate":
 	if typedInput.EarliestRestoreDate != nil {
 		earliestRestoreDate := *typedInput.EarliestRestoreDate
 		backup.EarliestRestoreDate = &earliestRestoreDate
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		backup.GeoRedundantBackup = &geoRedundantBackup
@@ -2022,13 +2022,13 @@ func (availability *HighAvailability) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &HighAvailability_ARM{}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if availability.Mode != nil {
 		mode := *availability.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if availability.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *availability.StandbyAvailabilityZone
 		result.StandbyAvailabilityZone = &standbyAvailabilityZone
@@ -2048,13 +2048,13 @@ func (availability *HighAvailability) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HighAvailability_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		availability.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if typedInput.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *typedInput.StandbyAvailabilityZone
 		availability.StandbyAvailabilityZone = &standbyAvailabilityZone
@@ -2135,19 +2135,19 @@ func (availability *HighAvailability_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HighAvailability_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		availability.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if typedInput.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *typedInput.StandbyAvailabilityZone
 		availability.StandbyAvailabilityZone = &standbyAvailabilityZone
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		availability.State = &state
@@ -2242,25 +2242,25 @@ func (window *MaintenanceWindow) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &MaintenanceWindow_ARM{}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if window.CustomWindow != nil {
 		customWindow := *window.CustomWindow
 		result.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if window.DayOfWeek != nil {
 		dayOfWeek := *window.DayOfWeek
 		result.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if window.StartHour != nil {
 		startHour := *window.StartHour
 		result.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if window.StartMinute != nil {
 		startMinute := *window.StartMinute
 		result.StartMinute = &startMinute
@@ -2280,25 +2280,25 @@ func (window *MaintenanceWindow) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceWindow_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if typedInput.CustomWindow != nil {
 		customWindow := *typedInput.CustomWindow
 		window.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		window.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if typedInput.StartHour != nil {
 		startHour := *typedInput.StartHour
 		window.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if typedInput.StartMinute != nil {
 		startMinute := *typedInput.StartMinute
 		window.StartMinute = &startMinute
@@ -2384,25 +2384,25 @@ func (window *MaintenanceWindow_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceWindow_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if typedInput.CustomWindow != nil {
 		customWindow := *typedInput.CustomWindow
 		window.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		window.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if typedInput.StartHour != nil {
 		startHour := *typedInput.StartHour
 		window.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if typedInput.StartMinute != nil {
 		startMinute := *typedInput.StartMinute
 		window.StartMinute = &startMinute
@@ -2477,7 +2477,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Network_ARM{}
 
-	// Set property ‘DelegatedSubnetResourceId’:
+	// Set property "DelegatedSubnetResourceId":
 	if network.DelegatedSubnetResourceReference != nil {
 		delegatedSubnetResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*network.DelegatedSubnetResourceReference)
 		if err != nil {
@@ -2487,7 +2487,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.DelegatedSubnetResourceId = &delegatedSubnetResourceReference
 	}
 
-	// Set property ‘PrivateDnsZoneArmResourceId’:
+	// Set property "PrivateDnsZoneArmResourceId":
 	if network.PrivateDnsZoneArmResourceReference != nil {
 		privateDnsZoneArmResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*network.PrivateDnsZoneArmResourceReference)
 		if err != nil {
@@ -2511,9 +2511,9 @@ func (network *Network) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Network_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘DelegatedSubnetResourceReference’
+	// no assignment for property "DelegatedSubnetResourceReference"
 
-	// no assignment for property ‘PrivateDnsZoneArmResourceReference’
+	// no assignment for property "PrivateDnsZoneArmResourceReference"
 
 	// No error
 	return nil
@@ -2600,19 +2600,19 @@ func (network *Network_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Network_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DelegatedSubnetResourceId’:
+	// Set property "DelegatedSubnetResourceId":
 	if typedInput.DelegatedSubnetResourceId != nil {
 		delegatedSubnetResourceId := *typedInput.DelegatedSubnetResourceId
 		network.DelegatedSubnetResourceId = &delegatedSubnetResourceId
 	}
 
-	// Set property ‘PrivateDnsZoneArmResourceId’:
+	// Set property "PrivateDnsZoneArmResourceId":
 	if typedInput.PrivateDnsZoneArmResourceId != nil {
 		privateDnsZoneArmResourceId := *typedInput.PrivateDnsZoneArmResourceId
 		network.PrivateDnsZoneArmResourceId = &privateDnsZoneArmResourceId
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		network.PublicNetworkAccess = &publicNetworkAccess
@@ -2745,13 +2745,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -2771,13 +2771,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2855,13 +2855,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2931,7 +2931,7 @@ func (storage *Storage) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Storage_ARM{}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if storage.StorageSizeGB != nil {
 		storageSizeGB := *storage.StorageSizeGB
 		result.StorageSizeGB = &storageSizeGB
@@ -2951,7 +2951,7 @@ func (storage *Storage) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Storage_ARM, got %T", armInput)
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if typedInput.StorageSizeGB != nil {
 		storageSizeGB := *typedInput.StorageSizeGB
 		storage.StorageSizeGB = &storageSizeGB
@@ -3010,7 +3010,7 @@ func (storage *Storage_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Storage_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if typedInput.StorageSizeGB != nil {
 		storageSizeGB := *typedInput.StorageSizeGB
 		storage.StorageSizeGB = &storageSizeGB
@@ -3084,37 +3084,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType

--- a/v2/api/dbforpostgresql/v1api20220120preview/flexible_servers_configuration_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20220120preview/flexible_servers_configuration_types_gen.go
@@ -340,10 +340,10 @@ func (configuration *FlexibleServers_Configuration_Spec) ConvertToARM(resolved g
 	}
 	result := &FlexibleServers_Configuration_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.Source != nil || configuration.Value != nil {
 		result.Properties = &ConfigurationProperties_ARM{}
 	}
@@ -370,13 +370,13 @@ func (configuration *FlexibleServers_Configuration_Spec) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Configuration_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	configuration.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	configuration.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -385,7 +385,7 @@ func (configuration *FlexibleServers_Configuration_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {
@@ -633,7 +633,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Configuration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedValues’:
+	// Set property "AllowedValues":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowedValues != nil {
@@ -642,9 +642,9 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DataType’:
+	// Set property "DataType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataType != nil {
@@ -653,7 +653,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DefaultValue’:
+	// Set property "DefaultValue":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultValue != nil {
@@ -662,7 +662,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -671,7 +671,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DocumentationLink’:
+	// Set property "DocumentationLink":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DocumentationLink != nil {
@@ -680,13 +680,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘IsConfigPendingRestart’:
+	// Set property "IsConfigPendingRestart":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsConfigPendingRestart != nil {
@@ -695,7 +695,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘IsDynamicConfig’:
+	// Set property "IsDynamicConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsDynamicConfig != nil {
@@ -704,7 +704,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘IsReadOnly’:
+	// Set property "IsReadOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsReadOnly != nil {
@@ -713,13 +713,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -728,7 +728,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -739,13 +739,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		configuration.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		configuration.Type = &typeVar
 	}
 
-	// Set property ‘Unit’:
+	// Set property "Unit":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Unit != nil {
@@ -754,7 +754,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {

--- a/v2/api/dbforpostgresql/v1api20220120preview/flexible_servers_database_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20220120preview/flexible_servers_database_types_gen.go
@@ -340,10 +340,10 @@ func (database *FlexibleServers_Database_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &FlexibleServers_Database_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.Charset != nil || database.Collation != nil {
 		result.Properties = &DatabaseProperties_ARM{}
 	}
@@ -370,10 +370,10 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Database_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -382,7 +382,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -391,7 +391,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -606,7 +606,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Database_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -615,7 +615,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -624,21 +624,21 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -649,7 +649,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		database.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar

--- a/v2/api/dbforpostgresql/v1api20220120preview/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20220120preview/flexible_servers_firewall_rule_types_gen.go
@@ -344,10 +344,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &FlexibleServers_FirewallRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.EndIpAddress != nil || rule.StartIpAddress != nil {
 		result.Properties = &FirewallRuleProperties_ARM{}
 	}
@@ -374,10 +374,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_FirewallRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -386,10 +386,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -630,9 +630,9 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_FirewallRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -641,19 +641,19 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -662,7 +662,7 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -673,7 +673,7 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_server_types_gen.go
@@ -376,16 +376,16 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FlexibleServer_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if server.Location != nil {
 		location := *server.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if server.AdministratorLogin != nil ||
 		server.AdministratorLoginPassword != nil ||
 		server.AvailabilityZone != nil ||
@@ -477,7 +477,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.Version = &version
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if server.Sku != nil {
 		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -487,7 +487,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if server.Tags != nil {
 		result.Tags = make(map[string]string, len(server.Tags))
 		for key, value := range server.Tags {
@@ -509,7 +509,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServer_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -518,9 +518,9 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘AdministratorLoginPassword’
+	// no assignment for property "AdministratorLoginPassword"
 
-	// Set property ‘AvailabilityZone’:
+	// Set property "AvailabilityZone":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityZone != nil {
@@ -529,10 +529,10 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	server.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Backup’:
+	// Set property "Backup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Backup != nil {
@@ -546,7 +546,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -555,7 +555,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HighAvailability’:
+	// Set property "HighAvailability":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailability != nil {
@@ -569,13 +569,13 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceWindow != nil {
@@ -589,7 +589,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Network’:
+	// Set property "Network":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Network != nil {
@@ -603,12 +603,12 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PointInTimeUTC’:
+	// Set property "PointInTimeUTC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PointInTimeUTC != nil {
@@ -617,7 +617,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -628,9 +628,9 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		server.Sku = &sku
 	}
 
-	// no assignment for property ‘SourceServerResourceReference’
+	// no assignment for property "SourceServerResourceReference"
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Storage != nil {
@@ -644,7 +644,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -652,7 +652,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1125,7 +1125,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServer_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -1134,7 +1134,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘AvailabilityZone’:
+	// Set property "AvailabilityZone":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityZone != nil {
@@ -1143,7 +1143,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Backup’:
+	// Set property "Backup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Backup != nil {
@@ -1157,9 +1157,9 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -1168,7 +1168,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘FullyQualifiedDomainName’:
+	// Set property "FullyQualifiedDomainName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FullyQualifiedDomainName != nil {
@@ -1177,7 +1177,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘HighAvailability’:
+	// Set property "HighAvailability":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailability != nil {
@@ -1191,19 +1191,19 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		server.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceWindow != nil {
@@ -1217,7 +1217,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘MinorVersion’:
+	// Set property "MinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinorVersion != nil {
@@ -1226,13 +1226,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		server.Name = &name
 	}
 
-	// Set property ‘Network’:
+	// Set property "Network":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Network != nil {
@@ -1246,7 +1246,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PointInTimeUTC’:
+	// Set property "PointInTimeUTC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PointInTimeUTC != nil {
@@ -1255,7 +1255,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1266,7 +1266,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.Sku = &sku
 	}
 
-	// Set property ‘SourceServerResourceId’:
+	// Set property "SourceServerResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceServerResourceId != nil {
@@ -1275,7 +1275,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1284,7 +1284,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Storage != nil {
@@ -1298,7 +1298,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1309,7 +1309,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1317,13 +1317,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		server.Type = &typeVar
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1662,13 +1662,13 @@ func (backup *Backup) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &Backup_ARM{}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if backup.BackupRetentionDays != nil {
 		backupRetentionDays := *backup.BackupRetentionDays
 		result.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if backup.GeoRedundantBackup != nil {
 		geoRedundantBackup := *backup.GeoRedundantBackup
 		result.GeoRedundantBackup = &geoRedundantBackup
@@ -1688,13 +1688,13 @@ func (backup *Backup) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Backup_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		backup.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		backup.GeoRedundantBackup = &geoRedundantBackup
@@ -1770,19 +1770,19 @@ func (backup *Backup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Backup_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		backup.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘EarliestRestoreDate’:
+	// Set property "EarliestRestoreDate":
 	if typedInput.EarliestRestoreDate != nil {
 		earliestRestoreDate := *typedInput.EarliestRestoreDate
 		backup.EarliestRestoreDate = &earliestRestoreDate
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		backup.GeoRedundantBackup = &geoRedundantBackup
@@ -1911,13 +1911,13 @@ func (availability *HighAvailability) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &HighAvailability_ARM{}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if availability.Mode != nil {
 		mode := *availability.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if availability.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *availability.StandbyAvailabilityZone
 		result.StandbyAvailabilityZone = &standbyAvailabilityZone
@@ -1937,13 +1937,13 @@ func (availability *HighAvailability) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HighAvailability_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		availability.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if typedInput.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *typedInput.StandbyAvailabilityZone
 		availability.StandbyAvailabilityZone = &standbyAvailabilityZone
@@ -2019,19 +2019,19 @@ func (availability *HighAvailability_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HighAvailability_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		availability.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if typedInput.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *typedInput.StandbyAvailabilityZone
 		availability.StandbyAvailabilityZone = &standbyAvailabilityZone
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		availability.State = &state
@@ -2119,25 +2119,25 @@ func (window *MaintenanceWindow) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &MaintenanceWindow_ARM{}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if window.CustomWindow != nil {
 		customWindow := *window.CustomWindow
 		result.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if window.DayOfWeek != nil {
 		dayOfWeek := *window.DayOfWeek
 		result.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if window.StartHour != nil {
 		startHour := *window.StartHour
 		result.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if window.StartMinute != nil {
 		startMinute := *window.StartMinute
 		result.StartMinute = &startMinute
@@ -2157,25 +2157,25 @@ func (window *MaintenanceWindow) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceWindow_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if typedInput.CustomWindow != nil {
 		customWindow := *typedInput.CustomWindow
 		window.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		window.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if typedInput.StartHour != nil {
 		startHour := *typedInput.StartHour
 		window.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if typedInput.StartMinute != nil {
 		startMinute := *typedInput.StartMinute
 		window.StartMinute = &startMinute
@@ -2254,25 +2254,25 @@ func (window *MaintenanceWindow_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceWindow_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if typedInput.CustomWindow != nil {
 		customWindow := *typedInput.CustomWindow
 		window.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		window.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if typedInput.StartHour != nil {
 		startHour := *typedInput.StartHour
 		window.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if typedInput.StartMinute != nil {
 		startMinute := *typedInput.StartMinute
 		window.StartMinute = &startMinute
@@ -2344,7 +2344,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Network_ARM{}
 
-	// Set property ‘DelegatedSubnetResourceId’:
+	// Set property "DelegatedSubnetResourceId":
 	if network.DelegatedSubnetResourceReference != nil {
 		delegatedSubnetResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*network.DelegatedSubnetResourceReference)
 		if err != nil {
@@ -2354,7 +2354,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.DelegatedSubnetResourceId = &delegatedSubnetResourceReference
 	}
 
-	// Set property ‘PrivateDnsZoneArmResourceId’:
+	// Set property "PrivateDnsZoneArmResourceId":
 	if network.PrivateDnsZoneArmResourceReference != nil {
 		privateDnsZoneArmResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*network.PrivateDnsZoneArmResourceReference)
 		if err != nil {
@@ -2378,9 +2378,9 @@ func (network *Network) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Network_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘DelegatedSubnetResourceReference’
+	// no assignment for property "DelegatedSubnetResourceReference"
 
-	// no assignment for property ‘PrivateDnsZoneArmResourceReference’
+	// no assignment for property "PrivateDnsZoneArmResourceReference"
 
 	// No error
 	return nil
@@ -2462,19 +2462,19 @@ func (network *Network_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Network_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DelegatedSubnetResourceId’:
+	// Set property "DelegatedSubnetResourceId":
 	if typedInput.DelegatedSubnetResourceId != nil {
 		delegatedSubnetResourceId := *typedInput.DelegatedSubnetResourceId
 		network.DelegatedSubnetResourceId = &delegatedSubnetResourceId
 	}
 
-	// Set property ‘PrivateDnsZoneArmResourceId’:
+	// Set property "PrivateDnsZoneArmResourceId":
 	if typedInput.PrivateDnsZoneArmResourceId != nil {
 		privateDnsZoneArmResourceId := *typedInput.PrivateDnsZoneArmResourceId
 		network.PrivateDnsZoneArmResourceId = &privateDnsZoneArmResourceId
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		network.PublicNetworkAccess = &publicNetworkAccess
@@ -2608,13 +2608,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -2634,13 +2634,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2715,13 +2715,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2790,7 +2790,7 @@ func (storage *Storage) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Storage_ARM{}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if storage.StorageSizeGB != nil {
 		storageSizeGB := *storage.StorageSizeGB
 		result.StorageSizeGB = &storageSizeGB
@@ -2810,7 +2810,7 @@ func (storage *Storage) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Storage_ARM, got %T", armInput)
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if typedInput.StorageSizeGB != nil {
 		storageSizeGB := *typedInput.StorageSizeGB
 		storage.StorageSizeGB = &storageSizeGB
@@ -2868,7 +2868,7 @@ func (storage *Storage_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Storage_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if typedInput.StorageSizeGB != nil {
 		storageSizeGB := *typedInput.StorageSizeGB
 		storage.StorageSizeGB = &storageSizeGB
@@ -2931,37 +2931,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_configuration_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_configuration_types_gen.go
@@ -332,10 +332,10 @@ func (configuration *FlexibleServers_Configuration_Spec) ConvertToARM(resolved g
 	}
 	result := &FlexibleServers_Configuration_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.Source != nil || configuration.Value != nil {
 		result.Properties = &ConfigurationProperties_ARM{}
 	}
@@ -362,13 +362,13 @@ func (configuration *FlexibleServers_Configuration_Spec) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Configuration_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	configuration.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	configuration.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -377,7 +377,7 @@ func (configuration *FlexibleServers_Configuration_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {
@@ -596,7 +596,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Configuration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedValues’:
+	// Set property "AllowedValues":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowedValues != nil {
@@ -605,9 +605,9 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DataType’:
+	// Set property "DataType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataType != nil {
@@ -616,7 +616,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DefaultValue’:
+	// Set property "DefaultValue":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultValue != nil {
@@ -625,7 +625,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -634,7 +634,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DocumentationLink’:
+	// Set property "DocumentationLink":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DocumentationLink != nil {
@@ -643,13 +643,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘IsConfigPendingRestart’:
+	// Set property "IsConfigPendingRestart":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsConfigPendingRestart != nil {
@@ -658,7 +658,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘IsDynamicConfig’:
+	// Set property "IsDynamicConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsDynamicConfig != nil {
@@ -667,7 +667,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘IsReadOnly’:
+	// Set property "IsReadOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsReadOnly != nil {
@@ -676,13 +676,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -691,7 +691,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -702,13 +702,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		configuration.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		configuration.Type = &typeVar
 	}
 
-	// Set property ‘Unit’:
+	// Set property "Unit":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Unit != nil {
@@ -717,7 +717,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_database_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_database_types_gen.go
@@ -332,10 +332,10 @@ func (database *FlexibleServers_Database_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &FlexibleServers_Database_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.Charset != nil || database.Collation != nil {
 		result.Properties = &DatabaseProperties_ARM{}
 	}
@@ -362,10 +362,10 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Database_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -374,7 +374,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -383,7 +383,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -587,7 +587,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Database_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -596,7 +596,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -605,21 +605,21 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -630,7 +630,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		database.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_firewall_rule_types_gen.go
@@ -338,10 +338,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &FlexibleServers_FirewallRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.EndIpAddress != nil || rule.StartIpAddress != nil {
 		result.Properties = &FirewallRuleProperties_ARM{}
 	}
@@ -368,10 +368,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_FirewallRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -380,10 +380,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -612,9 +612,9 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_FirewallRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -623,19 +623,19 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -644,7 +644,7 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -655,7 +655,7 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/dbforpostgresql/v1beta20220120preview/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20220120preview/flexible_server_types_gen.go
@@ -398,16 +398,16 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FlexibleServer_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if server.Location != nil {
 		location := *server.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if server.AdministratorLogin != nil ||
 		server.AdministratorLoginPassword != nil ||
 		server.AvailabilityZone != nil ||
@@ -499,7 +499,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.Version = &version
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if server.Sku != nil {
 		sku_ARM, err := (*server.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -509,7 +509,7 @@ func (server *FlexibleServer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if server.Tags != nil {
 		result.Tags = make(map[string]string, len(server.Tags))
 		for key, value := range server.Tags {
@@ -531,7 +531,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServer_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -540,9 +540,9 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘AdministratorLoginPassword’
+	// no assignment for property "AdministratorLoginPassword"
 
-	// Set property ‘AvailabilityZone’:
+	// Set property "AvailabilityZone":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityZone != nil {
@@ -551,10 +551,10 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	server.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Backup’:
+	// Set property "Backup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Backup != nil {
@@ -568,7 +568,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -577,7 +577,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HighAvailability’:
+	// Set property "HighAvailability":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailability != nil {
@@ -591,13 +591,13 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceWindow != nil {
@@ -611,7 +611,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Network’:
+	// Set property "Network":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Network != nil {
@@ -625,12 +625,12 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PointInTimeUTC’:
+	// Set property "PointInTimeUTC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PointInTimeUTC != nil {
@@ -639,7 +639,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -650,9 +650,9 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		server.Sku = &sku
 	}
 
-	// no assignment for property ‘SourceServerResourceReference’
+	// no assignment for property "SourceServerResourceReference"
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Storage != nil {
@@ -666,7 +666,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -674,7 +674,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1147,7 +1147,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServer_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -1156,7 +1156,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘AvailabilityZone’:
+	// Set property "AvailabilityZone":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityZone != nil {
@@ -1165,7 +1165,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Backup’:
+	// Set property "Backup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Backup != nil {
@@ -1179,9 +1179,9 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -1190,7 +1190,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘FullyQualifiedDomainName’:
+	// Set property "FullyQualifiedDomainName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FullyQualifiedDomainName != nil {
@@ -1199,7 +1199,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘HighAvailability’:
+	// Set property "HighAvailability":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailability != nil {
@@ -1213,19 +1213,19 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		server.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MaintenanceWindow’:
+	// Set property "MaintenanceWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceWindow != nil {
@@ -1239,7 +1239,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘MinorVersion’:
+	// Set property "MinorVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinorVersion != nil {
@@ -1248,13 +1248,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		server.Name = &name
 	}
 
-	// Set property ‘Network’:
+	// Set property "Network":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Network != nil {
@@ -1268,7 +1268,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PointInTimeUTC’:
+	// Set property "PointInTimeUTC":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PointInTimeUTC != nil {
@@ -1277,7 +1277,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1288,7 +1288,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.Sku = &sku
 	}
 
-	// Set property ‘SourceServerResourceId’:
+	// Set property "SourceServerResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceServerResourceId != nil {
@@ -1297,7 +1297,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1306,7 +1306,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Storage != nil {
@@ -1320,7 +1320,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1331,7 +1331,7 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		server.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1339,13 +1339,13 @@ func (server *FlexibleServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		server.Type = &typeVar
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1684,13 +1684,13 @@ func (backup *Backup) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &Backup_ARM{}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if backup.BackupRetentionDays != nil {
 		backupRetentionDays := *backup.BackupRetentionDays
 		result.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if backup.GeoRedundantBackup != nil {
 		geoRedundantBackup := *backup.GeoRedundantBackup
 		result.GeoRedundantBackup = &geoRedundantBackup
@@ -1710,13 +1710,13 @@ func (backup *Backup) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Backup_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		backup.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		backup.GeoRedundantBackup = &geoRedundantBackup
@@ -1792,19 +1792,19 @@ func (backup *Backup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Backup_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupRetentionDays’:
+	// Set property "BackupRetentionDays":
 	if typedInput.BackupRetentionDays != nil {
 		backupRetentionDays := *typedInput.BackupRetentionDays
 		backup.BackupRetentionDays = &backupRetentionDays
 	}
 
-	// Set property ‘EarliestRestoreDate’:
+	// Set property "EarliestRestoreDate":
 	if typedInput.EarliestRestoreDate != nil {
 		earliestRestoreDate := *typedInput.EarliestRestoreDate
 		backup.EarliestRestoreDate = &earliestRestoreDate
 	}
 
-	// Set property ‘GeoRedundantBackup’:
+	// Set property "GeoRedundantBackup":
 	if typedInput.GeoRedundantBackup != nil {
 		geoRedundantBackup := *typedInput.GeoRedundantBackup
 		backup.GeoRedundantBackup = &geoRedundantBackup
@@ -1933,13 +1933,13 @@ func (availability *HighAvailability) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &HighAvailability_ARM{}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if availability.Mode != nil {
 		mode := *availability.Mode
 		result.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if availability.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *availability.StandbyAvailabilityZone
 		result.StandbyAvailabilityZone = &standbyAvailabilityZone
@@ -1959,13 +1959,13 @@ func (availability *HighAvailability) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HighAvailability_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		availability.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if typedInput.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *typedInput.StandbyAvailabilityZone
 		availability.StandbyAvailabilityZone = &standbyAvailabilityZone
@@ -2041,19 +2041,19 @@ func (availability *HighAvailability_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HighAvailability_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		availability.Mode = &mode
 	}
 
-	// Set property ‘StandbyAvailabilityZone’:
+	// Set property "StandbyAvailabilityZone":
 	if typedInput.StandbyAvailabilityZone != nil {
 		standbyAvailabilityZone := *typedInput.StandbyAvailabilityZone
 		availability.StandbyAvailabilityZone = &standbyAvailabilityZone
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		availability.State = &state
@@ -2141,25 +2141,25 @@ func (window *MaintenanceWindow) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &MaintenanceWindow_ARM{}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if window.CustomWindow != nil {
 		customWindow := *window.CustomWindow
 		result.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if window.DayOfWeek != nil {
 		dayOfWeek := *window.DayOfWeek
 		result.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if window.StartHour != nil {
 		startHour := *window.StartHour
 		result.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if window.StartMinute != nil {
 		startMinute := *window.StartMinute
 		result.StartMinute = &startMinute
@@ -2179,25 +2179,25 @@ func (window *MaintenanceWindow) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceWindow_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if typedInput.CustomWindow != nil {
 		customWindow := *typedInput.CustomWindow
 		window.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		window.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if typedInput.StartHour != nil {
 		startHour := *typedInput.StartHour
 		window.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if typedInput.StartMinute != nil {
 		startMinute := *typedInput.StartMinute
 		window.StartMinute = &startMinute
@@ -2276,25 +2276,25 @@ func (window *MaintenanceWindow_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MaintenanceWindow_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomWindow’:
+	// Set property "CustomWindow":
 	if typedInput.CustomWindow != nil {
 		customWindow := *typedInput.CustomWindow
 		window.CustomWindow = &customWindow
 	}
 
-	// Set property ‘DayOfWeek’:
+	// Set property "DayOfWeek":
 	if typedInput.DayOfWeek != nil {
 		dayOfWeek := *typedInput.DayOfWeek
 		window.DayOfWeek = &dayOfWeek
 	}
 
-	// Set property ‘StartHour’:
+	// Set property "StartHour":
 	if typedInput.StartHour != nil {
 		startHour := *typedInput.StartHour
 		window.StartHour = &startHour
 	}
 
-	// Set property ‘StartMinute’:
+	// Set property "StartMinute":
 	if typedInput.StartMinute != nil {
 		startMinute := *typedInput.StartMinute
 		window.StartMinute = &startMinute
@@ -2366,7 +2366,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Network_ARM{}
 
-	// Set property ‘DelegatedSubnetResourceId’:
+	// Set property "DelegatedSubnetResourceId":
 	if network.DelegatedSubnetResourceReference != nil {
 		delegatedSubnetResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*network.DelegatedSubnetResourceReference)
 		if err != nil {
@@ -2376,7 +2376,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.DelegatedSubnetResourceId = &delegatedSubnetResourceReference
 	}
 
-	// Set property ‘PrivateDnsZoneArmResourceId’:
+	// Set property "PrivateDnsZoneArmResourceId":
 	if network.PrivateDnsZoneArmResourceReference != nil {
 		privateDnsZoneArmResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*network.PrivateDnsZoneArmResourceReference)
 		if err != nil {
@@ -2400,9 +2400,9 @@ func (network *Network) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Network_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘DelegatedSubnetResourceReference’
+	// no assignment for property "DelegatedSubnetResourceReference"
 
-	// no assignment for property ‘PrivateDnsZoneArmResourceReference’
+	// no assignment for property "PrivateDnsZoneArmResourceReference"
 
 	// No error
 	return nil
@@ -2484,19 +2484,19 @@ func (network *Network_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Network_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DelegatedSubnetResourceId’:
+	// Set property "DelegatedSubnetResourceId":
 	if typedInput.DelegatedSubnetResourceId != nil {
 		delegatedSubnetResourceId := *typedInput.DelegatedSubnetResourceId
 		network.DelegatedSubnetResourceId = &delegatedSubnetResourceId
 	}
 
-	// Set property ‘PrivateDnsZoneArmResourceId’:
+	// Set property "PrivateDnsZoneArmResourceId":
 	if typedInput.PrivateDnsZoneArmResourceId != nil {
 		privateDnsZoneArmResourceId := *typedInput.PrivateDnsZoneArmResourceId
 		network.PrivateDnsZoneArmResourceId = &privateDnsZoneArmResourceId
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		network.PublicNetworkAccess = &publicNetworkAccess
@@ -2631,13 +2631,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -2657,13 +2657,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2738,13 +2738,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2813,7 +2813,7 @@ func (storage *Storage) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Storage_ARM{}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if storage.StorageSizeGB != nil {
 		storageSizeGB := *storage.StorageSizeGB
 		result.StorageSizeGB = &storageSizeGB
@@ -2833,7 +2833,7 @@ func (storage *Storage) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Storage_ARM, got %T", armInput)
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if typedInput.StorageSizeGB != nil {
 		storageSizeGB := *typedInput.StorageSizeGB
 		storage.StorageSizeGB = &storageSizeGB
@@ -2891,7 +2891,7 @@ func (storage *Storage_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Storage_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘StorageSizeGB’:
+	// Set property "StorageSizeGB":
 	if typedInput.StorageSizeGB != nil {
 		storageSizeGB := *typedInput.StorageSizeGB
 		storage.StorageSizeGB = &storageSizeGB
@@ -2954,37 +2954,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType

--- a/v2/api/dbforpostgresql/v1beta20220120preview/flexible_servers_configuration_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20220120preview/flexible_servers_configuration_types_gen.go
@@ -332,10 +332,10 @@ func (configuration *FlexibleServers_Configuration_Spec) ConvertToARM(resolved g
 	}
 	result := &FlexibleServers_Configuration_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.Source != nil || configuration.Value != nil {
 		result.Properties = &ConfigurationProperties_ARM{}
 	}
@@ -362,13 +362,13 @@ func (configuration *FlexibleServers_Configuration_Spec) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Configuration_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	configuration.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	configuration.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -377,7 +377,7 @@ func (configuration *FlexibleServers_Configuration_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {
@@ -596,7 +596,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Configuration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedValues’:
+	// Set property "AllowedValues":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowedValues != nil {
@@ -605,9 +605,9 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DataType’:
+	// Set property "DataType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataType != nil {
@@ -616,7 +616,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DefaultValue’:
+	// Set property "DefaultValue":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultValue != nil {
@@ -625,7 +625,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -634,7 +634,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DocumentationLink’:
+	// Set property "DocumentationLink":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DocumentationLink != nil {
@@ -643,13 +643,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘IsConfigPendingRestart’:
+	// Set property "IsConfigPendingRestart":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsConfigPendingRestart != nil {
@@ -658,7 +658,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘IsDynamicConfig’:
+	// Set property "IsDynamicConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsDynamicConfig != nil {
@@ -667,7 +667,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘IsReadOnly’:
+	// Set property "IsReadOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsReadOnly != nil {
@@ -676,13 +676,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Source != nil {
@@ -691,7 +691,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -702,13 +702,13 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		configuration.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		configuration.Type = &typeVar
 	}
 
-	// Set property ‘Unit’:
+	// Set property "Unit":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Unit != nil {
@@ -717,7 +717,7 @@ func (configuration *FlexibleServers_Configuration_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {

--- a/v2/api/dbforpostgresql/v1beta20220120preview/flexible_servers_database_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20220120preview/flexible_servers_database_types_gen.go
@@ -332,10 +332,10 @@ func (database *FlexibleServers_Database_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &FlexibleServers_Database_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.Charset != nil || database.Collation != nil {
 		result.Properties = &DatabaseProperties_ARM{}
 	}
@@ -362,10 +362,10 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Database_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -374,7 +374,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -383,7 +383,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -587,7 +587,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_Database_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Charset’:
+	// Set property "Charset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Charset != nil {
@@ -596,7 +596,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -605,21 +605,21 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -630,7 +630,7 @@ func (database *FlexibleServers_Database_STATUS) PopulateFromARM(owner genruntim
 		database.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar

--- a/v2/api/dbforpostgresql/v1beta20220120preview/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20220120preview/flexible_servers_firewall_rule_types_gen.go
@@ -338,10 +338,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &FlexibleServers_FirewallRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.EndIpAddress != nil || rule.StartIpAddress != nil {
 		result.Properties = &FirewallRuleProperties_ARM{}
 	}
@@ -368,10 +368,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_FirewallRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -380,10 +380,10 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -612,9 +612,9 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlexibleServers_FirewallRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -623,19 +623,19 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -644,7 +644,7 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -655,7 +655,7 @@ func (rule *FlexibleServers_FirewallRule_STATUS) PopulateFromARM(owner genruntim
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/devices/v1api20210702/iot_hub_types_gen.go
+++ b/v2/api/devices/v1api20210702/iot_hub_types_gen.go
@@ -384,7 +384,7 @@ func (iotHub *IotHub_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &IotHub_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if iotHub.Identity != nil {
 		identity_ARM, err := (*iotHub.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -394,16 +394,16 @@ func (iotHub *IotHub_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if iotHub.Location != nil {
 		location := *iotHub.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if iotHub.Properties != nil {
 		properties_ARM, err := (*iotHub.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -413,7 +413,7 @@ func (iotHub *IotHub_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Properties = &properties
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if iotHub.Sku != nil {
 		sku_ARM, err := (*iotHub.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -423,7 +423,7 @@ func (iotHub *IotHub_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if iotHub.Tags != nil {
 		result.Tags = make(map[string]string, len(iotHub.Tags))
 		for key, value := range iotHub.Tags {
@@ -445,10 +445,10 @@ func (iotHub *IotHub_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IotHub_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	iotHub.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ArmIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -459,18 +459,18 @@ func (iotHub *IotHub_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		iotHub.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		iotHub.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	iotHub.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 IotHubProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -481,7 +481,7 @@ func (iotHub *IotHub_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		iotHub.Properties = &properties
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 IotHubSkuInfo
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -492,7 +492,7 @@ func (iotHub *IotHub_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		iotHub.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		iotHub.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -867,21 +867,21 @@ func (iotHub *IotHub_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IotHub_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		iotHub.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		iotHub.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ArmIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -892,19 +892,19 @@ func (iotHub *IotHub_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		iotHub.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		iotHub.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		iotHub.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 IotHubProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -915,7 +915,7 @@ func (iotHub *IotHub_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		iotHub.Properties = &properties
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 IotHubSkuInfo_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -926,7 +926,7 @@ func (iotHub *IotHub_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		iotHub.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -937,7 +937,7 @@ func (iotHub *IotHub_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		iotHub.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		iotHub.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -945,7 +945,7 @@ func (iotHub *IotHub_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		iotHub.Type = &typeVar
@@ -1132,13 +1132,13 @@ func (identity *ArmIdentity) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &ArmIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -1163,13 +1163,13 @@ func (identity *ArmIdentity) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ArmIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -1304,25 +1304,25 @@ func (identity *ArmIdentity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ArmIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]ArmUserIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -1556,12 +1556,12 @@ func (properties *IotHubProperties) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &IotHubProperties_ARM{}
 
-	// Set property ‘AllowedFqdnList’:
+	// Set property "AllowedFqdnList":
 	for _, item := range properties.AllowedFqdnList {
 		result.AllowedFqdnList = append(result.AllowedFqdnList, item)
 	}
 
-	// Set property ‘AuthorizationPolicies’:
+	// Set property "AuthorizationPolicies":
 	for _, item := range properties.AuthorizationPolicies {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1570,7 +1570,7 @@ func (properties *IotHubProperties) ConvertToARM(resolved genruntime.ConvertToAR
 		result.AuthorizationPolicies = append(result.AuthorizationPolicies, *item_ARM.(*SharedAccessSignatureAuthorizationRule_ARM))
 	}
 
-	// Set property ‘CloudToDevice’:
+	// Set property "CloudToDevice":
 	if properties.CloudToDevice != nil {
 		cloudToDevice_ARM, err := (*properties.CloudToDevice).ConvertToARM(resolved)
 		if err != nil {
@@ -1580,43 +1580,43 @@ func (properties *IotHubProperties) ConvertToARM(resolved genruntime.ConvertToAR
 		result.CloudToDevice = &cloudToDevice
 	}
 
-	// Set property ‘Comments’:
+	// Set property "Comments":
 	if properties.Comments != nil {
 		comments := *properties.Comments
 		result.Comments = &comments
 	}
 
-	// Set property ‘DisableDeviceSAS’:
+	// Set property "DisableDeviceSAS":
 	if properties.DisableDeviceSAS != nil {
 		disableDeviceSAS := *properties.DisableDeviceSAS
 		result.DisableDeviceSAS = &disableDeviceSAS
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if properties.DisableLocalAuth != nil {
 		disableLocalAuth := *properties.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘DisableModuleSAS’:
+	// Set property "DisableModuleSAS":
 	if properties.DisableModuleSAS != nil {
 		disableModuleSAS := *properties.DisableModuleSAS
 		result.DisableModuleSAS = &disableModuleSAS
 	}
 
-	// Set property ‘EnableDataResidency’:
+	// Set property "EnableDataResidency":
 	if properties.EnableDataResidency != nil {
 		enableDataResidency := *properties.EnableDataResidency
 		result.EnableDataResidency = &enableDataResidency
 	}
 
-	// Set property ‘EnableFileUploadNotifications’:
+	// Set property "EnableFileUploadNotifications":
 	if properties.EnableFileUploadNotifications != nil {
 		enableFileUploadNotifications := *properties.EnableFileUploadNotifications
 		result.EnableFileUploadNotifications = &enableFileUploadNotifications
 	}
 
-	// Set property ‘EventHubEndpoints’:
+	// Set property "EventHubEndpoints":
 	if properties.EventHubEndpoints != nil {
 		result.EventHubEndpoints = make(map[string]EventHubProperties_ARM, len(properties.EventHubEndpoints))
 		for key, value := range properties.EventHubEndpoints {
@@ -1628,13 +1628,13 @@ func (properties *IotHubProperties) ConvertToARM(resolved genruntime.ConvertToAR
 		}
 	}
 
-	// Set property ‘Features’:
+	// Set property "Features":
 	if properties.Features != nil {
 		features := *properties.Features
 		result.Features = &features
 	}
 
-	// Set property ‘IpFilterRules’:
+	// Set property "IpFilterRules":
 	for _, item := range properties.IpFilterRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1643,7 +1643,7 @@ func (properties *IotHubProperties) ConvertToARM(resolved genruntime.ConvertToAR
 		result.IpFilterRules = append(result.IpFilterRules, *item_ARM.(*IpFilterRule_ARM))
 	}
 
-	// Set property ‘MessagingEndpoints’:
+	// Set property "MessagingEndpoints":
 	if properties.MessagingEndpoints != nil {
 		result.MessagingEndpoints = make(map[string]MessagingEndpointProperties_ARM, len(properties.MessagingEndpoints))
 		for key, value := range properties.MessagingEndpoints {
@@ -1655,13 +1655,13 @@ func (properties *IotHubProperties) ConvertToARM(resolved genruntime.ConvertToAR
 		}
 	}
 
-	// Set property ‘MinTlsVersion’:
+	// Set property "MinTlsVersion":
 	if properties.MinTlsVersion != nil {
 		minTlsVersion := *properties.MinTlsVersion
 		result.MinTlsVersion = &minTlsVersion
 	}
 
-	// Set property ‘NetworkRuleSets’:
+	// Set property "NetworkRuleSets":
 	if properties.NetworkRuleSets != nil {
 		networkRuleSets_ARM, err := (*properties.NetworkRuleSets).ConvertToARM(resolved)
 		if err != nil {
@@ -1671,19 +1671,19 @@ func (properties *IotHubProperties) ConvertToARM(resolved genruntime.ConvertToAR
 		result.NetworkRuleSets = &networkRuleSets
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if properties.PublicNetworkAccess != nil {
 		publicNetworkAccess := *properties.PublicNetworkAccess
 		result.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘RestrictOutboundNetworkAccess’:
+	// Set property "RestrictOutboundNetworkAccess":
 	if properties.RestrictOutboundNetworkAccess != nil {
 		restrictOutboundNetworkAccess := *properties.RestrictOutboundNetworkAccess
 		result.RestrictOutboundNetworkAccess = &restrictOutboundNetworkAccess
 	}
 
-	// Set property ‘Routing’:
+	// Set property "Routing":
 	if properties.Routing != nil {
 		routing_ARM, err := (*properties.Routing).ConvertToARM(resolved)
 		if err != nil {
@@ -1693,7 +1693,7 @@ func (properties *IotHubProperties) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Routing = &routing
 	}
 
-	// Set property ‘StorageEndpoints’:
+	// Set property "StorageEndpoints":
 	if properties.StorageEndpoints != nil {
 		result.StorageEndpoints = make(map[string]StorageEndpointProperties_ARM, len(properties.StorageEndpoints))
 		for key, value := range properties.StorageEndpoints {
@@ -1719,12 +1719,12 @@ func (properties *IotHubProperties) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IotHubProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedFqdnList’:
+	// Set property "AllowedFqdnList":
 	for _, item := range typedInput.AllowedFqdnList {
 		properties.AllowedFqdnList = append(properties.AllowedFqdnList, item)
 	}
 
-	// Set property ‘AuthorizationPolicies’:
+	// Set property "AuthorizationPolicies":
 	for _, item := range typedInput.AuthorizationPolicies {
 		var item1 SharedAccessSignatureAuthorizationRule
 		err := item1.PopulateFromARM(owner, item)
@@ -1734,7 +1734,7 @@ func (properties *IotHubProperties) PopulateFromARM(owner genruntime.ArbitraryOw
 		properties.AuthorizationPolicies = append(properties.AuthorizationPolicies, item1)
 	}
 
-	// Set property ‘CloudToDevice’:
+	// Set property "CloudToDevice":
 	if typedInput.CloudToDevice != nil {
 		var cloudToDevice1 CloudToDeviceProperties
 		err := cloudToDevice1.PopulateFromARM(owner, *typedInput.CloudToDevice)
@@ -1745,43 +1745,43 @@ func (properties *IotHubProperties) PopulateFromARM(owner genruntime.ArbitraryOw
 		properties.CloudToDevice = &cloudToDevice
 	}
 
-	// Set property ‘Comments’:
+	// Set property "Comments":
 	if typedInput.Comments != nil {
 		comments := *typedInput.Comments
 		properties.Comments = &comments
 	}
 
-	// Set property ‘DisableDeviceSAS’:
+	// Set property "DisableDeviceSAS":
 	if typedInput.DisableDeviceSAS != nil {
 		disableDeviceSAS := *typedInput.DisableDeviceSAS
 		properties.DisableDeviceSAS = &disableDeviceSAS
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		properties.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘DisableModuleSAS’:
+	// Set property "DisableModuleSAS":
 	if typedInput.DisableModuleSAS != nil {
 		disableModuleSAS := *typedInput.DisableModuleSAS
 		properties.DisableModuleSAS = &disableModuleSAS
 	}
 
-	// Set property ‘EnableDataResidency’:
+	// Set property "EnableDataResidency":
 	if typedInput.EnableDataResidency != nil {
 		enableDataResidency := *typedInput.EnableDataResidency
 		properties.EnableDataResidency = &enableDataResidency
 	}
 
-	// Set property ‘EnableFileUploadNotifications’:
+	// Set property "EnableFileUploadNotifications":
 	if typedInput.EnableFileUploadNotifications != nil {
 		enableFileUploadNotifications := *typedInput.EnableFileUploadNotifications
 		properties.EnableFileUploadNotifications = &enableFileUploadNotifications
 	}
 
-	// Set property ‘EventHubEndpoints’:
+	// Set property "EventHubEndpoints":
 	if typedInput.EventHubEndpoints != nil {
 		properties.EventHubEndpoints = make(map[string]EventHubProperties, len(typedInput.EventHubEndpoints))
 		for key, value := range typedInput.EventHubEndpoints {
@@ -1794,13 +1794,13 @@ func (properties *IotHubProperties) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Features’:
+	// Set property "Features":
 	if typedInput.Features != nil {
 		features := *typedInput.Features
 		properties.Features = &features
 	}
 
-	// Set property ‘IpFilterRules’:
+	// Set property "IpFilterRules":
 	for _, item := range typedInput.IpFilterRules {
 		var item1 IpFilterRule
 		err := item1.PopulateFromARM(owner, item)
@@ -1810,7 +1810,7 @@ func (properties *IotHubProperties) PopulateFromARM(owner genruntime.ArbitraryOw
 		properties.IpFilterRules = append(properties.IpFilterRules, item1)
 	}
 
-	// Set property ‘MessagingEndpoints’:
+	// Set property "MessagingEndpoints":
 	if typedInput.MessagingEndpoints != nil {
 		properties.MessagingEndpoints = make(map[string]MessagingEndpointProperties, len(typedInput.MessagingEndpoints))
 		for key, value := range typedInput.MessagingEndpoints {
@@ -1823,13 +1823,13 @@ func (properties *IotHubProperties) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘MinTlsVersion’:
+	// Set property "MinTlsVersion":
 	if typedInput.MinTlsVersion != nil {
 		minTlsVersion := *typedInput.MinTlsVersion
 		properties.MinTlsVersion = &minTlsVersion
 	}
 
-	// Set property ‘NetworkRuleSets’:
+	// Set property "NetworkRuleSets":
 	if typedInput.NetworkRuleSets != nil {
 		var networkRuleSets1 NetworkRuleSetProperties
 		err := networkRuleSets1.PopulateFromARM(owner, *typedInput.NetworkRuleSets)
@@ -1840,19 +1840,19 @@ func (properties *IotHubProperties) PopulateFromARM(owner genruntime.ArbitraryOw
 		properties.NetworkRuleSets = &networkRuleSets
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘RestrictOutboundNetworkAccess’:
+	// Set property "RestrictOutboundNetworkAccess":
 	if typedInput.RestrictOutboundNetworkAccess != nil {
 		restrictOutboundNetworkAccess := *typedInput.RestrictOutboundNetworkAccess
 		properties.RestrictOutboundNetworkAccess = &restrictOutboundNetworkAccess
 	}
 
-	// Set property ‘Routing’:
+	// Set property "Routing":
 	if typedInput.Routing != nil {
 		var routing1 RoutingProperties
 		err := routing1.PopulateFromARM(owner, *typedInput.Routing)
@@ -1863,7 +1863,7 @@ func (properties *IotHubProperties) PopulateFromARM(owner genruntime.ArbitraryOw
 		properties.Routing = &routing
 	}
 
-	// Set property ‘StorageEndpoints’:
+	// Set property "StorageEndpoints":
 	if typedInput.StorageEndpoints != nil {
 		properties.StorageEndpoints = make(map[string]StorageEndpointProperties, len(typedInput.StorageEndpoints))
 		for key, value := range typedInput.StorageEndpoints {
@@ -2604,12 +2604,12 @@ func (properties *IotHubProperties_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IotHubProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedFqdnList’:
+	// Set property "AllowedFqdnList":
 	for _, item := range typedInput.AllowedFqdnList {
 		properties.AllowedFqdnList = append(properties.AllowedFqdnList, item)
 	}
 
-	// Set property ‘AuthorizationPolicies’:
+	// Set property "AuthorizationPolicies":
 	for _, item := range typedInput.AuthorizationPolicies {
 		var item1 SharedAccessSignatureAuthorizationRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2619,7 +2619,7 @@ func (properties *IotHubProperties_STATUS) PopulateFromARM(owner genruntime.Arbi
 		properties.AuthorizationPolicies = append(properties.AuthorizationPolicies, item1)
 	}
 
-	// Set property ‘CloudToDevice’:
+	// Set property "CloudToDevice":
 	if typedInput.CloudToDevice != nil {
 		var cloudToDevice1 CloudToDeviceProperties_STATUS
 		err := cloudToDevice1.PopulateFromARM(owner, *typedInput.CloudToDevice)
@@ -2630,43 +2630,43 @@ func (properties *IotHubProperties_STATUS) PopulateFromARM(owner genruntime.Arbi
 		properties.CloudToDevice = &cloudToDevice
 	}
 
-	// Set property ‘Comments’:
+	// Set property "Comments":
 	if typedInput.Comments != nil {
 		comments := *typedInput.Comments
 		properties.Comments = &comments
 	}
 
-	// Set property ‘DisableDeviceSAS’:
+	// Set property "DisableDeviceSAS":
 	if typedInput.DisableDeviceSAS != nil {
 		disableDeviceSAS := *typedInput.DisableDeviceSAS
 		properties.DisableDeviceSAS = &disableDeviceSAS
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		properties.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘DisableModuleSAS’:
+	// Set property "DisableModuleSAS":
 	if typedInput.DisableModuleSAS != nil {
 		disableModuleSAS := *typedInput.DisableModuleSAS
 		properties.DisableModuleSAS = &disableModuleSAS
 	}
 
-	// Set property ‘EnableDataResidency’:
+	// Set property "EnableDataResidency":
 	if typedInput.EnableDataResidency != nil {
 		enableDataResidency := *typedInput.EnableDataResidency
 		properties.EnableDataResidency = &enableDataResidency
 	}
 
-	// Set property ‘EnableFileUploadNotifications’:
+	// Set property "EnableFileUploadNotifications":
 	if typedInput.EnableFileUploadNotifications != nil {
 		enableFileUploadNotifications := *typedInput.EnableFileUploadNotifications
 		properties.EnableFileUploadNotifications = &enableFileUploadNotifications
 	}
 
-	// Set property ‘EventHubEndpoints’:
+	// Set property "EventHubEndpoints":
 	if typedInput.EventHubEndpoints != nil {
 		properties.EventHubEndpoints = make(map[string]EventHubProperties_STATUS, len(typedInput.EventHubEndpoints))
 		for key, value := range typedInput.EventHubEndpoints {
@@ -2679,19 +2679,19 @@ func (properties *IotHubProperties_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Features’:
+	// Set property "Features":
 	if typedInput.Features != nil {
 		features := *typedInput.Features
 		properties.Features = &features
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	if typedInput.HostName != nil {
 		hostName := *typedInput.HostName
 		properties.HostName = &hostName
 	}
 
-	// Set property ‘IpFilterRules’:
+	// Set property "IpFilterRules":
 	for _, item := range typedInput.IpFilterRules {
 		var item1 IpFilterRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2701,7 +2701,7 @@ func (properties *IotHubProperties_STATUS) PopulateFromARM(owner genruntime.Arbi
 		properties.IpFilterRules = append(properties.IpFilterRules, item1)
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	for _, item := range typedInput.Locations {
 		var item1 IotHubLocationDescription_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2711,7 +2711,7 @@ func (properties *IotHubProperties_STATUS) PopulateFromARM(owner genruntime.Arbi
 		properties.Locations = append(properties.Locations, item1)
 	}
 
-	// Set property ‘MessagingEndpoints’:
+	// Set property "MessagingEndpoints":
 	if typedInput.MessagingEndpoints != nil {
 		properties.MessagingEndpoints = make(map[string]MessagingEndpointProperties_STATUS, len(typedInput.MessagingEndpoints))
 		for key, value := range typedInput.MessagingEndpoints {
@@ -2724,13 +2724,13 @@ func (properties *IotHubProperties_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘MinTlsVersion’:
+	// Set property "MinTlsVersion":
 	if typedInput.MinTlsVersion != nil {
 		minTlsVersion := *typedInput.MinTlsVersion
 		properties.MinTlsVersion = &minTlsVersion
 	}
 
-	// Set property ‘NetworkRuleSets’:
+	// Set property "NetworkRuleSets":
 	if typedInput.NetworkRuleSets != nil {
 		var networkRuleSets1 NetworkRuleSetProperties_STATUS
 		err := networkRuleSets1.PopulateFromARM(owner, *typedInput.NetworkRuleSets)
@@ -2741,7 +2741,7 @@ func (properties *IotHubProperties_STATUS) PopulateFromARM(owner genruntime.Arbi
 		properties.NetworkRuleSets = &networkRuleSets
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	for _, item := range typedInput.PrivateEndpointConnections {
 		var item1 PrivateEndpointConnection_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2751,25 +2751,25 @@ func (properties *IotHubProperties_STATUS) PopulateFromARM(owner genruntime.Arbi
 		properties.PrivateEndpointConnections = append(properties.PrivateEndpointConnections, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		properties.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘RestrictOutboundNetworkAccess’:
+	// Set property "RestrictOutboundNetworkAccess":
 	if typedInput.RestrictOutboundNetworkAccess != nil {
 		restrictOutboundNetworkAccess := *typedInput.RestrictOutboundNetworkAccess
 		properties.RestrictOutboundNetworkAccess = &restrictOutboundNetworkAccess
 	}
 
-	// Set property ‘Routing’:
+	// Set property "Routing":
 	if typedInput.Routing != nil {
 		var routing1 RoutingProperties_STATUS
 		err := routing1.PopulateFromARM(owner, *typedInput.Routing)
@@ -2780,13 +2780,13 @@ func (properties *IotHubProperties_STATUS) PopulateFromARM(owner genruntime.Arbi
 		properties.Routing = &routing
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		properties.State = &state
 	}
 
-	// Set property ‘StorageEndpoints’:
+	// Set property "StorageEndpoints":
 	if typedInput.StorageEndpoints != nil {
 		properties.StorageEndpoints = make(map[string]StorageEndpointProperties_STATUS, len(typedInput.StorageEndpoints))
 		for key, value := range typedInput.StorageEndpoints {
@@ -3334,13 +3334,13 @@ func (info *IotHubSkuInfo) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &IotHubSkuInfo_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if info.Capacity != nil {
 		capacity := *info.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if info.Name != nil {
 		name := *info.Name
 		result.Name = &name
@@ -3360,13 +3360,13 @@ func (info *IotHubSkuInfo) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IotHubSkuInfo_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		info.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		info.Name = &name
@@ -3466,19 +3466,19 @@ func (info *IotHubSkuInfo_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IotHubSkuInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		info.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		info.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		info.Tier = &tier
@@ -3584,37 +3584,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -3722,13 +3722,13 @@ func (identity *ArmUserIdentity_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ArmUserIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
@@ -3798,13 +3798,13 @@ func (properties *CloudToDeviceProperties) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &CloudToDeviceProperties_ARM{}
 
-	// Set property ‘DefaultTtlAsIso8601’:
+	// Set property "DefaultTtlAsIso8601":
 	if properties.DefaultTtlAsIso8601 != nil {
 		defaultTtlAsIso8601 := *properties.DefaultTtlAsIso8601
 		result.DefaultTtlAsIso8601 = &defaultTtlAsIso8601
 	}
 
-	// Set property ‘Feedback’:
+	// Set property "Feedback":
 	if properties.Feedback != nil {
 		feedback_ARM, err := (*properties.Feedback).ConvertToARM(resolved)
 		if err != nil {
@@ -3814,7 +3814,7 @@ func (properties *CloudToDeviceProperties) ConvertToARM(resolved genruntime.Conv
 		result.Feedback = &feedback
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	if properties.MaxDeliveryCount != nil {
 		maxDeliveryCount := *properties.MaxDeliveryCount
 		result.MaxDeliveryCount = &maxDeliveryCount
@@ -3834,13 +3834,13 @@ func (properties *CloudToDeviceProperties) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CloudToDeviceProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultTtlAsIso8601’:
+	// Set property "DefaultTtlAsIso8601":
 	if typedInput.DefaultTtlAsIso8601 != nil {
 		defaultTtlAsIso8601 := *typedInput.DefaultTtlAsIso8601
 		properties.DefaultTtlAsIso8601 = &defaultTtlAsIso8601
 	}
 
-	// Set property ‘Feedback’:
+	// Set property "Feedback":
 	if typedInput.Feedback != nil {
 		var feedback1 FeedbackProperties
 		err := feedback1.PopulateFromARM(owner, *typedInput.Feedback)
@@ -3851,7 +3851,7 @@ func (properties *CloudToDeviceProperties) PopulateFromARM(owner genruntime.Arbi
 		properties.Feedback = &feedback
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	if typedInput.MaxDeliveryCount != nil {
 		maxDeliveryCount := *typedInput.MaxDeliveryCount
 		properties.MaxDeliveryCount = &maxDeliveryCount
@@ -3988,13 +3988,13 @@ func (properties *CloudToDeviceProperties_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CloudToDeviceProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultTtlAsIso8601’:
+	// Set property "DefaultTtlAsIso8601":
 	if typedInput.DefaultTtlAsIso8601 != nil {
 		defaultTtlAsIso8601 := *typedInput.DefaultTtlAsIso8601
 		properties.DefaultTtlAsIso8601 = &defaultTtlAsIso8601
 	}
 
-	// Set property ‘Feedback’:
+	// Set property "Feedback":
 	if typedInput.Feedback != nil {
 		var feedback1 FeedbackProperties_STATUS
 		err := feedback1.PopulateFromARM(owner, *typedInput.Feedback)
@@ -4005,7 +4005,7 @@ func (properties *CloudToDeviceProperties_STATUS) PopulateFromARM(owner genrunti
 		properties.Feedback = &feedback
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	if typedInput.MaxDeliveryCount != nil {
 		maxDeliveryCount := *typedInput.MaxDeliveryCount
 		properties.MaxDeliveryCount = &maxDeliveryCount
@@ -4094,13 +4094,13 @@ func (properties *EventHubProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &EventHubProperties_ARM{}
 
-	// Set property ‘PartitionCount’:
+	// Set property "PartitionCount":
 	if properties.PartitionCount != nil {
 		partitionCount := *properties.PartitionCount
 		result.PartitionCount = &partitionCount
 	}
 
-	// Set property ‘RetentionTimeInDays’:
+	// Set property "RetentionTimeInDays":
 	if properties.RetentionTimeInDays != nil {
 		retentionTimeInDays := *properties.RetentionTimeInDays
 		result.RetentionTimeInDays = &retentionTimeInDays
@@ -4120,13 +4120,13 @@ func (properties *EventHubProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventHubProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PartitionCount’:
+	// Set property "PartitionCount":
 	if typedInput.PartitionCount != nil {
 		partitionCount := *typedInput.PartitionCount
 		properties.PartitionCount = &partitionCount
 	}
 
-	// Set property ‘RetentionTimeInDays’:
+	// Set property "RetentionTimeInDays":
 	if typedInput.RetentionTimeInDays != nil {
 		retentionTimeInDays := *typedInput.RetentionTimeInDays
 		properties.RetentionTimeInDays = &retentionTimeInDays
@@ -4218,30 +4218,30 @@ func (properties *EventHubProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventHubProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Endpoint’:
+	// Set property "Endpoint":
 	if typedInput.Endpoint != nil {
 		endpoint := *typedInput.Endpoint
 		properties.Endpoint = &endpoint
 	}
 
-	// Set property ‘PartitionCount’:
+	// Set property "PartitionCount":
 	if typedInput.PartitionCount != nil {
 		partitionCount := *typedInput.PartitionCount
 		properties.PartitionCount = &partitionCount
 	}
 
-	// Set property ‘PartitionIds’:
+	// Set property "PartitionIds":
 	for _, item := range typedInput.PartitionIds {
 		properties.PartitionIds = append(properties.PartitionIds, item)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		properties.Path = &path
 	}
 
-	// Set property ‘RetentionTimeInDays’:
+	// Set property "RetentionTimeInDays":
 	if typedInput.RetentionTimeInDays != nil {
 		retentionTimeInDays := *typedInput.RetentionTimeInDays
 		properties.RetentionTimeInDays = &retentionTimeInDays
@@ -4329,13 +4329,13 @@ func (description *IotHubLocationDescription_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IotHubLocationDescription_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		description.Location = &location
 	}
 
-	// Set property ‘Role’:
+	// Set property "Role":
 	if typedInput.Role != nil {
 		role := *typedInput.Role
 		description.Role = &role
@@ -4639,19 +4639,19 @@ func (rule *IpFilterRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &IpFilterRule_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if rule.Action != nil {
 		action := *rule.Action
 		result.Action = &action
 	}
 
-	// Set property ‘FilterName’:
+	// Set property "FilterName":
 	if rule.FilterName != nil {
 		filterName := *rule.FilterName
 		result.FilterName = &filterName
 	}
 
-	// Set property ‘IpMask’:
+	// Set property "IpMask":
 	if rule.IpMask != nil {
 		ipMask := *rule.IpMask
 		result.IpMask = &ipMask
@@ -4671,19 +4671,19 @@ func (rule *IpFilterRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpFilterRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘FilterName’:
+	// Set property "FilterName":
 	if typedInput.FilterName != nil {
 		filterName := *typedInput.FilterName
 		rule.FilterName = &filterName
 	}
 
-	// Set property ‘IpMask’:
+	// Set property "IpMask":
 	if typedInput.IpMask != nil {
 		ipMask := *typedInput.IpMask
 		rule.IpMask = &ipMask
@@ -4791,19 +4791,19 @@ func (rule *IpFilterRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpFilterRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘FilterName’:
+	// Set property "FilterName":
 	if typedInput.FilterName != nil {
 		filterName := *typedInput.FilterName
 		rule.FilterName = &filterName
 	}
 
-	// Set property ‘IpMask’:
+	// Set property "IpMask":
 	if typedInput.IpMask != nil {
 		ipMask := *typedInput.IpMask
 		rule.IpMask = &ipMask
@@ -4889,19 +4889,19 @@ func (properties *MessagingEndpointProperties) ConvertToARM(resolved genruntime.
 	}
 	result := &MessagingEndpointProperties_ARM{}
 
-	// Set property ‘LockDurationAsIso8601’:
+	// Set property "LockDurationAsIso8601":
 	if properties.LockDurationAsIso8601 != nil {
 		lockDurationAsIso8601 := *properties.LockDurationAsIso8601
 		result.LockDurationAsIso8601 = &lockDurationAsIso8601
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	if properties.MaxDeliveryCount != nil {
 		maxDeliveryCount := *properties.MaxDeliveryCount
 		result.MaxDeliveryCount = &maxDeliveryCount
 	}
 
-	// Set property ‘TtlAsIso8601’:
+	// Set property "TtlAsIso8601":
 	if properties.TtlAsIso8601 != nil {
 		ttlAsIso8601 := *properties.TtlAsIso8601
 		result.TtlAsIso8601 = &ttlAsIso8601
@@ -4921,19 +4921,19 @@ func (properties *MessagingEndpointProperties) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MessagingEndpointProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LockDurationAsIso8601’:
+	// Set property "LockDurationAsIso8601":
 	if typedInput.LockDurationAsIso8601 != nil {
 		lockDurationAsIso8601 := *typedInput.LockDurationAsIso8601
 		properties.LockDurationAsIso8601 = &lockDurationAsIso8601
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	if typedInput.MaxDeliveryCount != nil {
 		maxDeliveryCount := *typedInput.MaxDeliveryCount
 		properties.MaxDeliveryCount = &maxDeliveryCount
 	}
 
-	// Set property ‘TtlAsIso8601’:
+	// Set property "TtlAsIso8601":
 	if typedInput.TtlAsIso8601 != nil {
 		ttlAsIso8601 := *typedInput.TtlAsIso8601
 		properties.TtlAsIso8601 = &ttlAsIso8601
@@ -5043,19 +5043,19 @@ func (properties *MessagingEndpointProperties_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MessagingEndpointProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LockDurationAsIso8601’:
+	// Set property "LockDurationAsIso8601":
 	if typedInput.LockDurationAsIso8601 != nil {
 		lockDurationAsIso8601 := *typedInput.LockDurationAsIso8601
 		properties.LockDurationAsIso8601 = &lockDurationAsIso8601
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	if typedInput.MaxDeliveryCount != nil {
 		maxDeliveryCount := *typedInput.MaxDeliveryCount
 		properties.MaxDeliveryCount = &maxDeliveryCount
 	}
 
-	// Set property ‘TtlAsIso8601’:
+	// Set property "TtlAsIso8601":
 	if typedInput.TtlAsIso8601 != nil {
 		ttlAsIso8601 := *typedInput.TtlAsIso8601
 		properties.TtlAsIso8601 = &ttlAsIso8601
@@ -5129,19 +5129,19 @@ func (properties *NetworkRuleSetProperties) ConvertToARM(resolved genruntime.Con
 	}
 	result := &NetworkRuleSetProperties_ARM{}
 
-	// Set property ‘ApplyToBuiltInEventHubEndpoint’:
+	// Set property "ApplyToBuiltInEventHubEndpoint":
 	if properties.ApplyToBuiltInEventHubEndpoint != nil {
 		applyToBuiltInEventHubEndpoint := *properties.ApplyToBuiltInEventHubEndpoint
 		result.ApplyToBuiltInEventHubEndpoint = &applyToBuiltInEventHubEndpoint
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if properties.DefaultAction != nil {
 		defaultAction := *properties.DefaultAction
 		result.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range properties.IpRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5164,19 +5164,19 @@ func (properties *NetworkRuleSetProperties) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSetProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplyToBuiltInEventHubEndpoint’:
+	// Set property "ApplyToBuiltInEventHubEndpoint":
 	if typedInput.ApplyToBuiltInEventHubEndpoint != nil {
 		applyToBuiltInEventHubEndpoint := *typedInput.ApplyToBuiltInEventHubEndpoint
 		properties.ApplyToBuiltInEventHubEndpoint = &applyToBuiltInEventHubEndpoint
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		properties.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 NetworkRuleSetIpRule
 		err := item1.PopulateFromARM(owner, item)
@@ -5348,19 +5348,19 @@ func (properties *NetworkRuleSetProperties_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSetProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplyToBuiltInEventHubEndpoint’:
+	// Set property "ApplyToBuiltInEventHubEndpoint":
 	if typedInput.ApplyToBuiltInEventHubEndpoint != nil {
 		applyToBuiltInEventHubEndpoint := *typedInput.ApplyToBuiltInEventHubEndpoint
 		properties.ApplyToBuiltInEventHubEndpoint = &applyToBuiltInEventHubEndpoint
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		properties.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 NetworkRuleSetIpRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5485,7 +5485,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -5555,7 +5555,7 @@ func (properties *RoutingProperties) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &RoutingProperties_ARM{}
 
-	// Set property ‘Endpoints’:
+	// Set property "Endpoints":
 	if properties.Endpoints != nil {
 		endpoints_ARM, err := (*properties.Endpoints).ConvertToARM(resolved)
 		if err != nil {
@@ -5565,7 +5565,7 @@ func (properties *RoutingProperties) ConvertToARM(resolved genruntime.ConvertToA
 		result.Endpoints = &endpoints
 	}
 
-	// Set property ‘Enrichments’:
+	// Set property "Enrichments":
 	for _, item := range properties.Enrichments {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5574,7 +5574,7 @@ func (properties *RoutingProperties) ConvertToARM(resolved genruntime.ConvertToA
 		result.Enrichments = append(result.Enrichments, *item_ARM.(*EnrichmentProperties_ARM))
 	}
 
-	// Set property ‘FallbackRoute’:
+	// Set property "FallbackRoute":
 	if properties.FallbackRoute != nil {
 		fallbackRoute_ARM, err := (*properties.FallbackRoute).ConvertToARM(resolved)
 		if err != nil {
@@ -5584,7 +5584,7 @@ func (properties *RoutingProperties) ConvertToARM(resolved genruntime.ConvertToA
 		result.FallbackRoute = &fallbackRoute
 	}
 
-	// Set property ‘Routes’:
+	// Set property "Routes":
 	for _, item := range properties.Routes {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5607,7 +5607,7 @@ func (properties *RoutingProperties) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Endpoints’:
+	// Set property "Endpoints":
 	if typedInput.Endpoints != nil {
 		var endpoints1 RoutingEndpoints
 		err := endpoints1.PopulateFromARM(owner, *typedInput.Endpoints)
@@ -5618,7 +5618,7 @@ func (properties *RoutingProperties) PopulateFromARM(owner genruntime.ArbitraryO
 		properties.Endpoints = &endpoints
 	}
 
-	// Set property ‘Enrichments’:
+	// Set property "Enrichments":
 	for _, item := range typedInput.Enrichments {
 		var item1 EnrichmentProperties
 		err := item1.PopulateFromARM(owner, item)
@@ -5628,7 +5628,7 @@ func (properties *RoutingProperties) PopulateFromARM(owner genruntime.ArbitraryO
 		properties.Enrichments = append(properties.Enrichments, item1)
 	}
 
-	// Set property ‘FallbackRoute’:
+	// Set property "FallbackRoute":
 	if typedInput.FallbackRoute != nil {
 		var fallbackRoute1 FallbackRouteProperties
 		err := fallbackRoute1.PopulateFromARM(owner, *typedInput.FallbackRoute)
@@ -5639,7 +5639,7 @@ func (properties *RoutingProperties) PopulateFromARM(owner genruntime.ArbitraryO
 		properties.FallbackRoute = &fallbackRoute
 	}
 
-	// Set property ‘Routes’:
+	// Set property "Routes":
 	for _, item := range typedInput.Routes {
 		var item1 RouteProperties
 		err := item1.PopulateFromARM(owner, item)
@@ -5899,7 +5899,7 @@ func (properties *RoutingProperties_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Endpoints’:
+	// Set property "Endpoints":
 	if typedInput.Endpoints != nil {
 		var endpoints1 RoutingEndpoints_STATUS
 		err := endpoints1.PopulateFromARM(owner, *typedInput.Endpoints)
@@ -5910,7 +5910,7 @@ func (properties *RoutingProperties_STATUS) PopulateFromARM(owner genruntime.Arb
 		properties.Endpoints = &endpoints
 	}
 
-	// Set property ‘Enrichments’:
+	// Set property "Enrichments":
 	for _, item := range typedInput.Enrichments {
 		var item1 EnrichmentProperties_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5920,7 +5920,7 @@ func (properties *RoutingProperties_STATUS) PopulateFromARM(owner genruntime.Arb
 		properties.Enrichments = append(properties.Enrichments, item1)
 	}
 
-	// Set property ‘FallbackRoute’:
+	// Set property "FallbackRoute":
 	if typedInput.FallbackRoute != nil {
 		var fallbackRoute1 FallbackRouteProperties_STATUS
 		err := fallbackRoute1.PopulateFromARM(owner, *typedInput.FallbackRoute)
@@ -5931,7 +5931,7 @@ func (properties *RoutingProperties_STATUS) PopulateFromARM(owner genruntime.Arb
 		properties.FallbackRoute = &fallbackRoute
 	}
 
-	// Set property ‘Routes’:
+	// Set property "Routes":
 	for _, item := range typedInput.Routes {
 		var item1 RouteProperties_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6108,13 +6108,13 @@ func (rule *SharedAccessSignatureAuthorizationRule) ConvertToARM(resolved genrun
 	}
 	result := &SharedAccessSignatureAuthorizationRule_ARM{}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if rule.KeyName != nil {
 		keyName := *rule.KeyName
 		result.KeyName = &keyName
 	}
 
-	// Set property ‘Rights’:
+	// Set property "Rights":
 	if rule.Rights != nil {
 		rights := *rule.Rights
 		result.Rights = &rights
@@ -6134,13 +6134,13 @@ func (rule *SharedAccessSignatureAuthorizationRule) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SharedAccessSignatureAuthorizationRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		rule.KeyName = &keyName
 	}
 
-	// Set property ‘Rights’:
+	// Set property "Rights":
 	if typedInput.Rights != nil {
 		rights := *typedInput.Rights
 		rule.Rights = &rights
@@ -6236,13 +6236,13 @@ func (rule *SharedAccessSignatureAuthorizationRule_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SharedAccessSignatureAuthorizationRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		rule.KeyName = &keyName
 	}
 
-	// Set property ‘Rights’:
+	// Set property "Rights":
 	if typedInput.Rights != nil {
 		rights := *typedInput.Rights
 		rule.Rights = &rights
@@ -6328,26 +6328,26 @@ func (properties *StorageEndpointProperties) ConvertToARM(resolved genruntime.Co
 	}
 	result := &StorageEndpointProperties_ARM{}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if properties.AuthenticationType != nil {
 		authenticationType := *properties.AuthenticationType
 		result.AuthenticationType = &authenticationType
 	}
 
-	// Set property ‘ConnectionString’:
+	// Set property "ConnectionString":
 	connectionStringSecret, err := resolved.ResolvedSecrets.Lookup(properties.ConnectionString)
 	if err != nil {
 		return nil, errors.Wrap(err, "looking up secret for property ConnectionString")
 	}
 	result.ConnectionString = connectionStringSecret
 
-	// Set property ‘ContainerName’:
+	// Set property "ContainerName":
 	if properties.ContainerName != nil {
 		containerName := *properties.ContainerName
 		result.ContainerName = &containerName
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if properties.Identity != nil {
 		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -6357,7 +6357,7 @@ func (properties *StorageEndpointProperties) ConvertToARM(resolved genruntime.Co
 		result.Identity = &identity
 	}
 
-	// Set property ‘SasTtlAsIso8601’:
+	// Set property "SasTtlAsIso8601":
 	if properties.SasTtlAsIso8601 != nil {
 		sasTtlAsIso8601 := *properties.SasTtlAsIso8601
 		result.SasTtlAsIso8601 = &sasTtlAsIso8601
@@ -6377,21 +6377,21 @@ func (properties *StorageEndpointProperties) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageEndpointProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if typedInput.AuthenticationType != nil {
 		authenticationType := *typedInput.AuthenticationType
 		properties.AuthenticationType = &authenticationType
 	}
 
-	// no assignment for property ‘ConnectionString’
+	// no assignment for property "ConnectionString"
 
-	// Set property ‘ContainerName’:
+	// Set property "ContainerName":
 	if typedInput.ContainerName != nil {
 		containerName := *typedInput.ContainerName
 		properties.ContainerName = &containerName
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -6402,7 +6402,7 @@ func (properties *StorageEndpointProperties) PopulateFromARM(owner genruntime.Ar
 		properties.Identity = &identity
 	}
 
-	// Set property ‘SasTtlAsIso8601’:
+	// Set property "SasTtlAsIso8601":
 	if typedInput.SasTtlAsIso8601 != nil {
 		sasTtlAsIso8601 := *typedInput.SasTtlAsIso8601
 		properties.SasTtlAsIso8601 = &sasTtlAsIso8601
@@ -6562,19 +6562,19 @@ func (properties *StorageEndpointProperties_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageEndpointProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if typedInput.AuthenticationType != nil {
 		authenticationType := *typedInput.AuthenticationType
 		properties.AuthenticationType = &authenticationType
 	}
 
-	// Set property ‘ContainerName’:
+	// Set property "ContainerName":
 	if typedInput.ContainerName != nil {
 		containerName := *typedInput.ContainerName
 		properties.ContainerName = &containerName
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -6585,7 +6585,7 @@ func (properties *StorageEndpointProperties_STATUS) PopulateFromARM(owner genrun
 		properties.Identity = &identity
 	}
 
-	// Set property ‘SasTtlAsIso8601’:
+	// Set property "SasTtlAsIso8601":
 	if typedInput.SasTtlAsIso8601 != nil {
 		sasTtlAsIso8601 := *typedInput.SasTtlAsIso8601
 		properties.SasTtlAsIso8601 = &sasTtlAsIso8601
@@ -6729,18 +6729,18 @@ func (properties *EnrichmentProperties) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &EnrichmentProperties_ARM{}
 
-	// Set property ‘EndpointNames’:
+	// Set property "EndpointNames":
 	for _, item := range properties.EndpointNames {
 		result.EndpointNames = append(result.EndpointNames, item)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if properties.Key != nil {
 		key := *properties.Key
 		result.Key = &key
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if properties.Value != nil {
 		value := *properties.Value
 		result.Value = &value
@@ -6760,18 +6760,18 @@ func (properties *EnrichmentProperties) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EnrichmentProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointNames’:
+	// Set property "EndpointNames":
 	for _, item := range typedInput.EndpointNames {
 		properties.EndpointNames = append(properties.EndpointNames, item)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		properties.Key = &key
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		properties.Value = &value
@@ -6894,18 +6894,18 @@ func (properties *EnrichmentProperties_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EnrichmentProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointNames’:
+	// Set property "EndpointNames":
 	for _, item := range typedInput.EndpointNames {
 		properties.EndpointNames = append(properties.EndpointNames, item)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		properties.Key = &key
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		properties.Value = &value
@@ -6992,30 +6992,30 @@ func (properties *FallbackRouteProperties) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &FallbackRouteProperties_ARM{}
 
-	// Set property ‘Condition’:
+	// Set property "Condition":
 	if properties.Condition != nil {
 		condition := *properties.Condition
 		result.Condition = &condition
 	}
 
-	// Set property ‘EndpointNames’:
+	// Set property "EndpointNames":
 	for _, item := range properties.EndpointNames {
 		result.EndpointNames = append(result.EndpointNames, item)
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if properties.IsEnabled != nil {
 		isEnabled := *properties.IsEnabled
 		result.IsEnabled = &isEnabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if properties.Name != nil {
 		name := *properties.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	if properties.Source != nil {
 		source := *properties.Source
 		result.Source = &source
@@ -7035,30 +7035,30 @@ func (properties *FallbackRouteProperties) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FallbackRouteProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Condition’:
+	// Set property "Condition":
 	if typedInput.Condition != nil {
 		condition := *typedInput.Condition
 		properties.Condition = &condition
 	}
 
-	// Set property ‘EndpointNames’:
+	// Set property "EndpointNames":
 	for _, item := range typedInput.EndpointNames {
 		properties.EndpointNames = append(properties.EndpointNames, item)
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if typedInput.IsEnabled != nil {
 		isEnabled := *typedInput.IsEnabled
 		properties.IsEnabled = &isEnabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		properties.Name = &name
 	}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	if typedInput.Source != nil {
 		source := *typedInput.Source
 		properties.Source = &source
@@ -7239,30 +7239,30 @@ func (properties *FallbackRouteProperties_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FallbackRouteProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Condition’:
+	// Set property "Condition":
 	if typedInput.Condition != nil {
 		condition := *typedInput.Condition
 		properties.Condition = &condition
 	}
 
-	// Set property ‘EndpointNames’:
+	// Set property "EndpointNames":
 	for _, item := range typedInput.EndpointNames {
 		properties.EndpointNames = append(properties.EndpointNames, item)
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if typedInput.IsEnabled != nil {
 		isEnabled := *typedInput.IsEnabled
 		properties.IsEnabled = &isEnabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		properties.Name = &name
 	}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	if typedInput.Source != nil {
 		source := *typedInput.Source
 		properties.Source = &source
@@ -7371,19 +7371,19 @@ func (properties *FeedbackProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &FeedbackProperties_ARM{}
 
-	// Set property ‘LockDurationAsIso8601’:
+	// Set property "LockDurationAsIso8601":
 	if properties.LockDurationAsIso8601 != nil {
 		lockDurationAsIso8601 := *properties.LockDurationAsIso8601
 		result.LockDurationAsIso8601 = &lockDurationAsIso8601
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	if properties.MaxDeliveryCount != nil {
 		maxDeliveryCount := *properties.MaxDeliveryCount
 		result.MaxDeliveryCount = &maxDeliveryCount
 	}
 
-	// Set property ‘TtlAsIso8601’:
+	// Set property "TtlAsIso8601":
 	if properties.TtlAsIso8601 != nil {
 		ttlAsIso8601 := *properties.TtlAsIso8601
 		result.TtlAsIso8601 = &ttlAsIso8601
@@ -7403,19 +7403,19 @@ func (properties *FeedbackProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FeedbackProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LockDurationAsIso8601’:
+	// Set property "LockDurationAsIso8601":
 	if typedInput.LockDurationAsIso8601 != nil {
 		lockDurationAsIso8601 := *typedInput.LockDurationAsIso8601
 		properties.LockDurationAsIso8601 = &lockDurationAsIso8601
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	if typedInput.MaxDeliveryCount != nil {
 		maxDeliveryCount := *typedInput.MaxDeliveryCount
 		properties.MaxDeliveryCount = &maxDeliveryCount
 	}
 
-	// Set property ‘TtlAsIso8601’:
+	// Set property "TtlAsIso8601":
 	if typedInput.TtlAsIso8601 != nil {
 		ttlAsIso8601 := *typedInput.TtlAsIso8601
 		properties.TtlAsIso8601 = &ttlAsIso8601
@@ -7526,19 +7526,19 @@ func (properties *FeedbackProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FeedbackProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LockDurationAsIso8601’:
+	// Set property "LockDurationAsIso8601":
 	if typedInput.LockDurationAsIso8601 != nil {
 		lockDurationAsIso8601 := *typedInput.LockDurationAsIso8601
 		properties.LockDurationAsIso8601 = &lockDurationAsIso8601
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	if typedInput.MaxDeliveryCount != nil {
 		maxDeliveryCount := *typedInput.MaxDeliveryCount
 		properties.MaxDeliveryCount = &maxDeliveryCount
 	}
 
-	// Set property ‘TtlAsIso8601’:
+	// Set property "TtlAsIso8601":
 	if typedInput.TtlAsIso8601 != nil {
 		ttlAsIso8601 := *typedInput.TtlAsIso8601
 		properties.TtlAsIso8601 = &ttlAsIso8601
@@ -7604,7 +7604,7 @@ func (identity *ManagedIdentity) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ManagedIdentity_ARM{}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if identity.UserAssignedIdentity != nil {
 		userAssignedIdentity := *identity.UserAssignedIdentity
 		result.UserAssignedIdentity = &userAssignedIdentity
@@ -7624,7 +7624,7 @@ func (identity *ManagedIdentity) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		identity.UserAssignedIdentity = &userAssignedIdentity
@@ -7693,7 +7693,7 @@ func (identity *ManagedIdentity_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		identity.UserAssignedIdentity = &userAssignedIdentity
@@ -7755,19 +7755,19 @@ func (rule *NetworkRuleSetIpRule) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &NetworkRuleSetIpRule_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if rule.Action != nil {
 		action := *rule.Action
 		result.Action = &action
 	}
 
-	// Set property ‘FilterName’:
+	// Set property "FilterName":
 	if rule.FilterName != nil {
 		filterName := *rule.FilterName
 		result.FilterName = &filterName
 	}
 
-	// Set property ‘IpMask’:
+	// Set property "IpMask":
 	if rule.IpMask != nil {
 		ipMask := *rule.IpMask
 		result.IpMask = &ipMask
@@ -7787,19 +7787,19 @@ func (rule *NetworkRuleSetIpRule) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSetIpRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘FilterName’:
+	// Set property "FilterName":
 	if typedInput.FilterName != nil {
 		filterName := *typedInput.FilterName
 		rule.FilterName = &filterName
 	}
 
-	// Set property ‘IpMask’:
+	// Set property "IpMask":
 	if typedInput.IpMask != nil {
 		ipMask := *typedInput.IpMask
 		rule.IpMask = &ipMask
@@ -7907,19 +7907,19 @@ func (rule *NetworkRuleSetIpRule_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSetIpRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘FilterName’:
+	// Set property "FilterName":
 	if typedInput.FilterName != nil {
 		filterName := *typedInput.FilterName
 		rule.FilterName = &filterName
 	}
 
-	// Set property ‘IpMask’:
+	// Set property "IpMask":
 	if typedInput.IpMask != nil {
 		ipMask := *typedInput.IpMask
 		rule.IpMask = &ipMask
@@ -8017,30 +8017,30 @@ func (properties *RouteProperties) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &RouteProperties_ARM{}
 
-	// Set property ‘Condition’:
+	// Set property "Condition":
 	if properties.Condition != nil {
 		condition := *properties.Condition
 		result.Condition = &condition
 	}
 
-	// Set property ‘EndpointNames’:
+	// Set property "EndpointNames":
 	for _, item := range properties.EndpointNames {
 		result.EndpointNames = append(result.EndpointNames, item)
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if properties.IsEnabled != nil {
 		isEnabled := *properties.IsEnabled
 		result.IsEnabled = &isEnabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if properties.Name != nil {
 		name := *properties.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	if properties.Source != nil {
 		source := *properties.Source
 		result.Source = &source
@@ -8060,30 +8060,30 @@ func (properties *RouteProperties) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Condition’:
+	// Set property "Condition":
 	if typedInput.Condition != nil {
 		condition := *typedInput.Condition
 		properties.Condition = &condition
 	}
 
-	// Set property ‘EndpointNames’:
+	// Set property "EndpointNames":
 	for _, item := range typedInput.EndpointNames {
 		properties.EndpointNames = append(properties.EndpointNames, item)
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if typedInput.IsEnabled != nil {
 		isEnabled := *typedInput.IsEnabled
 		properties.IsEnabled = &isEnabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		properties.Name = &name
 	}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	if typedInput.Source != nil {
 		source := *typedInput.Source
 		properties.Source = &source
@@ -8278,30 +8278,30 @@ func (properties *RouteProperties_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Condition’:
+	// Set property "Condition":
 	if typedInput.Condition != nil {
 		condition := *typedInput.Condition
 		properties.Condition = &condition
 	}
 
-	// Set property ‘EndpointNames’:
+	// Set property "EndpointNames":
 	for _, item := range typedInput.EndpointNames {
 		properties.EndpointNames = append(properties.EndpointNames, item)
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if typedInput.IsEnabled != nil {
 		isEnabled := *typedInput.IsEnabled
 		properties.IsEnabled = &isEnabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		properties.Name = &name
 	}
 
-	// Set property ‘Source’:
+	// Set property "Source":
 	if typedInput.Source != nil {
 		source := *typedInput.Source
 		properties.Source = &source
@@ -8413,7 +8413,7 @@ func (endpoints *RoutingEndpoints) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &RoutingEndpoints_ARM{}
 
-	// Set property ‘EventHubs’:
+	// Set property "EventHubs":
 	for _, item := range endpoints.EventHubs {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -8422,7 +8422,7 @@ func (endpoints *RoutingEndpoints) ConvertToARM(resolved genruntime.ConvertToARM
 		result.EventHubs = append(result.EventHubs, *item_ARM.(*RoutingEventHubProperties_ARM))
 	}
 
-	// Set property ‘ServiceBusQueues’:
+	// Set property "ServiceBusQueues":
 	for _, item := range endpoints.ServiceBusQueues {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -8431,7 +8431,7 @@ func (endpoints *RoutingEndpoints) ConvertToARM(resolved genruntime.ConvertToARM
 		result.ServiceBusQueues = append(result.ServiceBusQueues, *item_ARM.(*RoutingServiceBusQueueEndpointProperties_ARM))
 	}
 
-	// Set property ‘ServiceBusTopics’:
+	// Set property "ServiceBusTopics":
 	for _, item := range endpoints.ServiceBusTopics {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -8440,7 +8440,7 @@ func (endpoints *RoutingEndpoints) ConvertToARM(resolved genruntime.ConvertToARM
 		result.ServiceBusTopics = append(result.ServiceBusTopics, *item_ARM.(*RoutingServiceBusTopicEndpointProperties_ARM))
 	}
 
-	// Set property ‘StorageContainers’:
+	// Set property "StorageContainers":
 	for _, item := range endpoints.StorageContainers {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -8463,7 +8463,7 @@ func (endpoints *RoutingEndpoints) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingEndpoints_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EventHubs’:
+	// Set property "EventHubs":
 	for _, item := range typedInput.EventHubs {
 		var item1 RoutingEventHubProperties
 		err := item1.PopulateFromARM(owner, item)
@@ -8473,7 +8473,7 @@ func (endpoints *RoutingEndpoints) PopulateFromARM(owner genruntime.ArbitraryOwn
 		endpoints.EventHubs = append(endpoints.EventHubs, item1)
 	}
 
-	// Set property ‘ServiceBusQueues’:
+	// Set property "ServiceBusQueues":
 	for _, item := range typedInput.ServiceBusQueues {
 		var item1 RoutingServiceBusQueueEndpointProperties
 		err := item1.PopulateFromARM(owner, item)
@@ -8483,7 +8483,7 @@ func (endpoints *RoutingEndpoints) PopulateFromARM(owner genruntime.ArbitraryOwn
 		endpoints.ServiceBusQueues = append(endpoints.ServiceBusQueues, item1)
 	}
 
-	// Set property ‘ServiceBusTopics’:
+	// Set property "ServiceBusTopics":
 	for _, item := range typedInput.ServiceBusTopics {
 		var item1 RoutingServiceBusTopicEndpointProperties
 		err := item1.PopulateFromARM(owner, item)
@@ -8493,7 +8493,7 @@ func (endpoints *RoutingEndpoints) PopulateFromARM(owner genruntime.ArbitraryOwn
 		endpoints.ServiceBusTopics = append(endpoints.ServiceBusTopics, item1)
 	}
 
-	// Set property ‘StorageContainers’:
+	// Set property "StorageContainers":
 	for _, item := range typedInput.StorageContainers {
 		var item1 RoutingStorageContainerProperties
 		err := item1.PopulateFromARM(owner, item)
@@ -8787,7 +8787,7 @@ func (endpoints *RoutingEndpoints_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingEndpoints_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EventHubs’:
+	// Set property "EventHubs":
 	for _, item := range typedInput.EventHubs {
 		var item1 RoutingEventHubProperties_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8797,7 +8797,7 @@ func (endpoints *RoutingEndpoints_STATUS) PopulateFromARM(owner genruntime.Arbit
 		endpoints.EventHubs = append(endpoints.EventHubs, item1)
 	}
 
-	// Set property ‘ServiceBusQueues’:
+	// Set property "ServiceBusQueues":
 	for _, item := range typedInput.ServiceBusQueues {
 		var item1 RoutingServiceBusQueueEndpointProperties_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8807,7 +8807,7 @@ func (endpoints *RoutingEndpoints_STATUS) PopulateFromARM(owner genruntime.Arbit
 		endpoints.ServiceBusQueues = append(endpoints.ServiceBusQueues, item1)
 	}
 
-	// Set property ‘ServiceBusTopics’:
+	// Set property "ServiceBusTopics":
 	for _, item := range typedInput.ServiceBusTopics {
 		var item1 RoutingServiceBusTopicEndpointProperties_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8817,7 +8817,7 @@ func (endpoints *RoutingEndpoints_STATUS) PopulateFromARM(owner genruntime.Arbit
 		endpoints.ServiceBusTopics = append(endpoints.ServiceBusTopics, item1)
 	}
 
-	// Set property ‘StorageContainers’:
+	// Set property "StorageContainers":
 	for _, item := range typedInput.StorageContainers {
 		var item1 RoutingStorageContainerProperties_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -9041,13 +9041,13 @@ func (properties *RoutingEventHubProperties) ConvertToARM(resolved genruntime.Co
 	}
 	result := &RoutingEventHubProperties_ARM{}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if properties.AuthenticationType != nil {
 		authenticationType := *properties.AuthenticationType
 		result.AuthenticationType = &authenticationType
 	}
 
-	// Set property ‘ConnectionString’:
+	// Set property "ConnectionString":
 	if properties.ConnectionString != nil {
 		connectionStringSecret, err := resolved.ResolvedSecrets.Lookup(*properties.ConnectionString)
 		if err != nil {
@@ -9057,19 +9057,19 @@ func (properties *RoutingEventHubProperties) ConvertToARM(resolved genruntime.Co
 		result.ConnectionString = &connectionString
 	}
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if properties.EndpointUri != nil {
 		endpointUri := *properties.EndpointUri
 		result.EndpointUri = &endpointUri
 	}
 
-	// Set property ‘EntityPath’:
+	// Set property "EntityPath":
 	if properties.EntityPath != nil {
 		entityPath := *properties.EntityPath
 		result.EntityPath = &entityPath
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if properties.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.Reference)
 		if err != nil {
@@ -9079,7 +9079,7 @@ func (properties *RoutingEventHubProperties) ConvertToARM(resolved genruntime.Co
 		result.Id = &reference
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if properties.Identity != nil {
 		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -9089,19 +9089,19 @@ func (properties *RoutingEventHubProperties) ConvertToARM(resolved genruntime.Co
 		result.Identity = &identity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if properties.Name != nil {
 		name := *properties.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if properties.ResourceGroup != nil {
 		resourceGroup := *properties.ResourceGroup
 		result.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if properties.SubscriptionId != nil {
 		subscriptionId := *properties.SubscriptionId
 		result.SubscriptionId = &subscriptionId
@@ -9121,27 +9121,27 @@ func (properties *RoutingEventHubProperties) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingEventHubProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if typedInput.AuthenticationType != nil {
 		authenticationType := *typedInput.AuthenticationType
 		properties.AuthenticationType = &authenticationType
 	}
 
-	// no assignment for property ‘ConnectionString’
+	// no assignment for property "ConnectionString"
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if typedInput.EndpointUri != nil {
 		endpointUri := *typedInput.EndpointUri
 		properties.EndpointUri = &endpointUri
 	}
 
-	// Set property ‘EntityPath’:
+	// Set property "EntityPath":
 	if typedInput.EntityPath != nil {
 		entityPath := *typedInput.EntityPath
 		properties.EntityPath = &entityPath
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -9152,21 +9152,21 @@ func (properties *RoutingEventHubProperties) PopulateFromARM(owner genruntime.Ar
 		properties.Identity = &identity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		properties.Name = &name
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if typedInput.ResourceGroup != nil {
 		resourceGroup := *typedInput.ResourceGroup
 		properties.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
@@ -9409,31 +9409,31 @@ func (properties *RoutingEventHubProperties_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingEventHubProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if typedInput.AuthenticationType != nil {
 		authenticationType := *typedInput.AuthenticationType
 		properties.AuthenticationType = &authenticationType
 	}
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if typedInput.EndpointUri != nil {
 		endpointUri := *typedInput.EndpointUri
 		properties.EndpointUri = &endpointUri
 	}
 
-	// Set property ‘EntityPath’:
+	// Set property "EntityPath":
 	if typedInput.EntityPath != nil {
 		entityPath := *typedInput.EntityPath
 		properties.EntityPath = &entityPath
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		properties.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -9444,19 +9444,19 @@ func (properties *RoutingEventHubProperties_STATUS) PopulateFromARM(owner genrun
 		properties.Identity = &identity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		properties.Name = &name
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if typedInput.ResourceGroup != nil {
 		resourceGroup := *typedInput.ResourceGroup
 		properties.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
@@ -9608,13 +9608,13 @@ func (properties *RoutingServiceBusQueueEndpointProperties) ConvertToARM(resolve
 	}
 	result := &RoutingServiceBusQueueEndpointProperties_ARM{}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if properties.AuthenticationType != nil {
 		authenticationType := *properties.AuthenticationType
 		result.AuthenticationType = &authenticationType
 	}
 
-	// Set property ‘ConnectionString’:
+	// Set property "ConnectionString":
 	if properties.ConnectionString != nil {
 		connectionStringSecret, err := resolved.ResolvedSecrets.Lookup(*properties.ConnectionString)
 		if err != nil {
@@ -9624,19 +9624,19 @@ func (properties *RoutingServiceBusQueueEndpointProperties) ConvertToARM(resolve
 		result.ConnectionString = &connectionString
 	}
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if properties.EndpointUri != nil {
 		endpointUri := *properties.EndpointUri
 		result.EndpointUri = &endpointUri
 	}
 
-	// Set property ‘EntityPath’:
+	// Set property "EntityPath":
 	if properties.EntityPath != nil {
 		entityPath := *properties.EntityPath
 		result.EntityPath = &entityPath
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if properties.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.Reference)
 		if err != nil {
@@ -9646,7 +9646,7 @@ func (properties *RoutingServiceBusQueueEndpointProperties) ConvertToARM(resolve
 		result.Id = &reference
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if properties.Identity != nil {
 		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -9656,19 +9656,19 @@ func (properties *RoutingServiceBusQueueEndpointProperties) ConvertToARM(resolve
 		result.Identity = &identity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if properties.Name != nil {
 		name := *properties.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if properties.ResourceGroup != nil {
 		resourceGroup := *properties.ResourceGroup
 		result.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if properties.SubscriptionId != nil {
 		subscriptionId := *properties.SubscriptionId
 		result.SubscriptionId = &subscriptionId
@@ -9688,27 +9688,27 @@ func (properties *RoutingServiceBusQueueEndpointProperties) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingServiceBusQueueEndpointProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if typedInput.AuthenticationType != nil {
 		authenticationType := *typedInput.AuthenticationType
 		properties.AuthenticationType = &authenticationType
 	}
 
-	// no assignment for property ‘ConnectionString’
+	// no assignment for property "ConnectionString"
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if typedInput.EndpointUri != nil {
 		endpointUri := *typedInput.EndpointUri
 		properties.EndpointUri = &endpointUri
 	}
 
-	// Set property ‘EntityPath’:
+	// Set property "EntityPath":
 	if typedInput.EntityPath != nil {
 		entityPath := *typedInput.EntityPath
 		properties.EntityPath = &entityPath
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -9719,21 +9719,21 @@ func (properties *RoutingServiceBusQueueEndpointProperties) PopulateFromARM(owne
 		properties.Identity = &identity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		properties.Name = &name
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if typedInput.ResourceGroup != nil {
 		resourceGroup := *typedInput.ResourceGroup
 		properties.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
@@ -9976,31 +9976,31 @@ func (properties *RoutingServiceBusQueueEndpointProperties_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingServiceBusQueueEndpointProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if typedInput.AuthenticationType != nil {
 		authenticationType := *typedInput.AuthenticationType
 		properties.AuthenticationType = &authenticationType
 	}
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if typedInput.EndpointUri != nil {
 		endpointUri := *typedInput.EndpointUri
 		properties.EndpointUri = &endpointUri
 	}
 
-	// Set property ‘EntityPath’:
+	// Set property "EntityPath":
 	if typedInput.EntityPath != nil {
 		entityPath := *typedInput.EntityPath
 		properties.EntityPath = &entityPath
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		properties.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -10011,19 +10011,19 @@ func (properties *RoutingServiceBusQueueEndpointProperties_STATUS) PopulateFromA
 		properties.Identity = &identity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		properties.Name = &name
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if typedInput.ResourceGroup != nil {
 		resourceGroup := *typedInput.ResourceGroup
 		properties.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
@@ -10175,13 +10175,13 @@ func (properties *RoutingServiceBusTopicEndpointProperties) ConvertToARM(resolve
 	}
 	result := &RoutingServiceBusTopicEndpointProperties_ARM{}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if properties.AuthenticationType != nil {
 		authenticationType := *properties.AuthenticationType
 		result.AuthenticationType = &authenticationType
 	}
 
-	// Set property ‘ConnectionString’:
+	// Set property "ConnectionString":
 	if properties.ConnectionString != nil {
 		connectionStringSecret, err := resolved.ResolvedSecrets.Lookup(*properties.ConnectionString)
 		if err != nil {
@@ -10191,19 +10191,19 @@ func (properties *RoutingServiceBusTopicEndpointProperties) ConvertToARM(resolve
 		result.ConnectionString = &connectionString
 	}
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if properties.EndpointUri != nil {
 		endpointUri := *properties.EndpointUri
 		result.EndpointUri = &endpointUri
 	}
 
-	// Set property ‘EntityPath’:
+	// Set property "EntityPath":
 	if properties.EntityPath != nil {
 		entityPath := *properties.EntityPath
 		result.EntityPath = &entityPath
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if properties.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.Reference)
 		if err != nil {
@@ -10213,7 +10213,7 @@ func (properties *RoutingServiceBusTopicEndpointProperties) ConvertToARM(resolve
 		result.Id = &reference
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if properties.Identity != nil {
 		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -10223,19 +10223,19 @@ func (properties *RoutingServiceBusTopicEndpointProperties) ConvertToARM(resolve
 		result.Identity = &identity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if properties.Name != nil {
 		name := *properties.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if properties.ResourceGroup != nil {
 		resourceGroup := *properties.ResourceGroup
 		result.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if properties.SubscriptionId != nil {
 		subscriptionId := *properties.SubscriptionId
 		result.SubscriptionId = &subscriptionId
@@ -10255,27 +10255,27 @@ func (properties *RoutingServiceBusTopicEndpointProperties) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingServiceBusTopicEndpointProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if typedInput.AuthenticationType != nil {
 		authenticationType := *typedInput.AuthenticationType
 		properties.AuthenticationType = &authenticationType
 	}
 
-	// no assignment for property ‘ConnectionString’
+	// no assignment for property "ConnectionString"
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if typedInput.EndpointUri != nil {
 		endpointUri := *typedInput.EndpointUri
 		properties.EndpointUri = &endpointUri
 	}
 
-	// Set property ‘EntityPath’:
+	// Set property "EntityPath":
 	if typedInput.EntityPath != nil {
 		entityPath := *typedInput.EntityPath
 		properties.EntityPath = &entityPath
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -10286,21 +10286,21 @@ func (properties *RoutingServiceBusTopicEndpointProperties) PopulateFromARM(owne
 		properties.Identity = &identity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		properties.Name = &name
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if typedInput.ResourceGroup != nil {
 		resourceGroup := *typedInput.ResourceGroup
 		properties.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
@@ -10543,31 +10543,31 @@ func (properties *RoutingServiceBusTopicEndpointProperties_STATUS) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingServiceBusTopicEndpointProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if typedInput.AuthenticationType != nil {
 		authenticationType := *typedInput.AuthenticationType
 		properties.AuthenticationType = &authenticationType
 	}
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if typedInput.EndpointUri != nil {
 		endpointUri := *typedInput.EndpointUri
 		properties.EndpointUri = &endpointUri
 	}
 
-	// Set property ‘EntityPath’:
+	// Set property "EntityPath":
 	if typedInput.EntityPath != nil {
 		entityPath := *typedInput.EntityPath
 		properties.EntityPath = &entityPath
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		properties.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -10578,19 +10578,19 @@ func (properties *RoutingServiceBusTopicEndpointProperties_STATUS) PopulateFromA
 		properties.Identity = &identity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		properties.Name = &name
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if typedInput.ResourceGroup != nil {
 		resourceGroup := *typedInput.ResourceGroup
 		properties.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
@@ -10763,19 +10763,19 @@ func (properties *RoutingStorageContainerProperties) ConvertToARM(resolved genru
 	}
 	result := &RoutingStorageContainerProperties_ARM{}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if properties.AuthenticationType != nil {
 		authenticationType := *properties.AuthenticationType
 		result.AuthenticationType = &authenticationType
 	}
 
-	// Set property ‘BatchFrequencyInSeconds’:
+	// Set property "BatchFrequencyInSeconds":
 	if properties.BatchFrequencyInSeconds != nil {
 		batchFrequencyInSeconds := *properties.BatchFrequencyInSeconds
 		result.BatchFrequencyInSeconds = &batchFrequencyInSeconds
 	}
 
-	// Set property ‘ConnectionString’:
+	// Set property "ConnectionString":
 	if properties.ConnectionString != nil {
 		connectionStringSecret, err := resolved.ResolvedSecrets.Lookup(*properties.ConnectionString)
 		if err != nil {
@@ -10785,31 +10785,31 @@ func (properties *RoutingStorageContainerProperties) ConvertToARM(resolved genru
 		result.ConnectionString = &connectionString
 	}
 
-	// Set property ‘ContainerName’:
+	// Set property "ContainerName":
 	if properties.ContainerName != nil {
 		containerName := *properties.ContainerName
 		result.ContainerName = &containerName
 	}
 
-	// Set property ‘Encoding’:
+	// Set property "Encoding":
 	if properties.Encoding != nil {
 		encoding := *properties.Encoding
 		result.Encoding = &encoding
 	}
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if properties.EndpointUri != nil {
 		endpointUri := *properties.EndpointUri
 		result.EndpointUri = &endpointUri
 	}
 
-	// Set property ‘FileNameFormat’:
+	// Set property "FileNameFormat":
 	if properties.FileNameFormat != nil {
 		fileNameFormat := *properties.FileNameFormat
 		result.FileNameFormat = &fileNameFormat
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if properties.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.Reference)
 		if err != nil {
@@ -10819,7 +10819,7 @@ func (properties *RoutingStorageContainerProperties) ConvertToARM(resolved genru
 		result.Id = &reference
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if properties.Identity != nil {
 		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -10829,25 +10829,25 @@ func (properties *RoutingStorageContainerProperties) ConvertToARM(resolved genru
 		result.Identity = &identity
 	}
 
-	// Set property ‘MaxChunkSizeInBytes’:
+	// Set property "MaxChunkSizeInBytes":
 	if properties.MaxChunkSizeInBytes != nil {
 		maxChunkSizeInBytes := *properties.MaxChunkSizeInBytes
 		result.MaxChunkSizeInBytes = &maxChunkSizeInBytes
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if properties.Name != nil {
 		name := *properties.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if properties.ResourceGroup != nil {
 		resourceGroup := *properties.ResourceGroup
 		result.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if properties.SubscriptionId != nil {
 		subscriptionId := *properties.SubscriptionId
 		result.SubscriptionId = &subscriptionId
@@ -10867,45 +10867,45 @@ func (properties *RoutingStorageContainerProperties) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingStorageContainerProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if typedInput.AuthenticationType != nil {
 		authenticationType := *typedInput.AuthenticationType
 		properties.AuthenticationType = &authenticationType
 	}
 
-	// Set property ‘BatchFrequencyInSeconds’:
+	// Set property "BatchFrequencyInSeconds":
 	if typedInput.BatchFrequencyInSeconds != nil {
 		batchFrequencyInSeconds := *typedInput.BatchFrequencyInSeconds
 		properties.BatchFrequencyInSeconds = &batchFrequencyInSeconds
 	}
 
-	// no assignment for property ‘ConnectionString’
+	// no assignment for property "ConnectionString"
 
-	// Set property ‘ContainerName’:
+	// Set property "ContainerName":
 	if typedInput.ContainerName != nil {
 		containerName := *typedInput.ContainerName
 		properties.ContainerName = &containerName
 	}
 
-	// Set property ‘Encoding’:
+	// Set property "Encoding":
 	if typedInput.Encoding != nil {
 		encoding := *typedInput.Encoding
 		properties.Encoding = &encoding
 	}
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if typedInput.EndpointUri != nil {
 		endpointUri := *typedInput.EndpointUri
 		properties.EndpointUri = &endpointUri
 	}
 
-	// Set property ‘FileNameFormat’:
+	// Set property "FileNameFormat":
 	if typedInput.FileNameFormat != nil {
 		fileNameFormat := *typedInput.FileNameFormat
 		properties.FileNameFormat = &fileNameFormat
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -10916,27 +10916,27 @@ func (properties *RoutingStorageContainerProperties) PopulateFromARM(owner genru
 		properties.Identity = &identity
 	}
 
-	// Set property ‘MaxChunkSizeInBytes’:
+	// Set property "MaxChunkSizeInBytes":
 	if typedInput.MaxChunkSizeInBytes != nil {
 		maxChunkSizeInBytes := *typedInput.MaxChunkSizeInBytes
 		properties.MaxChunkSizeInBytes = &maxChunkSizeInBytes
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		properties.Name = &name
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if typedInput.ResourceGroup != nil {
 		resourceGroup := *typedInput.ResourceGroup
 		properties.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
@@ -11276,49 +11276,49 @@ func (properties *RoutingStorageContainerProperties_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingStorageContainerProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthenticationType’:
+	// Set property "AuthenticationType":
 	if typedInput.AuthenticationType != nil {
 		authenticationType := *typedInput.AuthenticationType
 		properties.AuthenticationType = &authenticationType
 	}
 
-	// Set property ‘BatchFrequencyInSeconds’:
+	// Set property "BatchFrequencyInSeconds":
 	if typedInput.BatchFrequencyInSeconds != nil {
 		batchFrequencyInSeconds := *typedInput.BatchFrequencyInSeconds
 		properties.BatchFrequencyInSeconds = &batchFrequencyInSeconds
 	}
 
-	// Set property ‘ContainerName’:
+	// Set property "ContainerName":
 	if typedInput.ContainerName != nil {
 		containerName := *typedInput.ContainerName
 		properties.ContainerName = &containerName
 	}
 
-	// Set property ‘Encoding’:
+	// Set property "Encoding":
 	if typedInput.Encoding != nil {
 		encoding := *typedInput.Encoding
 		properties.Encoding = &encoding
 	}
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if typedInput.EndpointUri != nil {
 		endpointUri := *typedInput.EndpointUri
 		properties.EndpointUri = &endpointUri
 	}
 
-	// Set property ‘FileNameFormat’:
+	// Set property "FileNameFormat":
 	if typedInput.FileNameFormat != nil {
 		fileNameFormat := *typedInput.FileNameFormat
 		properties.FileNameFormat = &fileNameFormat
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		properties.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -11329,25 +11329,25 @@ func (properties *RoutingStorageContainerProperties_STATUS) PopulateFromARM(owne
 		properties.Identity = &identity
 	}
 
-	// Set property ‘MaxChunkSizeInBytes’:
+	// Set property "MaxChunkSizeInBytes":
 	if typedInput.MaxChunkSizeInBytes != nil {
 		maxChunkSizeInBytes := *typedInput.MaxChunkSizeInBytes
 		properties.MaxChunkSizeInBytes = &maxChunkSizeInBytes
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		properties.Name = &name
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if typedInput.ResourceGroup != nil {
 		resourceGroup := *typedInput.ResourceGroup
 		properties.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId

--- a/v2/api/documentdb/v1api20210515/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/database_account_types_gen.go
@@ -450,7 +450,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &DatabaseAccount_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if account.Identity != nil {
 		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -460,22 +460,22 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Identity = &identity
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if account.Kind != nil {
 		kind := *account.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if account.Location != nil {
 		location := *account.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if account.AnalyticalStorageConfiguration != nil ||
 		account.ApiProperties != nil ||
 		account.BackupPolicy != nil ||
@@ -624,7 +624,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.VirtualNetworkRules = append(result.Properties.VirtualNetworkRules, *item_ARM.(*VirtualNetworkRule_ARM))
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if account.Tags != nil {
 		result.Tags = make(map[string]string, len(account.Tags))
 		for key, value := range account.Tags {
@@ -646,7 +646,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccount_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AnalyticalStorageConfiguration’:
+	// Set property "AnalyticalStorageConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AnalyticalStorageConfiguration != nil {
@@ -660,7 +660,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ApiProperties’:
+	// Set property "ApiProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApiProperties != nil {
@@ -674,10 +674,10 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	account.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BackupPolicy’:
+	// Set property "BackupPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackupPolicy != nil {
@@ -691,7 +691,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Capabilities’:
+	// Set property "Capabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Capabilities {
@@ -704,7 +704,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ConnectorOffer’:
+	// Set property "ConnectorOffer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConnectorOffer != nil {
@@ -713,7 +713,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ConsistencyPolicy’:
+	// Set property "ConsistencyPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConsistencyPolicy != nil {
@@ -727,7 +727,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Cors {
@@ -740,7 +740,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘DatabaseAccountOfferType’:
+	// Set property "DatabaseAccountOfferType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DatabaseAccountOfferType != nil {
@@ -749,7 +749,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘DefaultIdentity’:
+	// Set property "DefaultIdentity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultIdentity != nil {
@@ -758,7 +758,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘DisableKeyBasedMetadataWriteAccess’:
+	// Set property "DisableKeyBasedMetadataWriteAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableKeyBasedMetadataWriteAccess != nil {
@@ -767,7 +767,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘EnableAnalyticalStorage’:
+	// Set property "EnableAnalyticalStorage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAnalyticalStorage != nil {
@@ -776,7 +776,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘EnableAutomaticFailover’:
+	// Set property "EnableAutomaticFailover":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticFailover != nil {
@@ -785,7 +785,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘EnableCassandraConnector’:
+	// Set property "EnableCassandraConnector":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableCassandraConnector != nil {
@@ -794,7 +794,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘EnableFreeTier’:
+	// Set property "EnableFreeTier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFreeTier != nil {
@@ -803,7 +803,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘EnableMultipleWriteLocations’:
+	// Set property "EnableMultipleWriteLocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableMultipleWriteLocations != nil {
@@ -812,7 +812,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedServiceIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -823,7 +823,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		account.Identity = &identity
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpRules {
@@ -836,7 +836,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘IsVirtualNetworkFilterEnabled’:
+	// Set property "IsVirtualNetworkFilterEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsVirtualNetworkFilterEnabled != nil {
@@ -845,7 +845,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘KeyVaultKeyUri’:
+	// Set property "KeyVaultKeyUri":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVaultKeyUri != nil {
@@ -854,19 +854,19 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		account.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Locations {
@@ -879,7 +879,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NetworkAclBypass’:
+	// Set property "NetworkAclBypass":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAclBypass != nil {
@@ -888,7 +888,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NetworkAclBypassResourceIds’:
+	// Set property "NetworkAclBypassResourceIds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NetworkAclBypassResourceIds {
@@ -896,12 +896,12 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	account.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -910,7 +910,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -918,7 +918,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VirtualNetworkRules {
@@ -2032,7 +2032,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccount_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AnalyticalStorageConfiguration’:
+	// Set property "AnalyticalStorageConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AnalyticalStorageConfiguration != nil {
@@ -2046,7 +2046,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘ApiProperties’:
+	// Set property "ApiProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApiProperties != nil {
@@ -2060,7 +2060,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘BackupPolicy’:
+	// Set property "BackupPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackupPolicy != nil {
@@ -2074,7 +2074,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Capabilities’:
+	// Set property "Capabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Capabilities {
@@ -2087,9 +2087,9 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ConnectorOffer’:
+	// Set property "ConnectorOffer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConnectorOffer != nil {
@@ -2098,7 +2098,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘ConsistencyPolicy’:
+	// Set property "ConsistencyPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConsistencyPolicy != nil {
@@ -2112,7 +2112,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Cors {
@@ -2125,7 +2125,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DatabaseAccountOfferType’:
+	// Set property "DatabaseAccountOfferType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DatabaseAccountOfferType != nil {
@@ -2134,7 +2134,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DefaultIdentity’:
+	// Set property "DefaultIdentity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultIdentity != nil {
@@ -2143,7 +2143,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DisableKeyBasedMetadataWriteAccess’:
+	// Set property "DisableKeyBasedMetadataWriteAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableKeyBasedMetadataWriteAccess != nil {
@@ -2152,7 +2152,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DocumentEndpoint’:
+	// Set property "DocumentEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DocumentEndpoint != nil {
@@ -2161,7 +2161,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EnableAnalyticalStorage’:
+	// Set property "EnableAnalyticalStorage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAnalyticalStorage != nil {
@@ -2170,7 +2170,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EnableAutomaticFailover’:
+	// Set property "EnableAutomaticFailover":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticFailover != nil {
@@ -2179,7 +2179,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EnableCassandraConnector’:
+	// Set property "EnableCassandraConnector":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableCassandraConnector != nil {
@@ -2188,7 +2188,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EnableFreeTier’:
+	// Set property "EnableFreeTier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFreeTier != nil {
@@ -2197,7 +2197,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EnableMultipleWriteLocations’:
+	// Set property "EnableMultipleWriteLocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableMultipleWriteLocations != nil {
@@ -2206,7 +2206,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘FailoverPolicies’:
+	// Set property "FailoverPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.FailoverPolicies {
@@ -2219,13 +2219,13 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		account.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedServiceIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2236,7 +2236,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		account.Identity = &identity
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpRules {
@@ -2249,7 +2249,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘IsVirtualNetworkFilterEnabled’:
+	// Set property "IsVirtualNetworkFilterEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsVirtualNetworkFilterEnabled != nil {
@@ -2258,7 +2258,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘KeyVaultKeyUri’:
+	// Set property "KeyVaultKeyUri":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVaultKeyUri != nil {
@@ -2267,19 +2267,19 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		account.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Locations {
@@ -2292,13 +2292,13 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		account.Name = &name
 	}
 
-	// Set property ‘NetworkAclBypass’:
+	// Set property "NetworkAclBypass":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAclBypass != nil {
@@ -2307,7 +2307,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘NetworkAclBypassResourceIds’:
+	// Set property "NetworkAclBypassResourceIds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NetworkAclBypassResourceIds {
@@ -2315,7 +2315,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -2328,7 +2328,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2337,7 +2337,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -2346,7 +2346,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘ReadLocations’:
+	// Set property "ReadLocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ReadLocations {
@@ -2359,7 +2359,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -2367,13 +2367,13 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		account.Type = &typeVar
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VirtualNetworkRules {
@@ -2386,7 +2386,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘WriteLocations’:
+	// Set property "WriteLocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.WriteLocations {
@@ -3143,7 +3143,7 @@ func (configuration *AnalyticalStorageConfiguration) ConvertToARM(resolved genru
 	}
 	result := &AnalyticalStorageConfiguration_ARM{}
 
-	// Set property ‘SchemaType’:
+	// Set property "SchemaType":
 	if configuration.SchemaType != nil {
 		schemaType := *configuration.SchemaType
 		result.SchemaType = &schemaType
@@ -3163,7 +3163,7 @@ func (configuration *AnalyticalStorageConfiguration) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AnalyticalStorageConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SchemaType’:
+	// Set property "SchemaType":
 	if typedInput.SchemaType != nil {
 		schemaType := *typedInput.SchemaType
 		configuration.SchemaType = &schemaType
@@ -3247,7 +3247,7 @@ func (configuration *AnalyticalStorageConfiguration_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AnalyticalStorageConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SchemaType’:
+	// Set property "SchemaType":
 	if typedInput.SchemaType != nil {
 		schemaType := *typedInput.SchemaType
 		configuration.SchemaType = &schemaType
@@ -3310,7 +3310,7 @@ func (properties *ApiProperties) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ApiProperties_ARM{}
 
-	// Set property ‘ServerVersion’:
+	// Set property "ServerVersion":
 	if properties.ServerVersion != nil {
 		serverVersion := *properties.ServerVersion
 		result.ServerVersion = &serverVersion
@@ -3330,7 +3330,7 @@ func (properties *ApiProperties) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ServerVersion’:
+	// Set property "ServerVersion":
 	if typedInput.ServerVersion != nil {
 		serverVersion := *typedInput.ServerVersion
 		properties.ServerVersion = &serverVersion
@@ -3413,7 +3413,7 @@ func (properties *ApiProperties_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ServerVersion’:
+	// Set property "ServerVersion":
 	if typedInput.ServerVersion != nil {
 		serverVersion := *typedInput.ServerVersion
 		properties.ServerVersion = &serverVersion
@@ -3479,7 +3479,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &BackupPolicy_ARM{}
 
-	// Set property ‘Continuous’:
+	// Set property "Continuous":
 	if policy.Continuous != nil {
 		continuous_ARM, err := (*policy.Continuous).ConvertToARM(resolved)
 		if err != nil {
@@ -3489,7 +3489,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		result.Continuous = &continuous
 	}
 
-	// Set property ‘Periodic’:
+	// Set property "Periodic":
 	if policy.Periodic != nil {
 		periodic_ARM, err := (*policy.Periodic).ConvertToARM(resolved)
 		if err != nil {
@@ -3513,7 +3513,7 @@ func (policy *BackupPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Continuous’:
+	// Set property "Continuous":
 	if typedInput.Continuous != nil {
 		var continuous1 ContinuousModeBackupPolicy
 		err := continuous1.PopulateFromARM(owner, *typedInput.Continuous)
@@ -3524,7 +3524,7 @@ func (policy *BackupPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		policy.Continuous = &continuous
 	}
 
-	// Set property ‘Periodic’:
+	// Set property "Periodic":
 	if typedInput.Periodic != nil {
 		var periodic1 PeriodicModeBackupPolicy
 		err := periodic1.PopulateFromARM(owner, *typedInput.Periodic)
@@ -3663,7 +3663,7 @@ func (policy *BackupPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Continuous’:
+	// Set property "Continuous":
 	if typedInput.Continuous != nil {
 		var continuous1 ContinuousModeBackupPolicy_STATUS
 		err := continuous1.PopulateFromARM(owner, *typedInput.Continuous)
@@ -3674,7 +3674,7 @@ func (policy *BackupPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		policy.Continuous = &continuous
 	}
 
-	// Set property ‘Periodic’:
+	// Set property "Periodic":
 	if typedInput.Periodic != nil {
 		var periodic1 PeriodicModeBackupPolicy_STATUS
 		err := periodic1.PopulateFromARM(owner, *typedInput.Periodic)
@@ -3776,7 +3776,7 @@ func (capability *Capability) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Capability_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if capability.Name != nil {
 		name := *capability.Name
 		result.Name = &name
@@ -3796,7 +3796,7 @@ func (capability *Capability) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Capability_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		capability.Name = &name
@@ -3866,7 +3866,7 @@ func (capability *Capability_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Capability_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		capability.Name = &name
@@ -3946,19 +3946,19 @@ func (policy *ConsistencyPolicy) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ConsistencyPolicy_ARM{}
 
-	// Set property ‘DefaultConsistencyLevel’:
+	// Set property "DefaultConsistencyLevel":
 	if policy.DefaultConsistencyLevel != nil {
 		defaultConsistencyLevel := *policy.DefaultConsistencyLevel
 		result.DefaultConsistencyLevel = &defaultConsistencyLevel
 	}
 
-	// Set property ‘MaxIntervalInSeconds’:
+	// Set property "MaxIntervalInSeconds":
 	if policy.MaxIntervalInSeconds != nil {
 		maxIntervalInSeconds := *policy.MaxIntervalInSeconds
 		result.MaxIntervalInSeconds = &maxIntervalInSeconds
 	}
 
-	// Set property ‘MaxStalenessPrefix’:
+	// Set property "MaxStalenessPrefix":
 	if policy.MaxStalenessPrefix != nil {
 		maxStalenessPrefix := *policy.MaxStalenessPrefix
 		result.MaxStalenessPrefix = &maxStalenessPrefix
@@ -3978,19 +3978,19 @@ func (policy *ConsistencyPolicy) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConsistencyPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultConsistencyLevel’:
+	// Set property "DefaultConsistencyLevel":
 	if typedInput.DefaultConsistencyLevel != nil {
 		defaultConsistencyLevel := *typedInput.DefaultConsistencyLevel
 		policy.DefaultConsistencyLevel = &defaultConsistencyLevel
 	}
 
-	// Set property ‘MaxIntervalInSeconds’:
+	// Set property "MaxIntervalInSeconds":
 	if typedInput.MaxIntervalInSeconds != nil {
 		maxIntervalInSeconds := *typedInput.MaxIntervalInSeconds
 		policy.MaxIntervalInSeconds = &maxIntervalInSeconds
 	}
 
-	// Set property ‘MaxStalenessPrefix’:
+	// Set property "MaxStalenessPrefix":
 	if typedInput.MaxStalenessPrefix != nil {
 		maxStalenessPrefix := *typedInput.MaxStalenessPrefix
 		policy.MaxStalenessPrefix = &maxStalenessPrefix
@@ -4132,19 +4132,19 @@ func (policy *ConsistencyPolicy_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConsistencyPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultConsistencyLevel’:
+	// Set property "DefaultConsistencyLevel":
 	if typedInput.DefaultConsistencyLevel != nil {
 		defaultConsistencyLevel := *typedInput.DefaultConsistencyLevel
 		policy.DefaultConsistencyLevel = &defaultConsistencyLevel
 	}
 
-	// Set property ‘MaxIntervalInSeconds’:
+	// Set property "MaxIntervalInSeconds":
 	if typedInput.MaxIntervalInSeconds != nil {
 		maxIntervalInSeconds := *typedInput.MaxIntervalInSeconds
 		policy.MaxIntervalInSeconds = &maxIntervalInSeconds
 	}
 
-	// Set property ‘MaxStalenessPrefix’:
+	// Set property "MaxStalenessPrefix":
 	if typedInput.MaxStalenessPrefix != nil {
 		maxStalenessPrefix := *typedInput.MaxStalenessPrefix
 		policy.MaxStalenessPrefix = &maxStalenessPrefix
@@ -4236,31 +4236,31 @@ func (policy *CorsPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &CorsPolicy_ARM{}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	if policy.AllowedHeaders != nil {
 		allowedHeaders := *policy.AllowedHeaders
 		result.AllowedHeaders = &allowedHeaders
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	if policy.AllowedMethods != nil {
 		allowedMethods := *policy.AllowedMethods
 		result.AllowedMethods = &allowedMethods
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	if policy.AllowedOrigins != nil {
 		allowedOrigins := *policy.AllowedOrigins
 		result.AllowedOrigins = &allowedOrigins
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	if policy.ExposedHeaders != nil {
 		exposedHeaders := *policy.ExposedHeaders
 		result.ExposedHeaders = &exposedHeaders
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if policy.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *policy.MaxAgeInSeconds
 		result.MaxAgeInSeconds = &maxAgeInSeconds
@@ -4280,31 +4280,31 @@ func (policy *CorsPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	if typedInput.AllowedHeaders != nil {
 		allowedHeaders := *typedInput.AllowedHeaders
 		policy.AllowedHeaders = &allowedHeaders
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	if typedInput.AllowedMethods != nil {
 		allowedMethods := *typedInput.AllowedMethods
 		policy.AllowedMethods = &allowedMethods
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	if typedInput.AllowedOrigins != nil {
 		allowedOrigins := *typedInput.AllowedOrigins
 		policy.AllowedOrigins = &allowedOrigins
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	if typedInput.ExposedHeaders != nil {
 		exposedHeaders := *typedInput.ExposedHeaders
 		policy.ExposedHeaders = &exposedHeaders
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if typedInput.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *typedInput.MaxAgeInSeconds
 		policy.MaxAgeInSeconds = &maxAgeInSeconds
@@ -4437,31 +4437,31 @@ func (policy *CorsPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	if typedInput.AllowedHeaders != nil {
 		allowedHeaders := *typedInput.AllowedHeaders
 		policy.AllowedHeaders = &allowedHeaders
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	if typedInput.AllowedMethods != nil {
 		allowedMethods := *typedInput.AllowedMethods
 		policy.AllowedMethods = &allowedMethods
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	if typedInput.AllowedOrigins != nil {
 		allowedOrigins := *typedInput.AllowedOrigins
 		policy.AllowedOrigins = &allowedOrigins
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	if typedInput.ExposedHeaders != nil {
 		exposedHeaders := *typedInput.ExposedHeaders
 		policy.ExposedHeaders = &exposedHeaders
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if typedInput.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *typedInput.MaxAgeInSeconds
 		policy.MaxAgeInSeconds = &maxAgeInSeconds
@@ -4617,19 +4617,19 @@ func (policy *FailoverPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FailoverPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FailoverPriority’:
+	// Set property "FailoverPriority":
 	if typedInput.FailoverPriority != nil {
 		failoverPriority := *typedInput.FailoverPriority
 		policy.FailoverPriority = &failoverPriority
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		policy.Id = &id
 	}
 
-	// Set property ‘LocationName’:
+	// Set property "LocationName":
 	if typedInput.LocationName != nil {
 		locationName := *typedInput.LocationName
 		policy.LocationName = &locationName
@@ -4698,7 +4698,7 @@ func (orRange *IpAddressOrRange) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &IpAddressOrRange_ARM{}
 
-	// Set property ‘IpAddressOrRange’:
+	// Set property "IpAddressOrRange":
 	if orRange.IpAddressOrRange != nil {
 		ipAddressOrRange := *orRange.IpAddressOrRange
 		result.IpAddressOrRange = &ipAddressOrRange
@@ -4718,7 +4718,7 @@ func (orRange *IpAddressOrRange) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpAddressOrRange_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpAddressOrRange’:
+	// Set property "IpAddressOrRange":
 	if typedInput.IpAddressOrRange != nil {
 		ipAddressOrRange := *typedInput.IpAddressOrRange
 		orRange.IpAddressOrRange = &ipAddressOrRange
@@ -4790,7 +4790,7 @@ func (orRange *IpAddressOrRange_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpAddressOrRange_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpAddressOrRange’:
+	// Set property "IpAddressOrRange":
 	if typedInput.IpAddressOrRange != nil {
 		ipAddressOrRange := *typedInput.IpAddressOrRange
 		orRange.IpAddressOrRange = &ipAddressOrRange
@@ -4853,19 +4853,19 @@ func (location *Location) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Location_ARM{}
 
-	// Set property ‘FailoverPriority’:
+	// Set property "FailoverPriority":
 	if location.FailoverPriority != nil {
 		failoverPriority := *location.FailoverPriority
 		result.FailoverPriority = &failoverPriority
 	}
 
-	// Set property ‘IsZoneRedundant’:
+	// Set property "IsZoneRedundant":
 	if location.IsZoneRedundant != nil {
 		isZoneRedundant := *location.IsZoneRedundant
 		result.IsZoneRedundant = &isZoneRedundant
 	}
 
-	// Set property ‘LocationName’:
+	// Set property "LocationName":
 	if location.LocationName != nil {
 		locationName := *location.LocationName
 		result.LocationName = &locationName
@@ -4885,19 +4885,19 @@ func (location *Location) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Location_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FailoverPriority’:
+	// Set property "FailoverPriority":
 	if typedInput.FailoverPriority != nil {
 		failoverPriority := *typedInput.FailoverPriority
 		location.FailoverPriority = &failoverPriority
 	}
 
-	// Set property ‘IsZoneRedundant’:
+	// Set property "IsZoneRedundant":
 	if typedInput.IsZoneRedundant != nil {
 		isZoneRedundant := *typedInput.IsZoneRedundant
 		location.IsZoneRedundant = &isZoneRedundant
 	}
 
-	// Set property ‘LocationName’:
+	// Set property "LocationName":
 	if typedInput.LocationName != nil {
 		locationName := *typedInput.LocationName
 		location.LocationName = &locationName
@@ -5030,37 +5030,37 @@ func (location *Location_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Location_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DocumentEndpoint’:
+	// Set property "DocumentEndpoint":
 	if typedInput.DocumentEndpoint != nil {
 		documentEndpoint := *typedInput.DocumentEndpoint
 		location.DocumentEndpoint = &documentEndpoint
 	}
 
-	// Set property ‘FailoverPriority’:
+	// Set property "FailoverPriority":
 	if typedInput.FailoverPriority != nil {
 		failoverPriority := *typedInput.FailoverPriority
 		location.FailoverPriority = &failoverPriority
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		location.Id = &id
 	}
 
-	// Set property ‘IsZoneRedundant’:
+	// Set property "IsZoneRedundant":
 	if typedInput.IsZoneRedundant != nil {
 		isZoneRedundant := *typedInput.IsZoneRedundant
 		location.IsZoneRedundant = &isZoneRedundant
 	}
 
-	// Set property ‘LocationName’:
+	// Set property "LocationName":
 	if typedInput.LocationName != nil {
 		locationName := *typedInput.LocationName
 		location.LocationName = &locationName
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		location.ProvisioningState = &provisioningState
@@ -5160,13 +5160,13 @@ func (identity *ManagedServiceIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ManagedServiceIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -5191,13 +5191,13 @@ func (identity *ManagedServiceIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedServiceIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -5339,25 +5339,25 @@ func (identity *ManagedServiceIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedServiceIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]ManagedServiceIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -5499,7 +5499,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -5574,7 +5574,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &VirtualNetworkRule_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if rule.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.Reference)
 		if err != nil {
@@ -5584,7 +5584,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.Id = &reference
 	}
 
-	// Set property ‘IgnoreMissingVNetServiceEndpoint’:
+	// Set property "IgnoreMissingVNetServiceEndpoint":
 	if rule.IgnoreMissingVNetServiceEndpoint != nil {
 		ignoreMissingVNetServiceEndpoint := *rule.IgnoreMissingVNetServiceEndpoint
 		result.IgnoreMissingVNetServiceEndpoint = &ignoreMissingVNetServiceEndpoint
@@ -5604,13 +5604,13 @@ func (rule *VirtualNetworkRule) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IgnoreMissingVNetServiceEndpoint’:
+	// Set property "IgnoreMissingVNetServiceEndpoint":
 	if typedInput.IgnoreMissingVNetServiceEndpoint != nil {
 		ignoreMissingVNetServiceEndpoint := *typedInput.IgnoreMissingVNetServiceEndpoint
 		rule.IgnoreMissingVNetServiceEndpoint = &ignoreMissingVNetServiceEndpoint
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -5718,13 +5718,13 @@ func (rule *VirtualNetworkRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘IgnoreMissingVNetServiceEndpoint’:
+	// Set property "IgnoreMissingVNetServiceEndpoint":
 	if typedInput.IgnoreMissingVNetServiceEndpoint != nil {
 		ignoreMissingVNetServiceEndpoint := *typedInput.IgnoreMissingVNetServiceEndpoint
 		rule.IgnoreMissingVNetServiceEndpoint = &ignoreMissingVNetServiceEndpoint
@@ -5848,7 +5848,7 @@ func (policy *ContinuousModeBackupPolicy) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &ContinuousModeBackupPolicy_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if policy.Type != nil {
 		result.Type = *policy.Type
 	}
@@ -5867,7 +5867,7 @@ func (policy *ContinuousModeBackupPolicy) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContinuousModeBackupPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	policy.Type = &typedInput.Type
 
 	// No error
@@ -5946,7 +5946,7 @@ func (policy *ContinuousModeBackupPolicy_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContinuousModeBackupPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	policy.Type = &typedInput.Type
 
 	// No error
@@ -6139,13 +6139,13 @@ func (identities *ManagedServiceIdentity_UserAssignedIdentities_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedServiceIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -6207,7 +6207,7 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &PeriodicModeBackupPolicy_ARM{}
 
-	// Set property ‘PeriodicModeProperties’:
+	// Set property "PeriodicModeProperties":
 	if policy.PeriodicModeProperties != nil {
 		periodicModeProperties_ARM, err := (*policy.PeriodicModeProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -6217,7 +6217,7 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 		result.PeriodicModeProperties = &periodicModeProperties
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if policy.Type != nil {
 		result.Type = *policy.Type
 	}
@@ -6236,7 +6236,7 @@ func (policy *PeriodicModeBackupPolicy) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PeriodicModeBackupPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PeriodicModeProperties’:
+	// Set property "PeriodicModeProperties":
 	if typedInput.PeriodicModeProperties != nil {
 		var periodicModeProperties1 PeriodicModeProperties
 		err := periodicModeProperties1.PopulateFromARM(owner, *typedInput.PeriodicModeProperties)
@@ -6247,7 +6247,7 @@ func (policy *PeriodicModeBackupPolicy) PopulateFromARM(owner genruntime.Arbitra
 		policy.PeriodicModeProperties = &periodicModeProperties
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	policy.Type = &typedInput.Type
 
 	// No error
@@ -6364,7 +6364,7 @@ func (policy *PeriodicModeBackupPolicy_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PeriodicModeBackupPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PeriodicModeProperties’:
+	// Set property "PeriodicModeProperties":
 	if typedInput.PeriodicModeProperties != nil {
 		var periodicModeProperties1 PeriodicModeProperties_STATUS
 		err := periodicModeProperties1.PopulateFromARM(owner, *typedInput.PeriodicModeProperties)
@@ -6375,7 +6375,7 @@ func (policy *PeriodicModeBackupPolicy_STATUS) PopulateFromARM(owner genruntime.
 		policy.PeriodicModeProperties = &periodicModeProperties
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	policy.Type = &typedInput.Type
 
 	// No error
@@ -6517,13 +6517,13 @@ func (properties *PeriodicModeProperties) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &PeriodicModeProperties_ARM{}
 
-	// Set property ‘BackupIntervalInMinutes’:
+	// Set property "BackupIntervalInMinutes":
 	if properties.BackupIntervalInMinutes != nil {
 		backupIntervalInMinutes := *properties.BackupIntervalInMinutes
 		result.BackupIntervalInMinutes = &backupIntervalInMinutes
 	}
 
-	// Set property ‘BackupRetentionIntervalInHours’:
+	// Set property "BackupRetentionIntervalInHours":
 	if properties.BackupRetentionIntervalInHours != nil {
 		backupRetentionIntervalInHours := *properties.BackupRetentionIntervalInHours
 		result.BackupRetentionIntervalInHours = &backupRetentionIntervalInHours
@@ -6543,13 +6543,13 @@ func (properties *PeriodicModeProperties) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PeriodicModeProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupIntervalInMinutes’:
+	// Set property "BackupIntervalInMinutes":
 	if typedInput.BackupIntervalInMinutes != nil {
 		backupIntervalInMinutes := *typedInput.BackupIntervalInMinutes
 		properties.BackupIntervalInMinutes = &backupIntervalInMinutes
 	}
 
-	// Set property ‘BackupRetentionIntervalInHours’:
+	// Set property "BackupRetentionIntervalInHours":
 	if typedInput.BackupRetentionIntervalInHours != nil {
 		backupRetentionIntervalInHours := *typedInput.BackupRetentionIntervalInHours
 		properties.BackupRetentionIntervalInHours = &backupRetentionIntervalInHours
@@ -6660,13 +6660,13 @@ func (properties *PeriodicModeProperties_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PeriodicModeProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupIntervalInMinutes’:
+	// Set property "BackupIntervalInMinutes":
 	if typedInput.BackupIntervalInMinutes != nil {
 		backupIntervalInMinutes := *typedInput.BackupIntervalInMinutes
 		properties.BackupIntervalInMinutes = &backupIntervalInMinutes
 	}
 
-	// Set property ‘BackupRetentionIntervalInHours’:
+	// Set property "BackupRetentionIntervalInHours":
 	if typedInput.BackupRetentionIntervalInHours != nil {
 		backupRetentionIntervalInHours := *typedInput.BackupRetentionIntervalInHours
 		properties.BackupRetentionIntervalInHours = &backupRetentionIntervalInHours

--- a/v2/api/documentdb/v1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
@@ -328,16 +328,16 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 	}
 	result := &DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if setting.Location != nil {
 		location := *setting.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if setting.Resource != nil {
 		result.Properties = &ThroughputSettingsUpdateProperties_ARM{}
 	}
@@ -350,7 +350,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if setting.Tags != nil {
 		result.Tags = make(map[string]string, len(setting.Tags))
 		for key, value := range setting.Tags {
@@ -372,16 +372,16 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -395,7 +395,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -648,27 +648,27 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		setting.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		setting.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -682,7 +682,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -690,7 +690,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar
@@ -822,7 +822,7 @@ func (resource *ThroughputSettingsGetProperties_Resource_STATUS) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ThroughputSettingsGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoscaleSettings’:
+	// Set property "AutoscaleSettings":
 	if typedInput.AutoscaleSettings != nil {
 		var autoscaleSettings1 AutoscaleSettingsResource_STATUS
 		err := autoscaleSettings1.PopulateFromARM(owner, *typedInput.AutoscaleSettings)
@@ -833,37 +833,37 @@ func (resource *ThroughputSettingsGetProperties_Resource_STATUS) PopulateFromARM
 		resource.AutoscaleSettings = &autoscaleSettings
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘MinimumThroughput’:
+	// Set property "MinimumThroughput":
 	if typedInput.MinimumThroughput != nil {
 		minimumThroughput := *typedInput.MinimumThroughput
 		resource.MinimumThroughput = &minimumThroughput
 	}
 
-	// Set property ‘OfferReplacePending’:
+	// Set property "OfferReplacePending":
 	if typedInput.OfferReplacePending != nil {
 		offerReplacePending := *typedInput.OfferReplacePending
 		resource.OfferReplacePending = &offerReplacePending
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘Throughput’:
+	// Set property "Throughput":
 	if typedInput.Throughput != nil {
 		throughput := *typedInput.Throughput
 		resource.Throughput = &throughput
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
@@ -986,7 +986,7 @@ func (resource *ThroughputSettingsResource) ConvertToARM(resolved genruntime.Con
 	}
 	result := &ThroughputSettingsResource_ARM{}
 
-	// Set property ‘AutoscaleSettings’:
+	// Set property "AutoscaleSettings":
 	if resource.AutoscaleSettings != nil {
 		autoscaleSettings_ARM, err := (*resource.AutoscaleSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -996,7 +996,7 @@ func (resource *ThroughputSettingsResource) ConvertToARM(resolved genruntime.Con
 		result.AutoscaleSettings = &autoscaleSettings
 	}
 
-	// Set property ‘Throughput’:
+	// Set property "Throughput":
 	if resource.Throughput != nil {
 		throughput := *resource.Throughput
 		result.Throughput = &throughput
@@ -1016,7 +1016,7 @@ func (resource *ThroughputSettingsResource) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ThroughputSettingsResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoscaleSettings’:
+	// Set property "AutoscaleSettings":
 	if typedInput.AutoscaleSettings != nil {
 		var autoscaleSettings1 AutoscaleSettingsResource
 		err := autoscaleSettings1.PopulateFromARM(owner, *typedInput.AutoscaleSettings)
@@ -1027,7 +1027,7 @@ func (resource *ThroughputSettingsResource) PopulateFromARM(owner genruntime.Arb
 		resource.AutoscaleSettings = &autoscaleSettings
 	}
 
-	// Set property ‘Throughput’:
+	// Set property "Throughput":
 	if typedInput.Throughput != nil {
 		throughput := *typedInput.Throughput
 		resource.Throughput = &throughput
@@ -1131,7 +1131,7 @@ func (resource *AutoscaleSettingsResource) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &AutoscaleSettingsResource_ARM{}
 
-	// Set property ‘AutoUpgradePolicy’:
+	// Set property "AutoUpgradePolicy":
 	if resource.AutoUpgradePolicy != nil {
 		autoUpgradePolicy_ARM, err := (*resource.AutoUpgradePolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -1141,7 +1141,7 @@ func (resource *AutoscaleSettingsResource) ConvertToARM(resolved genruntime.Conv
 		result.AutoUpgradePolicy = &autoUpgradePolicy
 	}
 
-	// Set property ‘MaxThroughput’:
+	// Set property "MaxThroughput":
 	if resource.MaxThroughput != nil {
 		maxThroughput := *resource.MaxThroughput
 		result.MaxThroughput = &maxThroughput
@@ -1161,7 +1161,7 @@ func (resource *AutoscaleSettingsResource) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoscaleSettingsResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradePolicy’:
+	// Set property "AutoUpgradePolicy":
 	if typedInput.AutoUpgradePolicy != nil {
 		var autoUpgradePolicy1 AutoUpgradePolicyResource
 		err := autoUpgradePolicy1.PopulateFromARM(owner, *typedInput.AutoUpgradePolicy)
@@ -1172,7 +1172,7 @@ func (resource *AutoscaleSettingsResource) PopulateFromARM(owner genruntime.Arbi
 		resource.AutoUpgradePolicy = &autoUpgradePolicy
 	}
 
-	// Set property ‘MaxThroughput’:
+	// Set property "MaxThroughput":
 	if typedInput.MaxThroughput != nil {
 		maxThroughput := *typedInput.MaxThroughput
 		resource.MaxThroughput = &maxThroughput
@@ -1284,7 +1284,7 @@ func (resource *AutoscaleSettingsResource_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoscaleSettingsResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradePolicy’:
+	// Set property "AutoUpgradePolicy":
 	if typedInput.AutoUpgradePolicy != nil {
 		var autoUpgradePolicy1 AutoUpgradePolicyResource_STATUS
 		err := autoUpgradePolicy1.PopulateFromARM(owner, *typedInput.AutoUpgradePolicy)
@@ -1295,13 +1295,13 @@ func (resource *AutoscaleSettingsResource_STATUS) PopulateFromARM(owner genrunti
 		resource.AutoUpgradePolicy = &autoUpgradePolicy
 	}
 
-	// Set property ‘MaxThroughput’:
+	// Set property "MaxThroughput":
 	if typedInput.MaxThroughput != nil {
 		maxThroughput := *typedInput.MaxThroughput
 		resource.MaxThroughput = &maxThroughput
 	}
 
-	// Set property ‘TargetMaxThroughput’:
+	// Set property "TargetMaxThroughput":
 	if typedInput.TargetMaxThroughput != nil {
 		targetMaxThroughput := *typedInput.TargetMaxThroughput
 		resource.TargetMaxThroughput = &targetMaxThroughput
@@ -1385,7 +1385,7 @@ func (resource *AutoUpgradePolicyResource) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &AutoUpgradePolicyResource_ARM{}
 
-	// Set property ‘ThroughputPolicy’:
+	// Set property "ThroughputPolicy":
 	if resource.ThroughputPolicy != nil {
 		throughputPolicy_ARM, err := (*resource.ThroughputPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -1409,7 +1409,7 @@ func (resource *AutoUpgradePolicyResource) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoUpgradePolicyResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ThroughputPolicy’:
+	// Set property "ThroughputPolicy":
 	if typedInput.ThroughputPolicy != nil {
 		var throughputPolicy1 ThroughputPolicyResource
 		err := throughputPolicy1.PopulateFromARM(owner, *typedInput.ThroughputPolicy)
@@ -1510,7 +1510,7 @@ func (resource *AutoUpgradePolicyResource_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoUpgradePolicyResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ThroughputPolicy’:
+	// Set property "ThroughputPolicy":
 	if typedInput.ThroughputPolicy != nil {
 		var throughputPolicy1 ThroughputPolicyResource_STATUS
 		err := throughputPolicy1.PopulateFromARM(owner, *typedInput.ThroughputPolicy)
@@ -1590,13 +1590,13 @@ func (resource *ThroughputPolicyResource) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &ThroughputPolicyResource_ARM{}
 
-	// Set property ‘IncrementPercent’:
+	// Set property "IncrementPercent":
 	if resource.IncrementPercent != nil {
 		incrementPercent := *resource.IncrementPercent
 		result.IncrementPercent = &incrementPercent
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if resource.IsEnabled != nil {
 		isEnabled := *resource.IsEnabled
 		result.IsEnabled = &isEnabled
@@ -1616,13 +1616,13 @@ func (resource *ThroughputPolicyResource) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ThroughputPolicyResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IncrementPercent’:
+	// Set property "IncrementPercent":
 	if typedInput.IncrementPercent != nil {
 		incrementPercent := *typedInput.IncrementPercent
 		resource.IncrementPercent = &incrementPercent
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if typedInput.IsEnabled != nil {
 		isEnabled := *typedInput.IsEnabled
 		resource.IsEnabled = &isEnabled
@@ -1718,13 +1718,13 @@ func (resource *ThroughputPolicyResource_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ThroughputPolicyResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IncrementPercent’:
+	// Set property "IncrementPercent":
 	if typedInput.IncrementPercent != nil {
 		incrementPercent := *typedInput.IncrementPercent
 		resource.IncrementPercent = &incrementPercent
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if typedInput.IsEnabled != nil {
 		isEnabled := *typedInput.IsEnabled
 		resource.IsEnabled = &isEnabled

--- a/v2/api/documentdb/v1api20210515/mongodb_database_collection_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/mongodb_database_collection_types_gen.go
@@ -343,16 +343,16 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_Spec) ConvertToAR
 	}
 	result := &DatabaseAccounts_MongodbDatabases_Collection_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if collection.Location != nil {
 		location := *collection.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if collection.Options != nil || collection.Resource != nil {
 		result.Properties = &MongoDBCollectionCreateUpdateProperties_ARM{}
 	}
@@ -373,7 +373,7 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_Spec) ConvertToAR
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if collection.Tags != nil {
 		result.Tags = make(map[string]string, len(collection.Tags))
 		for key, value := range collection.Tags {
@@ -395,16 +395,16 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_Spec) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabases_Collection_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	collection.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		collection.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -418,10 +418,10 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_Spec) PopulateFro
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	collection.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -435,7 +435,7 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_Spec) PopulateFro
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		collection.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -738,27 +738,27 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_STATUS) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabases_Collection_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		collection.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		collection.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		collection.Name = &name
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -772,7 +772,7 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_STATUS) PopulateF
 		}
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -786,7 +786,7 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_STATUS) PopulateF
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		collection.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -794,7 +794,7 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_STATUS) PopulateF
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		collection.Type = &typeVar
@@ -948,25 +948,25 @@ func (resource *MongoDBCollectionGetProperties_Resource_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoDBCollectionGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AnalyticalStorageTtl’:
+	// Set property "AnalyticalStorageTtl":
 	if typedInput.AnalyticalStorageTtl != nil {
 		analyticalStorageTtl := *typedInput.AnalyticalStorageTtl
 		resource.AnalyticalStorageTtl = &analyticalStorageTtl
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Indexes’:
+	// Set property "Indexes":
 	for _, item := range typedInput.Indexes {
 		var item1 MongoIndex_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -976,13 +976,13 @@ func (resource *MongoDBCollectionGetProperties_Resource_STATUS) PopulateFromARM(
 		resource.Indexes = append(resource.Indexes, item1)
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘ShardKey’:
+	// Set property "ShardKey":
 	if typedInput.ShardKey != nil {
 		resource.ShardKey = make(map[string]string, len(typedInput.ShardKey))
 		for key, value := range typedInput.ShardKey {
@@ -990,7 +990,7 @@ func (resource *MongoDBCollectionGetProperties_Resource_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
@@ -1130,19 +1130,19 @@ func (resource *MongoDBCollectionResource) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &MongoDBCollectionResource_ARM{}
 
-	// Set property ‘AnalyticalStorageTtl’:
+	// Set property "AnalyticalStorageTtl":
 	if resource.AnalyticalStorageTtl != nil {
 		analyticalStorageTtl := *resource.AnalyticalStorageTtl
 		result.AnalyticalStorageTtl = &analyticalStorageTtl
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
 	}
 
-	// Set property ‘Indexes’:
+	// Set property "Indexes":
 	for _, item := range resource.Indexes {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1151,7 +1151,7 @@ func (resource *MongoDBCollectionResource) ConvertToARM(resolved genruntime.Conv
 		result.Indexes = append(result.Indexes, *item_ARM.(*MongoIndex_ARM))
 	}
 
-	// Set property ‘ShardKey’:
+	// Set property "ShardKey":
 	if resource.ShardKey != nil {
 		result.ShardKey = make(map[string]string, len(resource.ShardKey))
 		for key, value := range resource.ShardKey {
@@ -1173,19 +1173,19 @@ func (resource *MongoDBCollectionResource) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoDBCollectionResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AnalyticalStorageTtl’:
+	// Set property "AnalyticalStorageTtl":
 	if typedInput.AnalyticalStorageTtl != nil {
 		analyticalStorageTtl := *typedInput.AnalyticalStorageTtl
 		resource.AnalyticalStorageTtl = &analyticalStorageTtl
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Indexes’:
+	// Set property "Indexes":
 	for _, item := range typedInput.Indexes {
 		var item1 MongoIndex
 		err := item1.PopulateFromARM(owner, item)
@@ -1195,7 +1195,7 @@ func (resource *MongoDBCollectionResource) PopulateFromARM(owner genruntime.Arbi
 		resource.Indexes = append(resource.Indexes, item1)
 	}
 
-	// Set property ‘ShardKey’:
+	// Set property "ShardKey":
 	if typedInput.ShardKey != nil {
 		resource.ShardKey = make(map[string]string, len(typedInput.ShardKey))
 		for key, value := range typedInput.ShardKey {
@@ -1336,7 +1336,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &MongoIndex_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if index.Key != nil {
 		key_ARM, err := (*index.Key).ConvertToARM(resolved)
 		if err != nil {
@@ -1346,7 +1346,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Key = &key
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	if index.Options != nil {
 		options_ARM, err := (*index.Options).ConvertToARM(resolved)
 		if err != nil {
@@ -1370,7 +1370,7 @@ func (index *MongoIndex) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoIndex_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		var key1 MongoIndexKeys
 		err := key1.PopulateFromARM(owner, *typedInput.Key)
@@ -1381,7 +1381,7 @@ func (index *MongoIndex) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		index.Key = &key
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	if typedInput.Options != nil {
 		var options1 MongoIndexOptions
 		err := options1.PopulateFromARM(owner, *typedInput.Options)
@@ -1521,7 +1521,7 @@ func (index *MongoIndex_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoIndex_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		var key1 MongoIndexKeys_STATUS
 		err := key1.PopulateFromARM(owner, *typedInput.Key)
@@ -1532,7 +1532,7 @@ func (index *MongoIndex_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		index.Key = &key
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	if typedInput.Options != nil {
 		var options1 MongoIndexOptions_STATUS
 		err := options1.PopulateFromARM(owner, *typedInput.Options)
@@ -1633,7 +1633,7 @@ func (keys *MongoIndexKeys) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &MongoIndexKeys_ARM{}
 
-	// Set property ‘Keys’:
+	// Set property "Keys":
 	for _, item := range keys.Keys {
 		result.Keys = append(result.Keys, item)
 	}
@@ -1652,7 +1652,7 @@ func (keys *MongoIndexKeys) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoIndexKeys_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Keys’:
+	// Set property "Keys":
 	for _, item := range typedInput.Keys {
 		keys.Keys = append(keys.Keys, item)
 	}
@@ -1720,7 +1720,7 @@ func (keys *MongoIndexKeys_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoIndexKeys_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Keys’:
+	// Set property "Keys":
 	for _, item := range typedInput.Keys {
 		keys.Keys = append(keys.Keys, item)
 	}
@@ -1776,13 +1776,13 @@ func (options *MongoIndexOptions) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &MongoIndexOptions_ARM{}
 
-	// Set property ‘ExpireAfterSeconds’:
+	// Set property "ExpireAfterSeconds":
 	if options.ExpireAfterSeconds != nil {
 		expireAfterSeconds := *options.ExpireAfterSeconds
 		result.ExpireAfterSeconds = &expireAfterSeconds
 	}
 
-	// Set property ‘Unique’:
+	// Set property "Unique":
 	if options.Unique != nil {
 		unique := *options.Unique
 		result.Unique = &unique
@@ -1802,13 +1802,13 @@ func (options *MongoIndexOptions) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoIndexOptions_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpireAfterSeconds’:
+	// Set property "ExpireAfterSeconds":
 	if typedInput.ExpireAfterSeconds != nil {
 		expireAfterSeconds := *typedInput.ExpireAfterSeconds
 		options.ExpireAfterSeconds = &expireAfterSeconds
 	}
 
-	// Set property ‘Unique’:
+	// Set property "Unique":
 	if typedInput.Unique != nil {
 		unique := *typedInput.Unique
 		options.Unique = &unique
@@ -1904,13 +1904,13 @@ func (options *MongoIndexOptions_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoIndexOptions_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpireAfterSeconds’:
+	// Set property "ExpireAfterSeconds":
 	if typedInput.ExpireAfterSeconds != nil {
 		expireAfterSeconds := *typedInput.ExpireAfterSeconds
 		options.ExpireAfterSeconds = &expireAfterSeconds
 	}
 
-	// Set property ‘Unique’:
+	// Set property "Unique":
 	if typedInput.Unique != nil {
 		unique := *typedInput.Unique
 		options.Unique = &unique

--- a/v2/api/documentdb/v1api20210515/mongodb_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/mongodb_database_throughput_setting_types_gen.go
@@ -328,16 +328,16 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec) Convert
 	}
 	result := &DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if setting.Location != nil {
 		location := *setting.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if setting.Resource != nil {
 		result.Properties = &ThroughputSettingsUpdateProperties_ARM{}
 	}
@@ -350,7 +350,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec) Convert
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if setting.Tags != nil {
 		result.Tags = make(map[string]string, len(setting.Tags))
 		for key, value := range setting.Tags {
@@ -372,16 +372,16 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -395,7 +395,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec) Populat
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -648,27 +648,27 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_STATUS) Popul
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabases_ThroughputSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		setting.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		setting.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -682,7 +682,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_STATUS) Popul
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -690,7 +690,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_STATUS) Popul
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar

--- a/v2/api/documentdb/v1api20210515/mongodb_database_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/mongodb_database_types_gen.go
@@ -343,16 +343,16 @@ func (database *DatabaseAccounts_MongodbDatabase_Spec) ConvertToARM(resolved gen
 	}
 	result := &DatabaseAccounts_MongodbDatabase_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if database.Location != nil {
 		location := *database.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.Options != nil || database.Resource != nil {
 		result.Properties = &MongoDBDatabaseCreateUpdateProperties_ARM{}
 	}
@@ -373,7 +373,7 @@ func (database *DatabaseAccounts_MongodbDatabase_Spec) ConvertToARM(resolved gen
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if database.Tags != nil {
 		result.Tags = make(map[string]string, len(database.Tags))
 		for key, value := range database.Tags {
@@ -395,16 +395,16 @@ func (database *DatabaseAccounts_MongodbDatabase_Spec) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabase_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		database.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -418,10 +418,10 @@ func (database *DatabaseAccounts_MongodbDatabase_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -435,7 +435,7 @@ func (database *DatabaseAccounts_MongodbDatabase_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		database.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -738,27 +738,27 @@ func (database *DatabaseAccounts_MongodbDatabase_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabase_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		database.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -772,7 +772,7 @@ func (database *DatabaseAccounts_MongodbDatabase_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -786,7 +786,7 @@ func (database *DatabaseAccounts_MongodbDatabase_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		database.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -794,7 +794,7 @@ func (database *DatabaseAccounts_MongodbDatabase_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar
@@ -930,7 +930,7 @@ func (options *CreateUpdateOptions) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &CreateUpdateOptions_ARM{}
 
-	// Set property ‘AutoscaleSettings’:
+	// Set property "AutoscaleSettings":
 	if options.AutoscaleSettings != nil {
 		autoscaleSettings_ARM, err := (*options.AutoscaleSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -940,7 +940,7 @@ func (options *CreateUpdateOptions) ConvertToARM(resolved genruntime.ConvertToAR
 		result.AutoscaleSettings = &autoscaleSettings
 	}
 
-	// Set property ‘Throughput’:
+	// Set property "Throughput":
 	if options.Throughput != nil {
 		throughput := *options.Throughput
 		result.Throughput = &throughput
@@ -960,7 +960,7 @@ func (options *CreateUpdateOptions) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CreateUpdateOptions_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoscaleSettings’:
+	// Set property "AutoscaleSettings":
 	if typedInput.AutoscaleSettings != nil {
 		var autoscaleSettings1 AutoscaleSettings
 		err := autoscaleSettings1.PopulateFromARM(owner, *typedInput.AutoscaleSettings)
@@ -971,7 +971,7 @@ func (options *CreateUpdateOptions) PopulateFromARM(owner genruntime.ArbitraryOw
 		options.AutoscaleSettings = &autoscaleSettings
 	}
 
-	// Set property ‘Throughput’:
+	// Set property "Throughput":
 	if typedInput.Throughput != nil {
 		throughput := *typedInput.Throughput
 		options.Throughput = &throughput
@@ -1084,25 +1084,25 @@ func (resource *MongoDBDatabaseGetProperties_Resource_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoDBDatabaseGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
@@ -1185,7 +1185,7 @@ func (resource *MongoDBDatabaseResource) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &MongoDBDatabaseResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
@@ -1205,7 +1205,7 @@ func (resource *MongoDBDatabaseResource) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoDBDatabaseResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
@@ -1278,7 +1278,7 @@ func (resource *OptionsResource_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OptionsResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoscaleSettings’:
+	// Set property "AutoscaleSettings":
 	if typedInput.AutoscaleSettings != nil {
 		var autoscaleSettings1 AutoscaleSettings_STATUS
 		err := autoscaleSettings1.PopulateFromARM(owner, *typedInput.AutoscaleSettings)
@@ -1289,7 +1289,7 @@ func (resource *OptionsResource_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		resource.AutoscaleSettings = &autoscaleSettings
 	}
 
-	// Set property ‘Throughput’:
+	// Set property "Throughput":
 	if typedInput.Throughput != nil {
 		throughput := *typedInput.Throughput
 		resource.Throughput = &throughput
@@ -1366,7 +1366,7 @@ func (settings *AutoscaleSettings) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &AutoscaleSettings_ARM{}
 
-	// Set property ‘MaxThroughput’:
+	// Set property "MaxThroughput":
 	if settings.MaxThroughput != nil {
 		maxThroughput := *settings.MaxThroughput
 		result.MaxThroughput = &maxThroughput
@@ -1386,7 +1386,7 @@ func (settings *AutoscaleSettings) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoscaleSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxThroughput’:
+	// Set property "MaxThroughput":
 	if typedInput.MaxThroughput != nil {
 		maxThroughput := *typedInput.MaxThroughput
 		settings.MaxThroughput = &maxThroughput
@@ -1454,7 +1454,7 @@ func (settings *AutoscaleSettings_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoscaleSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxThroughput’:
+	// Set property "MaxThroughput":
 	if typedInput.MaxThroughput != nil {
 		maxThroughput := *typedInput.MaxThroughput
 		settings.MaxThroughput = &maxThroughput

--- a/v2/api/documentdb/v1api20210515/sql_database_container_stored_procedure_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_container_stored_procedure_types_gen.go
@@ -343,16 +343,16 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec) 
 	}
 	result := &DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if procedure.Location != nil {
 		location := *procedure.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if procedure.Options != nil || procedure.Resource != nil {
 		result.Properties = &SqlStoredProcedureCreateUpdateProperties_ARM{}
 	}
@@ -373,7 +373,7 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec) 
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if procedure.Tags != nil {
 		result.Tags = make(map[string]string, len(procedure.Tags))
 		for key, value := range procedure.Tags {
@@ -395,16 +395,16 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	procedure.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		procedure.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -418,10 +418,10 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec) 
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	procedure.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -435,7 +435,7 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec) 
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		procedure.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -723,27 +723,27 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_STATUS
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		procedure.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		procedure.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		procedure.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -757,7 +757,7 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_STATUS
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		procedure.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -765,7 +765,7 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_STATUS
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		procedure.Type = &typeVar
@@ -889,31 +889,31 @@ func (resource *SqlStoredProcedureGetProperties_Resource_STATUS) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlStoredProcedureGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if typedInput.Body != nil {
 		body := *typedInput.Body
 		resource.Body = &body
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
@@ -1005,13 +1005,13 @@ func (resource *SqlStoredProcedureResource) ConvertToARM(resolved genruntime.Con
 	}
 	result := &SqlStoredProcedureResource_ARM{}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if resource.Body != nil {
 		body := *resource.Body
 		result.Body = &body
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
@@ -1031,13 +1031,13 @@ func (resource *SqlStoredProcedureResource) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlStoredProcedureResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if typedInput.Body != nil {
 		body := *typedInput.Body
 		resource.Body = &body
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id

--- a/v2/api/documentdb/v1api20210515/sql_database_container_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_container_throughput_setting_types_gen.go
@@ -328,16 +328,16 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec) 
 	}
 	result := &DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if setting.Location != nil {
 		location := *setting.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if setting.Resource != nil {
 		result.Properties = &ThroughputSettingsUpdateProperties_ARM{}
 	}
@@ -350,7 +350,7 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec) 
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if setting.Tags != nil {
 		result.Tags = make(map[string]string, len(setting.Tags))
 		for key, value := range setting.Tags {
@@ -372,16 +372,16 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -395,7 +395,7 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec) 
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -648,27 +648,27 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_STATUS
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		setting.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		setting.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -682,7 +682,7 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_STATUS
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -690,7 +690,7 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_STATUS
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar

--- a/v2/api/documentdb/v1api20210515/sql_database_container_trigger_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_container_trigger_types_gen.go
@@ -343,16 +343,16 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec) ConvertToA
 	}
 	result := &DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if trigger.Location != nil {
 		location := *trigger.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if trigger.Options != nil || trigger.Resource != nil {
 		result.Properties = &SqlTriggerCreateUpdateProperties_ARM{}
 	}
@@ -373,7 +373,7 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec) ConvertToA
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if trigger.Tags != nil {
 		result.Tags = make(map[string]string, len(trigger.Tags))
 		for key, value := range trigger.Tags {
@@ -395,16 +395,16 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	trigger.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		trigger.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -418,10 +418,10 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec) PopulateFr
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	trigger.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -435,7 +435,7 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec) PopulateFr
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		trigger.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -723,27 +723,27 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_Trigger_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		trigger.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		trigger.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		trigger.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -757,7 +757,7 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		trigger.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -765,7 +765,7 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		trigger.Type = &typeVar
@@ -895,43 +895,43 @@ func (resource *SqlTriggerGetProperties_Resource_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlTriggerGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if typedInput.Body != nil {
 		body := *typedInput.Body
 		resource.Body = &body
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘TriggerOperation’:
+	// Set property "TriggerOperation":
 	if typedInput.TriggerOperation != nil {
 		triggerOperation := *typedInput.TriggerOperation
 		resource.TriggerOperation = &triggerOperation
 	}
 
-	// Set property ‘TriggerType’:
+	// Set property "TriggerType":
 	if typedInput.TriggerType != nil {
 		triggerType := *typedInput.TriggerType
 		resource.TriggerType = &triggerType
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
@@ -1061,25 +1061,25 @@ func (resource *SqlTriggerResource) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &SqlTriggerResource_ARM{}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if resource.Body != nil {
 		body := *resource.Body
 		result.Body = &body
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
 	}
 
-	// Set property ‘TriggerOperation’:
+	// Set property "TriggerOperation":
 	if resource.TriggerOperation != nil {
 		triggerOperation := *resource.TriggerOperation
 		result.TriggerOperation = &triggerOperation
 	}
 
-	// Set property ‘TriggerType’:
+	// Set property "TriggerType":
 	if resource.TriggerType != nil {
 		triggerType := *resource.TriggerType
 		result.TriggerType = &triggerType
@@ -1099,25 +1099,25 @@ func (resource *SqlTriggerResource) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlTriggerResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if typedInput.Body != nil {
 		body := *typedInput.Body
 		resource.Body = &body
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘TriggerOperation’:
+	// Set property "TriggerOperation":
 	if typedInput.TriggerOperation != nil {
 		triggerOperation := *typedInput.TriggerOperation
 		resource.TriggerOperation = &triggerOperation
 	}
 
-	// Set property ‘TriggerType’:
+	// Set property "TriggerType":
 	if typedInput.TriggerType != nil {
 		triggerType := *typedInput.TriggerType
 		resource.TriggerType = &triggerType

--- a/v2/api/documentdb/v1api20210515/sql_database_container_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_container_types_gen.go
@@ -343,16 +343,16 @@ func (container *DatabaseAccounts_SqlDatabases_Container_Spec) ConvertToARM(reso
 	}
 	result := &DatabaseAccounts_SqlDatabases_Container_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if container.Location != nil {
 		location := *container.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if container.Options != nil || container.Resource != nil {
 		result.Properties = &SqlContainerCreateUpdateProperties_ARM{}
 	}
@@ -373,7 +373,7 @@ func (container *DatabaseAccounts_SqlDatabases_Container_Spec) ConvertToARM(reso
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if container.Tags != nil {
 		result.Tags = make(map[string]string, len(container.Tags))
 		for key, value := range container.Tags {
@@ -395,16 +395,16 @@ func (container *DatabaseAccounts_SqlDatabases_Container_Spec) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Container_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	container.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		container.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -418,10 +418,10 @@ func (container *DatabaseAccounts_SqlDatabases_Container_Spec) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	container.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -435,7 +435,7 @@ func (container *DatabaseAccounts_SqlDatabases_Container_Spec) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		container.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -738,27 +738,27 @@ func (container *DatabaseAccounts_SqlDatabases_Container_STATUS) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Container_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		container.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		container.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		container.Name = &name
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -772,7 +772,7 @@ func (container *DatabaseAccounts_SqlDatabases_Container_STATUS) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -786,7 +786,7 @@ func (container *DatabaseAccounts_SqlDatabases_Container_STATUS) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		container.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -794,7 +794,7 @@ func (container *DatabaseAccounts_SqlDatabases_Container_STATUS) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		container.Type = &typeVar
@@ -959,13 +959,13 @@ func (resource *SqlContainerGetProperties_Resource_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlContainerGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AnalyticalStorageTtl’:
+	// Set property "AnalyticalStorageTtl":
 	if typedInput.AnalyticalStorageTtl != nil {
 		analyticalStorageTtl := *typedInput.AnalyticalStorageTtl
 		resource.AnalyticalStorageTtl = &analyticalStorageTtl
 	}
 
-	// Set property ‘ConflictResolutionPolicy’:
+	// Set property "ConflictResolutionPolicy":
 	if typedInput.ConflictResolutionPolicy != nil {
 		var conflictResolutionPolicy1 ConflictResolutionPolicy_STATUS
 		err := conflictResolutionPolicy1.PopulateFromARM(owner, *typedInput.ConflictResolutionPolicy)
@@ -976,25 +976,25 @@ func (resource *SqlContainerGetProperties_Resource_STATUS) PopulateFromARM(owner
 		resource.ConflictResolutionPolicy = &conflictResolutionPolicy
 	}
 
-	// Set property ‘DefaultTtl’:
+	// Set property "DefaultTtl":
 	if typedInput.DefaultTtl != nil {
 		defaultTtl := *typedInput.DefaultTtl
 		resource.DefaultTtl = &defaultTtl
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘IndexingPolicy’:
+	// Set property "IndexingPolicy":
 	if typedInput.IndexingPolicy != nil {
 		var indexingPolicy1 IndexingPolicy_STATUS
 		err := indexingPolicy1.PopulateFromARM(owner, *typedInput.IndexingPolicy)
@@ -1005,7 +1005,7 @@ func (resource *SqlContainerGetProperties_Resource_STATUS) PopulateFromARM(owner
 		resource.IndexingPolicy = &indexingPolicy
 	}
 
-	// Set property ‘PartitionKey’:
+	// Set property "PartitionKey":
 	if typedInput.PartitionKey != nil {
 		var partitionKey1 ContainerPartitionKey_STATUS
 		err := partitionKey1.PopulateFromARM(owner, *typedInput.PartitionKey)
@@ -1016,19 +1016,19 @@ func (resource *SqlContainerGetProperties_Resource_STATUS) PopulateFromARM(owner
 		resource.PartitionKey = &partitionKey
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
 	}
 
-	// Set property ‘UniqueKeyPolicy’:
+	// Set property "UniqueKeyPolicy":
 	if typedInput.UniqueKeyPolicy != nil {
 		var uniqueKeyPolicy1 UniqueKeyPolicy_STATUS
 		err := uniqueKeyPolicy1.PopulateFromARM(owner, *typedInput.UniqueKeyPolicy)
@@ -1244,13 +1244,13 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &SqlContainerResource_ARM{}
 
-	// Set property ‘AnalyticalStorageTtl’:
+	// Set property "AnalyticalStorageTtl":
 	if resource.AnalyticalStorageTtl != nil {
 		analyticalStorageTtl := *resource.AnalyticalStorageTtl
 		result.AnalyticalStorageTtl = &analyticalStorageTtl
 	}
 
-	// Set property ‘ConflictResolutionPolicy’:
+	// Set property "ConflictResolutionPolicy":
 	if resource.ConflictResolutionPolicy != nil {
 		conflictResolutionPolicy_ARM, err := (*resource.ConflictResolutionPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -1260,19 +1260,19 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		result.ConflictResolutionPolicy = &conflictResolutionPolicy
 	}
 
-	// Set property ‘DefaultTtl’:
+	// Set property "DefaultTtl":
 	if resource.DefaultTtl != nil {
 		defaultTtl := *resource.DefaultTtl
 		result.DefaultTtl = &defaultTtl
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
 	}
 
-	// Set property ‘IndexingPolicy’:
+	// Set property "IndexingPolicy":
 	if resource.IndexingPolicy != nil {
 		indexingPolicy_ARM, err := (*resource.IndexingPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -1282,7 +1282,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		result.IndexingPolicy = &indexingPolicy
 	}
 
-	// Set property ‘PartitionKey’:
+	// Set property "PartitionKey":
 	if resource.PartitionKey != nil {
 		partitionKey_ARM, err := (*resource.PartitionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -1292,7 +1292,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		result.PartitionKey = &partitionKey
 	}
 
-	// Set property ‘UniqueKeyPolicy’:
+	// Set property "UniqueKeyPolicy":
 	if resource.UniqueKeyPolicy != nil {
 		uniqueKeyPolicy_ARM, err := (*resource.UniqueKeyPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -1316,13 +1316,13 @@ func (resource *SqlContainerResource) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlContainerResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AnalyticalStorageTtl’:
+	// Set property "AnalyticalStorageTtl":
 	if typedInput.AnalyticalStorageTtl != nil {
 		analyticalStorageTtl := *typedInput.AnalyticalStorageTtl
 		resource.AnalyticalStorageTtl = &analyticalStorageTtl
 	}
 
-	// Set property ‘ConflictResolutionPolicy’:
+	// Set property "ConflictResolutionPolicy":
 	if typedInput.ConflictResolutionPolicy != nil {
 		var conflictResolutionPolicy1 ConflictResolutionPolicy
 		err := conflictResolutionPolicy1.PopulateFromARM(owner, *typedInput.ConflictResolutionPolicy)
@@ -1333,19 +1333,19 @@ func (resource *SqlContainerResource) PopulateFromARM(owner genruntime.Arbitrary
 		resource.ConflictResolutionPolicy = &conflictResolutionPolicy
 	}
 
-	// Set property ‘DefaultTtl’:
+	// Set property "DefaultTtl":
 	if typedInput.DefaultTtl != nil {
 		defaultTtl := *typedInput.DefaultTtl
 		resource.DefaultTtl = &defaultTtl
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘IndexingPolicy’:
+	// Set property "IndexingPolicy":
 	if typedInput.IndexingPolicy != nil {
 		var indexingPolicy1 IndexingPolicy
 		err := indexingPolicy1.PopulateFromARM(owner, *typedInput.IndexingPolicy)
@@ -1356,7 +1356,7 @@ func (resource *SqlContainerResource) PopulateFromARM(owner genruntime.Arbitrary
 		resource.IndexingPolicy = &indexingPolicy
 	}
 
-	// Set property ‘PartitionKey’:
+	// Set property "PartitionKey":
 	if typedInput.PartitionKey != nil {
 		var partitionKey1 ContainerPartitionKey
 		err := partitionKey1.PopulateFromARM(owner, *typedInput.PartitionKey)
@@ -1367,7 +1367,7 @@ func (resource *SqlContainerResource) PopulateFromARM(owner genruntime.Arbitrary
 		resource.PartitionKey = &partitionKey
 	}
 
-	// Set property ‘UniqueKeyPolicy’:
+	// Set property "UniqueKeyPolicy":
 	if typedInput.UniqueKeyPolicy != nil {
 		var uniqueKeyPolicy1 UniqueKeyPolicy
 		err := uniqueKeyPolicy1.PopulateFromARM(owner, *typedInput.UniqueKeyPolicy)
@@ -1604,19 +1604,19 @@ func (policy *ConflictResolutionPolicy) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ConflictResolutionPolicy_ARM{}
 
-	// Set property ‘ConflictResolutionPath’:
+	// Set property "ConflictResolutionPath":
 	if policy.ConflictResolutionPath != nil {
 		conflictResolutionPath := *policy.ConflictResolutionPath
 		result.ConflictResolutionPath = &conflictResolutionPath
 	}
 
-	// Set property ‘ConflictResolutionProcedure’:
+	// Set property "ConflictResolutionProcedure":
 	if policy.ConflictResolutionProcedure != nil {
 		conflictResolutionProcedure := *policy.ConflictResolutionProcedure
 		result.ConflictResolutionProcedure = &conflictResolutionProcedure
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if policy.Mode != nil {
 		mode := *policy.Mode
 		result.Mode = &mode
@@ -1636,19 +1636,19 @@ func (policy *ConflictResolutionPolicy) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConflictResolutionPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConflictResolutionPath’:
+	// Set property "ConflictResolutionPath":
 	if typedInput.ConflictResolutionPath != nil {
 		conflictResolutionPath := *typedInput.ConflictResolutionPath
 		policy.ConflictResolutionPath = &conflictResolutionPath
 	}
 
-	// Set property ‘ConflictResolutionProcedure’:
+	// Set property "ConflictResolutionProcedure":
 	if typedInput.ConflictResolutionProcedure != nil {
 		conflictResolutionProcedure := *typedInput.ConflictResolutionProcedure
 		policy.ConflictResolutionProcedure = &conflictResolutionProcedure
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		policy.Mode = &mode
@@ -1756,19 +1756,19 @@ func (policy *ConflictResolutionPolicy_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConflictResolutionPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConflictResolutionPath’:
+	// Set property "ConflictResolutionPath":
 	if typedInput.ConflictResolutionPath != nil {
 		conflictResolutionPath := *typedInput.ConflictResolutionPath
 		policy.ConflictResolutionPath = &conflictResolutionPath
 	}
 
-	// Set property ‘ConflictResolutionProcedure’:
+	// Set property "ConflictResolutionProcedure":
 	if typedInput.ConflictResolutionProcedure != nil {
 		conflictResolutionProcedure := *typedInput.ConflictResolutionProcedure
 		policy.ConflictResolutionProcedure = &conflictResolutionProcedure
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		policy.Mode = &mode
@@ -1853,18 +1853,18 @@ func (partitionKey *ContainerPartitionKey) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ContainerPartitionKey_ARM{}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if partitionKey.Kind != nil {
 		kind := *partitionKey.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Paths’:
+	// Set property "Paths":
 	for _, item := range partitionKey.Paths {
 		result.Paths = append(result.Paths, item)
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if partitionKey.Version != nil {
 		version := *partitionKey.Version
 		result.Version = &version
@@ -1884,18 +1884,18 @@ func (partitionKey *ContainerPartitionKey) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerPartitionKey_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		partitionKey.Kind = &kind
 	}
 
-	// Set property ‘Paths’:
+	// Set property "Paths":
 	for _, item := range typedInput.Paths {
 		partitionKey.Paths = append(partitionKey.Paths, item)
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		partitionKey.Version = &version
@@ -2022,24 +2022,24 @@ func (partitionKey *ContainerPartitionKey_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerPartitionKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		partitionKey.Kind = &kind
 	}
 
-	// Set property ‘Paths’:
+	// Set property "Paths":
 	for _, item := range typedInput.Paths {
 		partitionKey.Paths = append(partitionKey.Paths, item)
 	}
 
-	// Set property ‘SystemKey’:
+	// Set property "SystemKey":
 	if typedInput.SystemKey != nil {
 		systemKey := *typedInput.SystemKey
 		partitionKey.SystemKey = &systemKey
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		partitionKey.Version = &version
@@ -2146,13 +2146,13 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &IndexingPolicy_ARM{}
 
-	// Set property ‘Automatic’:
+	// Set property "Automatic":
 	if policy.Automatic != nil {
 		automatic := *policy.Automatic
 		result.Automatic = &automatic
 	}
 
-	// Set property ‘CompositeIndexes’:
+	// Set property "CompositeIndexes":
 	for _, item := range policy.CompositeIndexes {
 		var itemTemp []CompositePath_ARM
 		for _, item1 := range item {
@@ -2165,7 +2165,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.CompositeIndexes = append(result.CompositeIndexes, itemTemp)
 	}
 
-	// Set property ‘ExcludedPaths’:
+	// Set property "ExcludedPaths":
 	for _, item := range policy.ExcludedPaths {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2174,7 +2174,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.ExcludedPaths = append(result.ExcludedPaths, *item_ARM.(*ExcludedPath_ARM))
 	}
 
-	// Set property ‘IncludedPaths’:
+	// Set property "IncludedPaths":
 	for _, item := range policy.IncludedPaths {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2183,13 +2183,13 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.IncludedPaths = append(result.IncludedPaths, *item_ARM.(*IncludedPath_ARM))
 	}
 
-	// Set property ‘IndexingMode’:
+	// Set property "IndexingMode":
 	if policy.IndexingMode != nil {
 		indexingMode := *policy.IndexingMode
 		result.IndexingMode = &indexingMode
 	}
 
-	// Set property ‘SpatialIndexes’:
+	// Set property "SpatialIndexes":
 	for _, item := range policy.SpatialIndexes {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2212,13 +2212,13 @@ func (policy *IndexingPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IndexingPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Automatic’:
+	// Set property "Automatic":
 	if typedInput.Automatic != nil {
 		automatic := *typedInput.Automatic
 		policy.Automatic = &automatic
 	}
 
-	// Set property ‘CompositeIndexes’:
+	// Set property "CompositeIndexes":
 	for _, item := range typedInput.CompositeIndexes {
 		var itemTemp []CompositePath
 		for _, item1 := range item {
@@ -2232,7 +2232,7 @@ func (policy *IndexingPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		policy.CompositeIndexes = append(policy.CompositeIndexes, itemTemp)
 	}
 
-	// Set property ‘ExcludedPaths’:
+	// Set property "ExcludedPaths":
 	for _, item := range typedInput.ExcludedPaths {
 		var item1 ExcludedPath
 		err := item1.PopulateFromARM(owner, item)
@@ -2242,7 +2242,7 @@ func (policy *IndexingPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		policy.ExcludedPaths = append(policy.ExcludedPaths, item1)
 	}
 
-	// Set property ‘IncludedPaths’:
+	// Set property "IncludedPaths":
 	for _, item := range typedInput.IncludedPaths {
 		var item1 IncludedPath
 		err := item1.PopulateFromARM(owner, item)
@@ -2252,13 +2252,13 @@ func (policy *IndexingPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		policy.IncludedPaths = append(policy.IncludedPaths, item1)
 	}
 
-	// Set property ‘IndexingMode’:
+	// Set property "IndexingMode":
 	if typedInput.IndexingMode != nil {
 		indexingMode := *typedInput.IndexingMode
 		policy.IndexingMode = &indexingMode
 	}
 
-	// Set property ‘SpatialIndexes’:
+	// Set property "SpatialIndexes":
 	for _, item := range typedInput.SpatialIndexes {
 		var item1 SpatialSpec
 		err := item1.PopulateFromARM(owner, item)
@@ -2631,13 +2631,13 @@ func (policy *IndexingPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IndexingPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Automatic’:
+	// Set property "Automatic":
 	if typedInput.Automatic != nil {
 		automatic := *typedInput.Automatic
 		policy.Automatic = &automatic
 	}
 
-	// Set property ‘CompositeIndexes’:
+	// Set property "CompositeIndexes":
 	for _, item := range typedInput.CompositeIndexes {
 		var itemTemp []CompositePath_STATUS
 		for _, item1 := range item {
@@ -2651,7 +2651,7 @@ func (policy *IndexingPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		policy.CompositeIndexes = append(policy.CompositeIndexes, itemTemp)
 	}
 
-	// Set property ‘ExcludedPaths’:
+	// Set property "ExcludedPaths":
 	for _, item := range typedInput.ExcludedPaths {
 		var item1 ExcludedPath_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2661,7 +2661,7 @@ func (policy *IndexingPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		policy.ExcludedPaths = append(policy.ExcludedPaths, item1)
 	}
 
-	// Set property ‘IncludedPaths’:
+	// Set property "IncludedPaths":
 	for _, item := range typedInput.IncludedPaths {
 		var item1 IncludedPath_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2671,13 +2671,13 @@ func (policy *IndexingPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		policy.IncludedPaths = append(policy.IncludedPaths, item1)
 	}
 
-	// Set property ‘IndexingMode’:
+	// Set property "IndexingMode":
 	if typedInput.IndexingMode != nil {
 		indexingMode := *typedInput.IndexingMode
 		policy.IndexingMode = &indexingMode
 	}
 
-	// Set property ‘SpatialIndexes’:
+	// Set property "SpatialIndexes":
 	for _, item := range typedInput.SpatialIndexes {
 		var item1 SpatialSpec_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2927,7 +2927,7 @@ func (policy *UniqueKeyPolicy) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &UniqueKeyPolicy_ARM{}
 
-	// Set property ‘UniqueKeys’:
+	// Set property "UniqueKeys":
 	for _, item := range policy.UniqueKeys {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2950,7 +2950,7 @@ func (policy *UniqueKeyPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UniqueKeyPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UniqueKeys’:
+	// Set property "UniqueKeys":
 	for _, item := range typedInput.UniqueKeys {
 		var item1 UniqueKey
 		err := item1.PopulateFromARM(owner, item)
@@ -3070,7 +3070,7 @@ func (policy *UniqueKeyPolicy_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UniqueKeyPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UniqueKeys’:
+	// Set property "UniqueKeys":
 	for _, item := range typedInput.UniqueKeys {
 		var item1 UniqueKey_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3161,13 +3161,13 @@ func (path *CompositePath) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &CompositePath_ARM{}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if path.Order != nil {
 		order := *path.Order
 		result.Order = &order
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if path.Path != nil {
 		path1 := *path.Path
 		result.Path = &path1
@@ -3187,13 +3187,13 @@ func (path *CompositePath) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CompositePath_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if typedInput.Order != nil {
 		order := *typedInput.Order
 		path.Order = &order
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path1 := *typedInput.Path
 		path.Path = &path1
@@ -3289,13 +3289,13 @@ func (path *CompositePath_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CompositePath_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if typedInput.Order != nil {
 		order := *typedInput.Order
 		path.Order = &order
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path1 := *typedInput.Path
 		path.Path = &path1
@@ -3365,7 +3365,7 @@ func (path *ExcludedPath) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &ExcludedPath_ARM{}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if path.Path != nil {
 		path1 := *path.Path
 		result.Path = &path1
@@ -3385,7 +3385,7 @@ func (path *ExcludedPath) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExcludedPath_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path1 := *typedInput.Path
 		path.Path = &path1
@@ -3454,7 +3454,7 @@ func (path *ExcludedPath_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExcludedPath_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path1 := *typedInput.Path
 		path.Path = &path1
@@ -3512,7 +3512,7 @@ func (path *IncludedPath) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &IncludedPath_ARM{}
 
-	// Set property ‘Indexes’:
+	// Set property "Indexes":
 	for _, item := range path.Indexes {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3521,7 +3521,7 @@ func (path *IncludedPath) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Indexes = append(result.Indexes, *item_ARM.(*Indexes_ARM))
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if path.Path != nil {
 		path1 := *path.Path
 		result.Path = &path1
@@ -3541,7 +3541,7 @@ func (path *IncludedPath) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IncludedPath_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Indexes’:
+	// Set property "Indexes":
 	for _, item := range typedInput.Indexes {
 		var item1 Indexes
 		err := item1.PopulateFromARM(owner, item)
@@ -3551,7 +3551,7 @@ func (path *IncludedPath) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		path.Indexes = append(path.Indexes, item1)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path1 := *typedInput.Path
 		path.Path = &path1
@@ -3678,7 +3678,7 @@ func (path *IncludedPath_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IncludedPath_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Indexes’:
+	// Set property "Indexes":
 	for _, item := range typedInput.Indexes {
 		var item1 Indexes_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3688,7 +3688,7 @@ func (path *IncludedPath_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		path.Indexes = append(path.Indexes, item1)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path1 := *typedInput.Path
 		path.Path = &path1
@@ -3781,13 +3781,13 @@ func (spatial *SpatialSpec) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &SpatialSpec_ARM{}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if spatial.Path != nil {
 		path := *spatial.Path
 		result.Path = &path
 	}
 
-	// Set property ‘Types’:
+	// Set property "Types":
 	for _, item := range spatial.Types {
 		result.Types = append(result.Types, item)
 	}
@@ -3806,13 +3806,13 @@ func (spatial *SpatialSpec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SpatialSpec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		spatial.Path = &path
 	}
 
-	// Set property ‘Types’:
+	// Set property "Types":
 	for _, item := range typedInput.Types {
 		spatial.Types = append(spatial.Types, item)
 	}
@@ -3923,13 +3923,13 @@ func (spatial *SpatialSpec_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SpatialSpec_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		spatial.Path = &path
 	}
 
-	// Set property ‘Types’:
+	// Set property "Types":
 	for _, item := range typedInput.Types {
 		spatial.Types = append(spatial.Types, item)
 	}
@@ -4008,7 +4008,7 @@ func (uniqueKey *UniqueKey) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &UniqueKey_ARM{}
 
-	// Set property ‘Paths’:
+	// Set property "Paths":
 	for _, item := range uniqueKey.Paths {
 		result.Paths = append(result.Paths, item)
 	}
@@ -4027,7 +4027,7 @@ func (uniqueKey *UniqueKey) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UniqueKey_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Paths’:
+	// Set property "Paths":
 	for _, item := range typedInput.Paths {
 		uniqueKey.Paths = append(uniqueKey.Paths, item)
 	}
@@ -4095,7 +4095,7 @@ func (uniqueKey *UniqueKey_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UniqueKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Paths’:
+	// Set property "Paths":
 	for _, item := range typedInput.Paths {
 		uniqueKey.Paths = append(uniqueKey.Paths, item)
 	}
@@ -4154,19 +4154,19 @@ func (indexes *Indexes) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Indexes_ARM{}
 
-	// Set property ‘DataType’:
+	// Set property "DataType":
 	if indexes.DataType != nil {
 		dataType := *indexes.DataType
 		result.DataType = &dataType
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if indexes.Kind != nil {
 		kind := *indexes.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Precision’:
+	// Set property "Precision":
 	if indexes.Precision != nil {
 		precision := *indexes.Precision
 		result.Precision = &precision
@@ -4186,19 +4186,19 @@ func (indexes *Indexes) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Indexes_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataType’:
+	// Set property "DataType":
 	if typedInput.DataType != nil {
 		dataType := *typedInput.DataType
 		indexes.DataType = &dataType
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		indexes.Kind = &kind
 	}
 
-	// Set property ‘Precision’:
+	// Set property "Precision":
 	if typedInput.Precision != nil {
 		precision := *typedInput.Precision
 		indexes.Precision = &precision
@@ -4321,19 +4321,19 @@ func (indexes *Indexes_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Indexes_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataType’:
+	// Set property "DataType":
 	if typedInput.DataType != nil {
 		dataType := *typedInput.DataType
 		indexes.DataType = &dataType
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		indexes.Kind = &kind
 	}
 
-	// Set property ‘Precision’:
+	// Set property "Precision":
 	if typedInput.Precision != nil {
 		precision := *typedInput.Precision
 		indexes.Precision = &precision

--- a/v2/api/documentdb/v1api20210515/sql_database_container_user_defined_function_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_container_user_defined_function_types_gen.go
@@ -343,16 +343,16 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spe
 	}
 	result := &DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if function.Location != nil {
 		location := *function.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if function.Options != nil || function.Resource != nil {
 		result.Properties = &SqlUserDefinedFunctionCreateUpdateProperties_ARM{}
 	}
@@ -373,7 +373,7 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spe
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if function.Tags != nil {
 		result.Tags = make(map[string]string, len(function.Tags))
 		for key, value := range function.Tags {
@@ -395,16 +395,16 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	function.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		function.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -418,10 +418,10 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spe
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	function.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -435,7 +435,7 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		function.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -723,27 +723,27 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_STA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		function.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		function.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		function.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -757,7 +757,7 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_STA
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		function.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -765,7 +765,7 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_STA
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		function.Type = &typeVar
@@ -889,31 +889,31 @@ func (resource *SqlUserDefinedFunctionGetProperties_Resource_STATUS) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlUserDefinedFunctionGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if typedInput.Body != nil {
 		body := *typedInput.Body
 		resource.Body = &body
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
@@ -1005,13 +1005,13 @@ func (resource *SqlUserDefinedFunctionResource) ConvertToARM(resolved genruntime
 	}
 	result := &SqlUserDefinedFunctionResource_ARM{}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if resource.Body != nil {
 		body := *resource.Body
 		result.Body = &body
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
@@ -1031,13 +1031,13 @@ func (resource *SqlUserDefinedFunctionResource) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlUserDefinedFunctionResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if typedInput.Body != nil {
 		body := *typedInput.Body
 		resource.Body = &body
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id

--- a/v2/api/documentdb/v1api20210515/sql_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_throughput_setting_types_gen.go
@@ -328,16 +328,16 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec) ConvertToAR
 	}
 	result := &DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if setting.Location != nil {
 		location := *setting.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if setting.Resource != nil {
 		result.Properties = &ThroughputSettingsUpdateProperties_ARM{}
 	}
@@ -350,7 +350,7 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec) ConvertToAR
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if setting.Tags != nil {
 		result.Tags = make(map[string]string, len(setting.Tags))
 		for key, value := range setting.Tags {
@@ -372,16 +372,16 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -395,7 +395,7 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec) PopulateFro
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -648,27 +648,27 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_STATUS) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_ThroughputSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		setting.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		setting.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -682,7 +682,7 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_STATUS) PopulateF
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -690,7 +690,7 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_STATUS) PopulateF
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar

--- a/v2/api/documentdb/v1api20210515/sql_database_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_types_gen.go
@@ -343,16 +343,16 @@ func (database *DatabaseAccounts_SqlDatabase_Spec) ConvertToARM(resolved genrunt
 	}
 	result := &DatabaseAccounts_SqlDatabase_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if database.Location != nil {
 		location := *database.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.Options != nil || database.Resource != nil {
 		result.Properties = &SqlDatabaseCreateUpdateProperties_ARM{}
 	}
@@ -373,7 +373,7 @@ func (database *DatabaseAccounts_SqlDatabase_Spec) ConvertToARM(resolved genrunt
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if database.Tags != nil {
 		result.Tags = make(map[string]string, len(database.Tags))
 		for key, value := range database.Tags {
@@ -395,16 +395,16 @@ func (database *DatabaseAccounts_SqlDatabase_Spec) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabase_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		database.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -418,10 +418,10 @@ func (database *DatabaseAccounts_SqlDatabase_Spec) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -435,7 +435,7 @@ func (database *DatabaseAccounts_SqlDatabase_Spec) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		database.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -738,27 +738,27 @@ func (database *DatabaseAccounts_SqlDatabase_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabase_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		database.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -772,7 +772,7 @@ func (database *DatabaseAccounts_SqlDatabase_STATUS) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -786,7 +786,7 @@ func (database *DatabaseAccounts_SqlDatabase_STATUS) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		database.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -794,7 +794,7 @@ func (database *DatabaseAccounts_SqlDatabase_STATUS) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar
@@ -945,37 +945,37 @@ func (resource *SqlDatabaseGetProperties_Resource_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlDatabaseGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Colls’:
+	// Set property "Colls":
 	if typedInput.Colls != nil {
 		colls := *typedInput.Colls
 		resource.Colls = &colls
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
 	}
 
-	// Set property ‘Users’:
+	// Set property "Users":
 	if typedInput.Users != nil {
 		users := *typedInput.Users
 		resource.Users = &users
@@ -1070,7 +1070,7 @@ func (resource *SqlDatabaseResource) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &SqlDatabaseResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
@@ -1090,7 +1090,7 @@ func (resource *SqlDatabaseResource) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlDatabaseResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id

--- a/v2/api/documentdb/v1api20210515/sql_role_assignment_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_role_assignment_types_gen.go
@@ -352,10 +352,10 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_Spec) ConvertToARM(resolved
 	}
 	result := &DatabaseAccounts_SqlRoleAssignment_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if assignment.PrincipalId != nil ||
 		assignment.PrincipalIdFromConfig != nil ||
 		assignment.RoleDefinitionId != nil ||
@@ -397,13 +397,13 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_Spec) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlRoleAssignment_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	assignment.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	assignment.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalId != nil {
@@ -412,9 +412,9 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// no assignment for property ‘PrincipalIdFromConfig’
+	// no assignment for property "PrincipalIdFromConfig"
 
-	// Set property ‘RoleDefinitionId’:
+	// Set property "RoleDefinitionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RoleDefinitionId != nil {
@@ -423,7 +423,7 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Scope’:
+	// Set property "Scope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Scope != nil {
@@ -682,21 +682,21 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlRoleAssignment_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		assignment.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		assignment.Name = &name
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalId != nil {
@@ -705,7 +705,7 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘RoleDefinitionId’:
+	// Set property "RoleDefinitionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RoleDefinitionId != nil {
@@ -714,7 +714,7 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘Scope’:
+	// Set property "Scope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Scope != nil {
@@ -723,7 +723,7 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		assignment.Type = &typeVar

--- a/v2/api/documentdb/v1beta20210515/database_account_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_account_types_gen.go
@@ -397,7 +397,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &DatabaseAccount_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if account.Identity != nil {
 		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -407,22 +407,22 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Identity = &identity
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if account.Kind != nil {
 		kind := *account.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if account.Location != nil {
 		location := *account.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if account.AnalyticalStorageConfiguration != nil ||
 		account.ApiProperties != nil ||
 		account.BackupPolicy != nil ||
@@ -571,7 +571,7 @@ func (account *DatabaseAccount_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.VirtualNetworkRules = append(result.Properties.VirtualNetworkRules, *item_ARM.(*VirtualNetworkRule_ARM))
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if account.Tags != nil {
 		result.Tags = make(map[string]string, len(account.Tags))
 		for key, value := range account.Tags {
@@ -593,7 +593,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccount_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AnalyticalStorageConfiguration’:
+	// Set property "AnalyticalStorageConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AnalyticalStorageConfiguration != nil {
@@ -607,7 +607,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ApiProperties’:
+	// Set property "ApiProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApiProperties != nil {
@@ -621,10 +621,10 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	account.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BackupPolicy’:
+	// Set property "BackupPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackupPolicy != nil {
@@ -638,7 +638,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Capabilities’:
+	// Set property "Capabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Capabilities {
@@ -651,7 +651,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ConnectorOffer’:
+	// Set property "ConnectorOffer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConnectorOffer != nil {
@@ -660,7 +660,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ConsistencyPolicy’:
+	// Set property "ConsistencyPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConsistencyPolicy != nil {
@@ -674,7 +674,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Cors {
@@ -687,7 +687,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘DatabaseAccountOfferType’:
+	// Set property "DatabaseAccountOfferType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DatabaseAccountOfferType != nil {
@@ -696,7 +696,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘DefaultIdentity’:
+	// Set property "DefaultIdentity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultIdentity != nil {
@@ -705,7 +705,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘DisableKeyBasedMetadataWriteAccess’:
+	// Set property "DisableKeyBasedMetadataWriteAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableKeyBasedMetadataWriteAccess != nil {
@@ -714,7 +714,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘EnableAnalyticalStorage’:
+	// Set property "EnableAnalyticalStorage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAnalyticalStorage != nil {
@@ -723,7 +723,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘EnableAutomaticFailover’:
+	// Set property "EnableAutomaticFailover":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticFailover != nil {
@@ -732,7 +732,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘EnableCassandraConnector’:
+	// Set property "EnableCassandraConnector":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableCassandraConnector != nil {
@@ -741,7 +741,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘EnableFreeTier’:
+	// Set property "EnableFreeTier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFreeTier != nil {
@@ -750,7 +750,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘EnableMultipleWriteLocations’:
+	// Set property "EnableMultipleWriteLocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableMultipleWriteLocations != nil {
@@ -759,7 +759,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedServiceIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -770,7 +770,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		account.Identity = &identity
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpRules {
@@ -783,7 +783,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘IsVirtualNetworkFilterEnabled’:
+	// Set property "IsVirtualNetworkFilterEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsVirtualNetworkFilterEnabled != nil {
@@ -792,7 +792,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘KeyVaultKeyUri’:
+	// Set property "KeyVaultKeyUri":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVaultKeyUri != nil {
@@ -801,19 +801,19 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		account.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Locations {
@@ -826,7 +826,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NetworkAclBypass’:
+	// Set property "NetworkAclBypass":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAclBypass != nil {
@@ -835,7 +835,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NetworkAclBypassResourceIds’:
+	// Set property "NetworkAclBypassResourceIds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NetworkAclBypassResourceIds {
@@ -843,12 +843,12 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	account.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -857,7 +857,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -865,7 +865,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VirtualNetworkRules {
@@ -1641,7 +1641,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccount_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AnalyticalStorageConfiguration’:
+	// Set property "AnalyticalStorageConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AnalyticalStorageConfiguration != nil {
@@ -1655,7 +1655,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘ApiProperties’:
+	// Set property "ApiProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApiProperties != nil {
@@ -1669,7 +1669,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘BackupPolicy’:
+	// Set property "BackupPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackupPolicy != nil {
@@ -1683,7 +1683,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Capabilities’:
+	// Set property "Capabilities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Capabilities {
@@ -1696,9 +1696,9 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ConnectorOffer’:
+	// Set property "ConnectorOffer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConnectorOffer != nil {
@@ -1707,7 +1707,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘ConsistencyPolicy’:
+	// Set property "ConsistencyPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConsistencyPolicy != nil {
@@ -1721,7 +1721,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Cors {
@@ -1734,7 +1734,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DatabaseAccountOfferType’:
+	// Set property "DatabaseAccountOfferType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DatabaseAccountOfferType != nil {
@@ -1743,7 +1743,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DefaultIdentity’:
+	// Set property "DefaultIdentity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultIdentity != nil {
@@ -1752,7 +1752,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DisableKeyBasedMetadataWriteAccess’:
+	// Set property "DisableKeyBasedMetadataWriteAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableKeyBasedMetadataWriteAccess != nil {
@@ -1761,7 +1761,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DocumentEndpoint’:
+	// Set property "DocumentEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DocumentEndpoint != nil {
@@ -1770,7 +1770,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EnableAnalyticalStorage’:
+	// Set property "EnableAnalyticalStorage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAnalyticalStorage != nil {
@@ -1779,7 +1779,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EnableAutomaticFailover’:
+	// Set property "EnableAutomaticFailover":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAutomaticFailover != nil {
@@ -1788,7 +1788,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EnableCassandraConnector’:
+	// Set property "EnableCassandraConnector":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableCassandraConnector != nil {
@@ -1797,7 +1797,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EnableFreeTier’:
+	// Set property "EnableFreeTier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFreeTier != nil {
@@ -1806,7 +1806,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EnableMultipleWriteLocations’:
+	// Set property "EnableMultipleWriteLocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableMultipleWriteLocations != nil {
@@ -1815,7 +1815,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘FailoverPolicies’:
+	// Set property "FailoverPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.FailoverPolicies {
@@ -1828,13 +1828,13 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		account.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedServiceIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1845,7 +1845,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		account.Identity = &identity
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpRules {
@@ -1858,7 +1858,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘IsVirtualNetworkFilterEnabled’:
+	// Set property "IsVirtualNetworkFilterEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsVirtualNetworkFilterEnabled != nil {
@@ -1867,7 +1867,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘KeyVaultKeyUri’:
+	// Set property "KeyVaultKeyUri":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVaultKeyUri != nil {
@@ -1876,19 +1876,19 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		account.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Locations {
@@ -1901,13 +1901,13 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		account.Name = &name
 	}
 
-	// Set property ‘NetworkAclBypass’:
+	// Set property "NetworkAclBypass":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAclBypass != nil {
@@ -1916,7 +1916,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘NetworkAclBypassResourceIds’:
+	// Set property "NetworkAclBypassResourceIds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NetworkAclBypassResourceIds {
@@ -1924,7 +1924,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1937,7 +1937,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1946,7 +1946,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1955,7 +1955,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘ReadLocations’:
+	// Set property "ReadLocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ReadLocations {
@@ -1968,7 +1968,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1976,13 +1976,13 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		account.Type = &typeVar
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VirtualNetworkRules {
@@ -1995,7 +1995,7 @@ func (account *DatabaseAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘WriteLocations’:
+	// Set property "WriteLocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.WriteLocations {
@@ -2751,7 +2751,7 @@ func (configuration *AnalyticalStorageConfiguration) ConvertToARM(resolved genru
 	}
 	result := &AnalyticalStorageConfiguration_ARM{}
 
-	// Set property ‘SchemaType’:
+	// Set property "SchemaType":
 	if configuration.SchemaType != nil {
 		schemaType := *configuration.SchemaType
 		result.SchemaType = &schemaType
@@ -2771,7 +2771,7 @@ func (configuration *AnalyticalStorageConfiguration) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AnalyticalStorageConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SchemaType’:
+	// Set property "SchemaType":
 	if typedInput.SchemaType != nil {
 		schemaType := *typedInput.SchemaType
 		configuration.SchemaType = &schemaType
@@ -2839,7 +2839,7 @@ func (configuration *AnalyticalStorageConfiguration_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AnalyticalStorageConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SchemaType’:
+	// Set property "SchemaType":
 	if typedInput.SchemaType != nil {
 		schemaType := *typedInput.SchemaType
 		configuration.SchemaType = &schemaType
@@ -2902,7 +2902,7 @@ func (properties *ApiProperties) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ApiProperties_ARM{}
 
-	// Set property ‘ServerVersion’:
+	// Set property "ServerVersion":
 	if properties.ServerVersion != nil {
 		serverVersion := *properties.ServerVersion
 		result.ServerVersion = &serverVersion
@@ -2922,7 +2922,7 @@ func (properties *ApiProperties) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ServerVersion’:
+	// Set property "ServerVersion":
 	if typedInput.ServerVersion != nil {
 		serverVersion := *typedInput.ServerVersion
 		properties.ServerVersion = &serverVersion
@@ -2990,7 +2990,7 @@ func (properties *ApiProperties_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ServerVersion’:
+	// Set property "ServerVersion":
 	if typedInput.ServerVersion != nil {
 		serverVersion := *typedInput.ServerVersion
 		properties.ServerVersion = &serverVersion
@@ -3054,7 +3054,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &BackupPolicy_ARM{}
 
-	// Set property ‘Continuous’:
+	// Set property "Continuous":
 	if policy.Continuous != nil {
 		continuous_ARM, err := (*policy.Continuous).ConvertToARM(resolved)
 		if err != nil {
@@ -3064,7 +3064,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		result.Continuous = &continuous
 	}
 
-	// Set property ‘Periodic’:
+	// Set property "Periodic":
 	if policy.Periodic != nil {
 		periodic_ARM, err := (*policy.Periodic).ConvertToARM(resolved)
 		if err != nil {
@@ -3088,7 +3088,7 @@ func (policy *BackupPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Continuous’:
+	// Set property "Continuous":
 	if typedInput.Continuous != nil {
 		var continuous1 ContinuousModeBackupPolicy
 		err := continuous1.PopulateFromARM(owner, *typedInput.Continuous)
@@ -3099,7 +3099,7 @@ func (policy *BackupPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		policy.Continuous = &continuous
 	}
 
-	// Set property ‘Periodic’:
+	// Set property "Periodic":
 	if typedInput.Periodic != nil {
 		var periodic1 PeriodicModeBackupPolicy
 		err := periodic1.PopulateFromARM(owner, *typedInput.Periodic)
@@ -3205,7 +3205,7 @@ func (policy *BackupPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackupPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Continuous’:
+	// Set property "Continuous":
 	if typedInput.Continuous != nil {
 		var continuous1 ContinuousModeBackupPolicy_STATUS
 		err := continuous1.PopulateFromARM(owner, *typedInput.Continuous)
@@ -3216,7 +3216,7 @@ func (policy *BackupPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		policy.Continuous = &continuous
 	}
 
-	// Set property ‘Periodic’:
+	// Set property "Periodic":
 	if typedInput.Periodic != nil {
 		var periodic1 PeriodicModeBackupPolicy_STATUS
 		err := periodic1.PopulateFromARM(owner, *typedInput.Periodic)
@@ -3316,7 +3316,7 @@ func (capability *Capability) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Capability_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if capability.Name != nil {
 		name := *capability.Name
 		result.Name = &name
@@ -3336,7 +3336,7 @@ func (capability *Capability) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Capability_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		capability.Name = &name
@@ -3394,7 +3394,7 @@ func (capability *Capability_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Capability_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		capability.Name = &name
@@ -3467,19 +3467,19 @@ func (policy *ConsistencyPolicy) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ConsistencyPolicy_ARM{}
 
-	// Set property ‘DefaultConsistencyLevel’:
+	// Set property "DefaultConsistencyLevel":
 	if policy.DefaultConsistencyLevel != nil {
 		defaultConsistencyLevel := *policy.DefaultConsistencyLevel
 		result.DefaultConsistencyLevel = &defaultConsistencyLevel
 	}
 
-	// Set property ‘MaxIntervalInSeconds’:
+	// Set property "MaxIntervalInSeconds":
 	if policy.MaxIntervalInSeconds != nil {
 		maxIntervalInSeconds := *policy.MaxIntervalInSeconds
 		result.MaxIntervalInSeconds = &maxIntervalInSeconds
 	}
 
-	// Set property ‘MaxStalenessPrefix’:
+	// Set property "MaxStalenessPrefix":
 	if policy.MaxStalenessPrefix != nil {
 		maxStalenessPrefix := *policy.MaxStalenessPrefix
 		result.MaxStalenessPrefix = &maxStalenessPrefix
@@ -3499,19 +3499,19 @@ func (policy *ConsistencyPolicy) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConsistencyPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultConsistencyLevel’:
+	// Set property "DefaultConsistencyLevel":
 	if typedInput.DefaultConsistencyLevel != nil {
 		defaultConsistencyLevel := *typedInput.DefaultConsistencyLevel
 		policy.DefaultConsistencyLevel = &defaultConsistencyLevel
 	}
 
-	// Set property ‘MaxIntervalInSeconds’:
+	// Set property "MaxIntervalInSeconds":
 	if typedInput.MaxIntervalInSeconds != nil {
 		maxIntervalInSeconds := *typedInput.MaxIntervalInSeconds
 		policy.MaxIntervalInSeconds = &maxIntervalInSeconds
 	}
 
-	// Set property ‘MaxStalenessPrefix’:
+	// Set property "MaxStalenessPrefix":
 	if typedInput.MaxStalenessPrefix != nil {
 		maxStalenessPrefix := *typedInput.MaxStalenessPrefix
 		policy.MaxStalenessPrefix = &maxStalenessPrefix
@@ -3613,19 +3613,19 @@ func (policy *ConsistencyPolicy_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConsistencyPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultConsistencyLevel’:
+	// Set property "DefaultConsistencyLevel":
 	if typedInput.DefaultConsistencyLevel != nil {
 		defaultConsistencyLevel := *typedInput.DefaultConsistencyLevel
 		policy.DefaultConsistencyLevel = &defaultConsistencyLevel
 	}
 
-	// Set property ‘MaxIntervalInSeconds’:
+	// Set property "MaxIntervalInSeconds":
 	if typedInput.MaxIntervalInSeconds != nil {
 		maxIntervalInSeconds := *typedInput.MaxIntervalInSeconds
 		policy.MaxIntervalInSeconds = &maxIntervalInSeconds
 	}
 
-	// Set property ‘MaxStalenessPrefix’:
+	// Set property "MaxStalenessPrefix":
 	if typedInput.MaxStalenessPrefix != nil {
 		maxStalenessPrefix := *typedInput.MaxStalenessPrefix
 		policy.MaxStalenessPrefix = &maxStalenessPrefix
@@ -3709,31 +3709,31 @@ func (policy *CorsPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &CorsPolicy_ARM{}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	if policy.AllowedHeaders != nil {
 		allowedHeaders := *policy.AllowedHeaders
 		result.AllowedHeaders = &allowedHeaders
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	if policy.AllowedMethods != nil {
 		allowedMethods := *policy.AllowedMethods
 		result.AllowedMethods = &allowedMethods
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	if policy.AllowedOrigins != nil {
 		allowedOrigins := *policy.AllowedOrigins
 		result.AllowedOrigins = &allowedOrigins
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	if policy.ExposedHeaders != nil {
 		exposedHeaders := *policy.ExposedHeaders
 		result.ExposedHeaders = &exposedHeaders
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if policy.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *policy.MaxAgeInSeconds
 		result.MaxAgeInSeconds = &maxAgeInSeconds
@@ -3753,31 +3753,31 @@ func (policy *CorsPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	if typedInput.AllowedHeaders != nil {
 		allowedHeaders := *typedInput.AllowedHeaders
 		policy.AllowedHeaders = &allowedHeaders
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	if typedInput.AllowedMethods != nil {
 		allowedMethods := *typedInput.AllowedMethods
 		policy.AllowedMethods = &allowedMethods
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	if typedInput.AllowedOrigins != nil {
 		allowedOrigins := *typedInput.AllowedOrigins
 		policy.AllowedOrigins = &allowedOrigins
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	if typedInput.ExposedHeaders != nil {
 		exposedHeaders := *typedInput.ExposedHeaders
 		policy.ExposedHeaders = &exposedHeaders
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if typedInput.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *typedInput.MaxAgeInSeconds
 		policy.MaxAgeInSeconds = &maxAgeInSeconds
@@ -3873,31 +3873,31 @@ func (policy *CorsPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	if typedInput.AllowedHeaders != nil {
 		allowedHeaders := *typedInput.AllowedHeaders
 		policy.AllowedHeaders = &allowedHeaders
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	if typedInput.AllowedMethods != nil {
 		allowedMethods := *typedInput.AllowedMethods
 		policy.AllowedMethods = &allowedMethods
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	if typedInput.AllowedOrigins != nil {
 		allowedOrigins := *typedInput.AllowedOrigins
 		policy.AllowedOrigins = &allowedOrigins
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	if typedInput.ExposedHeaders != nil {
 		exposedHeaders := *typedInput.ExposedHeaders
 		policy.ExposedHeaders = &exposedHeaders
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if typedInput.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *typedInput.MaxAgeInSeconds
 		policy.MaxAgeInSeconds = &maxAgeInSeconds
@@ -4045,19 +4045,19 @@ func (policy *FailoverPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FailoverPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FailoverPriority’:
+	// Set property "FailoverPriority":
 	if typedInput.FailoverPriority != nil {
 		failoverPriority := *typedInput.FailoverPriority
 		policy.FailoverPriority = &failoverPriority
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		policy.Id = &id
 	}
 
-	// Set property ‘LocationName’:
+	// Set property "LocationName":
 	if typedInput.LocationName != nil {
 		locationName := *typedInput.LocationName
 		policy.LocationName = &locationName
@@ -4122,7 +4122,7 @@ func (orRange *IpAddressOrRange) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &IpAddressOrRange_ARM{}
 
-	// Set property ‘IpAddressOrRange’:
+	// Set property "IpAddressOrRange":
 	if orRange.IpAddressOrRange != nil {
 		ipAddressOrRange := *orRange.IpAddressOrRange
 		result.IpAddressOrRange = &ipAddressOrRange
@@ -4142,7 +4142,7 @@ func (orRange *IpAddressOrRange) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpAddressOrRange_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpAddressOrRange’:
+	// Set property "IpAddressOrRange":
 	if typedInput.IpAddressOrRange != nil {
 		ipAddressOrRange := *typedInput.IpAddressOrRange
 		orRange.IpAddressOrRange = &ipAddressOrRange
@@ -4200,7 +4200,7 @@ func (orRange *IpAddressOrRange_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpAddressOrRange_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpAddressOrRange’:
+	// Set property "IpAddressOrRange":
 	if typedInput.IpAddressOrRange != nil {
 		ipAddressOrRange := *typedInput.IpAddressOrRange
 		orRange.IpAddressOrRange = &ipAddressOrRange
@@ -4256,19 +4256,19 @@ func (location *Location) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Location_ARM{}
 
-	// Set property ‘FailoverPriority’:
+	// Set property "FailoverPriority":
 	if location.FailoverPriority != nil {
 		failoverPriority := *location.FailoverPriority
 		result.FailoverPriority = &failoverPriority
 	}
 
-	// Set property ‘IsZoneRedundant’:
+	// Set property "IsZoneRedundant":
 	if location.IsZoneRedundant != nil {
 		isZoneRedundant := *location.IsZoneRedundant
 		result.IsZoneRedundant = &isZoneRedundant
 	}
 
-	// Set property ‘LocationName’:
+	// Set property "LocationName":
 	if location.LocationName != nil {
 		locationName := *location.LocationName
 		result.LocationName = &locationName
@@ -4288,19 +4288,19 @@ func (location *Location) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Location_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FailoverPriority’:
+	// Set property "FailoverPriority":
 	if typedInput.FailoverPriority != nil {
 		failoverPriority := *typedInput.FailoverPriority
 		location.FailoverPriority = &failoverPriority
 	}
 
-	// Set property ‘IsZoneRedundant’:
+	// Set property "IsZoneRedundant":
 	if typedInput.IsZoneRedundant != nil {
 		isZoneRedundant := *typedInput.IsZoneRedundant
 		location.IsZoneRedundant = &isZoneRedundant
 	}
 
-	// Set property ‘LocationName’:
+	// Set property "LocationName":
 	if typedInput.LocationName != nil {
 		locationName := *typedInput.LocationName
 		location.LocationName = &locationName
@@ -4395,37 +4395,37 @@ func (location *Location_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Location_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DocumentEndpoint’:
+	// Set property "DocumentEndpoint":
 	if typedInput.DocumentEndpoint != nil {
 		documentEndpoint := *typedInput.DocumentEndpoint
 		location.DocumentEndpoint = &documentEndpoint
 	}
 
-	// Set property ‘FailoverPriority’:
+	// Set property "FailoverPriority":
 	if typedInput.FailoverPriority != nil {
 		failoverPriority := *typedInput.FailoverPriority
 		location.FailoverPriority = &failoverPriority
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		location.Id = &id
 	}
 
-	// Set property ‘IsZoneRedundant’:
+	// Set property "IsZoneRedundant":
 	if typedInput.IsZoneRedundant != nil {
 		isZoneRedundant := *typedInput.IsZoneRedundant
 		location.IsZoneRedundant = &isZoneRedundant
 	}
 
-	// Set property ‘LocationName’:
+	// Set property "LocationName":
 	if typedInput.LocationName != nil {
 		locationName := *typedInput.LocationName
 		location.LocationName = &locationName
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		location.ProvisioningState = &provisioningState
@@ -4519,13 +4519,13 @@ func (identity *ManagedServiceIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ManagedServiceIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -4550,13 +4550,13 @@ func (identity *ManagedServiceIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedServiceIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -4659,25 +4659,25 @@ func (identity *ManagedServiceIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedServiceIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]ManagedServiceIdentity_UserAssignedIdentities_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -4817,7 +4817,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -4888,7 +4888,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &VirtualNetworkRule_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if rule.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.Reference)
 		if err != nil {
@@ -4898,7 +4898,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.Id = &reference
 	}
 
-	// Set property ‘IgnoreMissingVNetServiceEndpoint’:
+	// Set property "IgnoreMissingVNetServiceEndpoint":
 	if rule.IgnoreMissingVNetServiceEndpoint != nil {
 		ignoreMissingVNetServiceEndpoint := *rule.IgnoreMissingVNetServiceEndpoint
 		result.IgnoreMissingVNetServiceEndpoint = &ignoreMissingVNetServiceEndpoint
@@ -4918,13 +4918,13 @@ func (rule *VirtualNetworkRule) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IgnoreMissingVNetServiceEndpoint’:
+	// Set property "IgnoreMissingVNetServiceEndpoint":
 	if typedInput.IgnoreMissingVNetServiceEndpoint != nil {
 		ignoreMissingVNetServiceEndpoint := *typedInput.IgnoreMissingVNetServiceEndpoint
 		rule.IgnoreMissingVNetServiceEndpoint = &ignoreMissingVNetServiceEndpoint
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -5005,13 +5005,13 @@ func (rule *VirtualNetworkRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘IgnoreMissingVNetServiceEndpoint’:
+	// Set property "IgnoreMissingVNetServiceEndpoint":
 	if typedInput.IgnoreMissingVNetServiceEndpoint != nil {
 		ignoreMissingVNetServiceEndpoint := *typedInput.IgnoreMissingVNetServiceEndpoint
 		rule.IgnoreMissingVNetServiceEndpoint = &ignoreMissingVNetServiceEndpoint
@@ -5142,7 +5142,7 @@ func (policy *ContinuousModeBackupPolicy) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &ContinuousModeBackupPolicy_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if policy.Type != nil {
 		result.Type = *policy.Type
 	}
@@ -5161,7 +5161,7 @@ func (policy *ContinuousModeBackupPolicy) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContinuousModeBackupPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	policy.Type = &typedInput.Type
 
 	// No error
@@ -5226,7 +5226,7 @@ func (policy *ContinuousModeBackupPolicy_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContinuousModeBackupPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	policy.Type = &typedInput.Type
 
 	// No error
@@ -5417,13 +5417,13 @@ func (identities *ManagedServiceIdentity_UserAssignedIdentities_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedServiceIdentity_UserAssignedIdentities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identities.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identities.PrincipalId = &principalId
@@ -5485,7 +5485,7 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &PeriodicModeBackupPolicy_ARM{}
 
-	// Set property ‘PeriodicModeProperties’:
+	// Set property "PeriodicModeProperties":
 	if policy.PeriodicModeProperties != nil {
 		periodicModeProperties_ARM, err := (*policy.PeriodicModeProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -5495,7 +5495,7 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 		result.PeriodicModeProperties = &periodicModeProperties
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if policy.Type != nil {
 		result.Type = *policy.Type
 	}
@@ -5514,7 +5514,7 @@ func (policy *PeriodicModeBackupPolicy) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PeriodicModeBackupPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PeriodicModeProperties’:
+	// Set property "PeriodicModeProperties":
 	if typedInput.PeriodicModeProperties != nil {
 		var periodicModeProperties1 PeriodicModeProperties
 		err := periodicModeProperties1.PopulateFromARM(owner, *typedInput.PeriodicModeProperties)
@@ -5525,7 +5525,7 @@ func (policy *PeriodicModeBackupPolicy) PopulateFromARM(owner genruntime.Arbitra
 		policy.PeriodicModeProperties = &periodicModeProperties
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	policy.Type = &typedInput.Type
 
 	// No error
@@ -5615,7 +5615,7 @@ func (policy *PeriodicModeBackupPolicy_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PeriodicModeBackupPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PeriodicModeProperties’:
+	// Set property "PeriodicModeProperties":
 	if typedInput.PeriodicModeProperties != nil {
 		var periodicModeProperties1 PeriodicModeProperties_STATUS
 		err := periodicModeProperties1.PopulateFromARM(owner, *typedInput.PeriodicModeProperties)
@@ -5626,7 +5626,7 @@ func (policy *PeriodicModeBackupPolicy_STATUS) PopulateFromARM(owner genruntime.
 		policy.PeriodicModeProperties = &periodicModeProperties
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	policy.Type = &typedInput.Type
 
 	// No error
@@ -5772,13 +5772,13 @@ func (properties *PeriodicModeProperties) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &PeriodicModeProperties_ARM{}
 
-	// Set property ‘BackupIntervalInMinutes’:
+	// Set property "BackupIntervalInMinutes":
 	if properties.BackupIntervalInMinutes != nil {
 		backupIntervalInMinutes := *properties.BackupIntervalInMinutes
 		result.BackupIntervalInMinutes = &backupIntervalInMinutes
 	}
 
-	// Set property ‘BackupRetentionIntervalInHours’:
+	// Set property "BackupRetentionIntervalInHours":
 	if properties.BackupRetentionIntervalInHours != nil {
 		backupRetentionIntervalInHours := *properties.BackupRetentionIntervalInHours
 		result.BackupRetentionIntervalInHours = &backupRetentionIntervalInHours
@@ -5798,13 +5798,13 @@ func (properties *PeriodicModeProperties) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PeriodicModeProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupIntervalInMinutes’:
+	// Set property "BackupIntervalInMinutes":
 	if typedInput.BackupIntervalInMinutes != nil {
 		backupIntervalInMinutes := *typedInput.BackupIntervalInMinutes
 		properties.BackupIntervalInMinutes = &backupIntervalInMinutes
 	}
 
-	// Set property ‘BackupRetentionIntervalInHours’:
+	// Set property "BackupRetentionIntervalInHours":
 	if typedInput.BackupRetentionIntervalInHours != nil {
 		backupRetentionIntervalInHours := *typedInput.BackupRetentionIntervalInHours
 		properties.BackupRetentionIntervalInHours = &backupRetentionIntervalInHours
@@ -5889,13 +5889,13 @@ func (properties *PeriodicModeProperties_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PeriodicModeProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackupIntervalInMinutes’:
+	// Set property "BackupIntervalInMinutes":
 	if typedInput.BackupIntervalInMinutes != nil {
 		backupIntervalInMinutes := *typedInput.BackupIntervalInMinutes
 		properties.BackupIntervalInMinutes = &backupIntervalInMinutes
 	}
 
-	// Set property ‘BackupRetentionIntervalInHours’:
+	// Set property "BackupRetentionIntervalInHours":
 	if typedInput.BackupRetentionIntervalInHours != nil {
 		backupRetentionIntervalInHours := *typedInput.BackupRetentionIntervalInHours
 		properties.BackupRetentionIntervalInHours = &backupRetentionIntervalInHours

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_collection_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_collection_throughput_setting_types_gen.go
@@ -325,16 +325,16 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 	}
 	result := &DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if setting.Location != nil {
 		location := *setting.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if setting.Resource != nil {
 		result.Properties = &ThroughputSettingsUpdateProperties_ARM{}
 	}
@@ -347,7 +347,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if setting.Tags != nil {
 		result.Tags = make(map[string]string, len(setting.Tags))
 		for key, value := range setting.Tags {
@@ -369,16 +369,16 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -392,7 +392,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -613,27 +613,27 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		setting.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		setting.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -647,7 +647,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -655,7 +655,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar
@@ -773,7 +773,7 @@ func (resource *ThroughputSettingsGetProperties_Resource_STATUS) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ThroughputSettingsGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoscaleSettings’:
+	// Set property "AutoscaleSettings":
 	if typedInput.AutoscaleSettings != nil {
 		var autoscaleSettings1 AutoscaleSettingsResource_STATUS
 		err := autoscaleSettings1.PopulateFromARM(owner, *typedInput.AutoscaleSettings)
@@ -784,37 +784,37 @@ func (resource *ThroughputSettingsGetProperties_Resource_STATUS) PopulateFromARM
 		resource.AutoscaleSettings = &autoscaleSettings
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘MinimumThroughput’:
+	// Set property "MinimumThroughput":
 	if typedInput.MinimumThroughput != nil {
 		minimumThroughput := *typedInput.MinimumThroughput
 		resource.MinimumThroughput = &minimumThroughput
 	}
 
-	// Set property ‘OfferReplacePending’:
+	// Set property "OfferReplacePending":
 	if typedInput.OfferReplacePending != nil {
 		offerReplacePending := *typedInput.OfferReplacePending
 		resource.OfferReplacePending = &offerReplacePending
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘Throughput’:
+	// Set property "Throughput":
 	if typedInput.Throughput != nil {
 		throughput := *typedInput.Throughput
 		resource.Throughput = &throughput
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
@@ -932,7 +932,7 @@ func (resource *ThroughputSettingsResource) ConvertToARM(resolved genruntime.Con
 	}
 	result := &ThroughputSettingsResource_ARM{}
 
-	// Set property ‘AutoscaleSettings’:
+	// Set property "AutoscaleSettings":
 	if resource.AutoscaleSettings != nil {
 		autoscaleSettings_ARM, err := (*resource.AutoscaleSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -942,7 +942,7 @@ func (resource *ThroughputSettingsResource) ConvertToARM(resolved genruntime.Con
 		result.AutoscaleSettings = &autoscaleSettings
 	}
 
-	// Set property ‘Throughput’:
+	// Set property "Throughput":
 	if resource.Throughput != nil {
 		throughput := *resource.Throughput
 		result.Throughput = &throughput
@@ -962,7 +962,7 @@ func (resource *ThroughputSettingsResource) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ThroughputSettingsResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoscaleSettings’:
+	// Set property "AutoscaleSettings":
 	if typedInput.AutoscaleSettings != nil {
 		var autoscaleSettings1 AutoscaleSettingsResource
 		err := autoscaleSettings1.PopulateFromARM(owner, *typedInput.AutoscaleSettings)
@@ -973,7 +973,7 @@ func (resource *ThroughputSettingsResource) PopulateFromARM(owner genruntime.Arb
 		resource.AutoscaleSettings = &autoscaleSettings
 	}
 
-	// Set property ‘Throughput’:
+	// Set property "Throughput":
 	if typedInput.Throughput != nil {
 		throughput := *typedInput.Throughput
 		resource.Throughput = &throughput
@@ -1053,7 +1053,7 @@ func (resource *AutoscaleSettingsResource) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &AutoscaleSettingsResource_ARM{}
 
-	// Set property ‘AutoUpgradePolicy’:
+	// Set property "AutoUpgradePolicy":
 	if resource.AutoUpgradePolicy != nil {
 		autoUpgradePolicy_ARM, err := (*resource.AutoUpgradePolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -1063,7 +1063,7 @@ func (resource *AutoscaleSettingsResource) ConvertToARM(resolved genruntime.Conv
 		result.AutoUpgradePolicy = &autoUpgradePolicy
 	}
 
-	// Set property ‘MaxThroughput’:
+	// Set property "MaxThroughput":
 	if resource.MaxThroughput != nil {
 		maxThroughput := *resource.MaxThroughput
 		result.MaxThroughput = &maxThroughput
@@ -1083,7 +1083,7 @@ func (resource *AutoscaleSettingsResource) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoscaleSettingsResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradePolicy’:
+	// Set property "AutoUpgradePolicy":
 	if typedInput.AutoUpgradePolicy != nil {
 		var autoUpgradePolicy1 AutoUpgradePolicyResource
 		err := autoUpgradePolicy1.PopulateFromARM(owner, *typedInput.AutoUpgradePolicy)
@@ -1094,7 +1094,7 @@ func (resource *AutoscaleSettingsResource) PopulateFromARM(owner genruntime.Arbi
 		resource.AutoUpgradePolicy = &autoUpgradePolicy
 	}
 
-	// Set property ‘MaxThroughput’:
+	// Set property "MaxThroughput":
 	if typedInput.MaxThroughput != nil {
 		maxThroughput := *typedInput.MaxThroughput
 		resource.MaxThroughput = &maxThroughput
@@ -1178,7 +1178,7 @@ func (resource *AutoscaleSettingsResource_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoscaleSettingsResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoUpgradePolicy’:
+	// Set property "AutoUpgradePolicy":
 	if typedInput.AutoUpgradePolicy != nil {
 		var autoUpgradePolicy1 AutoUpgradePolicyResource_STATUS
 		err := autoUpgradePolicy1.PopulateFromARM(owner, *typedInput.AutoUpgradePolicy)
@@ -1189,13 +1189,13 @@ func (resource *AutoscaleSettingsResource_STATUS) PopulateFromARM(owner genrunti
 		resource.AutoUpgradePolicy = &autoUpgradePolicy
 	}
 
-	// Set property ‘MaxThroughput’:
+	// Set property "MaxThroughput":
 	if typedInput.MaxThroughput != nil {
 		maxThroughput := *typedInput.MaxThroughput
 		resource.MaxThroughput = &maxThroughput
 	}
 
-	// Set property ‘TargetMaxThroughput’:
+	// Set property "TargetMaxThroughput":
 	if typedInput.TargetMaxThroughput != nil {
 		targetMaxThroughput := *typedInput.TargetMaxThroughput
 		resource.TargetMaxThroughput = &targetMaxThroughput
@@ -1278,7 +1278,7 @@ func (resource *AutoUpgradePolicyResource) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &AutoUpgradePolicyResource_ARM{}
 
-	// Set property ‘ThroughputPolicy’:
+	// Set property "ThroughputPolicy":
 	if resource.ThroughputPolicy != nil {
 		throughputPolicy_ARM, err := (*resource.ThroughputPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -1302,7 +1302,7 @@ func (resource *AutoUpgradePolicyResource) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoUpgradePolicyResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ThroughputPolicy’:
+	// Set property "ThroughputPolicy":
 	if typedInput.ThroughputPolicy != nil {
 		var throughputPolicy1 ThroughputPolicyResource
 		err := throughputPolicy1.PopulateFromARM(owner, *typedInput.ThroughputPolicy)
@@ -1383,7 +1383,7 @@ func (resource *AutoUpgradePolicyResource_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoUpgradePolicyResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ThroughputPolicy’:
+	// Set property "ThroughputPolicy":
 	if typedInput.ThroughputPolicy != nil {
 		var throughputPolicy1 ThroughputPolicyResource_STATUS
 		err := throughputPolicy1.PopulateFromARM(owner, *typedInput.ThroughputPolicy)
@@ -1460,13 +1460,13 @@ func (resource *ThroughputPolicyResource) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &ThroughputPolicyResource_ARM{}
 
-	// Set property ‘IncrementPercent’:
+	// Set property "IncrementPercent":
 	if resource.IncrementPercent != nil {
 		incrementPercent := *resource.IncrementPercent
 		result.IncrementPercent = &incrementPercent
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if resource.IsEnabled != nil {
 		isEnabled := *resource.IsEnabled
 		result.IsEnabled = &isEnabled
@@ -1486,13 +1486,13 @@ func (resource *ThroughputPolicyResource) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ThroughputPolicyResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IncrementPercent’:
+	// Set property "IncrementPercent":
 	if typedInput.IncrementPercent != nil {
 		incrementPercent := *typedInput.IncrementPercent
 		resource.IncrementPercent = &incrementPercent
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if typedInput.IsEnabled != nil {
 		isEnabled := *typedInput.IsEnabled
 		resource.IsEnabled = &isEnabled
@@ -1567,13 +1567,13 @@ func (resource *ThroughputPolicyResource_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ThroughputPolicyResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IncrementPercent’:
+	// Set property "IncrementPercent":
 	if typedInput.IncrementPercent != nil {
 		incrementPercent := *typedInput.IncrementPercent
 		resource.IncrementPercent = &incrementPercent
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if typedInput.IsEnabled != nil {
 		isEnabled := *typedInput.IsEnabled
 		resource.IsEnabled = &isEnabled

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_collection_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_collection_types_gen.go
@@ -336,16 +336,16 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_Spec) ConvertToAR
 	}
 	result := &DatabaseAccounts_MongodbDatabases_Collection_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if collection.Location != nil {
 		location := *collection.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if collection.Options != nil || collection.Resource != nil {
 		result.Properties = &MongoDBCollectionCreateUpdateProperties_ARM{}
 	}
@@ -366,7 +366,7 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_Spec) ConvertToAR
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if collection.Tags != nil {
 		result.Tags = make(map[string]string, len(collection.Tags))
 		for key, value := range collection.Tags {
@@ -388,16 +388,16 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_Spec) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabases_Collection_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	collection.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		collection.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -411,10 +411,10 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_Spec) PopulateFro
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	collection.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -428,7 +428,7 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_Spec) PopulateFro
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		collection.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -685,27 +685,27 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_STATUS) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabases_Collection_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		collection.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		collection.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		collection.Name = &name
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -719,7 +719,7 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_STATUS) PopulateF
 		}
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -733,7 +733,7 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_STATUS) PopulateF
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		collection.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -741,7 +741,7 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_STATUS) PopulateF
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		collection.Type = &typeVar
@@ -883,25 +883,25 @@ func (resource *MongoDBCollectionGetProperties_Resource_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoDBCollectionGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AnalyticalStorageTtl’:
+	// Set property "AnalyticalStorageTtl":
 	if typedInput.AnalyticalStorageTtl != nil {
 		analyticalStorageTtl := *typedInput.AnalyticalStorageTtl
 		resource.AnalyticalStorageTtl = &analyticalStorageTtl
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Indexes’:
+	// Set property "Indexes":
 	for _, item := range typedInput.Indexes {
 		var item1 MongoIndex_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -911,13 +911,13 @@ func (resource *MongoDBCollectionGetProperties_Resource_STATUS) PopulateFromARM(
 		resource.Indexes = append(resource.Indexes, item1)
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘ShardKey’:
+	// Set property "ShardKey":
 	if typedInput.ShardKey != nil {
 		resource.ShardKey = make(map[string]string, len(typedInput.ShardKey))
 		for key, value := range typedInput.ShardKey {
@@ -925,7 +925,7 @@ func (resource *MongoDBCollectionGetProperties_Resource_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
@@ -1059,19 +1059,19 @@ func (resource *MongoDBCollectionResource) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &MongoDBCollectionResource_ARM{}
 
-	// Set property ‘AnalyticalStorageTtl’:
+	// Set property "AnalyticalStorageTtl":
 	if resource.AnalyticalStorageTtl != nil {
 		analyticalStorageTtl := *resource.AnalyticalStorageTtl
 		result.AnalyticalStorageTtl = &analyticalStorageTtl
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
 	}
 
-	// Set property ‘Indexes’:
+	// Set property "Indexes":
 	for _, item := range resource.Indexes {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1080,7 +1080,7 @@ func (resource *MongoDBCollectionResource) ConvertToARM(resolved genruntime.Conv
 		result.Indexes = append(result.Indexes, *item_ARM.(*MongoIndex_ARM))
 	}
 
-	// Set property ‘ShardKey’:
+	// Set property "ShardKey":
 	if resource.ShardKey != nil {
 		result.ShardKey = make(map[string]string, len(resource.ShardKey))
 		for key, value := range resource.ShardKey {
@@ -1102,19 +1102,19 @@ func (resource *MongoDBCollectionResource) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoDBCollectionResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AnalyticalStorageTtl’:
+	// Set property "AnalyticalStorageTtl":
 	if typedInput.AnalyticalStorageTtl != nil {
 		analyticalStorageTtl := *typedInput.AnalyticalStorageTtl
 		resource.AnalyticalStorageTtl = &analyticalStorageTtl
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Indexes’:
+	// Set property "Indexes":
 	for _, item := range typedInput.Indexes {
 		var item1 MongoIndex
 		err := item1.PopulateFromARM(owner, item)
@@ -1124,7 +1124,7 @@ func (resource *MongoDBCollectionResource) PopulateFromARM(owner genruntime.Arbi
 		resource.Indexes = append(resource.Indexes, item1)
 	}
 
-	// Set property ‘ShardKey’:
+	// Set property "ShardKey":
 	if typedInput.ShardKey != nil {
 		resource.ShardKey = make(map[string]string, len(typedInput.ShardKey))
 		for key, value := range typedInput.ShardKey {
@@ -1228,7 +1228,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &MongoIndex_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if index.Key != nil {
 		key_ARM, err := (*index.Key).ConvertToARM(resolved)
 		if err != nil {
@@ -1238,7 +1238,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Key = &key
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	if index.Options != nil {
 		options_ARM, err := (*index.Options).ConvertToARM(resolved)
 		if err != nil {
@@ -1262,7 +1262,7 @@ func (index *MongoIndex) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoIndex_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		var key1 MongoIndexKeys
 		err := key1.PopulateFromARM(owner, *typedInput.Key)
@@ -1273,7 +1273,7 @@ func (index *MongoIndex) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		index.Key = &key
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	if typedInput.Options != nil {
 		var options1 MongoIndexOptions
 		err := options1.PopulateFromARM(owner, *typedInput.Options)
@@ -1379,7 +1379,7 @@ func (index *MongoIndex_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoIndex_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		var key1 MongoIndexKeys_STATUS
 		err := key1.PopulateFromARM(owner, *typedInput.Key)
@@ -1390,7 +1390,7 @@ func (index *MongoIndex_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		index.Key = &key
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	if typedInput.Options != nil {
 		var options1 MongoIndexOptions_STATUS
 		err := options1.PopulateFromARM(owner, *typedInput.Options)
@@ -1490,7 +1490,7 @@ func (keys *MongoIndexKeys) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &MongoIndexKeys_ARM{}
 
-	// Set property ‘Keys’:
+	// Set property "Keys":
 	for _, item := range keys.Keys {
 		result.Keys = append(result.Keys, item)
 	}
@@ -1509,7 +1509,7 @@ func (keys *MongoIndexKeys) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoIndexKeys_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Keys’:
+	// Set property "Keys":
 	for _, item := range typedInput.Keys {
 		keys.Keys = append(keys.Keys, item)
 	}
@@ -1566,7 +1566,7 @@ func (keys *MongoIndexKeys_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoIndexKeys_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Keys’:
+	// Set property "Keys":
 	for _, item := range typedInput.Keys {
 		keys.Keys = append(keys.Keys, item)
 	}
@@ -1619,13 +1619,13 @@ func (options *MongoIndexOptions) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &MongoIndexOptions_ARM{}
 
-	// Set property ‘ExpireAfterSeconds’:
+	// Set property "ExpireAfterSeconds":
 	if options.ExpireAfterSeconds != nil {
 		expireAfterSeconds := *options.ExpireAfterSeconds
 		result.ExpireAfterSeconds = &expireAfterSeconds
 	}
 
-	// Set property ‘Unique’:
+	// Set property "Unique":
 	if options.Unique != nil {
 		unique := *options.Unique
 		result.Unique = &unique
@@ -1645,13 +1645,13 @@ func (options *MongoIndexOptions) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoIndexOptions_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpireAfterSeconds’:
+	// Set property "ExpireAfterSeconds":
 	if typedInput.ExpireAfterSeconds != nil {
 		expireAfterSeconds := *typedInput.ExpireAfterSeconds
 		options.ExpireAfterSeconds = &expireAfterSeconds
 	}
 
-	// Set property ‘Unique’:
+	// Set property "Unique":
 	if typedInput.Unique != nil {
 		unique := *typedInput.Unique
 		options.Unique = &unique
@@ -1726,13 +1726,13 @@ func (options *MongoIndexOptions_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoIndexOptions_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpireAfterSeconds’:
+	// Set property "ExpireAfterSeconds":
 	if typedInput.ExpireAfterSeconds != nil {
 		expireAfterSeconds := *typedInput.ExpireAfterSeconds
 		options.ExpireAfterSeconds = &expireAfterSeconds
 	}
 
-	// Set property ‘Unique’:
+	// Set property "Unique":
 	if typedInput.Unique != nil {
 		unique := *typedInput.Unique
 		options.Unique = &unique

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_throughput_setting_types_gen.go
@@ -325,16 +325,16 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec) Convert
 	}
 	result := &DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if setting.Location != nil {
 		location := *setting.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if setting.Resource != nil {
 		result.Properties = &ThroughputSettingsUpdateProperties_ARM{}
 	}
@@ -347,7 +347,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec) Convert
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if setting.Tags != nil {
 		result.Tags = make(map[string]string, len(setting.Tags))
 		for key, value := range setting.Tags {
@@ -369,16 +369,16 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -392,7 +392,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec) Populat
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -613,27 +613,27 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_STATUS) Popul
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabases_ThroughputSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		setting.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		setting.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -647,7 +647,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_STATUS) Popul
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -655,7 +655,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_STATUS) Popul
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_types_gen.go
@@ -336,16 +336,16 @@ func (database *DatabaseAccounts_MongodbDatabase_Spec) ConvertToARM(resolved gen
 	}
 	result := &DatabaseAccounts_MongodbDatabase_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if database.Location != nil {
 		location := *database.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.Options != nil || database.Resource != nil {
 		result.Properties = &MongoDBDatabaseCreateUpdateProperties_ARM{}
 	}
@@ -366,7 +366,7 @@ func (database *DatabaseAccounts_MongodbDatabase_Spec) ConvertToARM(resolved gen
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if database.Tags != nil {
 		result.Tags = make(map[string]string, len(database.Tags))
 		for key, value := range database.Tags {
@@ -388,16 +388,16 @@ func (database *DatabaseAccounts_MongodbDatabase_Spec) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabase_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		database.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -411,10 +411,10 @@ func (database *DatabaseAccounts_MongodbDatabase_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -428,7 +428,7 @@ func (database *DatabaseAccounts_MongodbDatabase_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		database.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -685,27 +685,27 @@ func (database *DatabaseAccounts_MongodbDatabase_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_MongodbDatabase_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		database.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -719,7 +719,7 @@ func (database *DatabaseAccounts_MongodbDatabase_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -733,7 +733,7 @@ func (database *DatabaseAccounts_MongodbDatabase_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		database.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -741,7 +741,7 @@ func (database *DatabaseAccounts_MongodbDatabase_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar
@@ -873,7 +873,7 @@ func (options *CreateUpdateOptions) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &CreateUpdateOptions_ARM{}
 
-	// Set property ‘AutoscaleSettings’:
+	// Set property "AutoscaleSettings":
 	if options.AutoscaleSettings != nil {
 		autoscaleSettings_ARM, err := (*options.AutoscaleSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -883,7 +883,7 @@ func (options *CreateUpdateOptions) ConvertToARM(resolved genruntime.ConvertToAR
 		result.AutoscaleSettings = &autoscaleSettings
 	}
 
-	// Set property ‘Throughput’:
+	// Set property "Throughput":
 	if options.Throughput != nil {
 		throughput := *options.Throughput
 		result.Throughput = &throughput
@@ -903,7 +903,7 @@ func (options *CreateUpdateOptions) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CreateUpdateOptions_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoscaleSettings’:
+	// Set property "AutoscaleSettings":
 	if typedInput.AutoscaleSettings != nil {
 		var autoscaleSettings1 AutoscaleSettings
 		err := autoscaleSettings1.PopulateFromARM(owner, *typedInput.AutoscaleSettings)
@@ -914,7 +914,7 @@ func (options *CreateUpdateOptions) PopulateFromARM(owner genruntime.ArbitraryOw
 		options.AutoscaleSettings = &autoscaleSettings
 	}
 
-	// Set property ‘Throughput’:
+	// Set property "Throughput":
 	if typedInput.Throughput != nil {
 		throughput := *typedInput.Throughput
 		options.Throughput = &throughput
@@ -999,25 +999,25 @@ func (resource *MongoDBDatabaseGetProperties_Resource_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoDBDatabaseGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
@@ -1099,7 +1099,7 @@ func (resource *MongoDBDatabaseResource) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &MongoDBDatabaseResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
@@ -1119,7 +1119,7 @@ func (resource *MongoDBDatabaseResource) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MongoDBDatabaseResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
@@ -1178,7 +1178,7 @@ func (resource *OptionsResource_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OptionsResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoscaleSettings’:
+	// Set property "AutoscaleSettings":
 	if typedInput.AutoscaleSettings != nil {
 		var autoscaleSettings1 AutoscaleSettings_STATUS
 		err := autoscaleSettings1.PopulateFromARM(owner, *typedInput.AutoscaleSettings)
@@ -1189,7 +1189,7 @@ func (resource *OptionsResource_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		resource.AutoscaleSettings = &autoscaleSettings
 	}
 
-	// Set property ‘Throughput’:
+	// Set property "Throughput":
 	if typedInput.Throughput != nil {
 		throughput := *typedInput.Throughput
 		resource.Throughput = &throughput
@@ -1266,7 +1266,7 @@ func (settings *AutoscaleSettings) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &AutoscaleSettings_ARM{}
 
-	// Set property ‘MaxThroughput’:
+	// Set property "MaxThroughput":
 	if settings.MaxThroughput != nil {
 		maxThroughput := *settings.MaxThroughput
 		result.MaxThroughput = &maxThroughput
@@ -1286,7 +1286,7 @@ func (settings *AutoscaleSettings) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoscaleSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxThroughput’:
+	// Set property "MaxThroughput":
 	if typedInput.MaxThroughput != nil {
 		maxThroughput := *typedInput.MaxThroughput
 		settings.MaxThroughput = &maxThroughput
@@ -1344,7 +1344,7 @@ func (settings *AutoscaleSettings_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoscaleSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxThroughput’:
+	// Set property "MaxThroughput":
 	if typedInput.MaxThroughput != nil {
 		maxThroughput := *typedInput.MaxThroughput
 		settings.MaxThroughput = &maxThroughput

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_stored_procedure_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_stored_procedure_types_gen.go
@@ -336,16 +336,16 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec) 
 	}
 	result := &DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if procedure.Location != nil {
 		location := *procedure.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if procedure.Options != nil || procedure.Resource != nil {
 		result.Properties = &SqlStoredProcedureCreateUpdateProperties_ARM{}
 	}
@@ -366,7 +366,7 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec) 
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if procedure.Tags != nil {
 		result.Tags = make(map[string]string, len(procedure.Tags))
 		for key, value := range procedure.Tags {
@@ -388,16 +388,16 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	procedure.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		procedure.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -411,10 +411,10 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec) 
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	procedure.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -428,7 +428,7 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec) 
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		procedure.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -684,27 +684,27 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_STATUS
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		procedure.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		procedure.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		procedure.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -718,7 +718,7 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_STATUS
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		procedure.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -726,7 +726,7 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_STATUS
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		procedure.Type = &typeVar
@@ -842,31 +842,31 @@ func (resource *SqlStoredProcedureGetProperties_Resource_STATUS) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlStoredProcedureGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if typedInput.Body != nil {
 		body := *typedInput.Body
 		resource.Body = &body
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
@@ -956,13 +956,13 @@ func (resource *SqlStoredProcedureResource) ConvertToARM(resolved genruntime.Con
 	}
 	result := &SqlStoredProcedureResource_ARM{}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if resource.Body != nil {
 		body := *resource.Body
 		result.Body = &body
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
@@ -982,13 +982,13 @@ func (resource *SqlStoredProcedureResource) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlStoredProcedureResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if typedInput.Body != nil {
 		body := *typedInput.Body
 		resource.Body = &body
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_throughput_setting_types_gen.go
@@ -325,16 +325,16 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec) 
 	}
 	result := &DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if setting.Location != nil {
 		location := *setting.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if setting.Resource != nil {
 		result.Properties = &ThroughputSettingsUpdateProperties_ARM{}
 	}
@@ -347,7 +347,7 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec) 
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if setting.Tags != nil {
 		result.Tags = make(map[string]string, len(setting.Tags))
 		for key, value := range setting.Tags {
@@ -369,16 +369,16 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -392,7 +392,7 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec) 
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -613,27 +613,27 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_STATUS
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		setting.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		setting.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -647,7 +647,7 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_STATUS
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -655,7 +655,7 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_STATUS
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_trigger_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_trigger_types_gen.go
@@ -336,16 +336,16 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec) ConvertToA
 	}
 	result := &DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if trigger.Location != nil {
 		location := *trigger.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if trigger.Options != nil || trigger.Resource != nil {
 		result.Properties = &SqlTriggerCreateUpdateProperties_ARM{}
 	}
@@ -366,7 +366,7 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec) ConvertToA
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if trigger.Tags != nil {
 		result.Tags = make(map[string]string, len(trigger.Tags))
 		for key, value := range trigger.Tags {
@@ -388,16 +388,16 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	trigger.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		trigger.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -411,10 +411,10 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec) PopulateFr
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	trigger.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -428,7 +428,7 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec) PopulateFr
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		trigger.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -684,27 +684,27 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_Trigger_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		trigger.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		trigger.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		trigger.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -718,7 +718,7 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		trigger.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -726,7 +726,7 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_STATUS) Populate
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		trigger.Type = &typeVar
@@ -844,43 +844,43 @@ func (resource *SqlTriggerGetProperties_Resource_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlTriggerGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if typedInput.Body != nil {
 		body := *typedInput.Body
 		resource.Body = &body
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘TriggerOperation’:
+	// Set property "TriggerOperation":
 	if typedInput.TriggerOperation != nil {
 		triggerOperation := *typedInput.TriggerOperation
 		resource.TriggerOperation = &triggerOperation
 	}
 
-	// Set property ‘TriggerType’:
+	// Set property "TriggerType":
 	if typedInput.TriggerType != nil {
 		triggerType := *typedInput.TriggerType
 		resource.TriggerType = &triggerType
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
@@ -1004,25 +1004,25 @@ func (resource *SqlTriggerResource) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &SqlTriggerResource_ARM{}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if resource.Body != nil {
 		body := *resource.Body
 		result.Body = &body
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
 	}
 
-	// Set property ‘TriggerOperation’:
+	// Set property "TriggerOperation":
 	if resource.TriggerOperation != nil {
 		triggerOperation := *resource.TriggerOperation
 		result.TriggerOperation = &triggerOperation
 	}
 
-	// Set property ‘TriggerType’:
+	// Set property "TriggerType":
 	if resource.TriggerType != nil {
 		triggerType := *resource.TriggerType
 		result.TriggerType = &triggerType
@@ -1042,25 +1042,25 @@ func (resource *SqlTriggerResource) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlTriggerResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if typedInput.Body != nil {
 		body := *typedInput.Body
 		resource.Body = &body
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘TriggerOperation’:
+	// Set property "TriggerOperation":
 	if typedInput.TriggerOperation != nil {
 		triggerOperation := *typedInput.TriggerOperation
 		resource.TriggerOperation = &triggerOperation
 	}
 
-	// Set property ‘TriggerType’:
+	// Set property "TriggerType":
 	if typedInput.TriggerType != nil {
 		triggerType := *typedInput.TriggerType
 		resource.TriggerType = &triggerType

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_types_gen.go
@@ -336,16 +336,16 @@ func (container *DatabaseAccounts_SqlDatabases_Container_Spec) ConvertToARM(reso
 	}
 	result := &DatabaseAccounts_SqlDatabases_Container_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if container.Location != nil {
 		location := *container.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if container.Options != nil || container.Resource != nil {
 		result.Properties = &SqlContainerCreateUpdateProperties_ARM{}
 	}
@@ -366,7 +366,7 @@ func (container *DatabaseAccounts_SqlDatabases_Container_Spec) ConvertToARM(reso
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if container.Tags != nil {
 		result.Tags = make(map[string]string, len(container.Tags))
 		for key, value := range container.Tags {
@@ -388,16 +388,16 @@ func (container *DatabaseAccounts_SqlDatabases_Container_Spec) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Container_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	container.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		container.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -411,10 +411,10 @@ func (container *DatabaseAccounts_SqlDatabases_Container_Spec) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	container.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -428,7 +428,7 @@ func (container *DatabaseAccounts_SqlDatabases_Container_Spec) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		container.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -685,27 +685,27 @@ func (container *DatabaseAccounts_SqlDatabases_Container_STATUS) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Container_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		container.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		container.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		container.Name = &name
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -719,7 +719,7 @@ func (container *DatabaseAccounts_SqlDatabases_Container_STATUS) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -733,7 +733,7 @@ func (container *DatabaseAccounts_SqlDatabases_Container_STATUS) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		container.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -741,7 +741,7 @@ func (container *DatabaseAccounts_SqlDatabases_Container_STATUS) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		container.Type = &typeVar
@@ -886,13 +886,13 @@ func (resource *SqlContainerGetProperties_Resource_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlContainerGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AnalyticalStorageTtl’:
+	// Set property "AnalyticalStorageTtl":
 	if typedInput.AnalyticalStorageTtl != nil {
 		analyticalStorageTtl := *typedInput.AnalyticalStorageTtl
 		resource.AnalyticalStorageTtl = &analyticalStorageTtl
 	}
 
-	// Set property ‘ConflictResolutionPolicy’:
+	// Set property "ConflictResolutionPolicy":
 	if typedInput.ConflictResolutionPolicy != nil {
 		var conflictResolutionPolicy1 ConflictResolutionPolicy_STATUS
 		err := conflictResolutionPolicy1.PopulateFromARM(owner, *typedInput.ConflictResolutionPolicy)
@@ -903,25 +903,25 @@ func (resource *SqlContainerGetProperties_Resource_STATUS) PopulateFromARM(owner
 		resource.ConflictResolutionPolicy = &conflictResolutionPolicy
 	}
 
-	// Set property ‘DefaultTtl’:
+	// Set property "DefaultTtl":
 	if typedInput.DefaultTtl != nil {
 		defaultTtl := *typedInput.DefaultTtl
 		resource.DefaultTtl = &defaultTtl
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘IndexingPolicy’:
+	// Set property "IndexingPolicy":
 	if typedInput.IndexingPolicy != nil {
 		var indexingPolicy1 IndexingPolicy_STATUS
 		err := indexingPolicy1.PopulateFromARM(owner, *typedInput.IndexingPolicy)
@@ -932,7 +932,7 @@ func (resource *SqlContainerGetProperties_Resource_STATUS) PopulateFromARM(owner
 		resource.IndexingPolicy = &indexingPolicy
 	}
 
-	// Set property ‘PartitionKey’:
+	// Set property "PartitionKey":
 	if typedInput.PartitionKey != nil {
 		var partitionKey1 ContainerPartitionKey_STATUS
 		err := partitionKey1.PopulateFromARM(owner, *typedInput.PartitionKey)
@@ -943,19 +943,19 @@ func (resource *SqlContainerGetProperties_Resource_STATUS) PopulateFromARM(owner
 		resource.PartitionKey = &partitionKey
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
 	}
 
-	// Set property ‘UniqueKeyPolicy’:
+	// Set property "UniqueKeyPolicy":
 	if typedInput.UniqueKeyPolicy != nil {
 		var uniqueKeyPolicy1 UniqueKeyPolicy_STATUS
 		err := uniqueKeyPolicy1.PopulateFromARM(owner, *typedInput.UniqueKeyPolicy)
@@ -1157,13 +1157,13 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &SqlContainerResource_ARM{}
 
-	// Set property ‘AnalyticalStorageTtl’:
+	// Set property "AnalyticalStorageTtl":
 	if resource.AnalyticalStorageTtl != nil {
 		analyticalStorageTtl := *resource.AnalyticalStorageTtl
 		result.AnalyticalStorageTtl = &analyticalStorageTtl
 	}
 
-	// Set property ‘ConflictResolutionPolicy’:
+	// Set property "ConflictResolutionPolicy":
 	if resource.ConflictResolutionPolicy != nil {
 		conflictResolutionPolicy_ARM, err := (*resource.ConflictResolutionPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -1173,19 +1173,19 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		result.ConflictResolutionPolicy = &conflictResolutionPolicy
 	}
 
-	// Set property ‘DefaultTtl’:
+	// Set property "DefaultTtl":
 	if resource.DefaultTtl != nil {
 		defaultTtl := *resource.DefaultTtl
 		result.DefaultTtl = &defaultTtl
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
 	}
 
-	// Set property ‘IndexingPolicy’:
+	// Set property "IndexingPolicy":
 	if resource.IndexingPolicy != nil {
 		indexingPolicy_ARM, err := (*resource.IndexingPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -1195,7 +1195,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		result.IndexingPolicy = &indexingPolicy
 	}
 
-	// Set property ‘PartitionKey’:
+	// Set property "PartitionKey":
 	if resource.PartitionKey != nil {
 		partitionKey_ARM, err := (*resource.PartitionKey).ConvertToARM(resolved)
 		if err != nil {
@@ -1205,7 +1205,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		result.PartitionKey = &partitionKey
 	}
 
-	// Set property ‘UniqueKeyPolicy’:
+	// Set property "UniqueKeyPolicy":
 	if resource.UniqueKeyPolicy != nil {
 		uniqueKeyPolicy_ARM, err := (*resource.UniqueKeyPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -1229,13 +1229,13 @@ func (resource *SqlContainerResource) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlContainerResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AnalyticalStorageTtl’:
+	// Set property "AnalyticalStorageTtl":
 	if typedInput.AnalyticalStorageTtl != nil {
 		analyticalStorageTtl := *typedInput.AnalyticalStorageTtl
 		resource.AnalyticalStorageTtl = &analyticalStorageTtl
 	}
 
-	// Set property ‘ConflictResolutionPolicy’:
+	// Set property "ConflictResolutionPolicy":
 	if typedInput.ConflictResolutionPolicy != nil {
 		var conflictResolutionPolicy1 ConflictResolutionPolicy
 		err := conflictResolutionPolicy1.PopulateFromARM(owner, *typedInput.ConflictResolutionPolicy)
@@ -1246,19 +1246,19 @@ func (resource *SqlContainerResource) PopulateFromARM(owner genruntime.Arbitrary
 		resource.ConflictResolutionPolicy = &conflictResolutionPolicy
 	}
 
-	// Set property ‘DefaultTtl’:
+	// Set property "DefaultTtl":
 	if typedInput.DefaultTtl != nil {
 		defaultTtl := *typedInput.DefaultTtl
 		resource.DefaultTtl = &defaultTtl
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘IndexingPolicy’:
+	// Set property "IndexingPolicy":
 	if typedInput.IndexingPolicy != nil {
 		var indexingPolicy1 IndexingPolicy
 		err := indexingPolicy1.PopulateFromARM(owner, *typedInput.IndexingPolicy)
@@ -1269,7 +1269,7 @@ func (resource *SqlContainerResource) PopulateFromARM(owner genruntime.Arbitrary
 		resource.IndexingPolicy = &indexingPolicy
 	}
 
-	// Set property ‘PartitionKey’:
+	// Set property "PartitionKey":
 	if typedInput.PartitionKey != nil {
 		var partitionKey1 ContainerPartitionKey
 		err := partitionKey1.PopulateFromARM(owner, *typedInput.PartitionKey)
@@ -1280,7 +1280,7 @@ func (resource *SqlContainerResource) PopulateFromARM(owner genruntime.Arbitrary
 		resource.PartitionKey = &partitionKey
 	}
 
-	// Set property ‘UniqueKeyPolicy’:
+	// Set property "UniqueKeyPolicy":
 	if typedInput.UniqueKeyPolicy != nil {
 		var uniqueKeyPolicy1 UniqueKeyPolicy
 		err := uniqueKeyPolicy1.PopulateFromARM(owner, *typedInput.UniqueKeyPolicy)
@@ -1448,19 +1448,19 @@ func (policy *ConflictResolutionPolicy) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ConflictResolutionPolicy_ARM{}
 
-	// Set property ‘ConflictResolutionPath’:
+	// Set property "ConflictResolutionPath":
 	if policy.ConflictResolutionPath != nil {
 		conflictResolutionPath := *policy.ConflictResolutionPath
 		result.ConflictResolutionPath = &conflictResolutionPath
 	}
 
-	// Set property ‘ConflictResolutionProcedure’:
+	// Set property "ConflictResolutionProcedure":
 	if policy.ConflictResolutionProcedure != nil {
 		conflictResolutionProcedure := *policy.ConflictResolutionProcedure
 		result.ConflictResolutionProcedure = &conflictResolutionProcedure
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if policy.Mode != nil {
 		mode := *policy.Mode
 		result.Mode = &mode
@@ -1480,19 +1480,19 @@ func (policy *ConflictResolutionPolicy) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConflictResolutionPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConflictResolutionPath’:
+	// Set property "ConflictResolutionPath":
 	if typedInput.ConflictResolutionPath != nil {
 		conflictResolutionPath := *typedInput.ConflictResolutionPath
 		policy.ConflictResolutionPath = &conflictResolutionPath
 	}
 
-	// Set property ‘ConflictResolutionProcedure’:
+	// Set property "ConflictResolutionProcedure":
 	if typedInput.ConflictResolutionProcedure != nil {
 		conflictResolutionProcedure := *typedInput.ConflictResolutionProcedure
 		policy.ConflictResolutionProcedure = &conflictResolutionProcedure
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		policy.Mode = &mode
@@ -1574,19 +1574,19 @@ func (policy *ConflictResolutionPolicy_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConflictResolutionPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConflictResolutionPath’:
+	// Set property "ConflictResolutionPath":
 	if typedInput.ConflictResolutionPath != nil {
 		conflictResolutionPath := *typedInput.ConflictResolutionPath
 		policy.ConflictResolutionPath = &conflictResolutionPath
 	}
 
-	// Set property ‘ConflictResolutionProcedure’:
+	// Set property "ConflictResolutionProcedure":
 	if typedInput.ConflictResolutionProcedure != nil {
 		conflictResolutionProcedure := *typedInput.ConflictResolutionProcedure
 		policy.ConflictResolutionProcedure = &conflictResolutionProcedure
 	}
 
-	// Set property ‘Mode’:
+	// Set property "Mode":
 	if typedInput.Mode != nil {
 		mode := *typedInput.Mode
 		policy.Mode = &mode
@@ -1666,18 +1666,18 @@ func (partitionKey *ContainerPartitionKey) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &ContainerPartitionKey_ARM{}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if partitionKey.Kind != nil {
 		kind := *partitionKey.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Paths’:
+	// Set property "Paths":
 	for _, item := range partitionKey.Paths {
 		result.Paths = append(result.Paths, item)
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if partitionKey.Version != nil {
 		version := *partitionKey.Version
 		result.Version = &version
@@ -1697,18 +1697,18 @@ func (partitionKey *ContainerPartitionKey) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerPartitionKey_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		partitionKey.Kind = &kind
 	}
 
-	// Set property ‘Paths’:
+	// Set property "Paths":
 	for _, item := range typedInput.Paths {
 		partitionKey.Paths = append(partitionKey.Paths, item)
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		partitionKey.Version = &version
@@ -1801,24 +1801,24 @@ func (partitionKey *ContainerPartitionKey_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ContainerPartitionKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		partitionKey.Kind = &kind
 	}
 
-	// Set property ‘Paths’:
+	// Set property "Paths":
 	for _, item := range typedInput.Paths {
 		partitionKey.Paths = append(partitionKey.Paths, item)
 	}
 
-	// Set property ‘SystemKey’:
+	// Set property "SystemKey":
 	if typedInput.SystemKey != nil {
 		systemKey := *typedInput.SystemKey
 		partitionKey.SystemKey = &systemKey
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		partitionKey.Version = &version
@@ -1914,13 +1914,13 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &IndexingPolicy_ARM{}
 
-	// Set property ‘Automatic’:
+	// Set property "Automatic":
 	if policy.Automatic != nil {
 		automatic := *policy.Automatic
 		result.Automatic = &automatic
 	}
 
-	// Set property ‘CompositeIndexes’:
+	// Set property "CompositeIndexes":
 	for _, item := range policy.CompositeIndexes {
 		var itemTemp []CompositePath_ARM
 		for _, item1 := range item {
@@ -1933,7 +1933,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.CompositeIndexes = append(result.CompositeIndexes, itemTemp)
 	}
 
-	// Set property ‘ExcludedPaths’:
+	// Set property "ExcludedPaths":
 	for _, item := range policy.ExcludedPaths {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1942,7 +1942,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.ExcludedPaths = append(result.ExcludedPaths, *item_ARM.(*ExcludedPath_ARM))
 	}
 
-	// Set property ‘IncludedPaths’:
+	// Set property "IncludedPaths":
 	for _, item := range policy.IncludedPaths {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1951,13 +1951,13 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.IncludedPaths = append(result.IncludedPaths, *item_ARM.(*IncludedPath_ARM))
 	}
 
-	// Set property ‘IndexingMode’:
+	// Set property "IndexingMode":
 	if policy.IndexingMode != nil {
 		indexingMode := *policy.IndexingMode
 		result.IndexingMode = &indexingMode
 	}
 
-	// Set property ‘SpatialIndexes’:
+	// Set property "SpatialIndexes":
 	for _, item := range policy.SpatialIndexes {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1980,13 +1980,13 @@ func (policy *IndexingPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IndexingPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Automatic’:
+	// Set property "Automatic":
 	if typedInput.Automatic != nil {
 		automatic := *typedInput.Automatic
 		policy.Automatic = &automatic
 	}
 
-	// Set property ‘CompositeIndexes’:
+	// Set property "CompositeIndexes":
 	for _, item := range typedInput.CompositeIndexes {
 		var itemTemp []CompositePath
 		for _, item1 := range item {
@@ -2000,7 +2000,7 @@ func (policy *IndexingPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		policy.CompositeIndexes = append(policy.CompositeIndexes, itemTemp)
 	}
 
-	// Set property ‘ExcludedPaths’:
+	// Set property "ExcludedPaths":
 	for _, item := range typedInput.ExcludedPaths {
 		var item1 ExcludedPath
 		err := item1.PopulateFromARM(owner, item)
@@ -2010,7 +2010,7 @@ func (policy *IndexingPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		policy.ExcludedPaths = append(policy.ExcludedPaths, item1)
 	}
 
-	// Set property ‘IncludedPaths’:
+	// Set property "IncludedPaths":
 	for _, item := range typedInput.IncludedPaths {
 		var item1 IncludedPath
 		err := item1.PopulateFromARM(owner, item)
@@ -2020,13 +2020,13 @@ func (policy *IndexingPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		policy.IncludedPaths = append(policy.IncludedPaths, item1)
 	}
 
-	// Set property ‘IndexingMode’:
+	// Set property "IndexingMode":
 	if typedInput.IndexingMode != nil {
 		indexingMode := *typedInput.IndexingMode
 		policy.IndexingMode = &indexingMode
 	}
 
-	// Set property ‘SpatialIndexes’:
+	// Set property "SpatialIndexes":
 	for _, item := range typedInput.SpatialIndexes {
 		var item1 SpatialSpec
 		err := item1.PopulateFromARM(owner, item)
@@ -2283,13 +2283,13 @@ func (policy *IndexingPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IndexingPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Automatic’:
+	// Set property "Automatic":
 	if typedInput.Automatic != nil {
 		automatic := *typedInput.Automatic
 		policy.Automatic = &automatic
 	}
 
-	// Set property ‘CompositeIndexes’:
+	// Set property "CompositeIndexes":
 	for _, item := range typedInput.CompositeIndexes {
 		var itemTemp []CompositePath_STATUS
 		for _, item1 := range item {
@@ -2303,7 +2303,7 @@ func (policy *IndexingPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		policy.CompositeIndexes = append(policy.CompositeIndexes, itemTemp)
 	}
 
-	// Set property ‘ExcludedPaths’:
+	// Set property "ExcludedPaths":
 	for _, item := range typedInput.ExcludedPaths {
 		var item1 ExcludedPath_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2313,7 +2313,7 @@ func (policy *IndexingPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		policy.ExcludedPaths = append(policy.ExcludedPaths, item1)
 	}
 
-	// Set property ‘IncludedPaths’:
+	// Set property "IncludedPaths":
 	for _, item := range typedInput.IncludedPaths {
 		var item1 IncludedPath_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2323,13 +2323,13 @@ func (policy *IndexingPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		policy.IncludedPaths = append(policy.IncludedPaths, item1)
 	}
 
-	// Set property ‘IndexingMode’:
+	// Set property "IndexingMode":
 	if typedInput.IndexingMode != nil {
 		indexingMode := *typedInput.IndexingMode
 		policy.IndexingMode = &indexingMode
 	}
 
-	// Set property ‘SpatialIndexes’:
+	// Set property "SpatialIndexes":
 	for _, item := range typedInput.SpatialIndexes {
 		var item1 SpatialSpec_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2576,7 +2576,7 @@ func (policy *UniqueKeyPolicy) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &UniqueKeyPolicy_ARM{}
 
-	// Set property ‘UniqueKeys’:
+	// Set property "UniqueKeys":
 	for _, item := range policy.UniqueKeys {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2599,7 +2599,7 @@ func (policy *UniqueKeyPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UniqueKeyPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UniqueKeys’:
+	// Set property "UniqueKeys":
 	for _, item := range typedInput.UniqueKeys {
 		var item1 UniqueKey
 		err := item1.PopulateFromARM(owner, item)
@@ -2691,7 +2691,7 @@ func (policy *UniqueKeyPolicy_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UniqueKeyPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UniqueKeys’:
+	// Set property "UniqueKeys":
 	for _, item := range typedInput.UniqueKeys {
 		var item1 UniqueKey_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2779,13 +2779,13 @@ func (path *CompositePath) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &CompositePath_ARM{}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if path.Order != nil {
 		order := *path.Order
 		result.Order = &order
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if path.Path != nil {
 		path1 := *path.Path
 		result.Path = &path1
@@ -2805,13 +2805,13 @@ func (path *CompositePath) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CompositePath_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if typedInput.Order != nil {
 		order := *typedInput.Order
 		path.Order = &order
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path1 := *typedInput.Path
 		path.Path = &path1
@@ -2886,13 +2886,13 @@ func (path *CompositePath_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CompositePath_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Order’:
+	// Set property "Order":
 	if typedInput.Order != nil {
 		order := *typedInput.Order
 		path.Order = &order
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path1 := *typedInput.Path
 		path.Path = &path1
@@ -2961,7 +2961,7 @@ func (path *ExcludedPath) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &ExcludedPath_ARM{}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if path.Path != nil {
 		path1 := *path.Path
 		result.Path = &path1
@@ -2981,7 +2981,7 @@ func (path *ExcludedPath) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExcludedPath_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path1 := *typedInput.Path
 		path.Path = &path1
@@ -3039,7 +3039,7 @@ func (path *ExcludedPath_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExcludedPath_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path1 := *typedInput.Path
 		path.Path = &path1
@@ -3093,7 +3093,7 @@ func (path *IncludedPath) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &IncludedPath_ARM{}
 
-	// Set property ‘Indexes’:
+	// Set property "Indexes":
 	for _, item := range path.Indexes {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3102,7 +3102,7 @@ func (path *IncludedPath) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Indexes = append(result.Indexes, *item_ARM.(*Indexes_ARM))
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if path.Path != nil {
 		path1 := *path.Path
 		result.Path = &path1
@@ -3122,7 +3122,7 @@ func (path *IncludedPath) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IncludedPath_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Indexes’:
+	// Set property "Indexes":
 	for _, item := range typedInput.Indexes {
 		var item1 Indexes
 		err := item1.PopulateFromARM(owner, item)
@@ -3132,7 +3132,7 @@ func (path *IncludedPath) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		path.Indexes = append(path.Indexes, item1)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path1 := *typedInput.Path
 		path.Path = &path1
@@ -3227,7 +3227,7 @@ func (path *IncludedPath_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IncludedPath_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Indexes’:
+	// Set property "Indexes":
 	for _, item := range typedInput.Indexes {
 		var item1 Indexes_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3237,7 +3237,7 @@ func (path *IncludedPath_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		path.Indexes = append(path.Indexes, item1)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path1 := *typedInput.Path
 		path.Path = &path1
@@ -3327,13 +3327,13 @@ func (spatial *SpatialSpec) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &SpatialSpec_ARM{}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if spatial.Path != nil {
 		path := *spatial.Path
 		result.Path = &path
 	}
 
-	// Set property ‘Types’:
+	// Set property "Types":
 	for _, item := range spatial.Types {
 		result.Types = append(result.Types, item)
 	}
@@ -3352,13 +3352,13 @@ func (spatial *SpatialSpec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SpatialSpec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		spatial.Path = &path
 	}
 
-	// Set property ‘Types’:
+	// Set property "Types":
 	for _, item := range typedInput.Types {
 		spatial.Types = append(spatial.Types, item)
 	}
@@ -3442,13 +3442,13 @@ func (spatial *SpatialSpec_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SpatialSpec_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		spatial.Path = &path
 	}
 
-	// Set property ‘Types’:
+	// Set property "Types":
 	for _, item := range typedInput.Types {
 		spatial.Types = append(spatial.Types, item)
 	}
@@ -3526,7 +3526,7 @@ func (uniqueKey *UniqueKey) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &UniqueKey_ARM{}
 
-	// Set property ‘Paths’:
+	// Set property "Paths":
 	for _, item := range uniqueKey.Paths {
 		result.Paths = append(result.Paths, item)
 	}
@@ -3545,7 +3545,7 @@ func (uniqueKey *UniqueKey) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UniqueKey_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Paths’:
+	// Set property "Paths":
 	for _, item := range typedInput.Paths {
 		uniqueKey.Paths = append(uniqueKey.Paths, item)
 	}
@@ -3602,7 +3602,7 @@ func (uniqueKey *UniqueKey_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UniqueKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Paths’:
+	// Set property "Paths":
 	for _, item := range typedInput.Paths {
 		uniqueKey.Paths = append(uniqueKey.Paths, item)
 	}
@@ -3656,19 +3656,19 @@ func (indexes *Indexes) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Indexes_ARM{}
 
-	// Set property ‘DataType’:
+	// Set property "DataType":
 	if indexes.DataType != nil {
 		dataType := *indexes.DataType
 		result.DataType = &dataType
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if indexes.Kind != nil {
 		kind := *indexes.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Precision’:
+	// Set property "Precision":
 	if indexes.Precision != nil {
 		precision := *indexes.Precision
 		result.Precision = &precision
@@ -3688,19 +3688,19 @@ func (indexes *Indexes) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Indexes_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataType’:
+	// Set property "DataType":
 	if typedInput.DataType != nil {
 		dataType := *typedInput.DataType
 		indexes.DataType = &dataType
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		indexes.Kind = &kind
 	}
 
-	// Set property ‘Precision’:
+	// Set property "Precision":
 	if typedInput.Precision != nil {
 		precision := *typedInput.Precision
 		indexes.Precision = &precision
@@ -3792,19 +3792,19 @@ func (indexes *Indexes_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Indexes_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataType’:
+	// Set property "DataType":
 	if typedInput.DataType != nil {
 		dataType := *typedInput.DataType
 		indexes.DataType = &dataType
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		indexes.Kind = &kind
 	}
 
-	// Set property ‘Precision’:
+	// Set property "Precision":
 	if typedInput.Precision != nil {
 		precision := *typedInput.Precision
 		indexes.Precision = &precision

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_user_defined_function_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_user_defined_function_types_gen.go
@@ -336,16 +336,16 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spe
 	}
 	result := &DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if function.Location != nil {
 		location := *function.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if function.Options != nil || function.Resource != nil {
 		result.Properties = &SqlUserDefinedFunctionCreateUpdateProperties_ARM{}
 	}
@@ -366,7 +366,7 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spe
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if function.Tags != nil {
 		result.Tags = make(map[string]string, len(function.Tags))
 		for key, value := range function.Tags {
@@ -388,16 +388,16 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	function.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		function.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -411,10 +411,10 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spe
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	function.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -428,7 +428,7 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		function.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -684,27 +684,27 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_STA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		function.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		function.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		function.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -718,7 +718,7 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_STA
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		function.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -726,7 +726,7 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_STA
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		function.Type = &typeVar
@@ -842,31 +842,31 @@ func (resource *SqlUserDefinedFunctionGetProperties_Resource_STATUS) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlUserDefinedFunctionGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if typedInput.Body != nil {
 		body := *typedInput.Body
 		resource.Body = &body
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
@@ -956,13 +956,13 @@ func (resource *SqlUserDefinedFunctionResource) ConvertToARM(resolved genruntime
 	}
 	result := &SqlUserDefinedFunctionResource_ARM{}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if resource.Body != nil {
 		body := *resource.Body
 		result.Body = &body
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
@@ -982,13 +982,13 @@ func (resource *SqlUserDefinedFunctionResource) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlUserDefinedFunctionResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Body’:
+	// Set property "Body":
 	if typedInput.Body != nil {
 		body := *typedInput.Body
 		resource.Body = &body
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id

--- a/v2/api/documentdb/v1beta20210515/sql_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_throughput_setting_types_gen.go
@@ -325,16 +325,16 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec) ConvertToAR
 	}
 	result := &DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if setting.Location != nil {
 		location := *setting.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if setting.Resource != nil {
 		result.Properties = &ThroughputSettingsUpdateProperties_ARM{}
 	}
@@ -347,7 +347,7 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec) ConvertToAR
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if setting.Tags != nil {
 		result.Tags = make(map[string]string, len(setting.Tags))
 		for key, value := range setting.Tags {
@@ -369,16 +369,16 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -392,7 +392,7 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec) PopulateFro
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -613,27 +613,27 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_STATUS) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabases_ThroughputSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		setting.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		setting.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		setting.Name = &name
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -647,7 +647,7 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_STATUS) PopulateF
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		setting.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -655,7 +655,7 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_STATUS) PopulateF
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar

--- a/v2/api/documentdb/v1beta20210515/sql_database_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_types_gen.go
@@ -336,16 +336,16 @@ func (database *DatabaseAccounts_SqlDatabase_Spec) ConvertToARM(resolved genrunt
 	}
 	result := &DatabaseAccounts_SqlDatabase_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if database.Location != nil {
 		location := *database.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.Options != nil || database.Resource != nil {
 		result.Properties = &SqlDatabaseCreateUpdateProperties_ARM{}
 	}
@@ -366,7 +366,7 @@ func (database *DatabaseAccounts_SqlDatabase_Spec) ConvertToARM(resolved genrunt
 		result.Properties.Resource = &resource
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if database.Tags != nil {
 		result.Tags = make(map[string]string, len(database.Tags))
 		for key, value := range database.Tags {
@@ -388,16 +388,16 @@ func (database *DatabaseAccounts_SqlDatabase_Spec) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabase_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		database.Location = &location
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -411,10 +411,10 @@ func (database *DatabaseAccounts_SqlDatabase_Spec) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -428,7 +428,7 @@ func (database *DatabaseAccounts_SqlDatabase_Spec) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		database.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -685,27 +685,27 @@ func (database *DatabaseAccounts_SqlDatabase_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlDatabase_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		database.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘Options’:
+	// Set property "Options":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Options != nil {
@@ -719,7 +719,7 @@ func (database *DatabaseAccounts_SqlDatabase_STATUS) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Resource != nil {
@@ -733,7 +733,7 @@ func (database *DatabaseAccounts_SqlDatabase_STATUS) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		database.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -741,7 +741,7 @@ func (database *DatabaseAccounts_SqlDatabase_STATUS) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar
@@ -882,37 +882,37 @@ func (resource *SqlDatabaseGetProperties_Resource_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlDatabaseGetProperties_Resource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Colls’:
+	// Set property "Colls":
 	if typedInput.Colls != nil {
 		colls := *typedInput.Colls
 		resource.Colls = &colls
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resource.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
 	}
 
-	// Set property ‘Rid’:
+	// Set property "Rid":
 	if typedInput.Rid != nil {
 		rid := *typedInput.Rid
 		resource.Rid = &rid
 	}
 
-	// Set property ‘Ts’:
+	// Set property "Ts":
 	if typedInput.Ts != nil {
 		ts := *typedInput.Ts
 		resource.Ts = &ts
 	}
 
-	// Set property ‘Users’:
+	// Set property "Users":
 	if typedInput.Users != nil {
 		users := *typedInput.Users
 		resource.Users = &users
@@ -1006,7 +1006,7 @@ func (resource *SqlDatabaseResource) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &SqlDatabaseResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Id != nil {
 		id := *resource.Id
 		result.Id = &id
@@ -1026,7 +1026,7 @@ func (resource *SqlDatabaseResource) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlDatabaseResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id

--- a/v2/api/documentdb/v1beta20210515/sql_role_assignment_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_role_assignment_types_gen.go
@@ -340,10 +340,10 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_Spec) ConvertToARM(resolved
 	}
 	result := &DatabaseAccounts_SqlRoleAssignment_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if assignment.PrincipalId != nil ||
 		assignment.PrincipalIdFromConfig != nil ||
 		assignment.RoleDefinitionId != nil ||
@@ -385,13 +385,13 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_Spec) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlRoleAssignment_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	assignment.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	assignment.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalId != nil {
@@ -400,9 +400,9 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// no assignment for property ‘PrincipalIdFromConfig’
+	// no assignment for property "PrincipalIdFromConfig"
 
-	// Set property ‘RoleDefinitionId’:
+	// Set property "RoleDefinitionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RoleDefinitionId != nil {
@@ -411,7 +411,7 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Scope’:
+	// Set property "Scope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Scope != nil {
@@ -642,21 +642,21 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseAccounts_SqlRoleAssignment_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		assignment.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		assignment.Name = &name
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalId != nil {
@@ -665,7 +665,7 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘RoleDefinitionId’:
+	// Set property "RoleDefinitionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RoleDefinitionId != nil {
@@ -674,7 +674,7 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘Scope’:
+	// Set property "Scope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Scope != nil {
@@ -683,7 +683,7 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		assignment.Type = &typeVar

--- a/v2/api/eventgrid/v1api20200601/domain_types_gen.go
+++ b/v2/api/eventgrid/v1api20200601/domain_types_gen.go
@@ -358,16 +358,16 @@ func (domain *Domain_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &Domain_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if domain.Location != nil {
 		location := *domain.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if domain.InboundIpRules != nil ||
 		domain.InputSchema != nil ||
 		domain.InputSchemaMapping != nil ||
@@ -398,7 +398,7 @@ func (domain *Domain_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if domain.Tags != nil {
 		result.Tags = make(map[string]string, len(domain.Tags))
 		for key, value := range domain.Tags {
@@ -420,10 +420,10 @@ func (domain *Domain_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Domain_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	domain.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘InboundIpRules’:
+	// Set property "InboundIpRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundIpRules {
@@ -436,7 +436,7 @@ func (domain *Domain_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘InputSchema’:
+	// Set property "InputSchema":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchema != nil {
@@ -445,7 +445,7 @@ func (domain *Domain_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘InputSchemaMapping’:
+	// Set property "InputSchemaMapping":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchemaMapping != nil {
@@ -459,16 +459,16 @@ func (domain *Domain_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		domain.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	domain.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -477,7 +477,7 @@ func (domain *Domain_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		domain.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -873,9 +873,9 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Domain_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Endpoint’:
+	// Set property "Endpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Endpoint != nil {
@@ -884,13 +884,13 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		domain.Id = &id
 	}
 
-	// Set property ‘InboundIpRules’:
+	// Set property "InboundIpRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundIpRules {
@@ -903,7 +903,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘InputSchema’:
+	// Set property "InputSchema":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchema != nil {
@@ -912,7 +912,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘InputSchemaMapping’:
+	// Set property "InputSchemaMapping":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchemaMapping != nil {
@@ -926,13 +926,13 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		domain.Location = &location
 	}
 
-	// Set property ‘MetricResourceId’:
+	// Set property "MetricResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MetricResourceId != nil {
@@ -941,13 +941,13 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		domain.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -960,7 +960,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -969,7 +969,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -978,7 +978,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -989,7 +989,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		domain.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		domain.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -997,7 +997,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		domain.Type = &typeVar
@@ -1306,13 +1306,13 @@ func (rule *InboundIpRule) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &InboundIpRule_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if rule.Action != nil {
 		action := *rule.Action
 		result.Action = &action
 	}
 
-	// Set property ‘IpMask’:
+	// Set property "IpMask":
 	if rule.IpMask != nil {
 		ipMask := *rule.IpMask
 		result.IpMask = &ipMask
@@ -1332,13 +1332,13 @@ func (rule *InboundIpRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundIpRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘IpMask’:
+	// Set property "IpMask":
 	if typedInput.IpMask != nil {
 		ipMask := *typedInput.IpMask
 		rule.IpMask = &ipMask
@@ -1433,13 +1433,13 @@ func (rule *InboundIpRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundIpRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘IpMask’:
+	// Set property "IpMask":
 	if typedInput.IpMask != nil {
 		ipMask := *typedInput.IpMask
 		rule.IpMask = &ipMask
@@ -1508,7 +1508,7 @@ func (mapping *InputSchemaMapping) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &InputSchemaMapping_ARM{}
 
-	// Set property ‘Json’:
+	// Set property "Json":
 	if mapping.Json != nil {
 		json_ARM, err := (*mapping.Json).ConvertToARM(resolved)
 		if err != nil {
@@ -1532,7 +1532,7 @@ func (mapping *InputSchemaMapping) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InputSchemaMapping_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Json’:
+	// Set property "Json":
 	if typedInput.Json != nil {
 		var json1 JsonInputSchemaMapping
 		err := json1.PopulateFromARM(owner, *typedInput.Json)
@@ -1632,7 +1632,7 @@ func (mapping *InputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InputSchemaMapping_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Json’:
+	// Set property "Json":
 	if typedInput.Json != nil {
 		var json1 JsonInputSchemaMapping_STATUS
 		err := json1.PopulateFromARM(owner, *typedInput.Json)
@@ -1713,7 +1713,7 @@ func (embedded *PrivateEndpointConnection_STATUS_Domain_SubResourceEmbedded) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_Domain_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -1787,37 +1787,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -1948,12 +1948,12 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &JsonInputSchemaMapping_ARM{}
 
-	// Set property ‘InputSchemaMappingType’:
+	// Set property "InputSchemaMappingType":
 	if mapping.InputSchemaMappingType != nil {
 		result.InputSchemaMappingType = *mapping.InputSchemaMappingType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if mapping.DataVersion != nil ||
 		mapping.EventTime != nil ||
 		mapping.EventType != nil ||
@@ -2025,7 +2025,7 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected JsonInputSchemaMapping_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataVersion’:
+	// Set property "DataVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataVersion != nil {
@@ -2039,7 +2039,7 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EventTime’:
+	// Set property "EventTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EventTime != nil {
@@ -2053,7 +2053,7 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EventType’:
+	// Set property "EventType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EventType != nil {
@@ -2067,7 +2067,7 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Id != nil {
@@ -2081,10 +2081,10 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘InputSchemaMappingType’:
+	// Set property "InputSchemaMappingType":
 	mapping.InputSchemaMappingType = &typedInput.InputSchemaMappingType
 
-	// Set property ‘Subject’:
+	// Set property "Subject":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subject != nil {
@@ -2098,7 +2098,7 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Topic’:
+	// Set property "Topic":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Topic != nil {
@@ -2423,7 +2423,7 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected JsonInputSchemaMapping_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataVersion’:
+	// Set property "DataVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataVersion != nil {
@@ -2437,7 +2437,7 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EventTime’:
+	// Set property "EventTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EventTime != nil {
@@ -2451,7 +2451,7 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EventType’:
+	// Set property "EventType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EventType != nil {
@@ -2465,7 +2465,7 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Id != nil {
@@ -2479,10 +2479,10 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘InputSchemaMappingType’:
+	// Set property "InputSchemaMappingType":
 	mapping.InputSchemaMappingType = &typedInput.InputSchemaMappingType
 
-	// Set property ‘Subject’:
+	// Set property "Subject":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subject != nil {
@@ -2496,7 +2496,7 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Topic’:
+	// Set property "Topic":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Topic != nil {
@@ -2714,7 +2714,7 @@ func (field *JsonField) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &JsonField_ARM{}
 
-	// Set property ‘SourceField’:
+	// Set property "SourceField":
 	if field.SourceField != nil {
 		sourceField := *field.SourceField
 		result.SourceField = &sourceField
@@ -2734,7 +2734,7 @@ func (field *JsonField) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected JsonField_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceField’:
+	// Set property "SourceField":
 	if typedInput.SourceField != nil {
 		sourceField := *typedInput.SourceField
 		field.SourceField = &sourceField
@@ -2805,7 +2805,7 @@ func (field *JsonField_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected JsonField_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceField’:
+	// Set property "SourceField":
 	if typedInput.SourceField != nil {
 		sourceField := *typedInput.SourceField
 		field.SourceField = &sourceField
@@ -2869,13 +2869,13 @@ func (withDefault *JsonFieldWithDefault) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &JsonFieldWithDefault_ARM{}
 
-	// Set property ‘DefaultValue’:
+	// Set property "DefaultValue":
 	if withDefault.DefaultValue != nil {
 		defaultValue := *withDefault.DefaultValue
 		result.DefaultValue = &defaultValue
 	}
 
-	// Set property ‘SourceField’:
+	// Set property "SourceField":
 	if withDefault.SourceField != nil {
 		sourceField := *withDefault.SourceField
 		result.SourceField = &sourceField
@@ -2895,13 +2895,13 @@ func (withDefault *JsonFieldWithDefault) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected JsonFieldWithDefault_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultValue’:
+	// Set property "DefaultValue":
 	if typedInput.DefaultValue != nil {
 		defaultValue := *typedInput.DefaultValue
 		withDefault.DefaultValue = &defaultValue
 	}
 
-	// Set property ‘SourceField’:
+	// Set property "SourceField":
 	if typedInput.SourceField != nil {
 		sourceField := *typedInput.SourceField
 		withDefault.SourceField = &sourceField
@@ -2989,13 +2989,13 @@ func (withDefault *JsonFieldWithDefault_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected JsonFieldWithDefault_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultValue’:
+	// Set property "DefaultValue":
 	if typedInput.DefaultValue != nil {
 		defaultValue := *typedInput.DefaultValue
 		withDefault.DefaultValue = &defaultValue
 	}
 
-	// Set property ‘SourceField’:
+	// Set property "SourceField":
 	if typedInput.SourceField != nil {
 		sourceField := *typedInput.SourceField
 		withDefault.SourceField = &sourceField

--- a/v2/api/eventgrid/v1api20200601/domains_topic_types_gen.go
+++ b/v2/api/eventgrid/v1api20200601/domains_topic_types_gen.go
@@ -331,7 +331,7 @@ func (topic *Domains_Topic_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &Domains_Topic_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 	return result, nil
 }
@@ -348,10 +348,10 @@ func (topic *Domains_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Domains_Topic_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	topic.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	topic.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -555,21 +555,21 @@ func (topic *Domains_Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Domains_Topic_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		topic.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		topic.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -578,7 +578,7 @@ func (topic *Domains_Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -589,7 +589,7 @@ func (topic *Domains_Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		topic.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		topic.Type = &typeVar

--- a/v2/api/eventgrid/v1api20200601/event_subscription_types_gen.go
+++ b/v2/api/eventgrid/v1api20200601/event_subscription_types_gen.go
@@ -352,10 +352,10 @@ func (subscription *EventSubscription_Spec) ConvertToARM(resolved genruntime.Con
 	}
 	result := &EventSubscription_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if subscription.DeadLetterDestination != nil ||
 		subscription.Destination != nil ||
 		subscription.EventDeliverySchema != nil ||
@@ -423,10 +423,10 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventSubscription_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	subscription.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DeadLetterDestination’:
+	// Set property "DeadLetterDestination":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetterDestination != nil {
@@ -440,7 +440,7 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Destination != nil {
@@ -454,7 +454,7 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EventDeliverySchema’:
+	// Set property "EventDeliverySchema":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EventDeliverySchema != nil {
@@ -463,7 +463,7 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘ExpirationTimeUtc’:
+	// Set property "ExpirationTimeUtc":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExpirationTimeUtc != nil {
@@ -472,7 +472,7 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Filter’:
+	// Set property "Filter":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Filter != nil {
@@ -486,7 +486,7 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Labels’:
+	// Set property "Labels":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Labels {
@@ -494,10 +494,10 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	subscription.Owner = &owner
 
-	// Set property ‘RetryPolicy’:
+	// Set property "RetryPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetryPolicy != nil {
@@ -926,9 +926,9 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventSubscription_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DeadLetterDestination’:
+	// Set property "DeadLetterDestination":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetterDestination != nil {
@@ -942,7 +942,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Destination != nil {
@@ -956,7 +956,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EventDeliverySchema’:
+	// Set property "EventDeliverySchema":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EventDeliverySchema != nil {
@@ -965,7 +965,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ExpirationTimeUtc’:
+	// Set property "ExpirationTimeUtc":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExpirationTimeUtc != nil {
@@ -974,7 +974,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Filter’:
+	// Set property "Filter":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Filter != nil {
@@ -988,13 +988,13 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		subscription.Id = &id
 	}
 
-	// Set property ‘Labels’:
+	// Set property "Labels":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Labels {
@@ -1002,13 +1002,13 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		subscription.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1017,7 +1017,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘RetryPolicy’:
+	// Set property "RetryPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetryPolicy != nil {
@@ -1031,7 +1031,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1042,7 +1042,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		subscription.SystemData = &systemData
 	}
 
-	// Set property ‘Topic’:
+	// Set property "Topic":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Topic != nil {
@@ -1051,7 +1051,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		subscription.Type = &typeVar
@@ -1292,7 +1292,7 @@ func (destination *DeadLetterDestination) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &DeadLetterDestination_ARM{}
 
-	// Set property ‘StorageBlob’:
+	// Set property "StorageBlob":
 	if destination.StorageBlob != nil {
 		storageBlob_ARM, err := (*destination.StorageBlob).ConvertToARM(resolved)
 		if err != nil {
@@ -1316,7 +1316,7 @@ func (destination *DeadLetterDestination) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeadLetterDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘StorageBlob’:
+	// Set property "StorageBlob":
 	if typedInput.StorageBlob != nil {
 		var storageBlob1 StorageBlobDeadLetterDestination
 		err := storageBlob1.PopulateFromARM(owner, *typedInput.StorageBlob)
@@ -1416,7 +1416,7 @@ func (destination *DeadLetterDestination_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeadLetterDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘StorageBlob’:
+	// Set property "StorageBlob":
 	if typedInput.StorageBlob != nil {
 		var storageBlob1 StorageBlobDeadLetterDestination_STATUS
 		err := storageBlob1.PopulateFromARM(owner, *typedInput.StorageBlob)
@@ -1510,7 +1510,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 	}
 	result := &EventSubscriptionDestination_ARM{}
 
-	// Set property ‘AzureFunction’:
+	// Set property "AzureFunction":
 	if destination.AzureFunction != nil {
 		azureFunction_ARM, err := (*destination.AzureFunction).ConvertToARM(resolved)
 		if err != nil {
@@ -1520,7 +1520,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		result.AzureFunction = &azureFunction
 	}
 
-	// Set property ‘EventHub’:
+	// Set property "EventHub":
 	if destination.EventHub != nil {
 		eventHub_ARM, err := (*destination.EventHub).ConvertToARM(resolved)
 		if err != nil {
@@ -1530,7 +1530,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		result.EventHub = &eventHub
 	}
 
-	// Set property ‘HybridConnection’:
+	// Set property "HybridConnection":
 	if destination.HybridConnection != nil {
 		hybridConnection_ARM, err := (*destination.HybridConnection).ConvertToARM(resolved)
 		if err != nil {
@@ -1540,7 +1540,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		result.HybridConnection = &hybridConnection
 	}
 
-	// Set property ‘ServiceBusQueue’:
+	// Set property "ServiceBusQueue":
 	if destination.ServiceBusQueue != nil {
 		serviceBusQueue_ARM, err := (*destination.ServiceBusQueue).ConvertToARM(resolved)
 		if err != nil {
@@ -1550,7 +1550,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		result.ServiceBusQueue = &serviceBusQueue
 	}
 
-	// Set property ‘ServiceBusTopic’:
+	// Set property "ServiceBusTopic":
 	if destination.ServiceBusTopic != nil {
 		serviceBusTopic_ARM, err := (*destination.ServiceBusTopic).ConvertToARM(resolved)
 		if err != nil {
@@ -1560,7 +1560,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		result.ServiceBusTopic = &serviceBusTopic
 	}
 
-	// Set property ‘StorageQueue’:
+	// Set property "StorageQueue":
 	if destination.StorageQueue != nil {
 		storageQueue_ARM, err := (*destination.StorageQueue).ConvertToARM(resolved)
 		if err != nil {
@@ -1570,7 +1570,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		result.StorageQueue = &storageQueue
 	}
 
-	// Set property ‘WebHook’:
+	// Set property "WebHook":
 	if destination.WebHook != nil {
 		webHook_ARM, err := (*destination.WebHook).ConvertToARM(resolved)
 		if err != nil {
@@ -1594,7 +1594,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureFunction’:
+	// Set property "AzureFunction":
 	if typedInput.AzureFunction != nil {
 		var azureFunction1 AzureFunctionEventSubscriptionDestination
 		err := azureFunction1.PopulateFromARM(owner, *typedInput.AzureFunction)
@@ -1605,7 +1605,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		destination.AzureFunction = &azureFunction
 	}
 
-	// Set property ‘EventHub’:
+	// Set property "EventHub":
 	if typedInput.EventHub != nil {
 		var eventHub1 EventHubEventSubscriptionDestination
 		err := eventHub1.PopulateFromARM(owner, *typedInput.EventHub)
@@ -1616,7 +1616,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		destination.EventHub = &eventHub
 	}
 
-	// Set property ‘HybridConnection’:
+	// Set property "HybridConnection":
 	if typedInput.HybridConnection != nil {
 		var hybridConnection1 HybridConnectionEventSubscriptionDestination
 		err := hybridConnection1.PopulateFromARM(owner, *typedInput.HybridConnection)
@@ -1627,7 +1627,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		destination.HybridConnection = &hybridConnection
 	}
 
-	// Set property ‘ServiceBusQueue’:
+	// Set property "ServiceBusQueue":
 	if typedInput.ServiceBusQueue != nil {
 		var serviceBusQueue1 ServiceBusQueueEventSubscriptionDestination
 		err := serviceBusQueue1.PopulateFromARM(owner, *typedInput.ServiceBusQueue)
@@ -1638,7 +1638,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		destination.ServiceBusQueue = &serviceBusQueue
 	}
 
-	// Set property ‘ServiceBusTopic’:
+	// Set property "ServiceBusTopic":
 	if typedInput.ServiceBusTopic != nil {
 		var serviceBusTopic1 ServiceBusTopicEventSubscriptionDestination
 		err := serviceBusTopic1.PopulateFromARM(owner, *typedInput.ServiceBusTopic)
@@ -1649,7 +1649,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		destination.ServiceBusTopic = &serviceBusTopic
 	}
 
-	// Set property ‘StorageQueue’:
+	// Set property "StorageQueue":
 	if typedInput.StorageQueue != nil {
 		var storageQueue1 StorageQueueEventSubscriptionDestination
 		err := storageQueue1.PopulateFromARM(owner, *typedInput.StorageQueue)
@@ -1660,7 +1660,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		destination.StorageQueue = &storageQueue
 	}
 
-	// Set property ‘WebHook’:
+	// Set property "WebHook":
 	if typedInput.WebHook != nil {
 		var webHook1 WebHookEventSubscriptionDestination
 		err := webHook1.PopulateFromARM(owner, *typedInput.WebHook)
@@ -1994,7 +1994,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureFunction’:
+	// Set property "AzureFunction":
 	if typedInput.AzureFunction != nil {
 		var azureFunction1 AzureFunctionEventSubscriptionDestination_STATUS
 		err := azureFunction1.PopulateFromARM(owner, *typedInput.AzureFunction)
@@ -2005,7 +2005,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		destination.AzureFunction = &azureFunction
 	}
 
-	// Set property ‘EventHub’:
+	// Set property "EventHub":
 	if typedInput.EventHub != nil {
 		var eventHub1 EventHubEventSubscriptionDestination_STATUS
 		err := eventHub1.PopulateFromARM(owner, *typedInput.EventHub)
@@ -2016,7 +2016,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		destination.EventHub = &eventHub
 	}
 
-	// Set property ‘HybridConnection’:
+	// Set property "HybridConnection":
 	if typedInput.HybridConnection != nil {
 		var hybridConnection1 HybridConnectionEventSubscriptionDestination_STATUS
 		err := hybridConnection1.PopulateFromARM(owner, *typedInput.HybridConnection)
@@ -2027,7 +2027,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		destination.HybridConnection = &hybridConnection
 	}
 
-	// Set property ‘ServiceBusQueue’:
+	// Set property "ServiceBusQueue":
 	if typedInput.ServiceBusQueue != nil {
 		var serviceBusQueue1 ServiceBusQueueEventSubscriptionDestination_STATUS
 		err := serviceBusQueue1.PopulateFromARM(owner, *typedInput.ServiceBusQueue)
@@ -2038,7 +2038,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		destination.ServiceBusQueue = &serviceBusQueue
 	}
 
-	// Set property ‘ServiceBusTopic’:
+	// Set property "ServiceBusTopic":
 	if typedInput.ServiceBusTopic != nil {
 		var serviceBusTopic1 ServiceBusTopicEventSubscriptionDestination_STATUS
 		err := serviceBusTopic1.PopulateFromARM(owner, *typedInput.ServiceBusTopic)
@@ -2049,7 +2049,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		destination.ServiceBusTopic = &serviceBusTopic
 	}
 
-	// Set property ‘StorageQueue’:
+	// Set property "StorageQueue":
 	if typedInput.StorageQueue != nil {
 		var storageQueue1 StorageQueueEventSubscriptionDestination_STATUS
 		err := storageQueue1.PopulateFromARM(owner, *typedInput.StorageQueue)
@@ -2060,7 +2060,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		destination.StorageQueue = &storageQueue
 	}
 
-	// Set property ‘WebHook’:
+	// Set property "WebHook":
 	if typedInput.WebHook != nil {
 		var webHook1 WebHookEventSubscriptionDestination_STATUS
 		err := webHook1.PopulateFromARM(owner, *typedInput.WebHook)
@@ -2298,7 +2298,7 @@ func (filter *EventSubscriptionFilter) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &EventSubscriptionFilter_ARM{}
 
-	// Set property ‘AdvancedFilters’:
+	// Set property "AdvancedFilters":
 	for _, item := range filter.AdvancedFilters {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2307,24 +2307,24 @@ func (filter *EventSubscriptionFilter) ConvertToARM(resolved genruntime.ConvertT
 		result.AdvancedFilters = append(result.AdvancedFilters, *item_ARM.(*AdvancedFilter_ARM))
 	}
 
-	// Set property ‘IncludedEventTypes’:
+	// Set property "IncludedEventTypes":
 	for _, item := range filter.IncludedEventTypes {
 		result.IncludedEventTypes = append(result.IncludedEventTypes, item)
 	}
 
-	// Set property ‘IsSubjectCaseSensitive’:
+	// Set property "IsSubjectCaseSensitive":
 	if filter.IsSubjectCaseSensitive != nil {
 		isSubjectCaseSensitive := *filter.IsSubjectCaseSensitive
 		result.IsSubjectCaseSensitive = &isSubjectCaseSensitive
 	}
 
-	// Set property ‘SubjectBeginsWith’:
+	// Set property "SubjectBeginsWith":
 	if filter.SubjectBeginsWith != nil {
 		subjectBeginsWith := *filter.SubjectBeginsWith
 		result.SubjectBeginsWith = &subjectBeginsWith
 	}
 
-	// Set property ‘SubjectEndsWith’:
+	// Set property "SubjectEndsWith":
 	if filter.SubjectEndsWith != nil {
 		subjectEndsWith := *filter.SubjectEndsWith
 		result.SubjectEndsWith = &subjectEndsWith
@@ -2344,7 +2344,7 @@ func (filter *EventSubscriptionFilter) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventSubscriptionFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdvancedFilters’:
+	// Set property "AdvancedFilters":
 	for _, item := range typedInput.AdvancedFilters {
 		var item1 AdvancedFilter
 		err := item1.PopulateFromARM(owner, item)
@@ -2354,24 +2354,24 @@ func (filter *EventSubscriptionFilter) PopulateFromARM(owner genruntime.Arbitrar
 		filter.AdvancedFilters = append(filter.AdvancedFilters, item1)
 	}
 
-	// Set property ‘IncludedEventTypes’:
+	// Set property "IncludedEventTypes":
 	for _, item := range typedInput.IncludedEventTypes {
 		filter.IncludedEventTypes = append(filter.IncludedEventTypes, item)
 	}
 
-	// Set property ‘IsSubjectCaseSensitive’:
+	// Set property "IsSubjectCaseSensitive":
 	if typedInput.IsSubjectCaseSensitive != nil {
 		isSubjectCaseSensitive := *typedInput.IsSubjectCaseSensitive
 		filter.IsSubjectCaseSensitive = &isSubjectCaseSensitive
 	}
 
-	// Set property ‘SubjectBeginsWith’:
+	// Set property "SubjectBeginsWith":
 	if typedInput.SubjectBeginsWith != nil {
 		subjectBeginsWith := *typedInput.SubjectBeginsWith
 		filter.SubjectBeginsWith = &subjectBeginsWith
 	}
 
-	// Set property ‘SubjectEndsWith’:
+	// Set property "SubjectEndsWith":
 	if typedInput.SubjectEndsWith != nil {
 		subjectEndsWith := *typedInput.SubjectEndsWith
 		filter.SubjectEndsWith = &subjectEndsWith
@@ -2553,7 +2553,7 @@ func (filter *EventSubscriptionFilter_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventSubscriptionFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdvancedFilters’:
+	// Set property "AdvancedFilters":
 	for _, item := range typedInput.AdvancedFilters {
 		var item1 AdvancedFilter_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2563,24 +2563,24 @@ func (filter *EventSubscriptionFilter_STATUS) PopulateFromARM(owner genruntime.A
 		filter.AdvancedFilters = append(filter.AdvancedFilters, item1)
 	}
 
-	// Set property ‘IncludedEventTypes’:
+	// Set property "IncludedEventTypes":
 	for _, item := range typedInput.IncludedEventTypes {
 		filter.IncludedEventTypes = append(filter.IncludedEventTypes, item)
 	}
 
-	// Set property ‘IsSubjectCaseSensitive’:
+	// Set property "IsSubjectCaseSensitive":
 	if typedInput.IsSubjectCaseSensitive != nil {
 		isSubjectCaseSensitive := *typedInput.IsSubjectCaseSensitive
 		filter.IsSubjectCaseSensitive = &isSubjectCaseSensitive
 	}
 
-	// Set property ‘SubjectBeginsWith’:
+	// Set property "SubjectBeginsWith":
 	if typedInput.SubjectBeginsWith != nil {
 		subjectBeginsWith := *typedInput.SubjectBeginsWith
 		filter.SubjectBeginsWith = &subjectBeginsWith
 	}
 
-	// Set property ‘SubjectEndsWith’:
+	// Set property "SubjectEndsWith":
 	if typedInput.SubjectEndsWith != nil {
 		subjectEndsWith := *typedInput.SubjectEndsWith
 		filter.SubjectEndsWith = &subjectEndsWith
@@ -2730,13 +2730,13 @@ func (policy *RetryPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &RetryPolicy_ARM{}
 
-	// Set property ‘EventTimeToLiveInMinutes’:
+	// Set property "EventTimeToLiveInMinutes":
 	if policy.EventTimeToLiveInMinutes != nil {
 		eventTimeToLiveInMinutes := *policy.EventTimeToLiveInMinutes
 		result.EventTimeToLiveInMinutes = &eventTimeToLiveInMinutes
 	}
 
-	// Set property ‘MaxDeliveryAttempts’:
+	// Set property "MaxDeliveryAttempts":
 	if policy.MaxDeliveryAttempts != nil {
 		maxDeliveryAttempts := *policy.MaxDeliveryAttempts
 		result.MaxDeliveryAttempts = &maxDeliveryAttempts
@@ -2756,13 +2756,13 @@ func (policy *RetryPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RetryPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EventTimeToLiveInMinutes’:
+	// Set property "EventTimeToLiveInMinutes":
 	if typedInput.EventTimeToLiveInMinutes != nil {
 		eventTimeToLiveInMinutes := *typedInput.EventTimeToLiveInMinutes
 		policy.EventTimeToLiveInMinutes = &eventTimeToLiveInMinutes
 	}
 
-	// Set property ‘MaxDeliveryAttempts’:
+	// Set property "MaxDeliveryAttempts":
 	if typedInput.MaxDeliveryAttempts != nil {
 		maxDeliveryAttempts := *typedInput.MaxDeliveryAttempts
 		policy.MaxDeliveryAttempts = &maxDeliveryAttempts
@@ -2843,13 +2843,13 @@ func (policy *RetryPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RetryPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EventTimeToLiveInMinutes’:
+	// Set property "EventTimeToLiveInMinutes":
 	if typedInput.EventTimeToLiveInMinutes != nil {
 		eventTimeToLiveInMinutes := *typedInput.EventTimeToLiveInMinutes
 		policy.EventTimeToLiveInMinutes = &eventTimeToLiveInMinutes
 	}
 
-	// Set property ‘MaxDeliveryAttempts’:
+	// Set property "MaxDeliveryAttempts":
 	if typedInput.MaxDeliveryAttempts != nil {
 		maxDeliveryAttempts := *typedInput.MaxDeliveryAttempts
 		policy.MaxDeliveryAttempts = &maxDeliveryAttempts
@@ -2941,7 +2941,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &AdvancedFilter_ARM{}
 
-	// Set property ‘BoolEquals’:
+	// Set property "BoolEquals":
 	if filter.BoolEquals != nil {
 		boolEquals_ARM, err := (*filter.BoolEquals).ConvertToARM(resolved)
 		if err != nil {
@@ -2951,7 +2951,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.BoolEquals = &boolEquals
 	}
 
-	// Set property ‘NumberGreaterThan’:
+	// Set property "NumberGreaterThan":
 	if filter.NumberGreaterThan != nil {
 		numberGreaterThan_ARM, err := (*filter.NumberGreaterThan).ConvertToARM(resolved)
 		if err != nil {
@@ -2961,7 +2961,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.NumberGreaterThan = &numberGreaterThan
 	}
 
-	// Set property ‘NumberGreaterThanOrEquals’:
+	// Set property "NumberGreaterThanOrEquals":
 	if filter.NumberGreaterThanOrEquals != nil {
 		numberGreaterThanOrEquals_ARM, err := (*filter.NumberGreaterThanOrEquals).ConvertToARM(resolved)
 		if err != nil {
@@ -2971,7 +2971,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.NumberGreaterThanOrEquals = &numberGreaterThanOrEquals
 	}
 
-	// Set property ‘NumberIn’:
+	// Set property "NumberIn":
 	if filter.NumberIn != nil {
 		numberIn_ARM, err := (*filter.NumberIn).ConvertToARM(resolved)
 		if err != nil {
@@ -2981,7 +2981,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.NumberIn = &numberIn
 	}
 
-	// Set property ‘NumberLessThan’:
+	// Set property "NumberLessThan":
 	if filter.NumberLessThan != nil {
 		numberLessThan_ARM, err := (*filter.NumberLessThan).ConvertToARM(resolved)
 		if err != nil {
@@ -2991,7 +2991,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.NumberLessThan = &numberLessThan
 	}
 
-	// Set property ‘NumberLessThanOrEquals’:
+	// Set property "NumberLessThanOrEquals":
 	if filter.NumberLessThanOrEquals != nil {
 		numberLessThanOrEquals_ARM, err := (*filter.NumberLessThanOrEquals).ConvertToARM(resolved)
 		if err != nil {
@@ -3001,7 +3001,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.NumberLessThanOrEquals = &numberLessThanOrEquals
 	}
 
-	// Set property ‘NumberNotIn’:
+	// Set property "NumberNotIn":
 	if filter.NumberNotIn != nil {
 		numberNotIn_ARM, err := (*filter.NumberNotIn).ConvertToARM(resolved)
 		if err != nil {
@@ -3011,7 +3011,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.NumberNotIn = &numberNotIn
 	}
 
-	// Set property ‘StringBeginsWith’:
+	// Set property "StringBeginsWith":
 	if filter.StringBeginsWith != nil {
 		stringBeginsWith_ARM, err := (*filter.StringBeginsWith).ConvertToARM(resolved)
 		if err != nil {
@@ -3021,7 +3021,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.StringBeginsWith = &stringBeginsWith
 	}
 
-	// Set property ‘StringContains’:
+	// Set property "StringContains":
 	if filter.StringContains != nil {
 		stringContains_ARM, err := (*filter.StringContains).ConvertToARM(resolved)
 		if err != nil {
@@ -3031,7 +3031,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.StringContains = &stringContains
 	}
 
-	// Set property ‘StringEndsWith’:
+	// Set property "StringEndsWith":
 	if filter.StringEndsWith != nil {
 		stringEndsWith_ARM, err := (*filter.StringEndsWith).ConvertToARM(resolved)
 		if err != nil {
@@ -3041,7 +3041,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.StringEndsWith = &stringEndsWith
 	}
 
-	// Set property ‘StringIn’:
+	// Set property "StringIn":
 	if filter.StringIn != nil {
 		stringIn_ARM, err := (*filter.StringIn).ConvertToARM(resolved)
 		if err != nil {
@@ -3051,7 +3051,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.StringIn = &stringIn
 	}
 
-	// Set property ‘StringNotIn’:
+	// Set property "StringNotIn":
 	if filter.StringNotIn != nil {
 		stringNotIn_ARM, err := (*filter.StringNotIn).ConvertToARM(resolved)
 		if err != nil {
@@ -3075,7 +3075,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BoolEquals’:
+	// Set property "BoolEquals":
 	if typedInput.BoolEquals != nil {
 		var boolEquals1 BoolEqualsAdvancedFilter
 		err := boolEquals1.PopulateFromARM(owner, *typedInput.BoolEquals)
@@ -3086,7 +3086,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.BoolEquals = &boolEquals
 	}
 
-	// Set property ‘NumberGreaterThan’:
+	// Set property "NumberGreaterThan":
 	if typedInput.NumberGreaterThan != nil {
 		var numberGreaterThan1 NumberGreaterThanAdvancedFilter
 		err := numberGreaterThan1.PopulateFromARM(owner, *typedInput.NumberGreaterThan)
@@ -3097,7 +3097,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.NumberGreaterThan = &numberGreaterThan
 	}
 
-	// Set property ‘NumberGreaterThanOrEquals’:
+	// Set property "NumberGreaterThanOrEquals":
 	if typedInput.NumberGreaterThanOrEquals != nil {
 		var numberGreaterThanOrEquals1 NumberGreaterThanOrEqualsAdvancedFilter
 		err := numberGreaterThanOrEquals1.PopulateFromARM(owner, *typedInput.NumberGreaterThanOrEquals)
@@ -3108,7 +3108,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.NumberGreaterThanOrEquals = &numberGreaterThanOrEquals
 	}
 
-	// Set property ‘NumberIn’:
+	// Set property "NumberIn":
 	if typedInput.NumberIn != nil {
 		var numberIn1 NumberInAdvancedFilter
 		err := numberIn1.PopulateFromARM(owner, *typedInput.NumberIn)
@@ -3119,7 +3119,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.NumberIn = &numberIn
 	}
 
-	// Set property ‘NumberLessThan’:
+	// Set property "NumberLessThan":
 	if typedInput.NumberLessThan != nil {
 		var numberLessThan1 NumberLessThanAdvancedFilter
 		err := numberLessThan1.PopulateFromARM(owner, *typedInput.NumberLessThan)
@@ -3130,7 +3130,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.NumberLessThan = &numberLessThan
 	}
 
-	// Set property ‘NumberLessThanOrEquals’:
+	// Set property "NumberLessThanOrEquals":
 	if typedInput.NumberLessThanOrEquals != nil {
 		var numberLessThanOrEquals1 NumberLessThanOrEqualsAdvancedFilter
 		err := numberLessThanOrEquals1.PopulateFromARM(owner, *typedInput.NumberLessThanOrEquals)
@@ -3141,7 +3141,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.NumberLessThanOrEquals = &numberLessThanOrEquals
 	}
 
-	// Set property ‘NumberNotIn’:
+	// Set property "NumberNotIn":
 	if typedInput.NumberNotIn != nil {
 		var numberNotIn1 NumberNotInAdvancedFilter
 		err := numberNotIn1.PopulateFromARM(owner, *typedInput.NumberNotIn)
@@ -3152,7 +3152,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.NumberNotIn = &numberNotIn
 	}
 
-	// Set property ‘StringBeginsWith’:
+	// Set property "StringBeginsWith":
 	if typedInput.StringBeginsWith != nil {
 		var stringBeginsWith1 StringBeginsWithAdvancedFilter
 		err := stringBeginsWith1.PopulateFromARM(owner, *typedInput.StringBeginsWith)
@@ -3163,7 +3163,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.StringBeginsWith = &stringBeginsWith
 	}
 
-	// Set property ‘StringContains’:
+	// Set property "StringContains":
 	if typedInput.StringContains != nil {
 		var stringContains1 StringContainsAdvancedFilter
 		err := stringContains1.PopulateFromARM(owner, *typedInput.StringContains)
@@ -3174,7 +3174,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.StringContains = &stringContains
 	}
 
-	// Set property ‘StringEndsWith’:
+	// Set property "StringEndsWith":
 	if typedInput.StringEndsWith != nil {
 		var stringEndsWith1 StringEndsWithAdvancedFilter
 		err := stringEndsWith1.PopulateFromARM(owner, *typedInput.StringEndsWith)
@@ -3185,7 +3185,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.StringEndsWith = &stringEndsWith
 	}
 
-	// Set property ‘StringIn’:
+	// Set property "StringIn":
 	if typedInput.StringIn != nil {
 		var stringIn1 StringInAdvancedFilter
 		err := stringIn1.PopulateFromARM(owner, *typedInput.StringIn)
@@ -3196,7 +3196,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.StringIn = &stringIn
 	}
 
-	// Set property ‘StringNotIn’:
+	// Set property "StringNotIn":
 	if typedInput.StringNotIn != nil {
 		var stringNotIn1 StringNotInAdvancedFilter
 		err := stringNotIn1.PopulateFromARM(owner, *typedInput.StringNotIn)
@@ -3725,7 +3725,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BoolEquals’:
+	// Set property "BoolEquals":
 	if typedInput.BoolEquals != nil {
 		var boolEquals1 BoolEqualsAdvancedFilter_STATUS
 		err := boolEquals1.PopulateFromARM(owner, *typedInput.BoolEquals)
@@ -3736,7 +3736,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.BoolEquals = &boolEquals
 	}
 
-	// Set property ‘NumberGreaterThan’:
+	// Set property "NumberGreaterThan":
 	if typedInput.NumberGreaterThan != nil {
 		var numberGreaterThan1 NumberGreaterThanAdvancedFilter_STATUS
 		err := numberGreaterThan1.PopulateFromARM(owner, *typedInput.NumberGreaterThan)
@@ -3747,7 +3747,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.NumberGreaterThan = &numberGreaterThan
 	}
 
-	// Set property ‘NumberGreaterThanOrEquals’:
+	// Set property "NumberGreaterThanOrEquals":
 	if typedInput.NumberGreaterThanOrEquals != nil {
 		var numberGreaterThanOrEquals1 NumberGreaterThanOrEqualsAdvancedFilter_STATUS
 		err := numberGreaterThanOrEquals1.PopulateFromARM(owner, *typedInput.NumberGreaterThanOrEquals)
@@ -3758,7 +3758,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.NumberGreaterThanOrEquals = &numberGreaterThanOrEquals
 	}
 
-	// Set property ‘NumberIn’:
+	// Set property "NumberIn":
 	if typedInput.NumberIn != nil {
 		var numberIn1 NumberInAdvancedFilter_STATUS
 		err := numberIn1.PopulateFromARM(owner, *typedInput.NumberIn)
@@ -3769,7 +3769,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.NumberIn = &numberIn
 	}
 
-	// Set property ‘NumberLessThan’:
+	// Set property "NumberLessThan":
 	if typedInput.NumberLessThan != nil {
 		var numberLessThan1 NumberLessThanAdvancedFilter_STATUS
 		err := numberLessThan1.PopulateFromARM(owner, *typedInput.NumberLessThan)
@@ -3780,7 +3780,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.NumberLessThan = &numberLessThan
 	}
 
-	// Set property ‘NumberLessThanOrEquals’:
+	// Set property "NumberLessThanOrEquals":
 	if typedInput.NumberLessThanOrEquals != nil {
 		var numberLessThanOrEquals1 NumberLessThanOrEqualsAdvancedFilter_STATUS
 		err := numberLessThanOrEquals1.PopulateFromARM(owner, *typedInput.NumberLessThanOrEquals)
@@ -3791,7 +3791,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.NumberLessThanOrEquals = &numberLessThanOrEquals
 	}
 
-	// Set property ‘NumberNotIn’:
+	// Set property "NumberNotIn":
 	if typedInput.NumberNotIn != nil {
 		var numberNotIn1 NumberNotInAdvancedFilter_STATUS
 		err := numberNotIn1.PopulateFromARM(owner, *typedInput.NumberNotIn)
@@ -3802,7 +3802,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.NumberNotIn = &numberNotIn
 	}
 
-	// Set property ‘StringBeginsWith’:
+	// Set property "StringBeginsWith":
 	if typedInput.StringBeginsWith != nil {
 		var stringBeginsWith1 StringBeginsWithAdvancedFilter_STATUS
 		err := stringBeginsWith1.PopulateFromARM(owner, *typedInput.StringBeginsWith)
@@ -3813,7 +3813,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.StringBeginsWith = &stringBeginsWith
 	}
 
-	// Set property ‘StringContains’:
+	// Set property "StringContains":
 	if typedInput.StringContains != nil {
 		var stringContains1 StringContainsAdvancedFilter_STATUS
 		err := stringContains1.PopulateFromARM(owner, *typedInput.StringContains)
@@ -3824,7 +3824,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.StringContains = &stringContains
 	}
 
-	// Set property ‘StringEndsWith’:
+	// Set property "StringEndsWith":
 	if typedInput.StringEndsWith != nil {
 		var stringEndsWith1 StringEndsWithAdvancedFilter_STATUS
 		err := stringEndsWith1.PopulateFromARM(owner, *typedInput.StringEndsWith)
@@ -3835,7 +3835,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.StringEndsWith = &stringEndsWith
 	}
 
-	// Set property ‘StringIn’:
+	// Set property "StringIn":
 	if typedInput.StringIn != nil {
 		var stringIn1 StringInAdvancedFilter_STATUS
 		err := stringIn1.PopulateFromARM(owner, *typedInput.StringIn)
@@ -3846,7 +3846,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.StringIn = &stringIn
 	}
 
-	// Set property ‘StringNotIn’:
+	// Set property "StringNotIn":
 	if typedInput.StringNotIn != nil {
 		var stringNotIn1 StringNotInAdvancedFilter_STATUS
 		err := stringNotIn1.PopulateFromARM(owner, *typedInput.StringNotIn)
@@ -4197,12 +4197,12 @@ func (destination *AzureFunctionEventSubscriptionDestination) ConvertToARM(resol
 	}
 	result := &AzureFunctionEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.MaxEventsPerBatch != nil ||
 		destination.PreferredBatchSizeInKilobytes != nil ||
 		destination.ResourceReference != nil {
@@ -4239,10 +4239,10 @@ func (destination *AzureFunctionEventSubscriptionDestination) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFunctionEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘MaxEventsPerBatch’:
+	// Set property "MaxEventsPerBatch":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxEventsPerBatch != nil {
@@ -4251,7 +4251,7 @@ func (destination *AzureFunctionEventSubscriptionDestination) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘PreferredBatchSizeInKilobytes’:
+	// Set property "PreferredBatchSizeInKilobytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PreferredBatchSizeInKilobytes != nil {
@@ -4260,7 +4260,7 @@ func (destination *AzureFunctionEventSubscriptionDestination) PopulateFromARM(ow
 		}
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -4391,10 +4391,10 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFunctionEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘MaxEventsPerBatch’:
+	// Set property "MaxEventsPerBatch":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxEventsPerBatch != nil {
@@ -4403,7 +4403,7 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) PopulateFro
 		}
 	}
 
-	// Set property ‘PreferredBatchSizeInKilobytes’:
+	// Set property "PreferredBatchSizeInKilobytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PreferredBatchSizeInKilobytes != nil {
@@ -4412,7 +4412,7 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) PopulateFro
 		}
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -4501,12 +4501,12 @@ func (destination *EventHubEventSubscriptionDestination) ConvertToARM(resolved g
 	}
 	result := &EventHubEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.ResourceReference != nil {
 		result.Properties = &EventHubEventSubscriptionDestinationProperties_ARM{}
 	}
@@ -4533,10 +4533,10 @@ func (destination *EventHubEventSubscriptionDestination) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventHubEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -4642,10 +4642,10 @@ func (destination *EventHubEventSubscriptionDestination_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventHubEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -4721,12 +4721,12 @@ func (destination *HybridConnectionEventSubscriptionDestination) ConvertToARM(re
 	}
 	result := &HybridConnectionEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.ResourceReference != nil {
 		result.Properties = &HybridConnectionEventSubscriptionDestinationProperties_ARM{}
 	}
@@ -4753,10 +4753,10 @@ func (destination *HybridConnectionEventSubscriptionDestination) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HybridConnectionEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -4862,10 +4862,10 @@ func (destination *HybridConnectionEventSubscriptionDestination_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HybridConnectionEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -4942,12 +4942,12 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) ConvertToARM(res
 	}
 	result := &ServiceBusQueueEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.ResourceReference != nil {
 		result.Properties = &ServiceBusQueueEventSubscriptionDestinationProperties_ARM{}
 	}
@@ -4974,10 +4974,10 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceBusQueueEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -5083,10 +5083,10 @@ func (destination *ServiceBusQueueEventSubscriptionDestination_STATUS) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceBusQueueEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -5163,12 +5163,12 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) ConvertToARM(res
 	}
 	result := &ServiceBusTopicEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.ResourceReference != nil {
 		result.Properties = &ServiceBusTopicEventSubscriptionDestinationProperties_ARM{}
 	}
@@ -5195,10 +5195,10 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceBusTopicEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -5305,10 +5305,10 @@ func (destination *ServiceBusTopicEventSubscriptionDestination_STATUS) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceBusTopicEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -5387,12 +5387,12 @@ func (destination *StorageBlobDeadLetterDestination) ConvertToARM(resolved genru
 	}
 	result := &StorageBlobDeadLetterDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.BlobContainerName != nil || destination.ResourceReference != nil {
 		result.Properties = &StorageBlobDeadLetterDestinationProperties_ARM{}
 	}
@@ -5423,7 +5423,7 @@ func (destination *StorageBlobDeadLetterDestination) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageBlobDeadLetterDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobContainerName’:
+	// Set property "BlobContainerName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BlobContainerName != nil {
@@ -5432,10 +5432,10 @@ func (destination *StorageBlobDeadLetterDestination) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -5553,7 +5553,7 @@ func (destination *StorageBlobDeadLetterDestination_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageBlobDeadLetterDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobContainerName’:
+	// Set property "BlobContainerName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BlobContainerName != nil {
@@ -5562,10 +5562,10 @@ func (destination *StorageBlobDeadLetterDestination_STATUS) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -5651,12 +5651,12 @@ func (destination *StorageQueueEventSubscriptionDestination) ConvertToARM(resolv
 	}
 	result := &StorageQueueEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.QueueName != nil || destination.ResourceReference != nil {
 		result.Properties = &StorageQueueEventSubscriptionDestinationProperties_ARM{}
 	}
@@ -5687,10 +5687,10 @@ func (destination *StorageQueueEventSubscriptionDestination) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageQueueEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘QueueName’:
+	// Set property "QueueName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.QueueName != nil {
@@ -5699,7 +5699,7 @@ func (destination *StorageQueueEventSubscriptionDestination) PopulateFromARM(own
 		}
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -5818,10 +5818,10 @@ func (destination *StorageQueueEventSubscriptionDestination_STATUS) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageQueueEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘QueueName’:
+	// Set property "QueueName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.QueueName != nil {
@@ -5830,7 +5830,7 @@ func (destination *StorageQueueEventSubscriptionDestination_STATUS) PopulateFrom
 		}
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -5926,12 +5926,12 @@ func (destination *WebHookEventSubscriptionDestination) ConvertToARM(resolved ge
 	}
 	result := &WebHookEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.AzureActiveDirectoryApplicationIdOrUri != nil ||
 		destination.AzureActiveDirectoryTenantId != nil ||
 		destination.EndpointUrl != nil ||
@@ -5978,7 +5978,7 @@ func (destination *WebHookEventSubscriptionDestination) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebHookEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureActiveDirectoryApplicationIdOrUri’:
+	// Set property "AzureActiveDirectoryApplicationIdOrUri":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureActiveDirectoryApplicationIdOrUri != nil {
@@ -5987,7 +5987,7 @@ func (destination *WebHookEventSubscriptionDestination) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘AzureActiveDirectoryTenantId’:
+	// Set property "AzureActiveDirectoryTenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureActiveDirectoryTenantId != nil {
@@ -5996,12 +5996,12 @@ func (destination *WebHookEventSubscriptionDestination) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// no assignment for property ‘EndpointUrl’
+	// no assignment for property "EndpointUrl"
 
-	// Set property ‘MaxEventsPerBatch’:
+	// Set property "MaxEventsPerBatch":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxEventsPerBatch != nil {
@@ -6010,7 +6010,7 @@ func (destination *WebHookEventSubscriptionDestination) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘PreferredBatchSizeInKilobytes’:
+	// Set property "PreferredBatchSizeInKilobytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PreferredBatchSizeInKilobytes != nil {
@@ -6165,7 +6165,7 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebHookEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureActiveDirectoryApplicationIdOrUri’:
+	// Set property "AzureActiveDirectoryApplicationIdOrUri":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureActiveDirectoryApplicationIdOrUri != nil {
@@ -6174,7 +6174,7 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘AzureActiveDirectoryTenantId’:
+	// Set property "AzureActiveDirectoryTenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureActiveDirectoryTenantId != nil {
@@ -6183,7 +6183,7 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘EndpointBaseUrl’:
+	// Set property "EndpointBaseUrl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndpointBaseUrl != nil {
@@ -6192,10 +6192,10 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘MaxEventsPerBatch’:
+	// Set property "MaxEventsPerBatch":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxEventsPerBatch != nil {
@@ -6204,7 +6204,7 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘PreferredBatchSizeInKilobytes’:
+	// Set property "PreferredBatchSizeInKilobytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PreferredBatchSizeInKilobytes != nil {
@@ -6316,18 +6316,18 @@ func (filter *BoolEqualsAdvancedFilter) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &BoolEqualsAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if filter.Value != nil {
 		value := *filter.Value
 		result.Value = &value
@@ -6347,16 +6347,16 @@ func (filter *BoolEqualsAdvancedFilter) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BoolEqualsAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -6478,16 +6478,16 @@ func (filter *BoolEqualsAdvancedFilter_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BoolEqualsAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -6597,18 +6597,18 @@ func (filter *NumberGreaterThanAdvancedFilter) ConvertToARM(resolved genruntime.
 	}
 	result := &NumberGreaterThanAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if filter.Value != nil {
 		value := *filter.Value
 		result.Value = &value
@@ -6628,16 +6628,16 @@ func (filter *NumberGreaterThanAdvancedFilter) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberGreaterThanAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -6759,16 +6759,16 @@ func (filter *NumberGreaterThanAdvancedFilter_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberGreaterThanAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -6860,18 +6860,18 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter) ConvertToARM(resolved gen
 	}
 	result := &NumberGreaterThanOrEqualsAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if filter.Value != nil {
 		value := *filter.Value
 		result.Value = &value
@@ -6891,16 +6891,16 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberGreaterThanOrEqualsAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -7022,16 +7022,16 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberGreaterThanOrEqualsAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -7123,18 +7123,18 @@ func (filter *NumberInAdvancedFilter) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &NumberInAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -7153,16 +7153,16 @@ func (filter *NumberInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberInAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -7298,16 +7298,16 @@ func (filter *NumberInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberInAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -7408,18 +7408,18 @@ func (filter *NumberLessThanAdvancedFilter) ConvertToARM(resolved genruntime.Con
 	}
 	result := &NumberLessThanAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if filter.Value != nil {
 		value := *filter.Value
 		result.Value = &value
@@ -7439,16 +7439,16 @@ func (filter *NumberLessThanAdvancedFilter) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberLessThanAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -7570,16 +7570,16 @@ func (filter *NumberLessThanAdvancedFilter_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberLessThanAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -7671,18 +7671,18 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter) ConvertToARM(resolved genrun
 	}
 	result := &NumberLessThanOrEqualsAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if filter.Value != nil {
 		value := *filter.Value
 		result.Value = &value
@@ -7702,16 +7702,16 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberLessThanOrEqualsAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -7833,16 +7833,16 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberLessThanOrEqualsAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -7934,18 +7934,18 @@ func (filter *NumberNotInAdvancedFilter) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &NumberNotInAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -7964,16 +7964,16 @@ func (filter *NumberNotInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberNotInAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -8109,16 +8109,16 @@ func (filter *NumberNotInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberNotInAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -8255,18 +8255,18 @@ func (filter *StringBeginsWithAdvancedFilter) ConvertToARM(resolved genruntime.C
 	}
 	result := &StringBeginsWithAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -8285,16 +8285,16 @@ func (filter *StringBeginsWithAdvancedFilter) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringBeginsWithAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -8400,16 +8400,16 @@ func (filter *StringBeginsWithAdvancedFilter_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringBeginsWithAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -8490,18 +8490,18 @@ func (filter *StringContainsAdvancedFilter) ConvertToARM(resolved genruntime.Con
 	}
 	result := &StringContainsAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -8520,16 +8520,16 @@ func (filter *StringContainsAdvancedFilter) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringContainsAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -8635,16 +8635,16 @@ func (filter *StringContainsAdvancedFilter_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringContainsAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -8725,18 +8725,18 @@ func (filter *StringEndsWithAdvancedFilter) ConvertToARM(resolved genruntime.Con
 	}
 	result := &StringEndsWithAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -8755,16 +8755,16 @@ func (filter *StringEndsWithAdvancedFilter) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringEndsWithAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -8870,16 +8870,16 @@ func (filter *StringEndsWithAdvancedFilter_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringEndsWithAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -8960,18 +8960,18 @@ func (filter *StringInAdvancedFilter) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &StringInAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -8990,16 +8990,16 @@ func (filter *StringInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringInAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -9105,16 +9105,16 @@ func (filter *StringInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringInAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -9195,18 +9195,18 @@ func (filter *StringNotInAdvancedFilter) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &StringNotInAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -9225,16 +9225,16 @@ func (filter *StringNotInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringNotInAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -9340,16 +9340,16 @@ func (filter *StringNotInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringNotInAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}

--- a/v2/api/eventgrid/v1api20200601/topic_types_gen.go
+++ b/v2/api/eventgrid/v1api20200601/topic_types_gen.go
@@ -354,16 +354,16 @@ func (topic *Topic_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &Topic_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if topic.Location != nil {
 		location := *topic.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if topic.InboundIpRules != nil ||
 		topic.InputSchema != nil ||
 		topic.InputSchemaMapping != nil ||
@@ -394,7 +394,7 @@ func (topic *Topic_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if topic.Tags != nil {
 		result.Tags = make(map[string]string, len(topic.Tags))
 		for key, value := range topic.Tags {
@@ -416,10 +416,10 @@ func (topic *Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Topic_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	topic.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘InboundIpRules’:
+	// Set property "InboundIpRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundIpRules {
@@ -432,7 +432,7 @@ func (topic *Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘InputSchema’:
+	// Set property "InputSchema":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchema != nil {
@@ -441,7 +441,7 @@ func (topic *Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘InputSchemaMapping’:
+	// Set property "InputSchemaMapping":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchemaMapping != nil {
@@ -455,16 +455,16 @@ func (topic *Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		topic.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	topic.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -473,7 +473,7 @@ func (topic *Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		topic.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -868,9 +868,9 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Topic_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Endpoint’:
+	// Set property "Endpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Endpoint != nil {
@@ -879,13 +879,13 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		topic.Id = &id
 	}
 
-	// Set property ‘InboundIpRules’:
+	// Set property "InboundIpRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundIpRules {
@@ -898,7 +898,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘InputSchema’:
+	// Set property "InputSchema":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchema != nil {
@@ -907,7 +907,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘InputSchemaMapping’:
+	// Set property "InputSchemaMapping":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchemaMapping != nil {
@@ -921,13 +921,13 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		topic.Location = &location
 	}
 
-	// Set property ‘MetricResourceId’:
+	// Set property "MetricResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MetricResourceId != nil {
@@ -936,13 +936,13 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		topic.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -955,7 +955,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -964,7 +964,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -973,7 +973,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -984,7 +984,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		topic.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		topic.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -992,7 +992,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		topic.Type = &typeVar
@@ -1260,7 +1260,7 @@ func (embedded *PrivateEndpointConnection_STATUS_Topic_SubResourceEmbedded) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_Topic_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id

--- a/v2/api/eventgrid/v1beta20200601/domain_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/domain_types_gen.go
@@ -344,16 +344,16 @@ func (domain *Domain_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &Domain_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if domain.Location != nil {
 		location := *domain.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if domain.InboundIpRules != nil ||
 		domain.InputSchema != nil ||
 		domain.InputSchemaMapping != nil ||
@@ -384,7 +384,7 @@ func (domain *Domain_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if domain.Tags != nil {
 		result.Tags = make(map[string]string, len(domain.Tags))
 		for key, value := range domain.Tags {
@@ -406,10 +406,10 @@ func (domain *Domain_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Domain_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	domain.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘InboundIpRules’:
+	// Set property "InboundIpRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundIpRules {
@@ -422,7 +422,7 @@ func (domain *Domain_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘InputSchema’:
+	// Set property "InputSchema":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchema != nil {
@@ -431,7 +431,7 @@ func (domain *Domain_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘InputSchemaMapping’:
+	// Set property "InputSchemaMapping":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchemaMapping != nil {
@@ -445,16 +445,16 @@ func (domain *Domain_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		domain.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	domain.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -463,7 +463,7 @@ func (domain *Domain_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		domain.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -769,9 +769,9 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Domain_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Endpoint’:
+	// Set property "Endpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Endpoint != nil {
@@ -780,13 +780,13 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		domain.Id = &id
 	}
 
-	// Set property ‘InboundIpRules’:
+	// Set property "InboundIpRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundIpRules {
@@ -799,7 +799,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘InputSchema’:
+	// Set property "InputSchema":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchema != nil {
@@ -808,7 +808,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘InputSchemaMapping’:
+	// Set property "InputSchemaMapping":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchemaMapping != nil {
@@ -822,13 +822,13 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		domain.Location = &location
 	}
 
-	// Set property ‘MetricResourceId’:
+	// Set property "MetricResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MetricResourceId != nil {
@@ -837,13 +837,13 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		domain.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -856,7 +856,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -865,7 +865,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -874,7 +874,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -885,7 +885,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		domain.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		domain.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -893,7 +893,7 @@ func (domain *Domain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		domain.Type = &typeVar
@@ -1208,13 +1208,13 @@ func (rule *InboundIpRule) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &InboundIpRule_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if rule.Action != nil {
 		action := *rule.Action
 		result.Action = &action
 	}
 
-	// Set property ‘IpMask’:
+	// Set property "IpMask":
 	if rule.IpMask != nil {
 		ipMask := *rule.IpMask
 		result.IpMask = &ipMask
@@ -1234,13 +1234,13 @@ func (rule *InboundIpRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundIpRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘IpMask’:
+	// Set property "IpMask":
 	if typedInput.IpMask != nil {
 		ipMask := *typedInput.IpMask
 		rule.IpMask = &ipMask
@@ -1315,13 +1315,13 @@ func (rule *InboundIpRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundIpRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘IpMask’:
+	// Set property "IpMask":
 	if typedInput.IpMask != nil {
 		ipMask := *typedInput.IpMask
 		rule.IpMask = &ipMask
@@ -1390,7 +1390,7 @@ func (mapping *InputSchemaMapping) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &InputSchemaMapping_ARM{}
 
-	// Set property ‘Json’:
+	// Set property "Json":
 	if mapping.Json != nil {
 		json_ARM, err := (*mapping.Json).ConvertToARM(resolved)
 		if err != nil {
@@ -1414,7 +1414,7 @@ func (mapping *InputSchemaMapping) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InputSchemaMapping_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Json’:
+	// Set property "Json":
 	if typedInput.Json != nil {
 		var json1 JsonInputSchemaMapping
 		err := json1.PopulateFromARM(owner, *typedInput.Json)
@@ -1495,7 +1495,7 @@ func (mapping *InputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InputSchemaMapping_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Json’:
+	// Set property "Json":
 	if typedInput.Json != nil {
 		var json1 JsonInputSchemaMapping_STATUS
 		err := json1.PopulateFromARM(owner, *typedInput.Json)
@@ -1576,7 +1576,7 @@ func (embedded *PrivateEndpointConnection_STATUS_Domain_SubResourceEmbedded) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_Domain_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -1639,37 +1639,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -1791,12 +1791,12 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &JsonInputSchemaMapping_ARM{}
 
-	// Set property ‘InputSchemaMappingType’:
+	// Set property "InputSchemaMappingType":
 	if mapping.InputSchemaMappingType != nil {
 		result.InputSchemaMappingType = *mapping.InputSchemaMappingType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if mapping.DataVersion != nil ||
 		mapping.EventTime != nil ||
 		mapping.EventType != nil ||
@@ -1868,7 +1868,7 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected JsonInputSchemaMapping_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataVersion’:
+	// Set property "DataVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataVersion != nil {
@@ -1882,7 +1882,7 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EventTime’:
+	// Set property "EventTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EventTime != nil {
@@ -1896,7 +1896,7 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘EventType’:
+	// Set property "EventType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EventType != nil {
@@ -1910,7 +1910,7 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Id != nil {
@@ -1924,10 +1924,10 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘InputSchemaMappingType’:
+	// Set property "InputSchemaMappingType":
 	mapping.InputSchemaMappingType = &typedInput.InputSchemaMappingType
 
-	// Set property ‘Subject’:
+	// Set property "Subject":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subject != nil {
@@ -1941,7 +1941,7 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Topic’:
+	// Set property "Topic":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Topic != nil {
@@ -2167,7 +2167,7 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected JsonInputSchemaMapping_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataVersion’:
+	// Set property "DataVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataVersion != nil {
@@ -2181,7 +2181,7 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EventTime’:
+	// Set property "EventTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EventTime != nil {
@@ -2195,7 +2195,7 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EventType’:
+	// Set property "EventType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EventType != nil {
@@ -2209,7 +2209,7 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Id != nil {
@@ -2223,10 +2223,10 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘InputSchemaMappingType’:
+	// Set property "InputSchemaMappingType":
 	mapping.InputSchemaMappingType = &typedInput.InputSchemaMappingType
 
-	// Set property ‘Subject’:
+	// Set property "Subject":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subject != nil {
@@ -2240,7 +2240,7 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Topic’:
+	// Set property "Topic":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Topic != nil {
@@ -2455,7 +2455,7 @@ func (field *JsonField) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &JsonField_ARM{}
 
-	// Set property ‘SourceField’:
+	// Set property "SourceField":
 	if field.SourceField != nil {
 		sourceField := *field.SourceField
 		result.SourceField = &sourceField
@@ -2475,7 +2475,7 @@ func (field *JsonField) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected JsonField_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceField’:
+	// Set property "SourceField":
 	if typedInput.SourceField != nil {
 		sourceField := *typedInput.SourceField
 		field.SourceField = &sourceField
@@ -2533,7 +2533,7 @@ func (field *JsonField_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected JsonField_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘SourceField’:
+	// Set property "SourceField":
 	if typedInput.SourceField != nil {
 		sourceField := *typedInput.SourceField
 		field.SourceField = &sourceField
@@ -2587,13 +2587,13 @@ func (withDefault *JsonFieldWithDefault) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &JsonFieldWithDefault_ARM{}
 
-	// Set property ‘DefaultValue’:
+	// Set property "DefaultValue":
 	if withDefault.DefaultValue != nil {
 		defaultValue := *withDefault.DefaultValue
 		result.DefaultValue = &defaultValue
 	}
 
-	// Set property ‘SourceField’:
+	// Set property "SourceField":
 	if withDefault.SourceField != nil {
 		sourceField := *withDefault.SourceField
 		result.SourceField = &sourceField
@@ -2613,13 +2613,13 @@ func (withDefault *JsonFieldWithDefault) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected JsonFieldWithDefault_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultValue’:
+	// Set property "DefaultValue":
 	if typedInput.DefaultValue != nil {
 		defaultValue := *typedInput.DefaultValue
 		withDefault.DefaultValue = &defaultValue
 	}
 
-	// Set property ‘SourceField’:
+	// Set property "SourceField":
 	if typedInput.SourceField != nil {
 		sourceField := *typedInput.SourceField
 		withDefault.SourceField = &sourceField
@@ -2684,13 +2684,13 @@ func (withDefault *JsonFieldWithDefault_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected JsonFieldWithDefault_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultValue’:
+	// Set property "DefaultValue":
 	if typedInput.DefaultValue != nil {
 		defaultValue := *typedInput.DefaultValue
 		withDefault.DefaultValue = &defaultValue
 	}
 
-	// Set property ‘SourceField’:
+	// Set property "SourceField":
 	if typedInput.SourceField != nil {
 		sourceField := *typedInput.SourceField
 		withDefault.SourceField = &sourceField

--- a/v2/api/eventgrid/v1beta20200601/domains_topic_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/domains_topic_types_gen.go
@@ -330,7 +330,7 @@ func (topic *Domains_Topic_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &Domains_Topic_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 	return result, nil
 }
@@ -347,10 +347,10 @@ func (topic *Domains_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Domains_Topic_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	topic.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	topic.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -538,21 +538,21 @@ func (topic *Domains_Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Domains_Topic_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		topic.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		topic.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -561,7 +561,7 @@ func (topic *Domains_Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -572,7 +572,7 @@ func (topic *Domains_Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		topic.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		topic.Type = &typeVar

--- a/v2/api/eventgrid/v1beta20200601/event_subscription_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/event_subscription_types_gen.go
@@ -336,10 +336,10 @@ func (subscription *EventSubscription_Spec) ConvertToARM(resolved genruntime.Con
 	}
 	result := &EventSubscription_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if subscription.DeadLetterDestination != nil ||
 		subscription.Destination != nil ||
 		subscription.EventDeliverySchema != nil ||
@@ -407,10 +407,10 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventSubscription_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	subscription.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DeadLetterDestination’:
+	// Set property "DeadLetterDestination":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetterDestination != nil {
@@ -424,7 +424,7 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Destination != nil {
@@ -438,7 +438,7 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘EventDeliverySchema’:
+	// Set property "EventDeliverySchema":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EventDeliverySchema != nil {
@@ -447,7 +447,7 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘ExpirationTimeUtc’:
+	// Set property "ExpirationTimeUtc":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExpirationTimeUtc != nil {
@@ -456,7 +456,7 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Filter’:
+	// Set property "Filter":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Filter != nil {
@@ -470,7 +470,7 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Labels’:
+	// Set property "Labels":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Labels {
@@ -478,10 +478,10 @@ func (subscription *EventSubscription_Spec) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	subscription.Owner = &owner
 
-	// Set property ‘RetryPolicy’:
+	// Set property "RetryPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetryPolicy != nil {
@@ -814,9 +814,9 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventSubscription_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DeadLetterDestination’:
+	// Set property "DeadLetterDestination":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetterDestination != nil {
@@ -830,7 +830,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Destination != nil {
@@ -844,7 +844,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘EventDeliverySchema’:
+	// Set property "EventDeliverySchema":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EventDeliverySchema != nil {
@@ -853,7 +853,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ExpirationTimeUtc’:
+	// Set property "ExpirationTimeUtc":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExpirationTimeUtc != nil {
@@ -862,7 +862,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Filter’:
+	// Set property "Filter":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Filter != nil {
@@ -876,13 +876,13 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		subscription.Id = &id
 	}
 
-	// Set property ‘Labels’:
+	// Set property "Labels":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Labels {
@@ -890,13 +890,13 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		subscription.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -905,7 +905,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘RetryPolicy’:
+	// Set property "RetryPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetryPolicy != nil {
@@ -919,7 +919,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -930,7 +930,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		subscription.SystemData = &systemData
 	}
 
-	// Set property ‘Topic’:
+	// Set property "Topic":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Topic != nil {
@@ -939,7 +939,7 @@ func (subscription *EventSubscription_STATUS) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		subscription.Type = &typeVar
@@ -1180,7 +1180,7 @@ func (destination *DeadLetterDestination) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &DeadLetterDestination_ARM{}
 
-	// Set property ‘StorageBlob’:
+	// Set property "StorageBlob":
 	if destination.StorageBlob != nil {
 		storageBlob_ARM, err := (*destination.StorageBlob).ConvertToARM(resolved)
 		if err != nil {
@@ -1204,7 +1204,7 @@ func (destination *DeadLetterDestination) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeadLetterDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘StorageBlob’:
+	// Set property "StorageBlob":
 	if typedInput.StorageBlob != nil {
 		var storageBlob1 StorageBlobDeadLetterDestination
 		err := storageBlob1.PopulateFromARM(owner, *typedInput.StorageBlob)
@@ -1285,7 +1285,7 @@ func (destination *DeadLetterDestination_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeadLetterDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘StorageBlob’:
+	// Set property "StorageBlob":
 	if typedInput.StorageBlob != nil {
 		var storageBlob1 StorageBlobDeadLetterDestination_STATUS
 		err := storageBlob1.PopulateFromARM(owner, *typedInput.StorageBlob)
@@ -1367,7 +1367,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 	}
 	result := &EventSubscriptionDestination_ARM{}
 
-	// Set property ‘AzureFunction’:
+	// Set property "AzureFunction":
 	if destination.AzureFunction != nil {
 		azureFunction_ARM, err := (*destination.AzureFunction).ConvertToARM(resolved)
 		if err != nil {
@@ -1377,7 +1377,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		result.AzureFunction = &azureFunction
 	}
 
-	// Set property ‘EventHub’:
+	// Set property "EventHub":
 	if destination.EventHub != nil {
 		eventHub_ARM, err := (*destination.EventHub).ConvertToARM(resolved)
 		if err != nil {
@@ -1387,7 +1387,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		result.EventHub = &eventHub
 	}
 
-	// Set property ‘HybridConnection’:
+	// Set property "HybridConnection":
 	if destination.HybridConnection != nil {
 		hybridConnection_ARM, err := (*destination.HybridConnection).ConvertToARM(resolved)
 		if err != nil {
@@ -1397,7 +1397,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		result.HybridConnection = &hybridConnection
 	}
 
-	// Set property ‘ServiceBusQueue’:
+	// Set property "ServiceBusQueue":
 	if destination.ServiceBusQueue != nil {
 		serviceBusQueue_ARM, err := (*destination.ServiceBusQueue).ConvertToARM(resolved)
 		if err != nil {
@@ -1407,7 +1407,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		result.ServiceBusQueue = &serviceBusQueue
 	}
 
-	// Set property ‘ServiceBusTopic’:
+	// Set property "ServiceBusTopic":
 	if destination.ServiceBusTopic != nil {
 		serviceBusTopic_ARM, err := (*destination.ServiceBusTopic).ConvertToARM(resolved)
 		if err != nil {
@@ -1417,7 +1417,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		result.ServiceBusTopic = &serviceBusTopic
 	}
 
-	// Set property ‘StorageQueue’:
+	// Set property "StorageQueue":
 	if destination.StorageQueue != nil {
 		storageQueue_ARM, err := (*destination.StorageQueue).ConvertToARM(resolved)
 		if err != nil {
@@ -1427,7 +1427,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		result.StorageQueue = &storageQueue
 	}
 
-	// Set property ‘WebHook’:
+	// Set property "WebHook":
 	if destination.WebHook != nil {
 		webHook_ARM, err := (*destination.WebHook).ConvertToARM(resolved)
 		if err != nil {
@@ -1451,7 +1451,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureFunction’:
+	// Set property "AzureFunction":
 	if typedInput.AzureFunction != nil {
 		var azureFunction1 AzureFunctionEventSubscriptionDestination
 		err := azureFunction1.PopulateFromARM(owner, *typedInput.AzureFunction)
@@ -1462,7 +1462,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		destination.AzureFunction = &azureFunction
 	}
 
-	// Set property ‘EventHub’:
+	// Set property "EventHub":
 	if typedInput.EventHub != nil {
 		var eventHub1 EventHubEventSubscriptionDestination
 		err := eventHub1.PopulateFromARM(owner, *typedInput.EventHub)
@@ -1473,7 +1473,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		destination.EventHub = &eventHub
 	}
 
-	// Set property ‘HybridConnection’:
+	// Set property "HybridConnection":
 	if typedInput.HybridConnection != nil {
 		var hybridConnection1 HybridConnectionEventSubscriptionDestination
 		err := hybridConnection1.PopulateFromARM(owner, *typedInput.HybridConnection)
@@ -1484,7 +1484,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		destination.HybridConnection = &hybridConnection
 	}
 
-	// Set property ‘ServiceBusQueue’:
+	// Set property "ServiceBusQueue":
 	if typedInput.ServiceBusQueue != nil {
 		var serviceBusQueue1 ServiceBusQueueEventSubscriptionDestination
 		err := serviceBusQueue1.PopulateFromARM(owner, *typedInput.ServiceBusQueue)
@@ -1495,7 +1495,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		destination.ServiceBusQueue = &serviceBusQueue
 	}
 
-	// Set property ‘ServiceBusTopic’:
+	// Set property "ServiceBusTopic":
 	if typedInput.ServiceBusTopic != nil {
 		var serviceBusTopic1 ServiceBusTopicEventSubscriptionDestination
 		err := serviceBusTopic1.PopulateFromARM(owner, *typedInput.ServiceBusTopic)
@@ -1506,7 +1506,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		destination.ServiceBusTopic = &serviceBusTopic
 	}
 
-	// Set property ‘StorageQueue’:
+	// Set property "StorageQueue":
 	if typedInput.StorageQueue != nil {
 		var storageQueue1 StorageQueueEventSubscriptionDestination
 		err := storageQueue1.PopulateFromARM(owner, *typedInput.StorageQueue)
@@ -1517,7 +1517,7 @@ func (destination *EventSubscriptionDestination) PopulateFromARM(owner genruntim
 		destination.StorageQueue = &storageQueue
 	}
 
-	// Set property ‘WebHook’:
+	// Set property "WebHook":
 	if typedInput.WebHook != nil {
 		var webHook1 WebHookEventSubscriptionDestination
 		err := webHook1.PopulateFromARM(owner, *typedInput.WebHook)
@@ -1748,7 +1748,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureFunction’:
+	// Set property "AzureFunction":
 	if typedInput.AzureFunction != nil {
 		var azureFunction1 AzureFunctionEventSubscriptionDestination_STATUS
 		err := azureFunction1.PopulateFromARM(owner, *typedInput.AzureFunction)
@@ -1759,7 +1759,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		destination.AzureFunction = &azureFunction
 	}
 
-	// Set property ‘EventHub’:
+	// Set property "EventHub":
 	if typedInput.EventHub != nil {
 		var eventHub1 EventHubEventSubscriptionDestination_STATUS
 		err := eventHub1.PopulateFromARM(owner, *typedInput.EventHub)
@@ -1770,7 +1770,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		destination.EventHub = &eventHub
 	}
 
-	// Set property ‘HybridConnection’:
+	// Set property "HybridConnection":
 	if typedInput.HybridConnection != nil {
 		var hybridConnection1 HybridConnectionEventSubscriptionDestination_STATUS
 		err := hybridConnection1.PopulateFromARM(owner, *typedInput.HybridConnection)
@@ -1781,7 +1781,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		destination.HybridConnection = &hybridConnection
 	}
 
-	// Set property ‘ServiceBusQueue’:
+	// Set property "ServiceBusQueue":
 	if typedInput.ServiceBusQueue != nil {
 		var serviceBusQueue1 ServiceBusQueueEventSubscriptionDestination_STATUS
 		err := serviceBusQueue1.PopulateFromARM(owner, *typedInput.ServiceBusQueue)
@@ -1792,7 +1792,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		destination.ServiceBusQueue = &serviceBusQueue
 	}
 
-	// Set property ‘ServiceBusTopic’:
+	// Set property "ServiceBusTopic":
 	if typedInput.ServiceBusTopic != nil {
 		var serviceBusTopic1 ServiceBusTopicEventSubscriptionDestination_STATUS
 		err := serviceBusTopic1.PopulateFromARM(owner, *typedInput.ServiceBusTopic)
@@ -1803,7 +1803,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		destination.ServiceBusTopic = &serviceBusTopic
 	}
 
-	// Set property ‘StorageQueue’:
+	// Set property "StorageQueue":
 	if typedInput.StorageQueue != nil {
 		var storageQueue1 StorageQueueEventSubscriptionDestination_STATUS
 		err := storageQueue1.PopulateFromARM(owner, *typedInput.StorageQueue)
@@ -1814,7 +1814,7 @@ func (destination *EventSubscriptionDestination_STATUS) PopulateFromARM(owner ge
 		destination.StorageQueue = &storageQueue
 	}
 
-	// Set property ‘WebHook’:
+	// Set property "WebHook":
 	if typedInput.WebHook != nil {
 		var webHook1 WebHookEventSubscriptionDestination_STATUS
 		err := webHook1.PopulateFromARM(owner, *typedInput.WebHook)
@@ -2038,7 +2038,7 @@ func (filter *EventSubscriptionFilter) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &EventSubscriptionFilter_ARM{}
 
-	// Set property ‘AdvancedFilters’:
+	// Set property "AdvancedFilters":
 	for _, item := range filter.AdvancedFilters {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2047,24 +2047,24 @@ func (filter *EventSubscriptionFilter) ConvertToARM(resolved genruntime.ConvertT
 		result.AdvancedFilters = append(result.AdvancedFilters, *item_ARM.(*AdvancedFilter_ARM))
 	}
 
-	// Set property ‘IncludedEventTypes’:
+	// Set property "IncludedEventTypes":
 	for _, item := range filter.IncludedEventTypes {
 		result.IncludedEventTypes = append(result.IncludedEventTypes, item)
 	}
 
-	// Set property ‘IsSubjectCaseSensitive’:
+	// Set property "IsSubjectCaseSensitive":
 	if filter.IsSubjectCaseSensitive != nil {
 		isSubjectCaseSensitive := *filter.IsSubjectCaseSensitive
 		result.IsSubjectCaseSensitive = &isSubjectCaseSensitive
 	}
 
-	// Set property ‘SubjectBeginsWith’:
+	// Set property "SubjectBeginsWith":
 	if filter.SubjectBeginsWith != nil {
 		subjectBeginsWith := *filter.SubjectBeginsWith
 		result.SubjectBeginsWith = &subjectBeginsWith
 	}
 
-	// Set property ‘SubjectEndsWith’:
+	// Set property "SubjectEndsWith":
 	if filter.SubjectEndsWith != nil {
 		subjectEndsWith := *filter.SubjectEndsWith
 		result.SubjectEndsWith = &subjectEndsWith
@@ -2084,7 +2084,7 @@ func (filter *EventSubscriptionFilter) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventSubscriptionFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdvancedFilters’:
+	// Set property "AdvancedFilters":
 	for _, item := range typedInput.AdvancedFilters {
 		var item1 AdvancedFilter
 		err := item1.PopulateFromARM(owner, item)
@@ -2094,24 +2094,24 @@ func (filter *EventSubscriptionFilter) PopulateFromARM(owner genruntime.Arbitrar
 		filter.AdvancedFilters = append(filter.AdvancedFilters, item1)
 	}
 
-	// Set property ‘IncludedEventTypes’:
+	// Set property "IncludedEventTypes":
 	for _, item := range typedInput.IncludedEventTypes {
 		filter.IncludedEventTypes = append(filter.IncludedEventTypes, item)
 	}
 
-	// Set property ‘IsSubjectCaseSensitive’:
+	// Set property "IsSubjectCaseSensitive":
 	if typedInput.IsSubjectCaseSensitive != nil {
 		isSubjectCaseSensitive := *typedInput.IsSubjectCaseSensitive
 		filter.IsSubjectCaseSensitive = &isSubjectCaseSensitive
 	}
 
-	// Set property ‘SubjectBeginsWith’:
+	// Set property "SubjectBeginsWith":
 	if typedInput.SubjectBeginsWith != nil {
 		subjectBeginsWith := *typedInput.SubjectBeginsWith
 		filter.SubjectBeginsWith = &subjectBeginsWith
 	}
 
-	// Set property ‘SubjectEndsWith’:
+	// Set property "SubjectEndsWith":
 	if typedInput.SubjectEndsWith != nil {
 		subjectEndsWith := *typedInput.SubjectEndsWith
 		filter.SubjectEndsWith = &subjectEndsWith
@@ -2237,7 +2237,7 @@ func (filter *EventSubscriptionFilter_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventSubscriptionFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdvancedFilters’:
+	// Set property "AdvancedFilters":
 	for _, item := range typedInput.AdvancedFilters {
 		var item1 AdvancedFilter_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2247,24 +2247,24 @@ func (filter *EventSubscriptionFilter_STATUS) PopulateFromARM(owner genruntime.A
 		filter.AdvancedFilters = append(filter.AdvancedFilters, item1)
 	}
 
-	// Set property ‘IncludedEventTypes’:
+	// Set property "IncludedEventTypes":
 	for _, item := range typedInput.IncludedEventTypes {
 		filter.IncludedEventTypes = append(filter.IncludedEventTypes, item)
 	}
 
-	// Set property ‘IsSubjectCaseSensitive’:
+	// Set property "IsSubjectCaseSensitive":
 	if typedInput.IsSubjectCaseSensitive != nil {
 		isSubjectCaseSensitive := *typedInput.IsSubjectCaseSensitive
 		filter.IsSubjectCaseSensitive = &isSubjectCaseSensitive
 	}
 
-	// Set property ‘SubjectBeginsWith’:
+	// Set property "SubjectBeginsWith":
 	if typedInput.SubjectBeginsWith != nil {
 		subjectBeginsWith := *typedInput.SubjectBeginsWith
 		filter.SubjectBeginsWith = &subjectBeginsWith
 	}
 
-	// Set property ‘SubjectEndsWith’:
+	// Set property "SubjectEndsWith":
 	if typedInput.SubjectEndsWith != nil {
 		subjectEndsWith := *typedInput.SubjectEndsWith
 		filter.SubjectEndsWith = &subjectEndsWith
@@ -2417,13 +2417,13 @@ func (policy *RetryPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &RetryPolicy_ARM{}
 
-	// Set property ‘EventTimeToLiveInMinutes’:
+	// Set property "EventTimeToLiveInMinutes":
 	if policy.EventTimeToLiveInMinutes != nil {
 		eventTimeToLiveInMinutes := *policy.EventTimeToLiveInMinutes
 		result.EventTimeToLiveInMinutes = &eventTimeToLiveInMinutes
 	}
 
-	// Set property ‘MaxDeliveryAttempts’:
+	// Set property "MaxDeliveryAttempts":
 	if policy.MaxDeliveryAttempts != nil {
 		maxDeliveryAttempts := *policy.MaxDeliveryAttempts
 		result.MaxDeliveryAttempts = &maxDeliveryAttempts
@@ -2443,13 +2443,13 @@ func (policy *RetryPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RetryPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EventTimeToLiveInMinutes’:
+	// Set property "EventTimeToLiveInMinutes":
 	if typedInput.EventTimeToLiveInMinutes != nil {
 		eventTimeToLiveInMinutes := *typedInput.EventTimeToLiveInMinutes
 		policy.EventTimeToLiveInMinutes = &eventTimeToLiveInMinutes
 	}
 
-	// Set property ‘MaxDeliveryAttempts’:
+	// Set property "MaxDeliveryAttempts":
 	if typedInput.MaxDeliveryAttempts != nil {
 		maxDeliveryAttempts := *typedInput.MaxDeliveryAttempts
 		policy.MaxDeliveryAttempts = &maxDeliveryAttempts
@@ -2514,13 +2514,13 @@ func (policy *RetryPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RetryPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EventTimeToLiveInMinutes’:
+	// Set property "EventTimeToLiveInMinutes":
 	if typedInput.EventTimeToLiveInMinutes != nil {
 		eventTimeToLiveInMinutes := *typedInput.EventTimeToLiveInMinutes
 		policy.EventTimeToLiveInMinutes = &eventTimeToLiveInMinutes
 	}
 
-	// Set property ‘MaxDeliveryAttempts’:
+	// Set property "MaxDeliveryAttempts":
 	if typedInput.MaxDeliveryAttempts != nil {
 		maxDeliveryAttempts := *typedInput.MaxDeliveryAttempts
 		policy.MaxDeliveryAttempts = &maxDeliveryAttempts
@@ -2590,7 +2590,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &AdvancedFilter_ARM{}
 
-	// Set property ‘BoolEquals’:
+	// Set property "BoolEquals":
 	if filter.BoolEquals != nil {
 		boolEquals_ARM, err := (*filter.BoolEquals).ConvertToARM(resolved)
 		if err != nil {
@@ -2600,7 +2600,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.BoolEquals = &boolEquals
 	}
 
-	// Set property ‘NumberGreaterThan’:
+	// Set property "NumberGreaterThan":
 	if filter.NumberGreaterThan != nil {
 		numberGreaterThan_ARM, err := (*filter.NumberGreaterThan).ConvertToARM(resolved)
 		if err != nil {
@@ -2610,7 +2610,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.NumberGreaterThan = &numberGreaterThan
 	}
 
-	// Set property ‘NumberGreaterThanOrEquals’:
+	// Set property "NumberGreaterThanOrEquals":
 	if filter.NumberGreaterThanOrEquals != nil {
 		numberGreaterThanOrEquals_ARM, err := (*filter.NumberGreaterThanOrEquals).ConvertToARM(resolved)
 		if err != nil {
@@ -2620,7 +2620,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.NumberGreaterThanOrEquals = &numberGreaterThanOrEquals
 	}
 
-	// Set property ‘NumberIn’:
+	// Set property "NumberIn":
 	if filter.NumberIn != nil {
 		numberIn_ARM, err := (*filter.NumberIn).ConvertToARM(resolved)
 		if err != nil {
@@ -2630,7 +2630,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.NumberIn = &numberIn
 	}
 
-	// Set property ‘NumberLessThan’:
+	// Set property "NumberLessThan":
 	if filter.NumberLessThan != nil {
 		numberLessThan_ARM, err := (*filter.NumberLessThan).ConvertToARM(resolved)
 		if err != nil {
@@ -2640,7 +2640,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.NumberLessThan = &numberLessThan
 	}
 
-	// Set property ‘NumberLessThanOrEquals’:
+	// Set property "NumberLessThanOrEquals":
 	if filter.NumberLessThanOrEquals != nil {
 		numberLessThanOrEquals_ARM, err := (*filter.NumberLessThanOrEquals).ConvertToARM(resolved)
 		if err != nil {
@@ -2650,7 +2650,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.NumberLessThanOrEquals = &numberLessThanOrEquals
 	}
 
-	// Set property ‘NumberNotIn’:
+	// Set property "NumberNotIn":
 	if filter.NumberNotIn != nil {
 		numberNotIn_ARM, err := (*filter.NumberNotIn).ConvertToARM(resolved)
 		if err != nil {
@@ -2660,7 +2660,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.NumberNotIn = &numberNotIn
 	}
 
-	// Set property ‘StringBeginsWith’:
+	// Set property "StringBeginsWith":
 	if filter.StringBeginsWith != nil {
 		stringBeginsWith_ARM, err := (*filter.StringBeginsWith).ConvertToARM(resolved)
 		if err != nil {
@@ -2670,7 +2670,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.StringBeginsWith = &stringBeginsWith
 	}
 
-	// Set property ‘StringContains’:
+	// Set property "StringContains":
 	if filter.StringContains != nil {
 		stringContains_ARM, err := (*filter.StringContains).ConvertToARM(resolved)
 		if err != nil {
@@ -2680,7 +2680,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.StringContains = &stringContains
 	}
 
-	// Set property ‘StringEndsWith’:
+	// Set property "StringEndsWith":
 	if filter.StringEndsWith != nil {
 		stringEndsWith_ARM, err := (*filter.StringEndsWith).ConvertToARM(resolved)
 		if err != nil {
@@ -2690,7 +2690,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.StringEndsWith = &stringEndsWith
 	}
 
-	// Set property ‘StringIn’:
+	// Set property "StringIn":
 	if filter.StringIn != nil {
 		stringIn_ARM, err := (*filter.StringIn).ConvertToARM(resolved)
 		if err != nil {
@@ -2700,7 +2700,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.StringIn = &stringIn
 	}
 
-	// Set property ‘StringNotIn’:
+	// Set property "StringNotIn":
 	if filter.StringNotIn != nil {
 		stringNotIn_ARM, err := (*filter.StringNotIn).ConvertToARM(resolved)
 		if err != nil {
@@ -2724,7 +2724,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BoolEquals’:
+	// Set property "BoolEquals":
 	if typedInput.BoolEquals != nil {
 		var boolEquals1 BoolEqualsAdvancedFilter
 		err := boolEquals1.PopulateFromARM(owner, *typedInput.BoolEquals)
@@ -2735,7 +2735,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.BoolEquals = &boolEquals
 	}
 
-	// Set property ‘NumberGreaterThan’:
+	// Set property "NumberGreaterThan":
 	if typedInput.NumberGreaterThan != nil {
 		var numberGreaterThan1 NumberGreaterThanAdvancedFilter
 		err := numberGreaterThan1.PopulateFromARM(owner, *typedInput.NumberGreaterThan)
@@ -2746,7 +2746,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.NumberGreaterThan = &numberGreaterThan
 	}
 
-	// Set property ‘NumberGreaterThanOrEquals’:
+	// Set property "NumberGreaterThanOrEquals":
 	if typedInput.NumberGreaterThanOrEquals != nil {
 		var numberGreaterThanOrEquals1 NumberGreaterThanOrEqualsAdvancedFilter
 		err := numberGreaterThanOrEquals1.PopulateFromARM(owner, *typedInput.NumberGreaterThanOrEquals)
@@ -2757,7 +2757,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.NumberGreaterThanOrEquals = &numberGreaterThanOrEquals
 	}
 
-	// Set property ‘NumberIn’:
+	// Set property "NumberIn":
 	if typedInput.NumberIn != nil {
 		var numberIn1 NumberInAdvancedFilter
 		err := numberIn1.PopulateFromARM(owner, *typedInput.NumberIn)
@@ -2768,7 +2768,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.NumberIn = &numberIn
 	}
 
-	// Set property ‘NumberLessThan’:
+	// Set property "NumberLessThan":
 	if typedInput.NumberLessThan != nil {
 		var numberLessThan1 NumberLessThanAdvancedFilter
 		err := numberLessThan1.PopulateFromARM(owner, *typedInput.NumberLessThan)
@@ -2779,7 +2779,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.NumberLessThan = &numberLessThan
 	}
 
-	// Set property ‘NumberLessThanOrEquals’:
+	// Set property "NumberLessThanOrEquals":
 	if typedInput.NumberLessThanOrEquals != nil {
 		var numberLessThanOrEquals1 NumberLessThanOrEqualsAdvancedFilter
 		err := numberLessThanOrEquals1.PopulateFromARM(owner, *typedInput.NumberLessThanOrEquals)
@@ -2790,7 +2790,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.NumberLessThanOrEquals = &numberLessThanOrEquals
 	}
 
-	// Set property ‘NumberNotIn’:
+	// Set property "NumberNotIn":
 	if typedInput.NumberNotIn != nil {
 		var numberNotIn1 NumberNotInAdvancedFilter
 		err := numberNotIn1.PopulateFromARM(owner, *typedInput.NumberNotIn)
@@ -2801,7 +2801,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.NumberNotIn = &numberNotIn
 	}
 
-	// Set property ‘StringBeginsWith’:
+	// Set property "StringBeginsWith":
 	if typedInput.StringBeginsWith != nil {
 		var stringBeginsWith1 StringBeginsWithAdvancedFilter
 		err := stringBeginsWith1.PopulateFromARM(owner, *typedInput.StringBeginsWith)
@@ -2812,7 +2812,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.StringBeginsWith = &stringBeginsWith
 	}
 
-	// Set property ‘StringContains’:
+	// Set property "StringContains":
 	if typedInput.StringContains != nil {
 		var stringContains1 StringContainsAdvancedFilter
 		err := stringContains1.PopulateFromARM(owner, *typedInput.StringContains)
@@ -2823,7 +2823,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.StringContains = &stringContains
 	}
 
-	// Set property ‘StringEndsWith’:
+	// Set property "StringEndsWith":
 	if typedInput.StringEndsWith != nil {
 		var stringEndsWith1 StringEndsWithAdvancedFilter
 		err := stringEndsWith1.PopulateFromARM(owner, *typedInput.StringEndsWith)
@@ -2834,7 +2834,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.StringEndsWith = &stringEndsWith
 	}
 
-	// Set property ‘StringIn’:
+	// Set property "StringIn":
 	if typedInput.StringIn != nil {
 		var stringIn1 StringInAdvancedFilter
 		err := stringIn1.PopulateFromARM(owner, *typedInput.StringIn)
@@ -2845,7 +2845,7 @@ func (filter *AdvancedFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		filter.StringIn = &stringIn
 	}
 
-	// Set property ‘StringNotIn’:
+	// Set property "StringNotIn":
 	if typedInput.StringNotIn != nil {
 		var stringNotIn1 StringNotInAdvancedFilter
 		err := stringNotIn1.PopulateFromARM(owner, *typedInput.StringNotIn)
@@ -3201,7 +3201,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BoolEquals’:
+	// Set property "BoolEquals":
 	if typedInput.BoolEquals != nil {
 		var boolEquals1 BoolEqualsAdvancedFilter_STATUS
 		err := boolEquals1.PopulateFromARM(owner, *typedInput.BoolEquals)
@@ -3212,7 +3212,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.BoolEquals = &boolEquals
 	}
 
-	// Set property ‘NumberGreaterThan’:
+	// Set property "NumberGreaterThan":
 	if typedInput.NumberGreaterThan != nil {
 		var numberGreaterThan1 NumberGreaterThanAdvancedFilter_STATUS
 		err := numberGreaterThan1.PopulateFromARM(owner, *typedInput.NumberGreaterThan)
@@ -3223,7 +3223,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.NumberGreaterThan = &numberGreaterThan
 	}
 
-	// Set property ‘NumberGreaterThanOrEquals’:
+	// Set property "NumberGreaterThanOrEquals":
 	if typedInput.NumberGreaterThanOrEquals != nil {
 		var numberGreaterThanOrEquals1 NumberGreaterThanOrEqualsAdvancedFilter_STATUS
 		err := numberGreaterThanOrEquals1.PopulateFromARM(owner, *typedInput.NumberGreaterThanOrEquals)
@@ -3234,7 +3234,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.NumberGreaterThanOrEquals = &numberGreaterThanOrEquals
 	}
 
-	// Set property ‘NumberIn’:
+	// Set property "NumberIn":
 	if typedInput.NumberIn != nil {
 		var numberIn1 NumberInAdvancedFilter_STATUS
 		err := numberIn1.PopulateFromARM(owner, *typedInput.NumberIn)
@@ -3245,7 +3245,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.NumberIn = &numberIn
 	}
 
-	// Set property ‘NumberLessThan’:
+	// Set property "NumberLessThan":
 	if typedInput.NumberLessThan != nil {
 		var numberLessThan1 NumberLessThanAdvancedFilter_STATUS
 		err := numberLessThan1.PopulateFromARM(owner, *typedInput.NumberLessThan)
@@ -3256,7 +3256,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.NumberLessThan = &numberLessThan
 	}
 
-	// Set property ‘NumberLessThanOrEquals’:
+	// Set property "NumberLessThanOrEquals":
 	if typedInput.NumberLessThanOrEquals != nil {
 		var numberLessThanOrEquals1 NumberLessThanOrEqualsAdvancedFilter_STATUS
 		err := numberLessThanOrEquals1.PopulateFromARM(owner, *typedInput.NumberLessThanOrEquals)
@@ -3267,7 +3267,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.NumberLessThanOrEquals = &numberLessThanOrEquals
 	}
 
-	// Set property ‘NumberNotIn’:
+	// Set property "NumberNotIn":
 	if typedInput.NumberNotIn != nil {
 		var numberNotIn1 NumberNotInAdvancedFilter_STATUS
 		err := numberNotIn1.PopulateFromARM(owner, *typedInput.NumberNotIn)
@@ -3278,7 +3278,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.NumberNotIn = &numberNotIn
 	}
 
-	// Set property ‘StringBeginsWith’:
+	// Set property "StringBeginsWith":
 	if typedInput.StringBeginsWith != nil {
 		var stringBeginsWith1 StringBeginsWithAdvancedFilter_STATUS
 		err := stringBeginsWith1.PopulateFromARM(owner, *typedInput.StringBeginsWith)
@@ -3289,7 +3289,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.StringBeginsWith = &stringBeginsWith
 	}
 
-	// Set property ‘StringContains’:
+	// Set property "StringContains":
 	if typedInput.StringContains != nil {
 		var stringContains1 StringContainsAdvancedFilter_STATUS
 		err := stringContains1.PopulateFromARM(owner, *typedInput.StringContains)
@@ -3300,7 +3300,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.StringContains = &stringContains
 	}
 
-	// Set property ‘StringEndsWith’:
+	// Set property "StringEndsWith":
 	if typedInput.StringEndsWith != nil {
 		var stringEndsWith1 StringEndsWithAdvancedFilter_STATUS
 		err := stringEndsWith1.PopulateFromARM(owner, *typedInput.StringEndsWith)
@@ -3311,7 +3311,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.StringEndsWith = &stringEndsWith
 	}
 
-	// Set property ‘StringIn’:
+	// Set property "StringIn":
 	if typedInput.StringIn != nil {
 		var stringIn1 StringInAdvancedFilter_STATUS
 		err := stringIn1.PopulateFromARM(owner, *typedInput.StringIn)
@@ -3322,7 +3322,7 @@ func (filter *AdvancedFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		filter.StringIn = &stringIn
 	}
 
-	// Set property ‘StringNotIn’:
+	// Set property "StringNotIn":
 	if typedInput.StringNotIn != nil {
 		var stringNotIn1 StringNotInAdvancedFilter_STATUS
 		err := stringNotIn1.PopulateFromARM(owner, *typedInput.StringNotIn)
@@ -3666,12 +3666,12 @@ func (destination *AzureFunctionEventSubscriptionDestination) ConvertToARM(resol
 	}
 	result := &AzureFunctionEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.MaxEventsPerBatch != nil ||
 		destination.PreferredBatchSizeInKilobytes != nil ||
 		destination.ResourceReference != nil {
@@ -3708,10 +3708,10 @@ func (destination *AzureFunctionEventSubscriptionDestination) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFunctionEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘MaxEventsPerBatch’:
+	// Set property "MaxEventsPerBatch":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxEventsPerBatch != nil {
@@ -3720,7 +3720,7 @@ func (destination *AzureFunctionEventSubscriptionDestination) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘PreferredBatchSizeInKilobytes’:
+	// Set property "PreferredBatchSizeInKilobytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PreferredBatchSizeInKilobytes != nil {
@@ -3729,7 +3729,7 @@ func (destination *AzureFunctionEventSubscriptionDestination) PopulateFromARM(ow
 		}
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -3824,10 +3824,10 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFunctionEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘MaxEventsPerBatch’:
+	// Set property "MaxEventsPerBatch":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxEventsPerBatch != nil {
@@ -3836,7 +3836,7 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) PopulateFro
 		}
 	}
 
-	// Set property ‘PreferredBatchSizeInKilobytes’:
+	// Set property "PreferredBatchSizeInKilobytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PreferredBatchSizeInKilobytes != nil {
@@ -3845,7 +3845,7 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) PopulateFro
 		}
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -3931,12 +3931,12 @@ func (destination *EventHubEventSubscriptionDestination) ConvertToARM(resolved g
 	}
 	result := &EventHubEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.ResourceReference != nil {
 		result.Properties = &EventHubEventSubscriptionDestinationProperties_ARM{}
 	}
@@ -3963,10 +3963,10 @@ func (destination *EventHubEventSubscriptionDestination) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventHubEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -4047,10 +4047,10 @@ func (destination *EventHubEventSubscriptionDestination_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EventHubEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -4124,12 +4124,12 @@ func (destination *HybridConnectionEventSubscriptionDestination) ConvertToARM(re
 	}
 	result := &HybridConnectionEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.ResourceReference != nil {
 		result.Properties = &HybridConnectionEventSubscriptionDestinationProperties_ARM{}
 	}
@@ -4156,10 +4156,10 @@ func (destination *HybridConnectionEventSubscriptionDestination) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HybridConnectionEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -4240,10 +4240,10 @@ func (destination *HybridConnectionEventSubscriptionDestination_STATUS) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HybridConnectionEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -4317,12 +4317,12 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) ConvertToARM(res
 	}
 	result := &ServiceBusQueueEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.ResourceReference != nil {
 		result.Properties = &ServiceBusQueueEventSubscriptionDestinationProperties_ARM{}
 	}
@@ -4349,10 +4349,10 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceBusQueueEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -4433,10 +4433,10 @@ func (destination *ServiceBusQueueEventSubscriptionDestination_STATUS) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceBusQueueEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -4510,12 +4510,12 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) ConvertToARM(res
 	}
 	result := &ServiceBusTopicEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.ResourceReference != nil {
 		result.Properties = &ServiceBusTopicEventSubscriptionDestinationProperties_ARM{}
 	}
@@ -4542,10 +4542,10 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceBusTopicEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -4626,10 +4626,10 @@ func (destination *ServiceBusTopicEventSubscriptionDestination_STATUS) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceBusTopicEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -4705,12 +4705,12 @@ func (destination *StorageBlobDeadLetterDestination) ConvertToARM(resolved genru
 	}
 	result := &StorageBlobDeadLetterDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.BlobContainerName != nil || destination.ResourceReference != nil {
 		result.Properties = &StorageBlobDeadLetterDestinationProperties_ARM{}
 	}
@@ -4741,7 +4741,7 @@ func (destination *StorageBlobDeadLetterDestination) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageBlobDeadLetterDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobContainerName’:
+	// Set property "BlobContainerName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BlobContainerName != nil {
@@ -4750,10 +4750,10 @@ func (destination *StorageBlobDeadLetterDestination) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -4841,7 +4841,7 @@ func (destination *StorageBlobDeadLetterDestination_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageBlobDeadLetterDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobContainerName’:
+	// Set property "BlobContainerName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BlobContainerName != nil {
@@ -4850,10 +4850,10 @@ func (destination *StorageBlobDeadLetterDestination_STATUS) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -4934,12 +4934,12 @@ func (destination *StorageQueueEventSubscriptionDestination) ConvertToARM(resolv
 	}
 	result := &StorageQueueEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.QueueName != nil || destination.ResourceReference != nil {
 		result.Properties = &StorageQueueEventSubscriptionDestinationProperties_ARM{}
 	}
@@ -4970,10 +4970,10 @@ func (destination *StorageQueueEventSubscriptionDestination) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageQueueEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘QueueName’:
+	// Set property "QueueName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.QueueName != nil {
@@ -4982,7 +4982,7 @@ func (destination *StorageQueueEventSubscriptionDestination) PopulateFromARM(own
 		}
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -5070,10 +5070,10 @@ func (destination *StorageQueueEventSubscriptionDestination_STATUS) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageQueueEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘QueueName’:
+	// Set property "QueueName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.QueueName != nil {
@@ -5082,7 +5082,7 @@ func (destination *StorageQueueEventSubscriptionDestination_STATUS) PopulateFrom
 		}
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceId != nil {
@@ -5167,12 +5167,12 @@ func (destination *WebHookEventSubscriptionDestination) ConvertToARM(resolved ge
 	}
 	result := &WebHookEventSubscriptionDestination_ARM{}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	if destination.EndpointType != nil {
 		result.EndpointType = *destination.EndpointType
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.AzureActiveDirectoryApplicationIdOrUri != nil ||
 		destination.AzureActiveDirectoryTenantId != nil ||
 		destination.EndpointUrl != nil ||
@@ -5219,7 +5219,7 @@ func (destination *WebHookEventSubscriptionDestination) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebHookEventSubscriptionDestination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureActiveDirectoryApplicationIdOrUri’:
+	// Set property "AzureActiveDirectoryApplicationIdOrUri":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureActiveDirectoryApplicationIdOrUri != nil {
@@ -5228,7 +5228,7 @@ func (destination *WebHookEventSubscriptionDestination) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘AzureActiveDirectoryTenantId’:
+	// Set property "AzureActiveDirectoryTenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureActiveDirectoryTenantId != nil {
@@ -5237,12 +5237,12 @@ func (destination *WebHookEventSubscriptionDestination) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// no assignment for property ‘EndpointUrl’
+	// no assignment for property "EndpointUrl"
 
-	// Set property ‘MaxEventsPerBatch’:
+	// Set property "MaxEventsPerBatch":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxEventsPerBatch != nil {
@@ -5251,7 +5251,7 @@ func (destination *WebHookEventSubscriptionDestination) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘PreferredBatchSizeInKilobytes’:
+	// Set property "PreferredBatchSizeInKilobytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PreferredBatchSizeInKilobytes != nil {
@@ -5367,7 +5367,7 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebHookEventSubscriptionDestination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureActiveDirectoryApplicationIdOrUri’:
+	// Set property "AzureActiveDirectoryApplicationIdOrUri":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureActiveDirectoryApplicationIdOrUri != nil {
@@ -5376,7 +5376,7 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘AzureActiveDirectoryTenantId’:
+	// Set property "AzureActiveDirectoryTenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureActiveDirectoryTenantId != nil {
@@ -5385,7 +5385,7 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘EndpointBaseUrl’:
+	// Set property "EndpointBaseUrl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndpointBaseUrl != nil {
@@ -5394,10 +5394,10 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘EndpointType’:
+	// Set property "EndpointType":
 	destination.EndpointType = &typedInput.EndpointType
 
-	// Set property ‘MaxEventsPerBatch’:
+	// Set property "MaxEventsPerBatch":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxEventsPerBatch != nil {
@@ -5406,7 +5406,7 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘PreferredBatchSizeInKilobytes’:
+	// Set property "PreferredBatchSizeInKilobytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PreferredBatchSizeInKilobytes != nil {
@@ -5519,18 +5519,18 @@ func (filter *BoolEqualsAdvancedFilter) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &BoolEqualsAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if filter.Value != nil {
 		value := *filter.Value
 		result.Value = &value
@@ -5550,16 +5550,16 @@ func (filter *BoolEqualsAdvancedFilter) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BoolEqualsAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -5651,16 +5651,16 @@ func (filter *BoolEqualsAdvancedFilter_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BoolEqualsAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -5775,18 +5775,18 @@ func (filter *NumberGreaterThanAdvancedFilter) ConvertToARM(resolved genruntime.
 	}
 	result := &NumberGreaterThanAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if filter.Value != nil {
 		value := *filter.Value
 		result.Value = &value
@@ -5806,16 +5806,16 @@ func (filter *NumberGreaterThanAdvancedFilter) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberGreaterThanAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -5907,16 +5907,16 @@ func (filter *NumberGreaterThanAdvancedFilter_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberGreaterThanAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -6005,18 +6005,18 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter) ConvertToARM(resolved gen
 	}
 	result := &NumberGreaterThanOrEqualsAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if filter.Value != nil {
 		value := *filter.Value
 		result.Value = &value
@@ -6036,16 +6036,16 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberGreaterThanOrEqualsAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -6137,16 +6137,16 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberGreaterThanOrEqualsAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -6235,18 +6235,18 @@ func (filter *NumberInAdvancedFilter) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &NumberInAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -6265,16 +6265,16 @@ func (filter *NumberInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberInAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -6375,16 +6375,16 @@ func (filter *NumberInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberInAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -6482,18 +6482,18 @@ func (filter *NumberLessThanAdvancedFilter) ConvertToARM(resolved genruntime.Con
 	}
 	result := &NumberLessThanAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if filter.Value != nil {
 		value := *filter.Value
 		result.Value = &value
@@ -6513,16 +6513,16 @@ func (filter *NumberLessThanAdvancedFilter) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberLessThanAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -6614,16 +6614,16 @@ func (filter *NumberLessThanAdvancedFilter_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberLessThanAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -6712,18 +6712,18 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter) ConvertToARM(resolved genrun
 	}
 	result := &NumberLessThanOrEqualsAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if filter.Value != nil {
 		value := *filter.Value
 		result.Value = &value
@@ -6743,16 +6743,16 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberLessThanOrEqualsAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -6844,16 +6844,16 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberLessThanOrEqualsAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -6942,18 +6942,18 @@ func (filter *NumberNotInAdvancedFilter) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &NumberNotInAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -6972,16 +6972,16 @@ func (filter *NumberNotInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberNotInAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -7082,16 +7082,16 @@ func (filter *NumberNotInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NumberNotInAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -7241,18 +7241,18 @@ func (filter *StringBeginsWithAdvancedFilter) ConvertToARM(resolved genruntime.C
 	}
 	result := &StringBeginsWithAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -7271,16 +7271,16 @@ func (filter *StringBeginsWithAdvancedFilter) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringBeginsWithAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -7361,16 +7361,16 @@ func (filter *StringBeginsWithAdvancedFilter_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringBeginsWithAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -7448,18 +7448,18 @@ func (filter *StringContainsAdvancedFilter) ConvertToARM(resolved genruntime.Con
 	}
 	result := &StringContainsAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -7478,16 +7478,16 @@ func (filter *StringContainsAdvancedFilter) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringContainsAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -7568,16 +7568,16 @@ func (filter *StringContainsAdvancedFilter_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringContainsAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -7655,18 +7655,18 @@ func (filter *StringEndsWithAdvancedFilter) ConvertToARM(resolved genruntime.Con
 	}
 	result := &StringEndsWithAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -7685,16 +7685,16 @@ func (filter *StringEndsWithAdvancedFilter) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringEndsWithAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -7775,16 +7775,16 @@ func (filter *StringEndsWithAdvancedFilter_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringEndsWithAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -7862,18 +7862,18 @@ func (filter *StringInAdvancedFilter) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &StringInAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -7892,16 +7892,16 @@ func (filter *StringInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringInAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -7982,16 +7982,16 @@ func (filter *StringInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringInAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -8069,18 +8069,18 @@ func (filter *StringNotInAdvancedFilter) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &StringNotInAdvancedFilter_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if filter.Key != nil {
 		key := *filter.Key
 		result.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	if filter.OperatorType != nil {
 		result.OperatorType = *filter.OperatorType
 	}
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range filter.Values {
 		result.Values = append(result.Values, item)
 	}
@@ -8099,16 +8099,16 @@ func (filter *StringNotInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringNotInAdvancedFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}
@@ -8189,16 +8189,16 @@ func (filter *StringNotInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StringNotInAdvancedFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		filter.Key = &key
 	}
 
-	// Set property ‘OperatorType’:
+	// Set property "OperatorType":
 	filter.OperatorType = &typedInput.OperatorType
 
-	// Set property ‘Values’:
+	// Set property "Values":
 	for _, item := range typedInput.Values {
 		filter.Values = append(filter.Values, item)
 	}

--- a/v2/api/eventgrid/v1beta20200601/topic_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/topic_types_gen.go
@@ -338,16 +338,16 @@ func (topic *Topic_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &Topic_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if topic.Location != nil {
 		location := *topic.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if topic.InboundIpRules != nil ||
 		topic.InputSchema != nil ||
 		topic.InputSchemaMapping != nil ||
@@ -378,7 +378,7 @@ func (topic *Topic_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if topic.Tags != nil {
 		result.Tags = make(map[string]string, len(topic.Tags))
 		for key, value := range topic.Tags {
@@ -400,10 +400,10 @@ func (topic *Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Topic_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	topic.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘InboundIpRules’:
+	// Set property "InboundIpRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundIpRules {
@@ -416,7 +416,7 @@ func (topic *Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘InputSchema’:
+	// Set property "InputSchema":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchema != nil {
@@ -425,7 +425,7 @@ func (topic *Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘InputSchemaMapping’:
+	// Set property "InputSchemaMapping":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchemaMapping != nil {
@@ -439,16 +439,16 @@ func (topic *Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		topic.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	topic.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -457,7 +457,7 @@ func (topic *Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		topic.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -763,9 +763,9 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Topic_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Endpoint’:
+	// Set property "Endpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Endpoint != nil {
@@ -774,13 +774,13 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		topic.Id = &id
 	}
 
-	// Set property ‘InboundIpRules’:
+	// Set property "InboundIpRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundIpRules {
@@ -793,7 +793,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘InputSchema’:
+	// Set property "InputSchema":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchema != nil {
@@ -802,7 +802,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘InputSchemaMapping’:
+	// Set property "InputSchemaMapping":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InputSchemaMapping != nil {
@@ -816,13 +816,13 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		topic.Location = &location
 	}
 
-	// Set property ‘MetricResourceId’:
+	// Set property "MetricResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MetricResourceId != nil {
@@ -831,13 +831,13 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		topic.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -850,7 +850,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -859,7 +859,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -868,7 +868,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -879,7 +879,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		topic.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		topic.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -887,7 +887,7 @@ func (topic *Topic_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		topic.Type = &typeVar
@@ -1155,7 +1155,7 @@ func (embedded *PrivateEndpointConnection_STATUS_Topic_SubResourceEmbedded) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_Topic_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id

--- a/v2/api/eventhub/v1api20211101/namespace_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/namespace_types_gen.go
@@ -375,7 +375,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &Namespace_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if namespace.Identity != nil {
 		identity_ARM, err := (*namespace.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -385,16 +385,16 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if namespace.Location != nil {
 		location := *namespace.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if namespace.AlternateName != nil ||
 		namespace.ClusterArmReference != nil ||
 		namespace.DisableLocalAuth != nil ||
@@ -446,7 +446,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.ZoneRedundant = &zoneRedundant
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if namespace.Sku != nil {
 		sku_ARM, err := (*namespace.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -456,7 +456,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if namespace.Tags != nil {
 		result.Tags = make(map[string]string, len(namespace.Tags))
 		for key, value := range namespace.Tags {
@@ -478,7 +478,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespace_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AlternateName’:
+	// Set property "AlternateName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AlternateName != nil {
@@ -487,12 +487,12 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	namespace.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// no assignment for property ‘ClusterArmReference’
+	// no assignment for property "ClusterArmReference"
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -501,7 +501,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -515,7 +515,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -526,7 +526,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		namespace.Identity = &identity
 	}
 
-	// Set property ‘IsAutoInflateEnabled’:
+	// Set property "IsAutoInflateEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAutoInflateEnabled != nil {
@@ -535,7 +535,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘KafkaEnabled’:
+	// Set property "KafkaEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KafkaEnabled != nil {
@@ -544,13 +544,13 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		namespace.Location = &location
 	}
 
-	// Set property ‘MaximumThroughputUnits’:
+	// Set property "MaximumThroughputUnits":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaximumThroughputUnits != nil {
@@ -559,10 +559,10 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	namespace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -573,7 +573,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		namespace.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		namespace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -581,7 +581,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -1111,7 +1111,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespace_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AlternateName’:
+	// Set property "AlternateName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AlternateName != nil {
@@ -1120,7 +1120,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ClusterArmId’:
+	// Set property "ClusterArmId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClusterArmId != nil {
@@ -1129,9 +1129,9 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -1140,7 +1140,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -1149,7 +1149,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1163,13 +1163,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		namespace.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1180,7 +1180,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		namespace.Identity = &identity
 	}
 
-	// Set property ‘IsAutoInflateEnabled’:
+	// Set property "IsAutoInflateEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAutoInflateEnabled != nil {
@@ -1189,7 +1189,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘KafkaEnabled’:
+	// Set property "KafkaEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KafkaEnabled != nil {
@@ -1198,13 +1198,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		namespace.Location = &location
 	}
 
-	// Set property ‘MaximumThroughputUnits’:
+	// Set property "MaximumThroughputUnits":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaximumThroughputUnits != nil {
@@ -1213,7 +1213,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MetricId’:
+	// Set property "MetricId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MetricId != nil {
@@ -1222,13 +1222,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		namespace.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1241,7 +1241,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1250,7 +1250,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ServiceBusEndpoint’:
+	// Set property "ServiceBusEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceBusEndpoint != nil {
@@ -1259,7 +1259,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1270,7 +1270,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		namespace.Sku = &sku
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -1279,7 +1279,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1290,7 +1290,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		namespace.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		namespace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1298,13 +1298,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		namespace.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {
@@ -1313,7 +1313,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -1656,13 +1656,13 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Encryption_ARM{}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if encryption.KeySource != nil {
 		keySource := *encryption.KeySource
 		result.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	for _, item := range encryption.KeyVaultProperties {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1671,7 +1671,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.KeyVaultProperties = append(result.KeyVaultProperties, *item_ARM.(*KeyVaultProperties_ARM))
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if encryption.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *encryption.RequireInfrastructureEncryption
 		result.RequireInfrastructureEncryption = &requireInfrastructureEncryption
@@ -1691,13 +1691,13 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	for _, item := range typedInput.KeyVaultProperties {
 		var item1 KeyVaultProperties
 		err := item1.PopulateFromARM(owner, item)
@@ -1707,7 +1707,7 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		encryption.KeyVaultProperties = append(encryption.KeyVaultProperties, item1)
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
@@ -1875,13 +1875,13 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	for _, item := range typedInput.KeyVaultProperties {
 		var item1 KeyVaultProperties_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1891,7 +1891,7 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		encryption.KeyVaultProperties = append(encryption.KeyVaultProperties, item1)
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
@@ -2010,13 +2010,13 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Identity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -2041,13 +2041,13 @@ func (identity *Identity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -2184,25 +2184,25 @@ func (identity *Identity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2327,7 +2327,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -2390,19 +2390,19 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sku.Capacity != nil {
 		capacity := *sku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -2422,19 +2422,19 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2573,19 +2573,19 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2691,37 +2691,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -2842,7 +2842,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if properties.Identity != nil {
 		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -2852,19 +2852,19 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 		result.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if properties.KeyName != nil {
 		keyName := *properties.KeyName
 		result.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVaultUri’:
+	// Set property "KeyVaultUri":
 	if properties.KeyVaultUri != nil {
 		keyVaultUri := *properties.KeyVaultUri
 		result.KeyVaultUri = &keyVaultUri
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if properties.KeyVersion != nil {
 		keyVersion := *properties.KeyVersion
 		result.KeyVersion = &keyVersion
@@ -2884,7 +2884,7 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 UserAssignedIdentityProperties
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2895,19 +2895,19 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		properties.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		properties.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVaultUri’:
+	// Set property "KeyVaultUri":
 	if typedInput.KeyVaultUri != nil {
 		keyVaultUri := *typedInput.KeyVaultUri
 		properties.KeyVaultUri = &keyVaultUri
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		properties.KeyVersion = &keyVersion
@@ -3038,7 +3038,7 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 UserAssignedIdentityProperties_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -3049,19 +3049,19 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		properties.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		properties.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVaultUri’:
+	// Set property "KeyVaultUri":
 	if typedInput.KeyVaultUri != nil {
 		keyVaultUri := *typedInput.KeyVaultUri
 		properties.KeyVaultUri = &keyVaultUri
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		properties.KeyVersion = &keyVersion
@@ -3159,13 +3159,13 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
@@ -3258,7 +3258,7 @@ func (properties *UserAssignedIdentityProperties) ConvertToARM(resolved genrunti
 	}
 	result := &UserAssignedIdentityProperties_ARM{}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if properties.UserAssignedIdentityReference != nil {
 		userAssignedIdentityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.UserAssignedIdentityReference)
 		if err != nil {
@@ -3282,7 +3282,7 @@ func (properties *UserAssignedIdentityProperties) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentityProperties_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘UserAssignedIdentityReference’
+	// no assignment for property "UserAssignedIdentityReference"
 
 	// No error
 	return nil
@@ -3353,7 +3353,7 @@ func (properties *UserAssignedIdentityProperties_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentityProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		properties.UserAssignedIdentity = &userAssignedIdentity

--- a/v2/api/eventhub/v1api20211101/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/namespaces_authorization_rule_types_gen.go
@@ -336,10 +336,10 @@ func (rule *Namespaces_AuthorizationRule_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &Namespaces_AuthorizationRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.Rights != nil {
 		result.Properties = &Namespaces_AuthorizationRule_Properties_Spec_ARM{}
 	}
@@ -361,13 +361,13 @@ func (rule *Namespaces_AuthorizationRule_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_AuthorizationRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Rights’:
+	// Set property "Rights":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Rights {
@@ -622,27 +622,27 @@ func (rule *Namespaces_AuthorizationRule_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_AuthorizationRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		rule.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Rights’:
+	// Set property "Rights":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Rights {
@@ -650,7 +650,7 @@ func (rule *Namespaces_AuthorizationRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -661,7 +661,7 @@ func (rule *Namespaces_AuthorizationRule_STATUS) PopulateFromARM(owner genruntim
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/eventhub/v1api20211101/namespaces_eventhub_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/namespaces_eventhub_types_gen.go
@@ -344,10 +344,10 @@ func (eventhub *Namespaces_Eventhub_Spec) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &Namespaces_Eventhub_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if eventhub.CaptureDescription != nil ||
 		eventhub.MessageRetentionInDays != nil ||
 		eventhub.PartitionCount != nil {
@@ -384,10 +384,10 @@ func (eventhub *Namespaces_Eventhub_Spec) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Eventhub_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	eventhub.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CaptureDescription’:
+	// Set property "CaptureDescription":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CaptureDescription != nil {
@@ -401,7 +401,7 @@ func (eventhub *Namespaces_Eventhub_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘MessageRetentionInDays’:
+	// Set property "MessageRetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MessageRetentionInDays != nil {
@@ -410,10 +410,10 @@ func (eventhub *Namespaces_Eventhub_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	eventhub.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PartitionCount’:
+	// Set property "PartitionCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PartitionCount != nil {
@@ -731,7 +731,7 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Eventhub_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CaptureDescription’:
+	// Set property "CaptureDescription":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CaptureDescription != nil {
@@ -745,9 +745,9 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -756,19 +756,19 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		eventhub.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		eventhub.Location = &location
 	}
 
-	// Set property ‘MessageRetentionInDays’:
+	// Set property "MessageRetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MessageRetentionInDays != nil {
@@ -777,13 +777,13 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		eventhub.Name = &name
 	}
 
-	// Set property ‘PartitionCount’:
+	// Set property "PartitionCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PartitionCount != nil {
@@ -792,7 +792,7 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘PartitionIds’:
+	// Set property "PartitionIds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PartitionIds {
@@ -800,7 +800,7 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -809,7 +809,7 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -820,13 +820,13 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		eventhub.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		eventhub.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {
@@ -1019,7 +1019,7 @@ func (description *CaptureDescription) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &CaptureDescription_ARM{}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	if description.Destination != nil {
 		destination_ARM, err := (*description.Destination).ConvertToARM(resolved)
 		if err != nil {
@@ -1029,31 +1029,31 @@ func (description *CaptureDescription) ConvertToARM(resolved genruntime.ConvertT
 		result.Destination = &destination
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if description.Enabled != nil {
 		enabled := *description.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘Encoding’:
+	// Set property "Encoding":
 	if description.Encoding != nil {
 		encoding := *description.Encoding
 		result.Encoding = &encoding
 	}
 
-	// Set property ‘IntervalInSeconds’:
+	// Set property "IntervalInSeconds":
 	if description.IntervalInSeconds != nil {
 		intervalInSeconds := *description.IntervalInSeconds
 		result.IntervalInSeconds = &intervalInSeconds
 	}
 
-	// Set property ‘SizeLimitInBytes’:
+	// Set property "SizeLimitInBytes":
 	if description.SizeLimitInBytes != nil {
 		sizeLimitInBytes := *description.SizeLimitInBytes
 		result.SizeLimitInBytes = &sizeLimitInBytes
 	}
 
-	// Set property ‘SkipEmptyArchives’:
+	// Set property "SkipEmptyArchives":
 	if description.SkipEmptyArchives != nil {
 		skipEmptyArchives := *description.SkipEmptyArchives
 		result.SkipEmptyArchives = &skipEmptyArchives
@@ -1073,7 +1073,7 @@ func (description *CaptureDescription) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CaptureDescription_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	if typedInput.Destination != nil {
 		var destination1 Destination
 		err := destination1.PopulateFromARM(owner, *typedInput.Destination)
@@ -1084,31 +1084,31 @@ func (description *CaptureDescription) PopulateFromARM(owner genruntime.Arbitrar
 		description.Destination = &destination
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		description.Enabled = &enabled
 	}
 
-	// Set property ‘Encoding’:
+	// Set property "Encoding":
 	if typedInput.Encoding != nil {
 		encoding := *typedInput.Encoding
 		description.Encoding = &encoding
 	}
 
-	// Set property ‘IntervalInSeconds’:
+	// Set property "IntervalInSeconds":
 	if typedInput.IntervalInSeconds != nil {
 		intervalInSeconds := *typedInput.IntervalInSeconds
 		description.IntervalInSeconds = &intervalInSeconds
 	}
 
-	// Set property ‘SizeLimitInBytes’:
+	// Set property "SizeLimitInBytes":
 	if typedInput.SizeLimitInBytes != nil {
 		sizeLimitInBytes := *typedInput.SizeLimitInBytes
 		description.SizeLimitInBytes = &sizeLimitInBytes
 	}
 
-	// Set property ‘SkipEmptyArchives’:
+	// Set property "SkipEmptyArchives":
 	if typedInput.SkipEmptyArchives != nil {
 		skipEmptyArchives := *typedInput.SkipEmptyArchives
 		description.SkipEmptyArchives = &skipEmptyArchives
@@ -1312,7 +1312,7 @@ func (description *CaptureDescription_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CaptureDescription_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	if typedInput.Destination != nil {
 		var destination1 Destination_STATUS
 		err := destination1.PopulateFromARM(owner, *typedInput.Destination)
@@ -1323,31 +1323,31 @@ func (description *CaptureDescription_STATUS) PopulateFromARM(owner genruntime.A
 		description.Destination = &destination
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		description.Enabled = &enabled
 	}
 
-	// Set property ‘Encoding’:
+	// Set property "Encoding":
 	if typedInput.Encoding != nil {
 		encoding := *typedInput.Encoding
 		description.Encoding = &encoding
 	}
 
-	// Set property ‘IntervalInSeconds’:
+	// Set property "IntervalInSeconds":
 	if typedInput.IntervalInSeconds != nil {
 		intervalInSeconds := *typedInput.IntervalInSeconds
 		description.IntervalInSeconds = &intervalInSeconds
 	}
 
-	// Set property ‘SizeLimitInBytes’:
+	// Set property "SizeLimitInBytes":
 	if typedInput.SizeLimitInBytes != nil {
 		sizeLimitInBytes := *typedInput.SizeLimitInBytes
 		description.SizeLimitInBytes = &sizeLimitInBytes
 	}
 
-	// Set property ‘SkipEmptyArchives’:
+	// Set property "SkipEmptyArchives":
 	if typedInput.SkipEmptyArchives != nil {
 		skipEmptyArchives := *typedInput.SkipEmptyArchives
 		description.SkipEmptyArchives = &skipEmptyArchives
@@ -1529,13 +1529,13 @@ func (destination *Destination) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &Destination_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if destination.Name != nil {
 		name := *destination.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.ArchiveNameFormat != nil ||
 		destination.BlobContainer != nil ||
 		destination.DataLakeAccountName != nil ||
@@ -1587,7 +1587,7 @@ func (destination *Destination) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Destination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ArchiveNameFormat’:
+	// Set property "ArchiveNameFormat":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ArchiveNameFormat != nil {
@@ -1596,7 +1596,7 @@ func (destination *Destination) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘BlobContainer’:
+	// Set property "BlobContainer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BlobContainer != nil {
@@ -1605,7 +1605,7 @@ func (destination *Destination) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘DataLakeAccountName’:
+	// Set property "DataLakeAccountName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataLakeAccountName != nil {
@@ -1614,7 +1614,7 @@ func (destination *Destination) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘DataLakeFolderPath’:
+	// Set property "DataLakeFolderPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataLakeFolderPath != nil {
@@ -1623,7 +1623,7 @@ func (destination *Destination) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘DataLakeSubscriptionId’:
+	// Set property "DataLakeSubscriptionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataLakeSubscriptionId != nil {
@@ -1632,13 +1632,13 @@ func (destination *Destination) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		destination.Name = &name
 	}
 
-	// no assignment for property ‘StorageAccountResourceReference’
+	// no assignment for property "StorageAccountResourceReference"
 
 	// No error
 	return nil
@@ -1807,7 +1807,7 @@ func (destination *Destination_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Destination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ArchiveNameFormat’:
+	// Set property "ArchiveNameFormat":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ArchiveNameFormat != nil {
@@ -1816,7 +1816,7 @@ func (destination *Destination_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘BlobContainer’:
+	// Set property "BlobContainer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BlobContainer != nil {
@@ -1825,7 +1825,7 @@ func (destination *Destination_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DataLakeAccountName’:
+	// Set property "DataLakeAccountName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataLakeAccountName != nil {
@@ -1834,7 +1834,7 @@ func (destination *Destination_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DataLakeFolderPath’:
+	// Set property "DataLakeFolderPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataLakeFolderPath != nil {
@@ -1843,7 +1843,7 @@ func (destination *Destination_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DataLakeSubscriptionId’:
+	// Set property "DataLakeSubscriptionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataLakeSubscriptionId != nil {
@@ -1852,13 +1852,13 @@ func (destination *Destination_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		destination.Name = &name
 	}
 
-	// Set property ‘StorageAccountResourceId’:
+	// Set property "StorageAccountResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageAccountResourceId != nil {

--- a/v2/api/eventhub/v1api20211101/namespaces_eventhubs_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/namespaces_eventhubs_authorization_rule_types_gen.go
@@ -336,10 +336,10 @@ func (rule *Namespaces_Eventhubs_AuthorizationRule_Spec) ConvertToARM(resolved g
 	}
 	result := &Namespaces_Eventhubs_AuthorizationRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.Rights != nil {
 		result.Properties = &Namespaces_Eventhubs_AuthorizationRule_Properties_Spec_ARM{}
 	}
@@ -361,13 +361,13 @@ func (rule *Namespaces_Eventhubs_AuthorizationRule_Spec) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Eventhubs_AuthorizationRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Rights’:
+	// Set property "Rights":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Rights {
@@ -622,27 +622,27 @@ func (rule *Namespaces_Eventhubs_AuthorizationRule_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Eventhubs_AuthorizationRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		rule.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Rights’:
+	// Set property "Rights":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Rights {
@@ -650,7 +650,7 @@ func (rule *Namespaces_Eventhubs_AuthorizationRule_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -661,7 +661,7 @@ func (rule *Namespaces_Eventhubs_AuthorizationRule_STATUS) PopulateFromARM(owner
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/eventhub/v1api20211101/namespaces_eventhubs_consumer_group_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/namespaces_eventhubs_consumer_group_types_gen.go
@@ -338,10 +338,10 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_Spec) ConvertToARM(resol
 	}
 	result := &Namespaces_Eventhubs_Consumergroup_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if consumergroup.UserMetadata != nil {
 		result.Properties = &Namespaces_Eventhubs_Consumergroup_Properties_Spec_ARM{}
 	}
@@ -364,13 +364,13 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_Spec) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Eventhubs_Consumergroup_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	consumergroup.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	consumergroup.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘UserMetadata’:
+	// Set property "UserMetadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UserMetadata != nil {
@@ -603,9 +603,9 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Eventhubs_Consumergroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -614,25 +614,25 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		consumergroup.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		consumergroup.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		consumergroup.Name = &name
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -643,13 +643,13 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_STATUS) PopulateFromARM(
 		consumergroup.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		consumergroup.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {
@@ -658,7 +658,7 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘UserMetadata’:
+	// Set property "UserMetadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UserMetadata != nil {

--- a/v2/api/eventhub/v1beta20211101/namespace_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespace_types_gen.go
@@ -351,7 +351,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &Namespace_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if namespace.Identity != nil {
 		identity_ARM, err := (*namespace.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -361,16 +361,16 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if namespace.Location != nil {
 		location := *namespace.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if namespace.AlternateName != nil ||
 		namespace.ClusterArmReference != nil ||
 		namespace.DisableLocalAuth != nil ||
@@ -422,7 +422,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.ZoneRedundant = &zoneRedundant
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if namespace.Sku != nil {
 		sku_ARM, err := (*namespace.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -432,7 +432,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if namespace.Tags != nil {
 		result.Tags = make(map[string]string, len(namespace.Tags))
 		for key, value := range namespace.Tags {
@@ -454,7 +454,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespace_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AlternateName’:
+	// Set property "AlternateName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AlternateName != nil {
@@ -463,12 +463,12 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	namespace.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// no assignment for property ‘ClusterArmReference’
+	// no assignment for property "ClusterArmReference"
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -477,7 +477,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -491,7 +491,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -502,7 +502,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		namespace.Identity = &identity
 	}
 
-	// Set property ‘IsAutoInflateEnabled’:
+	// Set property "IsAutoInflateEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAutoInflateEnabled != nil {
@@ -511,7 +511,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘KafkaEnabled’:
+	// Set property "KafkaEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KafkaEnabled != nil {
@@ -520,13 +520,13 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		namespace.Location = &location
 	}
 
-	// Set property ‘MaximumThroughputUnits’:
+	// Set property "MaximumThroughputUnits":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaximumThroughputUnits != nil {
@@ -535,10 +535,10 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	namespace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -549,7 +549,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		namespace.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		namespace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -557,7 +557,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -946,7 +946,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespace_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AlternateName’:
+	// Set property "AlternateName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AlternateName != nil {
@@ -955,7 +955,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ClusterArmId’:
+	// Set property "ClusterArmId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClusterArmId != nil {
@@ -964,9 +964,9 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -975,7 +975,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -984,7 +984,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -998,13 +998,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		namespace.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1015,7 +1015,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		namespace.Identity = &identity
 	}
 
-	// Set property ‘IsAutoInflateEnabled’:
+	// Set property "IsAutoInflateEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAutoInflateEnabled != nil {
@@ -1024,7 +1024,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘KafkaEnabled’:
+	// Set property "KafkaEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KafkaEnabled != nil {
@@ -1033,13 +1033,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		namespace.Location = &location
 	}
 
-	// Set property ‘MaximumThroughputUnits’:
+	// Set property "MaximumThroughputUnits":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaximumThroughputUnits != nil {
@@ -1048,7 +1048,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MetricId’:
+	// Set property "MetricId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MetricId != nil {
@@ -1057,13 +1057,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		namespace.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1076,7 +1076,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1085,7 +1085,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ServiceBusEndpoint’:
+	// Set property "ServiceBusEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceBusEndpoint != nil {
@@ -1094,7 +1094,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1105,7 +1105,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		namespace.Sku = &sku
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -1114,7 +1114,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1125,7 +1125,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		namespace.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		namespace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1133,13 +1133,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		namespace.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {
@@ -1148,7 +1148,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -1486,13 +1486,13 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Encryption_ARM{}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if encryption.KeySource != nil {
 		keySource := *encryption.KeySource
 		result.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	for _, item := range encryption.KeyVaultProperties {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1501,7 +1501,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.KeyVaultProperties = append(result.KeyVaultProperties, *item_ARM.(*KeyVaultProperties_ARM))
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if encryption.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *encryption.RequireInfrastructureEncryption
 		result.RequireInfrastructureEncryption = &requireInfrastructureEncryption
@@ -1521,13 +1521,13 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	for _, item := range typedInput.KeyVaultProperties {
 		var item1 KeyVaultProperties
 		err := item1.PopulateFromARM(owner, item)
@@ -1537,7 +1537,7 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		encryption.KeyVaultProperties = append(encryption.KeyVaultProperties, item1)
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
@@ -1659,13 +1659,13 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	for _, item := range typedInput.KeyVaultProperties {
 		var item1 KeyVaultProperties_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1675,7 +1675,7 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		encryption.KeyVaultProperties = append(encryption.KeyVaultProperties, item1)
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
@@ -1791,13 +1791,13 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Identity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -1822,13 +1822,13 @@ func (identity *Identity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -1931,25 +1931,25 @@ func (identity *Identity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2072,7 +2072,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -2130,19 +2130,19 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sku.Capacity != nil {
 		capacity := *sku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -2162,19 +2162,19 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2276,19 +2276,19 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -2383,37 +2383,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -2530,7 +2530,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if properties.Identity != nil {
 		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -2540,19 +2540,19 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 		result.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if properties.KeyName != nil {
 		keyName := *properties.KeyName
 		result.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVaultUri’:
+	// Set property "KeyVaultUri":
 	if properties.KeyVaultUri != nil {
 		keyVaultUri := *properties.KeyVaultUri
 		result.KeyVaultUri = &keyVaultUri
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if properties.KeyVersion != nil {
 		keyVersion := *properties.KeyVersion
 		result.KeyVersion = &keyVersion
@@ -2572,7 +2572,7 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 UserAssignedIdentityProperties
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2583,19 +2583,19 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		properties.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		properties.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVaultUri’:
+	// Set property "KeyVaultUri":
 	if typedInput.KeyVaultUri != nil {
 		keyVaultUri := *typedInput.KeyVaultUri
 		properties.KeyVaultUri = &keyVaultUri
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		properties.KeyVersion = &keyVersion
@@ -2692,7 +2692,7 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 UserAssignedIdentityProperties_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2703,19 +2703,19 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		properties.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		properties.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVaultUri’:
+	// Set property "KeyVaultUri":
 	if typedInput.KeyVaultUri != nil {
 		keyVaultUri := *typedInput.KeyVaultUri
 		properties.KeyVaultUri = &keyVaultUri
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		properties.KeyVersion = &keyVersion
@@ -2810,13 +2810,13 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
@@ -2909,7 +2909,7 @@ func (properties *UserAssignedIdentityProperties) ConvertToARM(resolved genrunti
 	}
 	result := &UserAssignedIdentityProperties_ARM{}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if properties.UserAssignedIdentityReference != nil {
 		userAssignedIdentityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.UserAssignedIdentityReference)
 		if err != nil {
@@ -2933,7 +2933,7 @@ func (properties *UserAssignedIdentityProperties) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentityProperties_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘UserAssignedIdentityReference’
+	// no assignment for property "UserAssignedIdentityReference"
 
 	// No error
 	return nil
@@ -2997,7 +2997,7 @@ func (properties *UserAssignedIdentityProperties_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentityProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		properties.UserAssignedIdentity = &userAssignedIdentity

--- a/v2/api/eventhub/v1beta20211101/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_authorization_rule_types_gen.go
@@ -334,10 +334,10 @@ func (rule *Namespaces_AuthorizationRule_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &Namespaces_AuthorizationRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.Rights != nil {
 		result.Properties = &Namespaces_AuthorizationRule_Properties_Spec_ARM{}
 	}
@@ -359,13 +359,13 @@ func (rule *Namespaces_AuthorizationRule_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_AuthorizationRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Rights’:
+	// Set property "Rights":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Rights {
@@ -587,27 +587,27 @@ func (rule *Namespaces_AuthorizationRule_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_AuthorizationRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		rule.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Rights’:
+	// Set property "Rights":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Rights {
@@ -615,7 +615,7 @@ func (rule *Namespaces_AuthorizationRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -626,7 +626,7 @@ func (rule *Namespaces_AuthorizationRule_STATUS) PopulateFromARM(owner genruntim
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhub_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhub_types_gen.go
@@ -339,10 +339,10 @@ func (eventhub *Namespaces_Eventhub_Spec) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &Namespaces_Eventhub_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if eventhub.CaptureDescription != nil ||
 		eventhub.MessageRetentionInDays != nil ||
 		eventhub.PartitionCount != nil {
@@ -379,10 +379,10 @@ func (eventhub *Namespaces_Eventhub_Spec) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Eventhub_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	eventhub.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CaptureDescription’:
+	// Set property "CaptureDescription":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CaptureDescription != nil {
@@ -396,7 +396,7 @@ func (eventhub *Namespaces_Eventhub_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘MessageRetentionInDays’:
+	// Set property "MessageRetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MessageRetentionInDays != nil {
@@ -405,10 +405,10 @@ func (eventhub *Namespaces_Eventhub_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	eventhub.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PartitionCount’:
+	// Set property "PartitionCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PartitionCount != nil {
@@ -668,7 +668,7 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Eventhub_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CaptureDescription’:
+	// Set property "CaptureDescription":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CaptureDescription != nil {
@@ -682,9 +682,9 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -693,19 +693,19 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		eventhub.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		eventhub.Location = &location
 	}
 
-	// Set property ‘MessageRetentionInDays’:
+	// Set property "MessageRetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MessageRetentionInDays != nil {
@@ -714,13 +714,13 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		eventhub.Name = &name
 	}
 
-	// Set property ‘PartitionCount’:
+	// Set property "PartitionCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PartitionCount != nil {
@@ -729,7 +729,7 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘PartitionIds’:
+	// Set property "PartitionIds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PartitionIds {
@@ -737,7 +737,7 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -746,7 +746,7 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -757,13 +757,13 @@ func (eventhub *Namespaces_Eventhub_STATUS) PopulateFromARM(owner genruntime.Arb
 		eventhub.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		eventhub.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {
@@ -942,7 +942,7 @@ func (description *CaptureDescription) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &CaptureDescription_ARM{}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	if description.Destination != nil {
 		destination_ARM, err := (*description.Destination).ConvertToARM(resolved)
 		if err != nil {
@@ -952,31 +952,31 @@ func (description *CaptureDescription) ConvertToARM(resolved genruntime.ConvertT
 		result.Destination = &destination
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if description.Enabled != nil {
 		enabled := *description.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘Encoding’:
+	// Set property "Encoding":
 	if description.Encoding != nil {
 		encoding := *description.Encoding
 		result.Encoding = &encoding
 	}
 
-	// Set property ‘IntervalInSeconds’:
+	// Set property "IntervalInSeconds":
 	if description.IntervalInSeconds != nil {
 		intervalInSeconds := *description.IntervalInSeconds
 		result.IntervalInSeconds = &intervalInSeconds
 	}
 
-	// Set property ‘SizeLimitInBytes’:
+	// Set property "SizeLimitInBytes":
 	if description.SizeLimitInBytes != nil {
 		sizeLimitInBytes := *description.SizeLimitInBytes
 		result.SizeLimitInBytes = &sizeLimitInBytes
 	}
 
-	// Set property ‘SkipEmptyArchives’:
+	// Set property "SkipEmptyArchives":
 	if description.SkipEmptyArchives != nil {
 		skipEmptyArchives := *description.SkipEmptyArchives
 		result.SkipEmptyArchives = &skipEmptyArchives
@@ -996,7 +996,7 @@ func (description *CaptureDescription) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CaptureDescription_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	if typedInput.Destination != nil {
 		var destination1 Destination
 		err := destination1.PopulateFromARM(owner, *typedInput.Destination)
@@ -1007,31 +1007,31 @@ func (description *CaptureDescription) PopulateFromARM(owner genruntime.Arbitrar
 		description.Destination = &destination
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		description.Enabled = &enabled
 	}
 
-	// Set property ‘Encoding’:
+	// Set property "Encoding":
 	if typedInput.Encoding != nil {
 		encoding := *typedInput.Encoding
 		description.Encoding = &encoding
 	}
 
-	// Set property ‘IntervalInSeconds’:
+	// Set property "IntervalInSeconds":
 	if typedInput.IntervalInSeconds != nil {
 		intervalInSeconds := *typedInput.IntervalInSeconds
 		description.IntervalInSeconds = &intervalInSeconds
 	}
 
-	// Set property ‘SizeLimitInBytes’:
+	// Set property "SizeLimitInBytes":
 	if typedInput.SizeLimitInBytes != nil {
 		sizeLimitInBytes := *typedInput.SizeLimitInBytes
 		description.SizeLimitInBytes = &sizeLimitInBytes
 	}
 
-	// Set property ‘SkipEmptyArchives’:
+	// Set property "SkipEmptyArchives":
 	if typedInput.SkipEmptyArchives != nil {
 		skipEmptyArchives := *typedInput.SkipEmptyArchives
 		description.SkipEmptyArchives = &skipEmptyArchives
@@ -1172,7 +1172,7 @@ func (description *CaptureDescription_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CaptureDescription_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Destination’:
+	// Set property "Destination":
 	if typedInput.Destination != nil {
 		var destination1 Destination_STATUS
 		err := destination1.PopulateFromARM(owner, *typedInput.Destination)
@@ -1183,31 +1183,31 @@ func (description *CaptureDescription_STATUS) PopulateFromARM(owner genruntime.A
 		description.Destination = &destination
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		description.Enabled = &enabled
 	}
 
-	// Set property ‘Encoding’:
+	// Set property "Encoding":
 	if typedInput.Encoding != nil {
 		encoding := *typedInput.Encoding
 		description.Encoding = &encoding
 	}
 
-	// Set property ‘IntervalInSeconds’:
+	// Set property "IntervalInSeconds":
 	if typedInput.IntervalInSeconds != nil {
 		intervalInSeconds := *typedInput.IntervalInSeconds
 		description.IntervalInSeconds = &intervalInSeconds
 	}
 
-	// Set property ‘SizeLimitInBytes’:
+	// Set property "SizeLimitInBytes":
 	if typedInput.SizeLimitInBytes != nil {
 		sizeLimitInBytes := *typedInput.SizeLimitInBytes
 		description.SizeLimitInBytes = &sizeLimitInBytes
 	}
 
-	// Set property ‘SkipEmptyArchives’:
+	// Set property "SkipEmptyArchives":
 	if typedInput.SkipEmptyArchives != nil {
 		skipEmptyArchives := *typedInput.SkipEmptyArchives
 		description.SkipEmptyArchives = &skipEmptyArchives
@@ -1379,13 +1379,13 @@ func (destination *Destination) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &Destination_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if destination.Name != nil {
 		name := *destination.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if destination.ArchiveNameFormat != nil ||
 		destination.BlobContainer != nil ||
 		destination.DataLakeAccountName != nil ||
@@ -1437,7 +1437,7 @@ func (destination *Destination) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Destination_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ArchiveNameFormat’:
+	// Set property "ArchiveNameFormat":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ArchiveNameFormat != nil {
@@ -1446,7 +1446,7 @@ func (destination *Destination) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘BlobContainer’:
+	// Set property "BlobContainer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BlobContainer != nil {
@@ -1455,7 +1455,7 @@ func (destination *Destination) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘DataLakeAccountName’:
+	// Set property "DataLakeAccountName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataLakeAccountName != nil {
@@ -1464,7 +1464,7 @@ func (destination *Destination) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘DataLakeFolderPath’:
+	// Set property "DataLakeFolderPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataLakeFolderPath != nil {
@@ -1473,7 +1473,7 @@ func (destination *Destination) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘DataLakeSubscriptionId’:
+	// Set property "DataLakeSubscriptionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataLakeSubscriptionId != nil {
@@ -1482,13 +1482,13 @@ func (destination *Destination) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		destination.Name = &name
 	}
 
-	// no assignment for property ‘StorageAccountResourceReference’
+	// no assignment for property "StorageAccountResourceReference"
 
 	// No error
 	return nil
@@ -1604,7 +1604,7 @@ func (destination *Destination_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Destination_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ArchiveNameFormat’:
+	// Set property "ArchiveNameFormat":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ArchiveNameFormat != nil {
@@ -1613,7 +1613,7 @@ func (destination *Destination_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘BlobContainer’:
+	// Set property "BlobContainer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BlobContainer != nil {
@@ -1622,7 +1622,7 @@ func (destination *Destination_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DataLakeAccountName’:
+	// Set property "DataLakeAccountName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataLakeAccountName != nil {
@@ -1631,7 +1631,7 @@ func (destination *Destination_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DataLakeFolderPath’:
+	// Set property "DataLakeFolderPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataLakeFolderPath != nil {
@@ -1640,7 +1640,7 @@ func (destination *Destination_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘DataLakeSubscriptionId’:
+	// Set property "DataLakeSubscriptionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DataLakeSubscriptionId != nil {
@@ -1649,13 +1649,13 @@ func (destination *Destination_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		destination.Name = &name
 	}
 
-	// Set property ‘StorageAccountResourceId’:
+	// Set property "StorageAccountResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageAccountResourceId != nil {

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_authorization_rule_types_gen.go
@@ -334,10 +334,10 @@ func (rule *Namespaces_Eventhubs_AuthorizationRule_Spec) ConvertToARM(resolved g
 	}
 	result := &Namespaces_Eventhubs_AuthorizationRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.Rights != nil {
 		result.Properties = &Namespaces_Eventhubs_AuthorizationRule_Properties_Spec_ARM{}
 	}
@@ -359,13 +359,13 @@ func (rule *Namespaces_Eventhubs_AuthorizationRule_Spec) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Eventhubs_AuthorizationRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Rights’:
+	// Set property "Rights":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Rights {
@@ -587,27 +587,27 @@ func (rule *Namespaces_Eventhubs_AuthorizationRule_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Eventhubs_AuthorizationRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		rule.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Rights’:
+	// Set property "Rights":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Rights {
@@ -615,7 +615,7 @@ func (rule *Namespaces_Eventhubs_AuthorizationRule_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -626,7 +626,7 @@ func (rule *Namespaces_Eventhubs_AuthorizationRule_STATUS) PopulateFromARM(owner
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_consumer_group_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_consumer_group_types_gen.go
@@ -333,10 +333,10 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_Spec) ConvertToARM(resol
 	}
 	result := &Namespaces_Eventhubs_Consumergroup_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if consumergroup.UserMetadata != nil {
 		result.Properties = &Namespaces_Eventhubs_Consumergroup_Properties_Spec_ARM{}
 	}
@@ -359,13 +359,13 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_Spec) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Eventhubs_Consumergroup_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	consumergroup.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	consumergroup.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘UserMetadata’:
+	// Set property "UserMetadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UserMetadata != nil {
@@ -570,9 +570,9 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Eventhubs_Consumergroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -581,25 +581,25 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		consumergroup.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		consumergroup.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		consumergroup.Name = &name
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -610,13 +610,13 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_STATUS) PopulateFromARM(
 		consumergroup.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		consumergroup.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {
@@ -625,7 +625,7 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘UserMetadata’:
+	// Set property "UserMetadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UserMetadata != nil {

--- a/v2/api/insights/v1api20180501preview/webtest_types_gen.go
+++ b/v2/api/insights/v1api20180501preview/webtest_types_gen.go
@@ -384,16 +384,16 @@ func (webtest *Webtest_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &Webtest_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if webtest.Location != nil {
 		location := *webtest.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if webtest.Configuration != nil ||
 		webtest.Description != nil ||
 		webtest.Enabled != nil ||
@@ -472,7 +472,7 @@ func (webtest *Webtest_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.ValidationRules = &validationRules
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if webtest.Tags != nil {
 		result.Tags = make(map[string]string, len(webtest.Tags))
 		for key, value := range webtest.Tags {
@@ -494,10 +494,10 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Webtest_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	webtest.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Configuration’:
+	// Set property "Configuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Configuration != nil {
@@ -511,7 +511,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -520,7 +520,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Enabled != nil {
@@ -529,7 +529,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Frequency’:
+	// Set property "Frequency":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Frequency != nil {
@@ -538,7 +538,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Kind != nil {
@@ -547,13 +547,13 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		webtest.Location = &location
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Locations {
@@ -566,7 +566,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Name != nil {
@@ -575,10 +575,10 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	webtest.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Request’:
+	// Set property "Request":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Request != nil {
@@ -592,7 +592,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘RetryEnabled’:
+	// Set property "RetryEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetryEnabled != nil {
@@ -601,7 +601,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘SyntheticMonitorId’:
+	// Set property "SyntheticMonitorId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SyntheticMonitorId != nil {
@@ -610,7 +610,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		webtest.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -618,7 +618,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Timeout’:
+	// Set property "Timeout":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Timeout != nil {
@@ -627,7 +627,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘ValidationRules’:
+	// Set property "ValidationRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ValidationRules != nil {
@@ -1181,9 +1181,9 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Webtest_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Configuration’:
+	// Set property "Configuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Configuration != nil {
@@ -1197,7 +1197,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -1206,7 +1206,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Enabled != nil {
@@ -1215,7 +1215,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Frequency’:
+	// Set property "Frequency":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Frequency != nil {
@@ -1224,13 +1224,13 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		webtest.Id = &id
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Kind != nil {
@@ -1239,13 +1239,13 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		webtest.Location = &location
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Locations {
@@ -1258,13 +1258,13 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		webtest.Name = &name
 	}
 
-	// Set property ‘PropertiesName’:
+	// Set property "PropertiesName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Name != nil {
@@ -1273,7 +1273,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1282,7 +1282,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Request’:
+	// Set property "Request":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Request != nil {
@@ -1296,7 +1296,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘RetryEnabled’:
+	// Set property "RetryEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetryEnabled != nil {
@@ -1305,7 +1305,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘SyntheticMonitorId’:
+	// Set property "SyntheticMonitorId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SyntheticMonitorId != nil {
@@ -1314,7 +1314,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		webtest.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1322,7 +1322,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Timeout’:
+	// Set property "Timeout":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Timeout != nil {
@@ -1331,13 +1331,13 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		webtest.Type = &typeVar
 	}
 
-	// Set property ‘ValidationRules’:
+	// Set property "ValidationRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ValidationRules != nil {
@@ -1621,7 +1621,7 @@ func (geolocation *WebTestGeolocation) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &WebTestGeolocation_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if geolocation.Id != nil {
 		id := *geolocation.Id
 		result.Id = &id
@@ -1641,7 +1641,7 @@ func (geolocation *WebTestGeolocation) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestGeolocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		geolocation.Id = &id
@@ -1710,7 +1710,7 @@ func (geolocation *WebTestGeolocation_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestGeolocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		geolocation.Id = &id
@@ -1763,7 +1763,7 @@ func (configuration *WebTestProperties_Configuration) ConvertToARM(resolved genr
 	}
 	result := &WebTestProperties_Configuration_ARM{}
 
-	// Set property ‘WebTest’:
+	// Set property "WebTest":
 	if configuration.WebTest != nil {
 		webTest := *configuration.WebTest
 		result.WebTest = &webTest
@@ -1783,7 +1783,7 @@ func (configuration *WebTestProperties_Configuration) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_Configuration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘WebTest’:
+	// Set property "WebTest":
 	if typedInput.WebTest != nil {
 		webTest := *typedInput.WebTest
 		configuration.WebTest = &webTest
@@ -1851,7 +1851,7 @@ func (configuration *WebTestProperties_Configuration_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_Configuration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘WebTest’:
+	// Set property "WebTest":
 	if typedInput.WebTest != nil {
 		webTest := *typedInput.WebTest
 		configuration.WebTest = &webTest
@@ -1938,13 +1938,13 @@ func (request *WebTestProperties_Request) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &WebTestProperties_Request_ARM{}
 
-	// Set property ‘FollowRedirects’:
+	// Set property "FollowRedirects":
 	if request.FollowRedirects != nil {
 		followRedirects := *request.FollowRedirects
 		result.FollowRedirects = &followRedirects
 	}
 
-	// Set property ‘Headers’:
+	// Set property "Headers":
 	for _, item := range request.Headers {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1953,25 +1953,25 @@ func (request *WebTestProperties_Request) ConvertToARM(resolved genruntime.Conve
 		result.Headers = append(result.Headers, *item_ARM.(*HeaderField_ARM))
 	}
 
-	// Set property ‘HttpVerb’:
+	// Set property "HttpVerb":
 	if request.HttpVerb != nil {
 		httpVerb := *request.HttpVerb
 		result.HttpVerb = &httpVerb
 	}
 
-	// Set property ‘ParseDependentRequests’:
+	// Set property "ParseDependentRequests":
 	if request.ParseDependentRequests != nil {
 		parseDependentRequests := *request.ParseDependentRequests
 		result.ParseDependentRequests = &parseDependentRequests
 	}
 
-	// Set property ‘RequestBody’:
+	// Set property "RequestBody":
 	if request.RequestBody != nil {
 		requestBody := *request.RequestBody
 		result.RequestBody = &requestBody
 	}
 
-	// Set property ‘RequestUrl’:
+	// Set property "RequestUrl":
 	if request.RequestUrl != nil {
 		requestUrl := *request.RequestUrl
 		result.RequestUrl = &requestUrl
@@ -1991,13 +1991,13 @@ func (request *WebTestProperties_Request) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_Request_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FollowRedirects’:
+	// Set property "FollowRedirects":
 	if typedInput.FollowRedirects != nil {
 		followRedirects := *typedInput.FollowRedirects
 		request.FollowRedirects = &followRedirects
 	}
 
-	// Set property ‘Headers’:
+	// Set property "Headers":
 	for _, item := range typedInput.Headers {
 		var item1 HeaderField
 		err := item1.PopulateFromARM(owner, item)
@@ -2007,25 +2007,25 @@ func (request *WebTestProperties_Request) PopulateFromARM(owner genruntime.Arbit
 		request.Headers = append(request.Headers, item1)
 	}
 
-	// Set property ‘HttpVerb’:
+	// Set property "HttpVerb":
 	if typedInput.HttpVerb != nil {
 		httpVerb := *typedInput.HttpVerb
 		request.HttpVerb = &httpVerb
 	}
 
-	// Set property ‘ParseDependentRequests’:
+	// Set property "ParseDependentRequests":
 	if typedInput.ParseDependentRequests != nil {
 		parseDependentRequests := *typedInput.ParseDependentRequests
 		request.ParseDependentRequests = &parseDependentRequests
 	}
 
-	// Set property ‘RequestBody’:
+	// Set property "RequestBody":
 	if typedInput.RequestBody != nil {
 		requestBody := *typedInput.RequestBody
 		request.RequestBody = &requestBody
 	}
 
-	// Set property ‘RequestUrl’:
+	// Set property "RequestUrl":
 	if typedInput.RequestUrl != nil {
 		requestUrl := *typedInput.RequestUrl
 		request.RequestUrl = &requestUrl
@@ -2228,13 +2228,13 @@ func (request *WebTestProperties_Request_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_Request_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FollowRedirects’:
+	// Set property "FollowRedirects":
 	if typedInput.FollowRedirects != nil {
 		followRedirects := *typedInput.FollowRedirects
 		request.FollowRedirects = &followRedirects
 	}
 
-	// Set property ‘Headers’:
+	// Set property "Headers":
 	for _, item := range typedInput.Headers {
 		var item1 HeaderField_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2244,25 +2244,25 @@ func (request *WebTestProperties_Request_STATUS) PopulateFromARM(owner genruntim
 		request.Headers = append(request.Headers, item1)
 	}
 
-	// Set property ‘HttpVerb’:
+	// Set property "HttpVerb":
 	if typedInput.HttpVerb != nil {
 		httpVerb := *typedInput.HttpVerb
 		request.HttpVerb = &httpVerb
 	}
 
-	// Set property ‘ParseDependentRequests’:
+	// Set property "ParseDependentRequests":
 	if typedInput.ParseDependentRequests != nil {
 		parseDependentRequests := *typedInput.ParseDependentRequests
 		request.ParseDependentRequests = &parseDependentRequests
 	}
 
-	// Set property ‘RequestBody’:
+	// Set property "RequestBody":
 	if typedInput.RequestBody != nil {
 		requestBody := *typedInput.RequestBody
 		request.RequestBody = &requestBody
 	}
 
-	// Set property ‘RequestUrl’:
+	// Set property "RequestUrl":
 	if typedInput.RequestUrl != nil {
 		requestUrl := *typedInput.RequestUrl
 		request.RequestUrl = &requestUrl
@@ -2408,7 +2408,7 @@ func (rules *WebTestProperties_ValidationRules) ConvertToARM(resolved genruntime
 	}
 	result := &WebTestProperties_ValidationRules_ARM{}
 
-	// Set property ‘ContentValidation’:
+	// Set property "ContentValidation":
 	if rules.ContentValidation != nil {
 		contentValidation_ARM, err := (*rules.ContentValidation).ConvertToARM(resolved)
 		if err != nil {
@@ -2418,25 +2418,25 @@ func (rules *WebTestProperties_ValidationRules) ConvertToARM(resolved genruntime
 		result.ContentValidation = &contentValidation
 	}
 
-	// Set property ‘ExpectedHttpStatusCode’:
+	// Set property "ExpectedHttpStatusCode":
 	if rules.ExpectedHttpStatusCode != nil {
 		expectedHttpStatusCode := *rules.ExpectedHttpStatusCode
 		result.ExpectedHttpStatusCode = &expectedHttpStatusCode
 	}
 
-	// Set property ‘IgnoreHttpsStatusCode’:
+	// Set property "IgnoreHttpsStatusCode":
 	if rules.IgnoreHttpsStatusCode != nil {
 		ignoreHttpsStatusCode := *rules.IgnoreHttpsStatusCode
 		result.IgnoreHttpsStatusCode = &ignoreHttpsStatusCode
 	}
 
-	// Set property ‘SSLCertRemainingLifetimeCheck’:
+	// Set property "SSLCertRemainingLifetimeCheck":
 	if rules.SSLCertRemainingLifetimeCheck != nil {
 		sslCertRemainingLifetimeCheck := *rules.SSLCertRemainingLifetimeCheck
 		result.SSLCertRemainingLifetimeCheck = &sslCertRemainingLifetimeCheck
 	}
 
-	// Set property ‘SSLCheck’:
+	// Set property "SSLCheck":
 	if rules.SSLCheck != nil {
 		sslCheck := *rules.SSLCheck
 		result.SSLCheck = &sslCheck
@@ -2456,7 +2456,7 @@ func (rules *WebTestProperties_ValidationRules) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_ValidationRules_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContentValidation’:
+	// Set property "ContentValidation":
 	if typedInput.ContentValidation != nil {
 		var contentValidation1 WebTestProperties_ValidationRules_ContentValidation
 		err := contentValidation1.PopulateFromARM(owner, *typedInput.ContentValidation)
@@ -2467,25 +2467,25 @@ func (rules *WebTestProperties_ValidationRules) PopulateFromARM(owner genruntime
 		rules.ContentValidation = &contentValidation
 	}
 
-	// Set property ‘ExpectedHttpStatusCode’:
+	// Set property "ExpectedHttpStatusCode":
 	if typedInput.ExpectedHttpStatusCode != nil {
 		expectedHttpStatusCode := *typedInput.ExpectedHttpStatusCode
 		rules.ExpectedHttpStatusCode = &expectedHttpStatusCode
 	}
 
-	// Set property ‘IgnoreHttpsStatusCode’:
+	// Set property "IgnoreHttpsStatusCode":
 	if typedInput.IgnoreHttpsStatusCode != nil {
 		ignoreHttpsStatusCode := *typedInput.IgnoreHttpsStatusCode
 		rules.IgnoreHttpsStatusCode = &ignoreHttpsStatusCode
 	}
 
-	// Set property ‘SSLCertRemainingLifetimeCheck’:
+	// Set property "SSLCertRemainingLifetimeCheck":
 	if typedInput.SSLCertRemainingLifetimeCheck != nil {
 		sslCertRemainingLifetimeCheck := *typedInput.SSLCertRemainingLifetimeCheck
 		rules.SSLCertRemainingLifetimeCheck = &sslCertRemainingLifetimeCheck
 	}
 
-	// Set property ‘SSLCheck’:
+	// Set property "SSLCheck":
 	if typedInput.SSLCheck != nil {
 		sslCheck := *typedInput.SSLCheck
 		rules.SSLCheck = &sslCheck
@@ -2659,7 +2659,7 @@ func (rules *WebTestProperties_ValidationRules_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_ValidationRules_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContentValidation’:
+	// Set property "ContentValidation":
 	if typedInput.ContentValidation != nil {
 		var contentValidation1 WebTestProperties_ValidationRules_ContentValidation_STATUS
 		err := contentValidation1.PopulateFromARM(owner, *typedInput.ContentValidation)
@@ -2670,25 +2670,25 @@ func (rules *WebTestProperties_ValidationRules_STATUS) PopulateFromARM(owner gen
 		rules.ContentValidation = &contentValidation
 	}
 
-	// Set property ‘ExpectedHttpStatusCode’:
+	// Set property "ExpectedHttpStatusCode":
 	if typedInput.ExpectedHttpStatusCode != nil {
 		expectedHttpStatusCode := *typedInput.ExpectedHttpStatusCode
 		rules.ExpectedHttpStatusCode = &expectedHttpStatusCode
 	}
 
-	// Set property ‘IgnoreHttpsStatusCode’:
+	// Set property "IgnoreHttpsStatusCode":
 	if typedInput.IgnoreHttpsStatusCode != nil {
 		ignoreHttpsStatusCode := *typedInput.IgnoreHttpsStatusCode
 		rules.IgnoreHttpsStatusCode = &ignoreHttpsStatusCode
 	}
 
-	// Set property ‘SSLCertRemainingLifetimeCheck’:
+	// Set property "SSLCertRemainingLifetimeCheck":
 	if typedInput.SSLCertRemainingLifetimeCheck != nil {
 		sslCertRemainingLifetimeCheck := *typedInput.SSLCertRemainingLifetimeCheck
 		rules.SSLCertRemainingLifetimeCheck = &sslCertRemainingLifetimeCheck
 	}
 
-	// Set property ‘SSLCheck’:
+	// Set property "SSLCheck":
 	if typedInput.SSLCheck != nil {
 		sslCheck := *typedInput.SSLCheck
 		rules.SSLCheck = &sslCheck
@@ -2807,13 +2807,13 @@ func (field *HeaderField) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &HeaderField_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if field.Key != nil {
 		key := *field.Key
 		result.Key = &key
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if field.Value != nil {
 		value := *field.Value
 		result.Value = &value
@@ -2833,13 +2833,13 @@ func (field *HeaderField) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HeaderField_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		field.Key = &key
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		field.Value = &value
@@ -2920,13 +2920,13 @@ func (field *HeaderField_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HeaderField_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		field.Key = &key
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		field.Value = &value
@@ -2992,19 +2992,19 @@ func (validation *WebTestProperties_ValidationRules_ContentValidation) ConvertTo
 	}
 	result := &WebTestProperties_ValidationRules_ContentValidation_ARM{}
 
-	// Set property ‘ContentMatch’:
+	// Set property "ContentMatch":
 	if validation.ContentMatch != nil {
 		contentMatch := *validation.ContentMatch
 		result.ContentMatch = &contentMatch
 	}
 
-	// Set property ‘IgnoreCase’:
+	// Set property "IgnoreCase":
 	if validation.IgnoreCase != nil {
 		ignoreCase := *validation.IgnoreCase
 		result.IgnoreCase = &ignoreCase
 	}
 
-	// Set property ‘PassIfTextFound’:
+	// Set property "PassIfTextFound":
 	if validation.PassIfTextFound != nil {
 		passIfTextFound := *validation.PassIfTextFound
 		result.PassIfTextFound = &passIfTextFound
@@ -3024,19 +3024,19 @@ func (validation *WebTestProperties_ValidationRules_ContentValidation) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_ValidationRules_ContentValidation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContentMatch’:
+	// Set property "ContentMatch":
 	if typedInput.ContentMatch != nil {
 		contentMatch := *typedInput.ContentMatch
 		validation.ContentMatch = &contentMatch
 	}
 
-	// Set property ‘IgnoreCase’:
+	// Set property "IgnoreCase":
 	if typedInput.IgnoreCase != nil {
 		ignoreCase := *typedInput.IgnoreCase
 		validation.IgnoreCase = &ignoreCase
 	}
 
-	// Set property ‘PassIfTextFound’:
+	// Set property "PassIfTextFound":
 	if typedInput.PassIfTextFound != nil {
 		passIfTextFound := *typedInput.PassIfTextFound
 		validation.PassIfTextFound = &passIfTextFound
@@ -3159,19 +3159,19 @@ func (validation *WebTestProperties_ValidationRules_ContentValidation_STATUS) Po
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_ValidationRules_ContentValidation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContentMatch’:
+	// Set property "ContentMatch":
 	if typedInput.ContentMatch != nil {
 		contentMatch := *typedInput.ContentMatch
 		validation.ContentMatch = &contentMatch
 	}
 
-	// Set property ‘IgnoreCase’:
+	// Set property "IgnoreCase":
 	if typedInput.IgnoreCase != nil {
 		ignoreCase := *typedInput.IgnoreCase
 		validation.IgnoreCase = &ignoreCase
 	}
 
-	// Set property ‘PassIfTextFound’:
+	// Set property "PassIfTextFound":
 	if typedInput.PassIfTextFound != nil {
 		passIfTextFound := *typedInput.PassIfTextFound
 		validation.PassIfTextFound = &passIfTextFound

--- a/v2/api/insights/v1api20200202/component_types_gen.go
+++ b/v2/api/insights/v1api20200202/component_types_gen.go
@@ -449,28 +449,28 @@ func (component *Component_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &Component_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if component.Etag != nil {
 		etag := *component.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if component.Kind != nil {
 		kind := *component.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if component.Location != nil {
 		location := *component.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if component.Application_Type != nil ||
 		component.DisableIpMasking != nil ||
 		component.DisableLocalAuth != nil ||
@@ -548,7 +548,7 @@ func (component *Component_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.WorkspaceResourceId = &workspaceResourceId
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if component.Tags != nil {
 		result.Tags = make(map[string]string, len(component.Tags))
 		for key, value := range component.Tags {
@@ -570,7 +570,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Component_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Application_Type’:
+	// Set property "Application_Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Application_Type != nil {
@@ -579,10 +579,10 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	component.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DisableIpMasking’:
+	// Set property "DisableIpMasking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableIpMasking != nil {
@@ -591,7 +591,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -600,13 +600,13 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		component.Etag = &etag
 	}
 
-	// Set property ‘Flow_Type’:
+	// Set property "Flow_Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Flow_Type != nil {
@@ -615,7 +615,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ForceCustomerStorageForProfiler’:
+	// Set property "ForceCustomerStorageForProfiler":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceCustomerStorageForProfiler != nil {
@@ -624,7 +624,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘HockeyAppId’:
+	// Set property "HockeyAppId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HockeyAppId != nil {
@@ -633,7 +633,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ImmediatePurgeDataOn30Days’:
+	// Set property "ImmediatePurgeDataOn30Days":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmediatePurgeDataOn30Days != nil {
@@ -642,7 +642,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘IngestionMode’:
+	// Set property "IngestionMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IngestionMode != nil {
@@ -651,24 +651,24 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		component.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		component.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	component.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccessForIngestion’:
+	// Set property "PublicNetworkAccessForIngestion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForIngestion != nil {
@@ -677,7 +677,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForQuery’:
+	// Set property "PublicNetworkAccessForQuery":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForQuery != nil {
@@ -686,7 +686,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Request_Source’:
+	// Set property "Request_Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Request_Source != nil {
@@ -695,7 +695,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionInDays != nil {
@@ -704,7 +704,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘SamplingPercentage’:
+	// Set property "SamplingPercentage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SamplingPercentage != nil {
@@ -713,7 +713,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		component.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -721,7 +721,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// no assignment for property ‘WorkspaceResourceReference’
+	// no assignment for property "WorkspaceResourceReference"
 
 	// No error
 	return nil
@@ -1381,7 +1381,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Component_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AppId’:
+	// Set property "AppId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AppId != nil {
@@ -1390,7 +1390,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ApplicationId’:
+	// Set property "ApplicationId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApplicationId != nil {
@@ -1399,7 +1399,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Application_Type’:
+	// Set property "Application_Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Application_Type != nil {
@@ -1408,9 +1408,9 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ConnectionString’:
+	// Set property "ConnectionString":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConnectionString != nil {
@@ -1419,7 +1419,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CreationDate’:
+	// Set property "CreationDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationDate != nil {
@@ -1428,7 +1428,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘DisableIpMasking’:
+	// Set property "DisableIpMasking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableIpMasking != nil {
@@ -1437,7 +1437,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -1446,13 +1446,13 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		component.Etag = &etag
 	}
 
-	// Set property ‘Flow_Type’:
+	// Set property "Flow_Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Flow_Type != nil {
@@ -1461,7 +1461,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ForceCustomerStorageForProfiler’:
+	// Set property "ForceCustomerStorageForProfiler":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceCustomerStorageForProfiler != nil {
@@ -1470,7 +1470,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HockeyAppId’:
+	// Set property "HockeyAppId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HockeyAppId != nil {
@@ -1479,7 +1479,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HockeyAppToken’:
+	// Set property "HockeyAppToken":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HockeyAppToken != nil {
@@ -1488,13 +1488,13 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		component.Id = &id
 	}
 
-	// Set property ‘ImmediatePurgeDataOn30Days’:
+	// Set property "ImmediatePurgeDataOn30Days":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmediatePurgeDataOn30Days != nil {
@@ -1503,7 +1503,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘IngestionMode’:
+	// Set property "IngestionMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IngestionMode != nil {
@@ -1512,7 +1512,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘InstrumentationKey’:
+	// Set property "InstrumentationKey":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstrumentationKey != nil {
@@ -1521,13 +1521,13 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		component.Kind = &kind
 	}
 
-	// Set property ‘LaMigrationDate’:
+	// Set property "LaMigrationDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LaMigrationDate != nil {
@@ -1536,19 +1536,19 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		component.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		component.Name = &name
 	}
 
-	// Set property ‘PrivateLinkScopedResources’:
+	// Set property "PrivateLinkScopedResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkScopedResources {
@@ -1561,7 +1561,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PropertiesName’:
+	// Set property "PropertiesName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Name != nil {
@@ -1570,7 +1570,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1579,7 +1579,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForIngestion’:
+	// Set property "PublicNetworkAccessForIngestion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForIngestion != nil {
@@ -1588,7 +1588,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForQuery’:
+	// Set property "PublicNetworkAccessForQuery":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForQuery != nil {
@@ -1597,7 +1597,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Request_Source’:
+	// Set property "Request_Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Request_Source != nil {
@@ -1606,7 +1606,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionInDays != nil {
@@ -1615,7 +1615,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SamplingPercentage’:
+	// Set property "SamplingPercentage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SamplingPercentage != nil {
@@ -1624,7 +1624,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		component.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1632,7 +1632,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantId != nil {
@@ -1641,13 +1641,13 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		component.Type = &typeVar
 	}
 
-	// Set property ‘WorkspaceResourceId’:
+	// Set property "WorkspaceResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkspaceResourceId != nil {
@@ -2147,13 +2147,13 @@ func (resource *PrivateLinkScopedResource_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkScopedResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		resource.ResourceId = &resourceId
 	}
 
-	// Set property ‘ScopeId’:
+	// Set property "ScopeId":
 	if typedInput.ScopeId != nil {
 		scopeId := *typedInput.ScopeId
 		resource.ScopeId = &scopeId

--- a/v2/api/insights/v1beta20180501preview/webtest_types_gen.go
+++ b/v2/api/insights/v1beta20180501preview/webtest_types_gen.go
@@ -360,16 +360,16 @@ func (webtest *Webtest_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &Webtest_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if webtest.Location != nil {
 		location := *webtest.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if webtest.Configuration != nil ||
 		webtest.Description != nil ||
 		webtest.Enabled != nil ||
@@ -448,7 +448,7 @@ func (webtest *Webtest_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.ValidationRules = &validationRules
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if webtest.Tags != nil {
 		result.Tags = make(map[string]string, len(webtest.Tags))
 		for key, value := range webtest.Tags {
@@ -470,10 +470,10 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Webtest_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	webtest.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Configuration’:
+	// Set property "Configuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Configuration != nil {
@@ -487,7 +487,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -496,7 +496,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Enabled != nil {
@@ -505,7 +505,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Frequency’:
+	// Set property "Frequency":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Frequency != nil {
@@ -514,7 +514,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Kind != nil {
@@ -523,13 +523,13 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		webtest.Location = &location
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Locations {
@@ -542,7 +542,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Name != nil {
@@ -551,10 +551,10 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	webtest.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Request’:
+	// Set property "Request":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Request != nil {
@@ -568,7 +568,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘RetryEnabled’:
+	// Set property "RetryEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetryEnabled != nil {
@@ -577,7 +577,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘SyntheticMonitorId’:
+	// Set property "SyntheticMonitorId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SyntheticMonitorId != nil {
@@ -586,7 +586,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		webtest.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -594,7 +594,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Timeout’:
+	// Set property "Timeout":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Timeout != nil {
@@ -603,7 +603,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘ValidationRules’:
+	// Set property "ValidationRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ValidationRules != nil {
@@ -1013,9 +1013,9 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Webtest_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Configuration’:
+	// Set property "Configuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Configuration != nil {
@@ -1029,7 +1029,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -1038,7 +1038,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Enabled != nil {
@@ -1047,7 +1047,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Frequency’:
+	// Set property "Frequency":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Frequency != nil {
@@ -1056,13 +1056,13 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		webtest.Id = &id
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Kind != nil {
@@ -1071,13 +1071,13 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		webtest.Location = &location
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Locations {
@@ -1090,13 +1090,13 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		webtest.Name = &name
 	}
 
-	// Set property ‘PropertiesName’:
+	// Set property "PropertiesName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Name != nil {
@@ -1105,7 +1105,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1114,7 +1114,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Request’:
+	// Set property "Request":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Request != nil {
@@ -1128,7 +1128,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘RetryEnabled’:
+	// Set property "RetryEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetryEnabled != nil {
@@ -1137,7 +1137,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘SyntheticMonitorId’:
+	// Set property "SyntheticMonitorId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SyntheticMonitorId != nil {
@@ -1146,7 +1146,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		webtest.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1154,7 +1154,7 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Timeout’:
+	// Set property "Timeout":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Timeout != nil {
@@ -1163,13 +1163,13 @@ func (webtest *Webtest_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		webtest.Type = &typeVar
 	}
 
-	// Set property ‘ValidationRules’:
+	// Set property "ValidationRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ValidationRules != nil {
@@ -1452,7 +1452,7 @@ func (geolocation *WebTestGeolocation) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &WebTestGeolocation_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if geolocation.Id != nil {
 		id := *geolocation.Id
 		result.Id = &id
@@ -1472,7 +1472,7 @@ func (geolocation *WebTestGeolocation) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestGeolocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		geolocation.Id = &id
@@ -1530,7 +1530,7 @@ func (geolocation *WebTestGeolocation_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestGeolocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		geolocation.Id = &id
@@ -1583,7 +1583,7 @@ func (configuration *WebTestProperties_Configuration) ConvertToARM(resolved genr
 	}
 	result := &WebTestProperties_Configuration_ARM{}
 
-	// Set property ‘WebTest’:
+	// Set property "WebTest":
 	if configuration.WebTest != nil {
 		webTest := *configuration.WebTest
 		result.WebTest = &webTest
@@ -1603,7 +1603,7 @@ func (configuration *WebTestProperties_Configuration) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_Configuration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘WebTest’:
+	// Set property "WebTest":
 	if typedInput.WebTest != nil {
 		webTest := *typedInput.WebTest
 		configuration.WebTest = &webTest
@@ -1661,7 +1661,7 @@ func (configuration *WebTestProperties_Configuration_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_Configuration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘WebTest’:
+	// Set property "WebTest":
 	if typedInput.WebTest != nil {
 		webTest := *typedInput.WebTest
 		configuration.WebTest = &webTest
@@ -1740,13 +1740,13 @@ func (request *WebTestProperties_Request) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &WebTestProperties_Request_ARM{}
 
-	// Set property ‘FollowRedirects’:
+	// Set property "FollowRedirects":
 	if request.FollowRedirects != nil {
 		followRedirects := *request.FollowRedirects
 		result.FollowRedirects = &followRedirects
 	}
 
-	// Set property ‘Headers’:
+	// Set property "Headers":
 	for _, item := range request.Headers {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1755,25 +1755,25 @@ func (request *WebTestProperties_Request) ConvertToARM(resolved genruntime.Conve
 		result.Headers = append(result.Headers, *item_ARM.(*HeaderField_ARM))
 	}
 
-	// Set property ‘HttpVerb’:
+	// Set property "HttpVerb":
 	if request.HttpVerb != nil {
 		httpVerb := *request.HttpVerb
 		result.HttpVerb = &httpVerb
 	}
 
-	// Set property ‘ParseDependentRequests’:
+	// Set property "ParseDependentRequests":
 	if request.ParseDependentRequests != nil {
 		parseDependentRequests := *request.ParseDependentRequests
 		result.ParseDependentRequests = &parseDependentRequests
 	}
 
-	// Set property ‘RequestBody’:
+	// Set property "RequestBody":
 	if request.RequestBody != nil {
 		requestBody := *request.RequestBody
 		result.RequestBody = &requestBody
 	}
 
-	// Set property ‘RequestUrl’:
+	// Set property "RequestUrl":
 	if request.RequestUrl != nil {
 		requestUrl := *request.RequestUrl
 		result.RequestUrl = &requestUrl
@@ -1793,13 +1793,13 @@ func (request *WebTestProperties_Request) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_Request_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FollowRedirects’:
+	// Set property "FollowRedirects":
 	if typedInput.FollowRedirects != nil {
 		followRedirects := *typedInput.FollowRedirects
 		request.FollowRedirects = &followRedirects
 	}
 
-	// Set property ‘Headers’:
+	// Set property "Headers":
 	for _, item := range typedInput.Headers {
 		var item1 HeaderField
 		err := item1.PopulateFromARM(owner, item)
@@ -1809,25 +1809,25 @@ func (request *WebTestProperties_Request) PopulateFromARM(owner genruntime.Arbit
 		request.Headers = append(request.Headers, item1)
 	}
 
-	// Set property ‘HttpVerb’:
+	// Set property "HttpVerb":
 	if typedInput.HttpVerb != nil {
 		httpVerb := *typedInput.HttpVerb
 		request.HttpVerb = &httpVerb
 	}
 
-	// Set property ‘ParseDependentRequests’:
+	// Set property "ParseDependentRequests":
 	if typedInput.ParseDependentRequests != nil {
 		parseDependentRequests := *typedInput.ParseDependentRequests
 		request.ParseDependentRequests = &parseDependentRequests
 	}
 
-	// Set property ‘RequestBody’:
+	// Set property "RequestBody":
 	if typedInput.RequestBody != nil {
 		requestBody := *typedInput.RequestBody
 		request.RequestBody = &requestBody
 	}
 
-	// Set property ‘RequestUrl’:
+	// Set property "RequestUrl":
 	if typedInput.RequestUrl != nil {
 		requestUrl := *typedInput.RequestUrl
 		request.RequestUrl = &requestUrl
@@ -1970,13 +1970,13 @@ func (request *WebTestProperties_Request_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_Request_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FollowRedirects’:
+	// Set property "FollowRedirects":
 	if typedInput.FollowRedirects != nil {
 		followRedirects := *typedInput.FollowRedirects
 		request.FollowRedirects = &followRedirects
 	}
 
-	// Set property ‘Headers’:
+	// Set property "Headers":
 	for _, item := range typedInput.Headers {
 		var item1 HeaderField_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1986,25 +1986,25 @@ func (request *WebTestProperties_Request_STATUS) PopulateFromARM(owner genruntim
 		request.Headers = append(request.Headers, item1)
 	}
 
-	// Set property ‘HttpVerb’:
+	// Set property "HttpVerb":
 	if typedInput.HttpVerb != nil {
 		httpVerb := *typedInput.HttpVerb
 		request.HttpVerb = &httpVerb
 	}
 
-	// Set property ‘ParseDependentRequests’:
+	// Set property "ParseDependentRequests":
 	if typedInput.ParseDependentRequests != nil {
 		parseDependentRequests := *typedInput.ParseDependentRequests
 		request.ParseDependentRequests = &parseDependentRequests
 	}
 
-	// Set property ‘RequestBody’:
+	// Set property "RequestBody":
 	if typedInput.RequestBody != nil {
 		requestBody := *typedInput.RequestBody
 		request.RequestBody = &requestBody
 	}
 
-	// Set property ‘RequestUrl’:
+	// Set property "RequestUrl":
 	if typedInput.RequestUrl != nil {
 		requestUrl := *typedInput.RequestUrl
 		request.RequestUrl = &requestUrl
@@ -2141,7 +2141,7 @@ func (rules *WebTestProperties_ValidationRules) ConvertToARM(resolved genruntime
 	}
 	result := &WebTestProperties_ValidationRules_ARM{}
 
-	// Set property ‘ContentValidation’:
+	// Set property "ContentValidation":
 	if rules.ContentValidation != nil {
 		contentValidation_ARM, err := (*rules.ContentValidation).ConvertToARM(resolved)
 		if err != nil {
@@ -2151,25 +2151,25 @@ func (rules *WebTestProperties_ValidationRules) ConvertToARM(resolved genruntime
 		result.ContentValidation = &contentValidation
 	}
 
-	// Set property ‘ExpectedHttpStatusCode’:
+	// Set property "ExpectedHttpStatusCode":
 	if rules.ExpectedHttpStatusCode != nil {
 		expectedHttpStatusCode := *rules.ExpectedHttpStatusCode
 		result.ExpectedHttpStatusCode = &expectedHttpStatusCode
 	}
 
-	// Set property ‘IgnoreHttpsStatusCode’:
+	// Set property "IgnoreHttpsStatusCode":
 	if rules.IgnoreHttpsStatusCode != nil {
 		ignoreHttpsStatusCode := *rules.IgnoreHttpsStatusCode
 		result.IgnoreHttpsStatusCode = &ignoreHttpsStatusCode
 	}
 
-	// Set property ‘SSLCertRemainingLifetimeCheck’:
+	// Set property "SSLCertRemainingLifetimeCheck":
 	if rules.SSLCertRemainingLifetimeCheck != nil {
 		sslCertRemainingLifetimeCheck := *rules.SSLCertRemainingLifetimeCheck
 		result.SSLCertRemainingLifetimeCheck = &sslCertRemainingLifetimeCheck
 	}
 
-	// Set property ‘SSLCheck’:
+	// Set property "SSLCheck":
 	if rules.SSLCheck != nil {
 		sslCheck := *rules.SSLCheck
 		result.SSLCheck = &sslCheck
@@ -2189,7 +2189,7 @@ func (rules *WebTestProperties_ValidationRules) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_ValidationRules_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContentValidation’:
+	// Set property "ContentValidation":
 	if typedInput.ContentValidation != nil {
 		var contentValidation1 WebTestProperties_ValidationRules_ContentValidation
 		err := contentValidation1.PopulateFromARM(owner, *typedInput.ContentValidation)
@@ -2200,25 +2200,25 @@ func (rules *WebTestProperties_ValidationRules) PopulateFromARM(owner genruntime
 		rules.ContentValidation = &contentValidation
 	}
 
-	// Set property ‘ExpectedHttpStatusCode’:
+	// Set property "ExpectedHttpStatusCode":
 	if typedInput.ExpectedHttpStatusCode != nil {
 		expectedHttpStatusCode := *typedInput.ExpectedHttpStatusCode
 		rules.ExpectedHttpStatusCode = &expectedHttpStatusCode
 	}
 
-	// Set property ‘IgnoreHttpsStatusCode’:
+	// Set property "IgnoreHttpsStatusCode":
 	if typedInput.IgnoreHttpsStatusCode != nil {
 		ignoreHttpsStatusCode := *typedInput.IgnoreHttpsStatusCode
 		rules.IgnoreHttpsStatusCode = &ignoreHttpsStatusCode
 	}
 
-	// Set property ‘SSLCertRemainingLifetimeCheck’:
+	// Set property "SSLCertRemainingLifetimeCheck":
 	if typedInput.SSLCertRemainingLifetimeCheck != nil {
 		sslCertRemainingLifetimeCheck := *typedInput.SSLCertRemainingLifetimeCheck
 		rules.SSLCertRemainingLifetimeCheck = &sslCertRemainingLifetimeCheck
 	}
 
-	// Set property ‘SSLCheck’:
+	// Set property "SSLCheck":
 	if typedInput.SSLCheck != nil {
 		sslCheck := *typedInput.SSLCheck
 		rules.SSLCheck = &sslCheck
@@ -2342,7 +2342,7 @@ func (rules *WebTestProperties_ValidationRules_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_ValidationRules_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContentValidation’:
+	// Set property "ContentValidation":
 	if typedInput.ContentValidation != nil {
 		var contentValidation1 WebTestProperties_ValidationRules_ContentValidation_STATUS
 		err := contentValidation1.PopulateFromARM(owner, *typedInput.ContentValidation)
@@ -2353,25 +2353,25 @@ func (rules *WebTestProperties_ValidationRules_STATUS) PopulateFromARM(owner gen
 		rules.ContentValidation = &contentValidation
 	}
 
-	// Set property ‘ExpectedHttpStatusCode’:
+	// Set property "ExpectedHttpStatusCode":
 	if typedInput.ExpectedHttpStatusCode != nil {
 		expectedHttpStatusCode := *typedInput.ExpectedHttpStatusCode
 		rules.ExpectedHttpStatusCode = &expectedHttpStatusCode
 	}
 
-	// Set property ‘IgnoreHttpsStatusCode’:
+	// Set property "IgnoreHttpsStatusCode":
 	if typedInput.IgnoreHttpsStatusCode != nil {
 		ignoreHttpsStatusCode := *typedInput.IgnoreHttpsStatusCode
 		rules.IgnoreHttpsStatusCode = &ignoreHttpsStatusCode
 	}
 
-	// Set property ‘SSLCertRemainingLifetimeCheck’:
+	// Set property "SSLCertRemainingLifetimeCheck":
 	if typedInput.SSLCertRemainingLifetimeCheck != nil {
 		sslCertRemainingLifetimeCheck := *typedInput.SSLCertRemainingLifetimeCheck
 		rules.SSLCertRemainingLifetimeCheck = &sslCertRemainingLifetimeCheck
 	}
 
-	// Set property ‘SSLCheck’:
+	// Set property "SSLCheck":
 	if typedInput.SSLCheck != nil {
 		sslCheck := *typedInput.SSLCheck
 		rules.SSLCheck = &sslCheck
@@ -2487,13 +2487,13 @@ func (field *HeaderField) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &HeaderField_ARM{}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if field.Key != nil {
 		key := *field.Key
 		result.Key = &key
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if field.Value != nil {
 		value := *field.Value
 		result.Value = &value
@@ -2513,13 +2513,13 @@ func (field *HeaderField) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HeaderField_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		field.Key = &key
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		field.Value = &value
@@ -2584,13 +2584,13 @@ func (field *HeaderField_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HeaderField_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		field.Key = &key
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		field.Value = &value
@@ -2651,19 +2651,19 @@ func (validation *WebTestProperties_ValidationRules_ContentValidation) ConvertTo
 	}
 	result := &WebTestProperties_ValidationRules_ContentValidation_ARM{}
 
-	// Set property ‘ContentMatch’:
+	// Set property "ContentMatch":
 	if validation.ContentMatch != nil {
 		contentMatch := *validation.ContentMatch
 		result.ContentMatch = &contentMatch
 	}
 
-	// Set property ‘IgnoreCase’:
+	// Set property "IgnoreCase":
 	if validation.IgnoreCase != nil {
 		ignoreCase := *validation.IgnoreCase
 		result.IgnoreCase = &ignoreCase
 	}
 
-	// Set property ‘PassIfTextFound’:
+	// Set property "PassIfTextFound":
 	if validation.PassIfTextFound != nil {
 		passIfTextFound := *validation.PassIfTextFound
 		result.PassIfTextFound = &passIfTextFound
@@ -2683,19 +2683,19 @@ func (validation *WebTestProperties_ValidationRules_ContentValidation) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_ValidationRules_ContentValidation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContentMatch’:
+	// Set property "ContentMatch":
 	if typedInput.ContentMatch != nil {
 		contentMatch := *typedInput.ContentMatch
 		validation.ContentMatch = &contentMatch
 	}
 
-	// Set property ‘IgnoreCase’:
+	// Set property "IgnoreCase":
 	if typedInput.IgnoreCase != nil {
 		ignoreCase := *typedInput.IgnoreCase
 		validation.IgnoreCase = &ignoreCase
 	}
 
-	// Set property ‘PassIfTextFound’:
+	// Set property "PassIfTextFound":
 	if typedInput.PassIfTextFound != nil {
 		passIfTextFound := *typedInput.PassIfTextFound
 		validation.PassIfTextFound = &passIfTextFound
@@ -2787,19 +2787,19 @@ func (validation *WebTestProperties_ValidationRules_ContentValidation_STATUS) Po
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WebTestProperties_ValidationRules_ContentValidation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContentMatch’:
+	// Set property "ContentMatch":
 	if typedInput.ContentMatch != nil {
 		contentMatch := *typedInput.ContentMatch
 		validation.ContentMatch = &contentMatch
 	}
 
-	// Set property ‘IgnoreCase’:
+	// Set property "IgnoreCase":
 	if typedInput.IgnoreCase != nil {
 		ignoreCase := *typedInput.IgnoreCase
 		validation.IgnoreCase = &ignoreCase
 	}
 
-	// Set property ‘PassIfTextFound’:
+	// Set property "PassIfTextFound":
 	if typedInput.PassIfTextFound != nil {
 		passIfTextFound := *typedInput.PassIfTextFound
 		validation.PassIfTextFound = &passIfTextFound

--- a/v2/api/insights/v1beta20200202/component_types_gen.go
+++ b/v2/api/insights/v1beta20200202/component_types_gen.go
@@ -410,28 +410,28 @@ func (component *Component_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &Component_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if component.Etag != nil {
 		etag := *component.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if component.Kind != nil {
 		kind := *component.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if component.Location != nil {
 		location := *component.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if component.Application_Type != nil ||
 		component.DisableIpMasking != nil ||
 		component.DisableLocalAuth != nil ||
@@ -509,7 +509,7 @@ func (component *Component_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.WorkspaceResourceId = &workspaceResourceId
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if component.Tags != nil {
 		result.Tags = make(map[string]string, len(component.Tags))
 		for key, value := range component.Tags {
@@ -531,7 +531,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Component_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Application_Type’:
+	// Set property "Application_Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Application_Type != nil {
@@ -540,10 +540,10 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	component.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DisableIpMasking’:
+	// Set property "DisableIpMasking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableIpMasking != nil {
@@ -552,7 +552,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -561,13 +561,13 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		component.Etag = &etag
 	}
 
-	// Set property ‘Flow_Type’:
+	// Set property "Flow_Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Flow_Type != nil {
@@ -576,7 +576,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ForceCustomerStorageForProfiler’:
+	// Set property "ForceCustomerStorageForProfiler":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceCustomerStorageForProfiler != nil {
@@ -585,7 +585,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘HockeyAppId’:
+	// Set property "HockeyAppId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HockeyAppId != nil {
@@ -594,7 +594,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ImmediatePurgeDataOn30Days’:
+	// Set property "ImmediatePurgeDataOn30Days":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmediatePurgeDataOn30Days != nil {
@@ -603,7 +603,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘IngestionMode’:
+	// Set property "IngestionMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IngestionMode != nil {
@@ -612,24 +612,24 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		component.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		component.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	component.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccessForIngestion’:
+	// Set property "PublicNetworkAccessForIngestion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForIngestion != nil {
@@ -638,7 +638,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForQuery’:
+	// Set property "PublicNetworkAccessForQuery":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForQuery != nil {
@@ -647,7 +647,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Request_Source’:
+	// Set property "Request_Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Request_Source != nil {
@@ -656,7 +656,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionInDays != nil {
@@ -665,7 +665,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘SamplingPercentage’:
+	// Set property "SamplingPercentage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SamplingPercentage != nil {
@@ -674,7 +674,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		component.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -682,7 +682,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// no assignment for property ‘WorkspaceResourceReference’
+	// no assignment for property "WorkspaceResourceReference"
 
 	// No error
 	return nil
@@ -1149,7 +1149,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Component_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AppId’:
+	// Set property "AppId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AppId != nil {
@@ -1158,7 +1158,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ApplicationId’:
+	// Set property "ApplicationId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApplicationId != nil {
@@ -1167,7 +1167,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Application_Type’:
+	// Set property "Application_Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Application_Type != nil {
@@ -1176,9 +1176,9 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ConnectionString’:
+	// Set property "ConnectionString":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConnectionString != nil {
@@ -1187,7 +1187,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CreationDate’:
+	// Set property "CreationDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationDate != nil {
@@ -1196,7 +1196,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘DisableIpMasking’:
+	// Set property "DisableIpMasking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableIpMasking != nil {
@@ -1205,7 +1205,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -1214,13 +1214,13 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		component.Etag = &etag
 	}
 
-	// Set property ‘Flow_Type’:
+	// Set property "Flow_Type":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Flow_Type != nil {
@@ -1229,7 +1229,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ForceCustomerStorageForProfiler’:
+	// Set property "ForceCustomerStorageForProfiler":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceCustomerStorageForProfiler != nil {
@@ -1238,7 +1238,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HockeyAppId’:
+	// Set property "HockeyAppId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HockeyAppId != nil {
@@ -1247,7 +1247,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HockeyAppToken’:
+	// Set property "HockeyAppToken":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HockeyAppToken != nil {
@@ -1256,13 +1256,13 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		component.Id = &id
 	}
 
-	// Set property ‘ImmediatePurgeDataOn30Days’:
+	// Set property "ImmediatePurgeDataOn30Days":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmediatePurgeDataOn30Days != nil {
@@ -1271,7 +1271,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘IngestionMode’:
+	// Set property "IngestionMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IngestionMode != nil {
@@ -1280,7 +1280,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘InstrumentationKey’:
+	// Set property "InstrumentationKey":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InstrumentationKey != nil {
@@ -1289,13 +1289,13 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		component.Kind = &kind
 	}
 
-	// Set property ‘LaMigrationDate’:
+	// Set property "LaMigrationDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LaMigrationDate != nil {
@@ -1304,19 +1304,19 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		component.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		component.Name = &name
 	}
 
-	// Set property ‘PrivateLinkScopedResources’:
+	// Set property "PrivateLinkScopedResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkScopedResources {
@@ -1329,7 +1329,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PropertiesName’:
+	// Set property "PropertiesName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Name != nil {
@@ -1338,7 +1338,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1347,7 +1347,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForIngestion’:
+	// Set property "PublicNetworkAccessForIngestion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForIngestion != nil {
@@ -1356,7 +1356,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForQuery’:
+	// Set property "PublicNetworkAccessForQuery":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForQuery != nil {
@@ -1365,7 +1365,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Request_Source’:
+	// Set property "Request_Source":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Request_Source != nil {
@@ -1374,7 +1374,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionInDays != nil {
@@ -1383,7 +1383,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SamplingPercentage’:
+	// Set property "SamplingPercentage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SamplingPercentage != nil {
@@ -1392,7 +1392,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		component.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1400,7 +1400,7 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantId != nil {
@@ -1409,13 +1409,13 @@ func (component *Component_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		component.Type = &typeVar
 	}
 
-	// Set property ‘WorkspaceResourceId’:
+	// Set property "WorkspaceResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkspaceResourceId != nil {
@@ -1928,13 +1928,13 @@ func (resource *PrivateLinkScopedResource_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkScopedResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		resource.ResourceId = &resourceId
 	}
 
-	// Set property ‘ScopeId’:
+	// Set property "ScopeId":
 	if typedInput.ScopeId != nil {
 		scopeId := *typedInput.ScopeId
 		resource.ScopeId = &scopeId

--- a/v2/api/keyvault/v1api20210401preview/vault_types_gen.go
+++ b/v2/api/keyvault/v1api20210401preview/vault_types_gen.go
@@ -361,16 +361,16 @@ func (vault *Vault_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &Vault_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if vault.Location != nil {
 		location := *vault.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if vault.Properties != nil {
 		properties_ARM, err := (*vault.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -380,7 +380,7 @@ func (vault *Vault_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties = &properties
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if vault.Tags != nil {
 		result.Tags = make(map[string]string, len(vault.Tags))
 		for key, value := range vault.Tags {
@@ -402,19 +402,19 @@ func (vault *Vault_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Vault_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	vault.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		vault.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	vault.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 VaultProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -425,7 +425,7 @@ func (vault *Vault_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		vault.Properties = &properties
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		vault.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -695,27 +695,27 @@ func (vault *Vault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Vault_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		vault.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		vault.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		vault.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 VaultProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -726,7 +726,7 @@ func (vault *Vault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		vault.Properties = &properties
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -737,7 +737,7 @@ func (vault *Vault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		vault.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		vault.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -745,7 +745,7 @@ func (vault *Vault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		vault.Type = &typeVar
@@ -897,37 +897,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -1090,7 +1090,7 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &VaultProperties_ARM{}
 
-	// Set property ‘AccessPolicies’:
+	// Set property "AccessPolicies":
 	for _, item := range properties.AccessPolicies {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1099,49 +1099,49 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 		result.AccessPolicies = append(result.AccessPolicies, *item_ARM.(*AccessPolicyEntry_ARM))
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if properties.CreateMode != nil {
 		createMode := *properties.CreateMode
 		result.CreateMode = &createMode
 	}
 
-	// Set property ‘EnablePurgeProtection’:
+	// Set property "EnablePurgeProtection":
 	if properties.EnablePurgeProtection != nil {
 		enablePurgeProtection := *properties.EnablePurgeProtection
 		result.EnablePurgeProtection = &enablePurgeProtection
 	}
 
-	// Set property ‘EnableRbacAuthorization’:
+	// Set property "EnableRbacAuthorization":
 	if properties.EnableRbacAuthorization != nil {
 		enableRbacAuthorization := *properties.EnableRbacAuthorization
 		result.EnableRbacAuthorization = &enableRbacAuthorization
 	}
 
-	// Set property ‘EnableSoftDelete’:
+	// Set property "EnableSoftDelete":
 	if properties.EnableSoftDelete != nil {
 		enableSoftDelete := *properties.EnableSoftDelete
 		result.EnableSoftDelete = &enableSoftDelete
 	}
 
-	// Set property ‘EnabledForDeployment’:
+	// Set property "EnabledForDeployment":
 	if properties.EnabledForDeployment != nil {
 		enabledForDeployment := *properties.EnabledForDeployment
 		result.EnabledForDeployment = &enabledForDeployment
 	}
 
-	// Set property ‘EnabledForDiskEncryption’:
+	// Set property "EnabledForDiskEncryption":
 	if properties.EnabledForDiskEncryption != nil {
 		enabledForDiskEncryption := *properties.EnabledForDiskEncryption
 		result.EnabledForDiskEncryption = &enabledForDiskEncryption
 	}
 
-	// Set property ‘EnabledForTemplateDeployment’:
+	// Set property "EnabledForTemplateDeployment":
 	if properties.EnabledForTemplateDeployment != nil {
 		enabledForTemplateDeployment := *properties.EnabledForTemplateDeployment
 		result.EnabledForTemplateDeployment = &enabledForTemplateDeployment
 	}
 
-	// Set property ‘NetworkAcls’:
+	// Set property "NetworkAcls":
 	if properties.NetworkAcls != nil {
 		networkAcls_ARM, err := (*properties.NetworkAcls).ConvertToARM(resolved)
 		if err != nil {
@@ -1151,13 +1151,13 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 		result.NetworkAcls = &networkAcls
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if properties.ProvisioningState != nil {
 		provisioningState := *properties.ProvisioningState
 		result.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if properties.Sku != nil {
 		sku_ARM, err := (*properties.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -1167,13 +1167,13 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘SoftDeleteRetentionInDays’:
+	// Set property "SoftDeleteRetentionInDays":
 	if properties.SoftDeleteRetentionInDays != nil {
 		softDeleteRetentionInDays := *properties.SoftDeleteRetentionInDays
 		result.SoftDeleteRetentionInDays = &softDeleteRetentionInDays
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if properties.TenantId != nil {
 		tenantId := *properties.TenantId
 		result.TenantId = &tenantId
@@ -1187,7 +1187,7 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 		result.TenantId = &tenantId
 	}
 
-	// Set property ‘VaultUri’:
+	// Set property "VaultUri":
 	if properties.VaultUri != nil {
 		vaultUri := *properties.VaultUri
 		result.VaultUri = &vaultUri
@@ -1207,7 +1207,7 @@ func (properties *VaultProperties) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessPolicies’:
+	// Set property "AccessPolicies":
 	for _, item := range typedInput.AccessPolicies {
 		var item1 AccessPolicyEntry
 		err := item1.PopulateFromARM(owner, item)
@@ -1217,49 +1217,49 @@ func (properties *VaultProperties) PopulateFromARM(owner genruntime.ArbitraryOwn
 		properties.AccessPolicies = append(properties.AccessPolicies, item1)
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if typedInput.CreateMode != nil {
 		createMode := *typedInput.CreateMode
 		properties.CreateMode = &createMode
 	}
 
-	// Set property ‘EnablePurgeProtection’:
+	// Set property "EnablePurgeProtection":
 	if typedInput.EnablePurgeProtection != nil {
 		enablePurgeProtection := *typedInput.EnablePurgeProtection
 		properties.EnablePurgeProtection = &enablePurgeProtection
 	}
 
-	// Set property ‘EnableRbacAuthorization’:
+	// Set property "EnableRbacAuthorization":
 	if typedInput.EnableRbacAuthorization != nil {
 		enableRbacAuthorization := *typedInput.EnableRbacAuthorization
 		properties.EnableRbacAuthorization = &enableRbacAuthorization
 	}
 
-	// Set property ‘EnableSoftDelete’:
+	// Set property "EnableSoftDelete":
 	if typedInput.EnableSoftDelete != nil {
 		enableSoftDelete := *typedInput.EnableSoftDelete
 		properties.EnableSoftDelete = &enableSoftDelete
 	}
 
-	// Set property ‘EnabledForDeployment’:
+	// Set property "EnabledForDeployment":
 	if typedInput.EnabledForDeployment != nil {
 		enabledForDeployment := *typedInput.EnabledForDeployment
 		properties.EnabledForDeployment = &enabledForDeployment
 	}
 
-	// Set property ‘EnabledForDiskEncryption’:
+	// Set property "EnabledForDiskEncryption":
 	if typedInput.EnabledForDiskEncryption != nil {
 		enabledForDiskEncryption := *typedInput.EnabledForDiskEncryption
 		properties.EnabledForDiskEncryption = &enabledForDiskEncryption
 	}
 
-	// Set property ‘EnabledForTemplateDeployment’:
+	// Set property "EnabledForTemplateDeployment":
 	if typedInput.EnabledForTemplateDeployment != nil {
 		enabledForTemplateDeployment := *typedInput.EnabledForTemplateDeployment
 		properties.EnabledForTemplateDeployment = &enabledForTemplateDeployment
 	}
 
-	// Set property ‘NetworkAcls’:
+	// Set property "NetworkAcls":
 	if typedInput.NetworkAcls != nil {
 		var networkAcls1 NetworkRuleSet
 		err := networkAcls1.PopulateFromARM(owner, *typedInput.NetworkAcls)
@@ -1270,13 +1270,13 @@ func (properties *VaultProperties) PopulateFromARM(owner genruntime.ArbitraryOwn
 		properties.NetworkAcls = &networkAcls
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		properties.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1287,21 +1287,21 @@ func (properties *VaultProperties) PopulateFromARM(owner genruntime.ArbitraryOwn
 		properties.Sku = &sku
 	}
 
-	// Set property ‘SoftDeleteRetentionInDays’:
+	// Set property "SoftDeleteRetentionInDays":
 	if typedInput.SoftDeleteRetentionInDays != nil {
 		softDeleteRetentionInDays := *typedInput.SoftDeleteRetentionInDays
 		properties.SoftDeleteRetentionInDays = &softDeleteRetentionInDays
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		properties.TenantId = &tenantId
 	}
 
-	// no assignment for property ‘TenantIdFromConfig’
+	// no assignment for property "TenantIdFromConfig"
 
-	// Set property ‘VaultUri’:
+	// Set property "VaultUri":
 	if typedInput.VaultUri != nil {
 		vaultUri := *typedInput.VaultUri
 		properties.VaultUri = &vaultUri
@@ -1796,7 +1796,7 @@ func (properties *VaultProperties_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessPolicies’:
+	// Set property "AccessPolicies":
 	for _, item := range typedInput.AccessPolicies {
 		var item1 AccessPolicyEntry_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1806,55 +1806,55 @@ func (properties *VaultProperties_STATUS) PopulateFromARM(owner genruntime.Arbit
 		properties.AccessPolicies = append(properties.AccessPolicies, item1)
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if typedInput.CreateMode != nil {
 		createMode := *typedInput.CreateMode
 		properties.CreateMode = &createMode
 	}
 
-	// Set property ‘EnablePurgeProtection’:
+	// Set property "EnablePurgeProtection":
 	if typedInput.EnablePurgeProtection != nil {
 		enablePurgeProtection := *typedInput.EnablePurgeProtection
 		properties.EnablePurgeProtection = &enablePurgeProtection
 	}
 
-	// Set property ‘EnableRbacAuthorization’:
+	// Set property "EnableRbacAuthorization":
 	if typedInput.EnableRbacAuthorization != nil {
 		enableRbacAuthorization := *typedInput.EnableRbacAuthorization
 		properties.EnableRbacAuthorization = &enableRbacAuthorization
 	}
 
-	// Set property ‘EnableSoftDelete’:
+	// Set property "EnableSoftDelete":
 	if typedInput.EnableSoftDelete != nil {
 		enableSoftDelete := *typedInput.EnableSoftDelete
 		properties.EnableSoftDelete = &enableSoftDelete
 	}
 
-	// Set property ‘EnabledForDeployment’:
+	// Set property "EnabledForDeployment":
 	if typedInput.EnabledForDeployment != nil {
 		enabledForDeployment := *typedInput.EnabledForDeployment
 		properties.EnabledForDeployment = &enabledForDeployment
 	}
 
-	// Set property ‘EnabledForDiskEncryption’:
+	// Set property "EnabledForDiskEncryption":
 	if typedInput.EnabledForDiskEncryption != nil {
 		enabledForDiskEncryption := *typedInput.EnabledForDiskEncryption
 		properties.EnabledForDiskEncryption = &enabledForDiskEncryption
 	}
 
-	// Set property ‘EnabledForTemplateDeployment’:
+	// Set property "EnabledForTemplateDeployment":
 	if typedInput.EnabledForTemplateDeployment != nil {
 		enabledForTemplateDeployment := *typedInput.EnabledForTemplateDeployment
 		properties.EnabledForTemplateDeployment = &enabledForTemplateDeployment
 	}
 
-	// Set property ‘HsmPoolResourceId’:
+	// Set property "HsmPoolResourceId":
 	if typedInput.HsmPoolResourceId != nil {
 		hsmPoolResourceId := *typedInput.HsmPoolResourceId
 		properties.HsmPoolResourceId = &hsmPoolResourceId
 	}
 
-	// Set property ‘NetworkAcls’:
+	// Set property "NetworkAcls":
 	if typedInput.NetworkAcls != nil {
 		var networkAcls1 NetworkRuleSet_STATUS
 		err := networkAcls1.PopulateFromARM(owner, *typedInput.NetworkAcls)
@@ -1865,7 +1865,7 @@ func (properties *VaultProperties_STATUS) PopulateFromARM(owner genruntime.Arbit
 		properties.NetworkAcls = &networkAcls
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	for _, item := range typedInput.PrivateEndpointConnections {
 		var item1 PrivateEndpointConnectionItem_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1875,13 +1875,13 @@ func (properties *VaultProperties_STATUS) PopulateFromARM(owner genruntime.Arbit
 		properties.PrivateEndpointConnections = append(properties.PrivateEndpointConnections, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		properties.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1892,19 +1892,19 @@ func (properties *VaultProperties_STATUS) PopulateFromARM(owner genruntime.Arbit
 		properties.Sku = &sku
 	}
 
-	// Set property ‘SoftDeleteRetentionInDays’:
+	// Set property "SoftDeleteRetentionInDays":
 	if typedInput.SoftDeleteRetentionInDays != nil {
 		softDeleteRetentionInDays := *typedInput.SoftDeleteRetentionInDays
 		properties.SoftDeleteRetentionInDays = &softDeleteRetentionInDays
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		properties.TenantId = &tenantId
 	}
 
-	// Set property ‘VaultUri’:
+	// Set property "VaultUri":
 	if typedInput.VaultUri != nil {
 		vaultUri := *typedInput.VaultUri
 		properties.VaultUri = &vaultUri
@@ -2249,7 +2249,7 @@ func (entry *AccessPolicyEntry) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &AccessPolicyEntry_ARM{}
 
-	// Set property ‘ApplicationId’:
+	// Set property "ApplicationId":
 	if entry.ApplicationId != nil {
 		applicationId := *entry.ApplicationId
 		result.ApplicationId = &applicationId
@@ -2263,7 +2263,7 @@ func (entry *AccessPolicyEntry) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.ApplicationId = &applicationId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if entry.ObjectId != nil {
 		objectId := *entry.ObjectId
 		result.ObjectId = &objectId
@@ -2277,7 +2277,7 @@ func (entry *AccessPolicyEntry) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.ObjectId = &objectId
 	}
 
-	// Set property ‘Permissions’:
+	// Set property "Permissions":
 	if entry.Permissions != nil {
 		permissions_ARM, err := (*entry.Permissions).ConvertToARM(resolved)
 		if err != nil {
@@ -2287,7 +2287,7 @@ func (entry *AccessPolicyEntry) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.Permissions = &permissions
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if entry.TenantId != nil {
 		tenantId := *entry.TenantId
 		result.TenantId = &tenantId
@@ -2315,23 +2315,23 @@ func (entry *AccessPolicyEntry) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AccessPolicyEntry_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationId’:
+	// Set property "ApplicationId":
 	if typedInput.ApplicationId != nil {
 		applicationId := *typedInput.ApplicationId
 		entry.ApplicationId = &applicationId
 	}
 
-	// no assignment for property ‘ApplicationIdFromConfig’
+	// no assignment for property "ApplicationIdFromConfig"
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		entry.ObjectId = &objectId
 	}
 
-	// no assignment for property ‘ObjectIdFromConfig’
+	// no assignment for property "ObjectIdFromConfig"
 
-	// Set property ‘Permissions’:
+	// Set property "Permissions":
 	if typedInput.Permissions != nil {
 		var permissions1 Permissions
 		err := permissions1.PopulateFromARM(owner, *typedInput.Permissions)
@@ -2342,13 +2342,13 @@ func (entry *AccessPolicyEntry) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		entry.Permissions = &permissions
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		entry.TenantId = &tenantId
 	}
 
-	// no assignment for property ‘TenantIdFromConfig’
+	// no assignment for property "TenantIdFromConfig"
 
 	// No error
 	return nil
@@ -2556,19 +2556,19 @@ func (entry *AccessPolicyEntry_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AccessPolicyEntry_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationId’:
+	// Set property "ApplicationId":
 	if typedInput.ApplicationId != nil {
 		applicationId := *typedInput.ApplicationId
 		entry.ApplicationId = &applicationId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		entry.ObjectId = &objectId
 	}
 
-	// Set property ‘Permissions’:
+	// Set property "Permissions":
 	if typedInput.Permissions != nil {
 		var permissions1 Permissions_STATUS
 		err := permissions1.PopulateFromARM(owner, *typedInput.Permissions)
@@ -2579,7 +2579,7 @@ func (entry *AccessPolicyEntry_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		entry.Permissions = &permissions
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		entry.TenantId = &tenantId
@@ -2680,19 +2680,19 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &NetworkRuleSet_ARM{}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if ruleSet.Bypass != nil {
 		bypass := *ruleSet.Bypass
 		result.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if ruleSet.DefaultAction != nil {
 		defaultAction := *ruleSet.DefaultAction
 		result.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range ruleSet.IpRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2701,7 +2701,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.IpRules = append(result.IpRules, *item_ARM.(*IPRule_ARM))
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range ruleSet.VirtualNetworkRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2724,19 +2724,19 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if typedInput.Bypass != nil {
 		bypass := *typedInput.Bypass
 		ruleSet.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule
 		err := item1.PopulateFromARM(owner, item)
@@ -2746,7 +2746,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		ruleSet.IpRules = append(ruleSet.IpRules, item1)
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range typedInput.VirtualNetworkRules {
 		var item1 VirtualNetworkRule
 		err := item1.PopulateFromARM(owner, item)
@@ -2977,19 +2977,19 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if typedInput.Bypass != nil {
 		bypass := *typedInput.Bypass
 		ruleSet.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2999,7 +2999,7 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		ruleSet.IpRules = append(ruleSet.IpRules, item1)
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range typedInput.VirtualNetworkRules {
 		var item1 VirtualNetworkRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3172,19 +3172,19 @@ func (item *PrivateEndpointConnectionItem_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnectionItem_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		item.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		item.Id = &id
 	}
 
-	// Set property ‘PrivateEndpoint’:
+	// Set property "PrivateEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateEndpoint != nil {
@@ -3198,7 +3198,7 @@ func (item *PrivateEndpointConnectionItem_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘PrivateLinkServiceConnectionState’:
+	// Set property "PrivateLinkServiceConnectionState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkServiceConnectionState != nil {
@@ -3212,7 +3212,7 @@ func (item *PrivateEndpointConnectionItem_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -3344,13 +3344,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if sku.Family != nil {
 		family := *sku.Family
 		result.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -3370,13 +3370,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -3487,13 +3487,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -3575,7 +3575,7 @@ func (rule *IPRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &IPRule_ARM{}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if rule.Value != nil {
 		value := *rule.Value
 		result.Value = &value
@@ -3595,7 +3595,7 @@ func (rule *IPRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -3665,7 +3665,7 @@ func (rule *IPRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -3728,22 +3728,22 @@ func (permissions *Permissions) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &Permissions_ARM{}
 
-	// Set property ‘Certificates’:
+	// Set property "Certificates":
 	for _, item := range permissions.Certificates {
 		result.Certificates = append(result.Certificates, item)
 	}
 
-	// Set property ‘Keys’:
+	// Set property "Keys":
 	for _, item := range permissions.Keys {
 		result.Keys = append(result.Keys, item)
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range permissions.Secrets {
 		result.Secrets = append(result.Secrets, item)
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	for _, item := range permissions.Storage {
 		result.Storage = append(result.Storage, item)
 	}
@@ -3762,22 +3762,22 @@ func (permissions *Permissions) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Permissions_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Certificates’:
+	// Set property "Certificates":
 	for _, item := range typedInput.Certificates {
 		permissions.Certificates = append(permissions.Certificates, item)
 	}
 
-	// Set property ‘Keys’:
+	// Set property "Keys":
 	for _, item := range typedInput.Keys {
 		permissions.Keys = append(permissions.Keys, item)
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		permissions.Secrets = append(permissions.Secrets, item)
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	for _, item := range typedInput.Storage {
 		permissions.Storage = append(permissions.Storage, item)
 	}
@@ -4005,22 +4005,22 @@ func (permissions *Permissions_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Permissions_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Certificates’:
+	// Set property "Certificates":
 	for _, item := range typedInput.Certificates {
 		permissions.Certificates = append(permissions.Certificates, item)
 	}
 
-	// Set property ‘Keys’:
+	// Set property "Keys":
 	for _, item := range typedInput.Keys {
 		permissions.Keys = append(permissions.Keys, item)
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		permissions.Secrets = append(permissions.Secrets, item)
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	for _, item := range typedInput.Storage {
 		permissions.Storage = append(permissions.Storage, item)
 	}
@@ -4176,7 +4176,7 @@ func (endpoint *PrivateEndpoint_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpoint_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		endpoint.Id = &id
@@ -4253,19 +4253,19 @@ func (state *PrivateLinkServiceConnectionState_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkServiceConnectionState_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionsRequired’:
+	// Set property "ActionsRequired":
 	if typedInput.ActionsRequired != nil {
 		actionsRequired := *typedInput.ActionsRequired
 		state.ActionsRequired = &actionsRequired
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		state.Description = &description
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		state.Status = &status
@@ -4357,7 +4357,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &VirtualNetworkRule_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if rule.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.Reference)
 		if err != nil {
@@ -4367,7 +4367,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.Id = &reference
 	}
 
-	// Set property ‘IgnoreMissingVnetServiceEndpoint’:
+	// Set property "IgnoreMissingVnetServiceEndpoint":
 	if rule.IgnoreMissingVnetServiceEndpoint != nil {
 		ignoreMissingVnetServiceEndpoint := *rule.IgnoreMissingVnetServiceEndpoint
 		result.IgnoreMissingVnetServiceEndpoint = &ignoreMissingVnetServiceEndpoint
@@ -4387,13 +4387,13 @@ func (rule *VirtualNetworkRule) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IgnoreMissingVnetServiceEndpoint’:
+	// Set property "IgnoreMissingVnetServiceEndpoint":
 	if typedInput.IgnoreMissingVnetServiceEndpoint != nil {
 		ignoreMissingVnetServiceEndpoint := *typedInput.IgnoreMissingVnetServiceEndpoint
 		rule.IgnoreMissingVnetServiceEndpoint = &ignoreMissingVnetServiceEndpoint
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -4502,13 +4502,13 @@ func (rule *VirtualNetworkRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘IgnoreMissingVnetServiceEndpoint’:
+	// Set property "IgnoreMissingVnetServiceEndpoint":
 	if typedInput.IgnoreMissingVnetServiceEndpoint != nil {
 		ignoreMissingVnetServiceEndpoint := *typedInput.IgnoreMissingVnetServiceEndpoint
 		rule.IgnoreMissingVnetServiceEndpoint = &ignoreMissingVnetServiceEndpoint

--- a/v2/api/keyvault/v1beta20210401preview/vault_types_gen.go
+++ b/v2/api/keyvault/v1beta20210401preview/vault_types_gen.go
@@ -357,16 +357,16 @@ func (vault *Vault_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &Vault_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if vault.Location != nil {
 		location := *vault.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if vault.Properties != nil {
 		properties_ARM, err := (*vault.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -376,7 +376,7 @@ func (vault *Vault_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.Properties = &properties
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if vault.Tags != nil {
 		result.Tags = make(map[string]string, len(vault.Tags))
 		for key, value := range vault.Tags {
@@ -398,19 +398,19 @@ func (vault *Vault_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Vault_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	vault.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		vault.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	vault.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 VaultProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -421,7 +421,7 @@ func (vault *Vault_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		vault.Properties = &properties
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		vault.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -652,27 +652,27 @@ func (vault *Vault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Vault_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		vault.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		vault.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		vault.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 VaultProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -683,7 +683,7 @@ func (vault *Vault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		vault.Properties = &properties
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -694,7 +694,7 @@ func (vault *Vault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		vault.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		vault.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -702,7 +702,7 @@ func (vault *Vault_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		vault.Type = &typeVar
@@ -843,37 +843,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -994,7 +994,7 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &VaultProperties_ARM{}
 
-	// Set property ‘AccessPolicies’:
+	// Set property "AccessPolicies":
 	for _, item := range properties.AccessPolicies {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1003,49 +1003,49 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 		result.AccessPolicies = append(result.AccessPolicies, *item_ARM.(*AccessPolicyEntry_ARM))
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if properties.CreateMode != nil {
 		createMode := *properties.CreateMode
 		result.CreateMode = &createMode
 	}
 
-	// Set property ‘EnablePurgeProtection’:
+	// Set property "EnablePurgeProtection":
 	if properties.EnablePurgeProtection != nil {
 		enablePurgeProtection := *properties.EnablePurgeProtection
 		result.EnablePurgeProtection = &enablePurgeProtection
 	}
 
-	// Set property ‘EnableRbacAuthorization’:
+	// Set property "EnableRbacAuthorization":
 	if properties.EnableRbacAuthorization != nil {
 		enableRbacAuthorization := *properties.EnableRbacAuthorization
 		result.EnableRbacAuthorization = &enableRbacAuthorization
 	}
 
-	// Set property ‘EnableSoftDelete’:
+	// Set property "EnableSoftDelete":
 	if properties.EnableSoftDelete != nil {
 		enableSoftDelete := *properties.EnableSoftDelete
 		result.EnableSoftDelete = &enableSoftDelete
 	}
 
-	// Set property ‘EnabledForDeployment’:
+	// Set property "EnabledForDeployment":
 	if properties.EnabledForDeployment != nil {
 		enabledForDeployment := *properties.EnabledForDeployment
 		result.EnabledForDeployment = &enabledForDeployment
 	}
 
-	// Set property ‘EnabledForDiskEncryption’:
+	// Set property "EnabledForDiskEncryption":
 	if properties.EnabledForDiskEncryption != nil {
 		enabledForDiskEncryption := *properties.EnabledForDiskEncryption
 		result.EnabledForDiskEncryption = &enabledForDiskEncryption
 	}
 
-	// Set property ‘EnabledForTemplateDeployment’:
+	// Set property "EnabledForTemplateDeployment":
 	if properties.EnabledForTemplateDeployment != nil {
 		enabledForTemplateDeployment := *properties.EnabledForTemplateDeployment
 		result.EnabledForTemplateDeployment = &enabledForTemplateDeployment
 	}
 
-	// Set property ‘NetworkAcls’:
+	// Set property "NetworkAcls":
 	if properties.NetworkAcls != nil {
 		networkAcls_ARM, err := (*properties.NetworkAcls).ConvertToARM(resolved)
 		if err != nil {
@@ -1055,13 +1055,13 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 		result.NetworkAcls = &networkAcls
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if properties.ProvisioningState != nil {
 		provisioningState := *properties.ProvisioningState
 		result.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if properties.Sku != nil {
 		sku_ARM, err := (*properties.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -1071,13 +1071,13 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘SoftDeleteRetentionInDays’:
+	// Set property "SoftDeleteRetentionInDays":
 	if properties.SoftDeleteRetentionInDays != nil {
 		softDeleteRetentionInDays := *properties.SoftDeleteRetentionInDays
 		result.SoftDeleteRetentionInDays = &softDeleteRetentionInDays
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if properties.TenantId != nil {
 		tenantId := *properties.TenantId
 		result.TenantId = &tenantId
@@ -1091,7 +1091,7 @@ func (properties *VaultProperties) ConvertToARM(resolved genruntime.ConvertToARM
 		result.TenantId = &tenantId
 	}
 
-	// Set property ‘VaultUri’:
+	// Set property "VaultUri":
 	if properties.VaultUri != nil {
 		vaultUri := *properties.VaultUri
 		result.VaultUri = &vaultUri
@@ -1111,7 +1111,7 @@ func (properties *VaultProperties) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessPolicies’:
+	// Set property "AccessPolicies":
 	for _, item := range typedInput.AccessPolicies {
 		var item1 AccessPolicyEntry
 		err := item1.PopulateFromARM(owner, item)
@@ -1121,49 +1121,49 @@ func (properties *VaultProperties) PopulateFromARM(owner genruntime.ArbitraryOwn
 		properties.AccessPolicies = append(properties.AccessPolicies, item1)
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if typedInput.CreateMode != nil {
 		createMode := *typedInput.CreateMode
 		properties.CreateMode = &createMode
 	}
 
-	// Set property ‘EnablePurgeProtection’:
+	// Set property "EnablePurgeProtection":
 	if typedInput.EnablePurgeProtection != nil {
 		enablePurgeProtection := *typedInput.EnablePurgeProtection
 		properties.EnablePurgeProtection = &enablePurgeProtection
 	}
 
-	// Set property ‘EnableRbacAuthorization’:
+	// Set property "EnableRbacAuthorization":
 	if typedInput.EnableRbacAuthorization != nil {
 		enableRbacAuthorization := *typedInput.EnableRbacAuthorization
 		properties.EnableRbacAuthorization = &enableRbacAuthorization
 	}
 
-	// Set property ‘EnableSoftDelete’:
+	// Set property "EnableSoftDelete":
 	if typedInput.EnableSoftDelete != nil {
 		enableSoftDelete := *typedInput.EnableSoftDelete
 		properties.EnableSoftDelete = &enableSoftDelete
 	}
 
-	// Set property ‘EnabledForDeployment’:
+	// Set property "EnabledForDeployment":
 	if typedInput.EnabledForDeployment != nil {
 		enabledForDeployment := *typedInput.EnabledForDeployment
 		properties.EnabledForDeployment = &enabledForDeployment
 	}
 
-	// Set property ‘EnabledForDiskEncryption’:
+	// Set property "EnabledForDiskEncryption":
 	if typedInput.EnabledForDiskEncryption != nil {
 		enabledForDiskEncryption := *typedInput.EnabledForDiskEncryption
 		properties.EnabledForDiskEncryption = &enabledForDiskEncryption
 	}
 
-	// Set property ‘EnabledForTemplateDeployment’:
+	// Set property "EnabledForTemplateDeployment":
 	if typedInput.EnabledForTemplateDeployment != nil {
 		enabledForTemplateDeployment := *typedInput.EnabledForTemplateDeployment
 		properties.EnabledForTemplateDeployment = &enabledForTemplateDeployment
 	}
 
-	// Set property ‘NetworkAcls’:
+	// Set property "NetworkAcls":
 	if typedInput.NetworkAcls != nil {
 		var networkAcls1 NetworkRuleSet
 		err := networkAcls1.PopulateFromARM(owner, *typedInput.NetworkAcls)
@@ -1174,13 +1174,13 @@ func (properties *VaultProperties) PopulateFromARM(owner genruntime.ArbitraryOwn
 		properties.NetworkAcls = &networkAcls
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		properties.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1191,21 +1191,21 @@ func (properties *VaultProperties) PopulateFromARM(owner genruntime.ArbitraryOwn
 		properties.Sku = &sku
 	}
 
-	// Set property ‘SoftDeleteRetentionInDays’:
+	// Set property "SoftDeleteRetentionInDays":
 	if typedInput.SoftDeleteRetentionInDays != nil {
 		softDeleteRetentionInDays := *typedInput.SoftDeleteRetentionInDays
 		properties.SoftDeleteRetentionInDays = &softDeleteRetentionInDays
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		properties.TenantId = &tenantId
 	}
 
-	// no assignment for property ‘TenantIdFromConfig’
+	// no assignment for property "TenantIdFromConfig"
 
-	// Set property ‘VaultUri’:
+	// Set property "VaultUri":
 	if typedInput.VaultUri != nil {
 		vaultUri := *typedInput.VaultUri
 		properties.VaultUri = &vaultUri
@@ -1528,7 +1528,7 @@ func (properties *VaultProperties_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessPolicies’:
+	// Set property "AccessPolicies":
 	for _, item := range typedInput.AccessPolicies {
 		var item1 AccessPolicyEntry_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1538,55 +1538,55 @@ func (properties *VaultProperties_STATUS) PopulateFromARM(owner genruntime.Arbit
 		properties.AccessPolicies = append(properties.AccessPolicies, item1)
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	if typedInput.CreateMode != nil {
 		createMode := *typedInput.CreateMode
 		properties.CreateMode = &createMode
 	}
 
-	// Set property ‘EnablePurgeProtection’:
+	// Set property "EnablePurgeProtection":
 	if typedInput.EnablePurgeProtection != nil {
 		enablePurgeProtection := *typedInput.EnablePurgeProtection
 		properties.EnablePurgeProtection = &enablePurgeProtection
 	}
 
-	// Set property ‘EnableRbacAuthorization’:
+	// Set property "EnableRbacAuthorization":
 	if typedInput.EnableRbacAuthorization != nil {
 		enableRbacAuthorization := *typedInput.EnableRbacAuthorization
 		properties.EnableRbacAuthorization = &enableRbacAuthorization
 	}
 
-	// Set property ‘EnableSoftDelete’:
+	// Set property "EnableSoftDelete":
 	if typedInput.EnableSoftDelete != nil {
 		enableSoftDelete := *typedInput.EnableSoftDelete
 		properties.EnableSoftDelete = &enableSoftDelete
 	}
 
-	// Set property ‘EnabledForDeployment’:
+	// Set property "EnabledForDeployment":
 	if typedInput.EnabledForDeployment != nil {
 		enabledForDeployment := *typedInput.EnabledForDeployment
 		properties.EnabledForDeployment = &enabledForDeployment
 	}
 
-	// Set property ‘EnabledForDiskEncryption’:
+	// Set property "EnabledForDiskEncryption":
 	if typedInput.EnabledForDiskEncryption != nil {
 		enabledForDiskEncryption := *typedInput.EnabledForDiskEncryption
 		properties.EnabledForDiskEncryption = &enabledForDiskEncryption
 	}
 
-	// Set property ‘EnabledForTemplateDeployment’:
+	// Set property "EnabledForTemplateDeployment":
 	if typedInput.EnabledForTemplateDeployment != nil {
 		enabledForTemplateDeployment := *typedInput.EnabledForTemplateDeployment
 		properties.EnabledForTemplateDeployment = &enabledForTemplateDeployment
 	}
 
-	// Set property ‘HsmPoolResourceId’:
+	// Set property "HsmPoolResourceId":
 	if typedInput.HsmPoolResourceId != nil {
 		hsmPoolResourceId := *typedInput.HsmPoolResourceId
 		properties.HsmPoolResourceId = &hsmPoolResourceId
 	}
 
-	// Set property ‘NetworkAcls’:
+	// Set property "NetworkAcls":
 	if typedInput.NetworkAcls != nil {
 		var networkAcls1 NetworkRuleSet_STATUS
 		err := networkAcls1.PopulateFromARM(owner, *typedInput.NetworkAcls)
@@ -1597,7 +1597,7 @@ func (properties *VaultProperties_STATUS) PopulateFromARM(owner genruntime.Arbit
 		properties.NetworkAcls = &networkAcls
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	for _, item := range typedInput.PrivateEndpointConnections {
 		var item1 PrivateEndpointConnectionItem_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1607,13 +1607,13 @@ func (properties *VaultProperties_STATUS) PopulateFromARM(owner genruntime.Arbit
 		properties.PrivateEndpointConnections = append(properties.PrivateEndpointConnections, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		properties.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1624,19 +1624,19 @@ func (properties *VaultProperties_STATUS) PopulateFromARM(owner genruntime.Arbit
 		properties.Sku = &sku
 	}
 
-	// Set property ‘SoftDeleteRetentionInDays’:
+	// Set property "SoftDeleteRetentionInDays":
 	if typedInput.SoftDeleteRetentionInDays != nil {
 		softDeleteRetentionInDays := *typedInput.SoftDeleteRetentionInDays
 		properties.SoftDeleteRetentionInDays = &softDeleteRetentionInDays
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		properties.TenantId = &tenantId
 	}
 
-	// Set property ‘VaultUri’:
+	// Set property "VaultUri":
 	if typedInput.VaultUri != nil {
 		vaultUri := *typedInput.VaultUri
 		properties.VaultUri = &vaultUri
@@ -1966,7 +1966,7 @@ func (entry *AccessPolicyEntry) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &AccessPolicyEntry_ARM{}
 
-	// Set property ‘ApplicationId’:
+	// Set property "ApplicationId":
 	if entry.ApplicationId != nil {
 		applicationId := *entry.ApplicationId
 		result.ApplicationId = &applicationId
@@ -1980,7 +1980,7 @@ func (entry *AccessPolicyEntry) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.ApplicationId = &applicationId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if entry.ObjectId != nil {
 		objectId := *entry.ObjectId
 		result.ObjectId = &objectId
@@ -1994,7 +1994,7 @@ func (entry *AccessPolicyEntry) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.ObjectId = &objectId
 	}
 
-	// Set property ‘Permissions’:
+	// Set property "Permissions":
 	if entry.Permissions != nil {
 		permissions_ARM, err := (*entry.Permissions).ConvertToARM(resolved)
 		if err != nil {
@@ -2004,7 +2004,7 @@ func (entry *AccessPolicyEntry) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.Permissions = &permissions
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if entry.TenantId != nil {
 		tenantId := *entry.TenantId
 		result.TenantId = &tenantId
@@ -2032,23 +2032,23 @@ func (entry *AccessPolicyEntry) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AccessPolicyEntry_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationId’:
+	// Set property "ApplicationId":
 	if typedInput.ApplicationId != nil {
 		applicationId := *typedInput.ApplicationId
 		entry.ApplicationId = &applicationId
 	}
 
-	// no assignment for property ‘ApplicationIdFromConfig’
+	// no assignment for property "ApplicationIdFromConfig"
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		entry.ObjectId = &objectId
 	}
 
-	// no assignment for property ‘ObjectIdFromConfig’
+	// no assignment for property "ObjectIdFromConfig"
 
-	// Set property ‘Permissions’:
+	// Set property "Permissions":
 	if typedInput.Permissions != nil {
 		var permissions1 Permissions
 		err := permissions1.PopulateFromARM(owner, *typedInput.Permissions)
@@ -2059,13 +2059,13 @@ func (entry *AccessPolicyEntry) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		entry.Permissions = &permissions
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		entry.TenantId = &tenantId
 	}
 
-	// no assignment for property ‘TenantIdFromConfig’
+	// no assignment for property "TenantIdFromConfig"
 
 	// No error
 	return nil
@@ -2226,19 +2226,19 @@ func (entry *AccessPolicyEntry_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AccessPolicyEntry_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationId’:
+	// Set property "ApplicationId":
 	if typedInput.ApplicationId != nil {
 		applicationId := *typedInput.ApplicationId
 		entry.ApplicationId = &applicationId
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		entry.ObjectId = &objectId
 	}
 
-	// Set property ‘Permissions’:
+	// Set property "Permissions":
 	if typedInput.Permissions != nil {
 		var permissions1 Permissions_STATUS
 		err := permissions1.PopulateFromARM(owner, *typedInput.Permissions)
@@ -2249,7 +2249,7 @@ func (entry *AccessPolicyEntry_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		entry.Permissions = &permissions
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		entry.TenantId = &tenantId
@@ -2341,19 +2341,19 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &NetworkRuleSet_ARM{}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if ruleSet.Bypass != nil {
 		bypass := *ruleSet.Bypass
 		result.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if ruleSet.DefaultAction != nil {
 		defaultAction := *ruleSet.DefaultAction
 		result.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range ruleSet.IpRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2362,7 +2362,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.IpRules = append(result.IpRules, *item_ARM.(*IPRule_ARM))
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range ruleSet.VirtualNetworkRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2385,19 +2385,19 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if typedInput.Bypass != nil {
 		bypass := *typedInput.Bypass
 		ruleSet.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule
 		err := item1.PopulateFromARM(owner, item)
@@ -2407,7 +2407,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		ruleSet.IpRules = append(ruleSet.IpRules, item1)
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range typedInput.VirtualNetworkRules {
 		var item1 VirtualNetworkRule
 		err := item1.PopulateFromARM(owner, item)
@@ -2570,19 +2570,19 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if typedInput.Bypass != nil {
 		bypass := *typedInput.Bypass
 		ruleSet.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2592,7 +2592,7 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		ruleSet.IpRules = append(ruleSet.IpRules, item1)
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range typedInput.VirtualNetworkRules {
 		var item1 VirtualNetworkRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2756,19 +2756,19 @@ func (item *PrivateEndpointConnectionItem_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnectionItem_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		item.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		item.Id = &id
 	}
 
-	// Set property ‘PrivateEndpoint’:
+	// Set property "PrivateEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateEndpoint != nil {
@@ -2782,7 +2782,7 @@ func (item *PrivateEndpointConnectionItem_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘PrivateLinkServiceConnectionState’:
+	// Set property "PrivateLinkServiceConnectionState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkServiceConnectionState != nil {
@@ -2796,7 +2796,7 @@ func (item *PrivateEndpointConnectionItem_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2926,13 +2926,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if sku.Family != nil {
 		family := *sku.Family
 		result.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -2952,13 +2952,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -3043,13 +3043,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -3129,7 +3129,7 @@ func (rule *IPRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &IPRule_ARM{}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if rule.Value != nil {
 		value := *rule.Value
 		result.Value = &value
@@ -3149,7 +3149,7 @@ func (rule *IPRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -3207,7 +3207,7 @@ func (rule *IPRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -3263,22 +3263,22 @@ func (permissions *Permissions) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &Permissions_ARM{}
 
-	// Set property ‘Certificates’:
+	// Set property "Certificates":
 	for _, item := range permissions.Certificates {
 		result.Certificates = append(result.Certificates, item)
 	}
 
-	// Set property ‘Keys’:
+	// Set property "Keys":
 	for _, item := range permissions.Keys {
 		result.Keys = append(result.Keys, item)
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range permissions.Secrets {
 		result.Secrets = append(result.Secrets, item)
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	for _, item := range permissions.Storage {
 		result.Storage = append(result.Storage, item)
 	}
@@ -3297,22 +3297,22 @@ func (permissions *Permissions) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Permissions_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Certificates’:
+	// Set property "Certificates":
 	for _, item := range typedInput.Certificates {
 		permissions.Certificates = append(permissions.Certificates, item)
 	}
 
-	// Set property ‘Keys’:
+	// Set property "Keys":
 	for _, item := range typedInput.Keys {
 		permissions.Keys = append(permissions.Keys, item)
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		permissions.Secrets = append(permissions.Secrets, item)
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	for _, item := range typedInput.Storage {
 		permissions.Storage = append(permissions.Storage, item)
 	}
@@ -3470,22 +3470,22 @@ func (permissions *Permissions_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Permissions_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Certificates’:
+	// Set property "Certificates":
 	for _, item := range typedInput.Certificates {
 		permissions.Certificates = append(permissions.Certificates, item)
 	}
 
-	// Set property ‘Keys’:
+	// Set property "Keys":
 	for _, item := range typedInput.Keys {
 		permissions.Keys = append(permissions.Keys, item)
 	}
 
-	// Set property ‘Secrets’:
+	// Set property "Secrets":
 	for _, item := range typedInput.Secrets {
 		permissions.Secrets = append(permissions.Secrets, item)
 	}
 
-	// Set property ‘Storage’:
+	// Set property "Storage":
 	for _, item := range typedInput.Storage {
 		permissions.Storage = append(permissions.Storage, item)
 	}
@@ -3640,7 +3640,7 @@ func (endpoint *PrivateEndpoint_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpoint_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		endpoint.Id = &id
@@ -3713,19 +3713,19 @@ func (state *PrivateLinkServiceConnectionState_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkServiceConnectionState_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionsRequired’:
+	// Set property "ActionsRequired":
 	if typedInput.ActionsRequired != nil {
 		actionsRequired := *typedInput.ActionsRequired
 		state.ActionsRequired = &actionsRequired
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		state.Description = &description
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		state.Status = &status
@@ -3813,7 +3813,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &VirtualNetworkRule_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if rule.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.Reference)
 		if err != nil {
@@ -3823,7 +3823,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.Id = &reference
 	}
 
-	// Set property ‘IgnoreMissingVnetServiceEndpoint’:
+	// Set property "IgnoreMissingVnetServiceEndpoint":
 	if rule.IgnoreMissingVnetServiceEndpoint != nil {
 		ignoreMissingVnetServiceEndpoint := *rule.IgnoreMissingVnetServiceEndpoint
 		result.IgnoreMissingVnetServiceEndpoint = &ignoreMissingVnetServiceEndpoint
@@ -3843,13 +3843,13 @@ func (rule *VirtualNetworkRule) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IgnoreMissingVnetServiceEndpoint’:
+	// Set property "IgnoreMissingVnetServiceEndpoint":
 	if typedInput.IgnoreMissingVnetServiceEndpoint != nil {
 		ignoreMissingVnetServiceEndpoint := *typedInput.IgnoreMissingVnetServiceEndpoint
 		rule.IgnoreMissingVnetServiceEndpoint = &ignoreMissingVnetServiceEndpoint
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3930,13 +3930,13 @@ func (rule *VirtualNetworkRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘IgnoreMissingVnetServiceEndpoint’:
+	// Set property "IgnoreMissingVnetServiceEndpoint":
 	if typedInput.IgnoreMissingVnetServiceEndpoint != nil {
 		ignoreMissingVnetServiceEndpoint := *typedInput.IgnoreMissingVnetServiceEndpoint
 		rule.IgnoreMissingVnetServiceEndpoint = &ignoreMissingVnetServiceEndpoint

--- a/v2/api/machinelearningservices/v1api20210701/workspace_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20210701/workspace_types_gen.go
@@ -428,7 +428,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &Workspace_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if workspace.Identity != nil {
 		identity_ARM, err := (*workspace.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -438,16 +438,16 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if workspace.Location != nil {
 		location := *workspace.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if workspace.AllowPublicAccessWhenBehindVnet != nil ||
 		workspace.ApplicationInsightsReference != nil ||
 		workspace.ContainerRegistryReference != nil ||
@@ -557,7 +557,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.StorageAccount = &storageAccount
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if workspace.Sku != nil {
 		sku_ARM, err := (*workspace.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -567,7 +567,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if workspace.SystemData != nil {
 		systemData_ARM, err := (*workspace.SystemData).ConvertToARM(resolved)
 		if err != nil {
@@ -577,7 +577,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if workspace.Tags != nil {
 		result.Tags = make(map[string]string, len(workspace.Tags))
 		for key, value := range workspace.Tags {
@@ -599,7 +599,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspace_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowPublicAccessWhenBehindVnet’:
+	// Set property "AllowPublicAccessWhenBehindVnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowPublicAccessWhenBehindVnet != nil {
@@ -608,14 +608,14 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// no assignment for property ‘ApplicationInsightsReference’
+	// no assignment for property "ApplicationInsightsReference"
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	workspace.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// no assignment for property ‘ContainerRegistryReference’
+	// no assignment for property "ContainerRegistryReference"
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -624,7 +624,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DiscoveryUrl’:
+	// Set property "DiscoveryUrl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiscoveryUrl != nil {
@@ -633,7 +633,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -647,7 +647,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘FriendlyName’:
+	// Set property "FriendlyName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FriendlyName != nil {
@@ -656,7 +656,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘HbiWorkspace’:
+	// Set property "HbiWorkspace":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HbiWorkspace != nil {
@@ -665,7 +665,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -676,7 +676,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		workspace.Identity = &identity
 	}
 
-	// Set property ‘ImageBuildCompute’:
+	// Set property "ImageBuildCompute":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImageBuildCompute != nil {
@@ -685,22 +685,22 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// no assignment for property ‘KeyVaultReference’
+	// no assignment for property "KeyVaultReference"
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		workspace.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	workspace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// no assignment for property ‘PrimaryUserAssignedIdentityReference’
+	// no assignment for property "PrimaryUserAssignedIdentityReference"
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -709,7 +709,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ServiceManagedResourcesSettings’:
+	// Set property "ServiceManagedResourcesSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceManagedResourcesSettings != nil {
@@ -723,7 +723,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘SharedPrivateLinkResources’:
+	// Set property "SharedPrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SharedPrivateLinkResources {
@@ -736,7 +736,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -747,9 +747,9 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		workspace.Sku = &sku
 	}
 
-	// no assignment for property ‘StorageAccountReference’
+	// no assignment for property "StorageAccountReference"
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -760,7 +760,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		workspace.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		workspace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1522,7 +1522,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspace_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowPublicAccessWhenBehindVnet’:
+	// Set property "AllowPublicAccessWhenBehindVnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowPublicAccessWhenBehindVnet != nil {
@@ -1531,7 +1531,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ApplicationInsights’:
+	// Set property "ApplicationInsights":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApplicationInsights != nil {
@@ -1540,9 +1540,9 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ContainerRegistry’:
+	// Set property "ContainerRegistry":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ContainerRegistry != nil {
@@ -1551,7 +1551,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -1560,7 +1560,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘DiscoveryUrl’:
+	// Set property "DiscoveryUrl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiscoveryUrl != nil {
@@ -1569,7 +1569,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1583,7 +1583,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘FriendlyName’:
+	// Set property "FriendlyName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FriendlyName != nil {
@@ -1592,7 +1592,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HbiWorkspace’:
+	// Set property "HbiWorkspace":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HbiWorkspace != nil {
@@ -1601,13 +1601,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		workspace.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1618,7 +1618,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		workspace.Identity = &identity
 	}
 
-	// Set property ‘ImageBuildCompute’:
+	// Set property "ImageBuildCompute":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImageBuildCompute != nil {
@@ -1627,7 +1627,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘KeyVault’:
+	// Set property "KeyVault":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVault != nil {
@@ -1636,13 +1636,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		workspace.Location = &location
 	}
 
-	// Set property ‘MlFlowTrackingUri’:
+	// Set property "MlFlowTrackingUri":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MlFlowTrackingUri != nil {
@@ -1651,13 +1651,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		workspace.Name = &name
 	}
 
-	// Set property ‘NotebookInfo’:
+	// Set property "NotebookInfo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NotebookInfo != nil {
@@ -1671,7 +1671,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PrimaryUserAssignedIdentity’:
+	// Set property "PrimaryUserAssignedIdentity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrimaryUserAssignedIdentity != nil {
@@ -1680,7 +1680,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1693,7 +1693,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PrivateLinkCount’:
+	// Set property "PrivateLinkCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkCount != nil {
@@ -1702,7 +1702,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1711,7 +1711,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1720,7 +1720,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ServiceManagedResourcesSettings’:
+	// Set property "ServiceManagedResourcesSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceManagedResourcesSettings != nil {
@@ -1734,7 +1734,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ServiceProvisionedResourceGroup’:
+	// Set property "ServiceProvisionedResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceProvisionedResourceGroup != nil {
@@ -1743,7 +1743,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SharedPrivateLinkResources’:
+	// Set property "SharedPrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SharedPrivateLinkResources {
@@ -1756,7 +1756,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1767,7 +1767,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		workspace.Sku = &sku
 	}
 
-	// Set property ‘StorageAccount’:
+	// Set property "StorageAccount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageAccount != nil {
@@ -1776,7 +1776,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘StorageHnsEnabled’:
+	// Set property "StorageHnsEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageHnsEnabled != nil {
@@ -1785,7 +1785,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1796,7 +1796,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		workspace.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		workspace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1804,7 +1804,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantId != nil {
@@ -1813,13 +1813,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		workspace.Type = &typeVar
 	}
 
-	// Set property ‘WorkspaceId’:
+	// Set property "WorkspaceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkspaceId != nil {
@@ -2293,7 +2293,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &EncryptionProperty_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if property.Identity != nil {
 		identity_ARM, err := (*property.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -2303,7 +2303,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Identity = &identity
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if property.KeyVaultProperties != nil {
 		keyVaultProperties_ARM, err := (*property.KeyVaultProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -2313,7 +2313,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 		result.KeyVaultProperties = &keyVaultProperties
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if property.Status != nil {
 		status := *property.Status
 		result.Status = &status
@@ -2333,7 +2333,7 @@ func (property *EncryptionProperty) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperty_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 IdentityForCmk
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2344,7 +2344,7 @@ func (property *EncryptionProperty) PopulateFromARM(owner genruntime.ArbitraryOw
 		property.Identity = &identity
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -2355,7 +2355,7 @@ func (property *EncryptionProperty) PopulateFromARM(owner genruntime.ArbitraryOw
 		property.KeyVaultProperties = &keyVaultProperties
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		property.Status = &status
@@ -2516,7 +2516,7 @@ func (property *EncryptionProperty_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 IdentityForCmk_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2527,7 +2527,7 @@ func (property *EncryptionProperty_STATUS) PopulateFromARM(owner genruntime.Arbi
 		property.Identity = &identity
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties_STATUS
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -2538,7 +2538,7 @@ func (property *EncryptionProperty_STATUS) PopulateFromARM(owner genruntime.Arbi
 		property.KeyVaultProperties = &keyVaultProperties
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		property.Status = &status
@@ -2653,13 +2653,13 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Identity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -2684,13 +2684,13 @@ func (identity *Identity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -2827,25 +2827,25 @@ func (identity *Identity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2973,13 +2973,13 @@ func (info *NotebookResourceInfo_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NotebookResourceInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	if typedInput.Fqdn != nil {
 		fqdn := *typedInput.Fqdn
 		info.Fqdn = &fqdn
 	}
 
-	// Set property ‘NotebookPreparationError’:
+	// Set property "NotebookPreparationError":
 	if typedInput.NotebookPreparationError != nil {
 		var notebookPreparationError1 NotebookPreparationError_STATUS
 		err := notebookPreparationError1.PopulateFromARM(owner, *typedInput.NotebookPreparationError)
@@ -2990,7 +2990,7 @@ func (info *NotebookResourceInfo_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		info.NotebookPreparationError = &notebookPreparationError
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		info.ResourceId = &resourceId
@@ -3080,7 +3080,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -3133,7 +3133,7 @@ func (settings *ServiceManagedResourcesSettings) ConvertToARM(resolved genruntim
 	}
 	result := &ServiceManagedResourcesSettings_ARM{}
 
-	// Set property ‘CosmosDb’:
+	// Set property "CosmosDb":
 	if settings.CosmosDb != nil {
 		cosmosDb_ARM, err := (*settings.CosmosDb).ConvertToARM(resolved)
 		if err != nil {
@@ -3157,7 +3157,7 @@ func (settings *ServiceManagedResourcesSettings) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceManagedResourcesSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CosmosDb’:
+	// Set property "CosmosDb":
 	if typedInput.CosmosDb != nil {
 		var cosmosDb1 CosmosDbSettings
 		err := cosmosDb1.PopulateFromARM(owner, *typedInput.CosmosDb)
@@ -3257,7 +3257,7 @@ func (settings *ServiceManagedResourcesSettings_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceManagedResourcesSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CosmosDb’:
+	// Set property "CosmosDb":
 	if typedInput.CosmosDb != nil {
 		var cosmosDb1 CosmosDbSettings_STATUS
 		err := cosmosDb1.PopulateFromARM(owner, *typedInput.CosmosDb)
@@ -3345,13 +3345,13 @@ func (resource *SharedPrivateLinkResource) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &SharedPrivateLinkResource_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if resource.Name != nil {
 		name := *resource.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if resource.GroupId != nil ||
 		resource.PrivateLinkResourceReference != nil ||
 		resource.RequestMessage != nil ||
@@ -3393,7 +3393,7 @@ func (resource *SharedPrivateLinkResource) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SharedPrivateLinkResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GroupId != nil {
@@ -3402,15 +3402,15 @@ func (resource *SharedPrivateLinkResource) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resource.Name = &name
 	}
 
-	// no assignment for property ‘PrivateLinkResourceReference’
+	// no assignment for property "PrivateLinkResourceReference"
 
-	// Set property ‘RequestMessage’:
+	// Set property "RequestMessage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequestMessage != nil {
@@ -3419,7 +3419,7 @@ func (resource *SharedPrivateLinkResource) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -3568,7 +3568,7 @@ func (resource *SharedPrivateLinkResource_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SharedPrivateLinkResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GroupId != nil {
@@ -3577,13 +3577,13 @@ func (resource *SharedPrivateLinkResource_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resource.Name = &name
 	}
 
-	// Set property ‘PrivateLinkResourceId’:
+	// Set property "PrivateLinkResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkResourceId != nil {
@@ -3592,7 +3592,7 @@ func (resource *SharedPrivateLinkResource_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘RequestMessage’:
+	// Set property "RequestMessage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequestMessage != nil {
@@ -3601,7 +3601,7 @@ func (resource *SharedPrivateLinkResource_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -3695,13 +3695,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -3721,13 +3721,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3808,13 +3808,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3889,37 +3889,37 @@ func (data *SystemData) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &SystemData_ARM{}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if data.CreatedAt != nil {
 		createdAt := *data.CreatedAt
 		result.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if data.CreatedBy != nil {
 		createdBy := *data.CreatedBy
 		result.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if data.CreatedByType != nil {
 		createdByType := *data.CreatedByType
 		result.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if data.LastModifiedAt != nil {
 		lastModifiedAt := *data.LastModifiedAt
 		result.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if data.LastModifiedBy != nil {
 		lastModifiedBy := *data.LastModifiedBy
 		result.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if data.LastModifiedByType != nil {
 		lastModifiedByType := *data.LastModifiedByType
 		result.LastModifiedByType = &lastModifiedByType
@@ -3939,37 +3939,37 @@ func (data *SystemData) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -4128,37 +4128,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -4341,7 +4341,7 @@ func (settings *CosmosDbSettings) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &CosmosDbSettings_ARM{}
 
-	// Set property ‘CollectionsThroughput’:
+	// Set property "CollectionsThroughput":
 	if settings.CollectionsThroughput != nil {
 		collectionsThroughput := *settings.CollectionsThroughput
 		result.CollectionsThroughput = &collectionsThroughput
@@ -4361,7 +4361,7 @@ func (settings *CosmosDbSettings) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CosmosDbSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CollectionsThroughput’:
+	// Set property "CollectionsThroughput":
 	if typedInput.CollectionsThroughput != nil {
 		collectionsThroughput := *typedInput.CollectionsThroughput
 		settings.CollectionsThroughput = &collectionsThroughput
@@ -4429,7 +4429,7 @@ func (settings *CosmosDbSettings_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CosmosDbSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CollectionsThroughput’:
+	// Set property "CollectionsThroughput":
 	if typedInput.CollectionsThroughput != nil {
 		collectionsThroughput := *typedInput.CollectionsThroughput
 		settings.CollectionsThroughput = &collectionsThroughput
@@ -4498,7 +4498,7 @@ func (forCmk *IdentityForCmk) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &IdentityForCmk_ARM{}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if forCmk.UserAssignedIdentity != nil {
 		userAssignedIdentity := *forCmk.UserAssignedIdentity
 		result.UserAssignedIdentity = &userAssignedIdentity
@@ -4518,7 +4518,7 @@ func (forCmk *IdentityForCmk) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IdentityForCmk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		forCmk.UserAssignedIdentity = &userAssignedIdentity
@@ -4587,7 +4587,7 @@ func (forCmk *IdentityForCmk_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IdentityForCmk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		forCmk.UserAssignedIdentity = &userAssignedIdentity
@@ -4648,19 +4648,19 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘IdentityClientId’:
+	// Set property "IdentityClientId":
 	if properties.IdentityClientId != nil {
 		identityClientId := *properties.IdentityClientId
 		result.IdentityClientId = &identityClientId
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if properties.KeyIdentifier != nil {
 		keyIdentifier := *properties.KeyIdentifier
 		result.KeyIdentifier = &keyIdentifier
 	}
 
-	// Set property ‘KeyVaultArmId’:
+	// Set property "KeyVaultArmId":
 	if properties.KeyVaultArmId != nil {
 		keyVaultArmId := *properties.KeyVaultArmId
 		result.KeyVaultArmId = &keyVaultArmId
@@ -4680,19 +4680,19 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IdentityClientId’:
+	// Set property "IdentityClientId":
 	if typedInput.IdentityClientId != nil {
 		identityClientId := *typedInput.IdentityClientId
 		properties.IdentityClientId = &identityClientId
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
 	}
 
-	// Set property ‘KeyVaultArmId’:
+	// Set property "KeyVaultArmId":
 	if typedInput.KeyVaultArmId != nil {
 		keyVaultArmId := *typedInput.KeyVaultArmId
 		properties.KeyVaultArmId = &keyVaultArmId
@@ -4784,19 +4784,19 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IdentityClientId’:
+	// Set property "IdentityClientId":
 	if typedInput.IdentityClientId != nil {
 		identityClientId := *typedInput.IdentityClientId
 		properties.IdentityClientId = &identityClientId
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
 	}
 
-	// Set property ‘KeyVaultArmId’:
+	// Set property "KeyVaultArmId":
 	if typedInput.KeyVaultArmId != nil {
 		keyVaultArmId := *typedInput.KeyVaultArmId
 		properties.KeyVaultArmId = &keyVaultArmId
@@ -4866,13 +4866,13 @@ func (error *NotebookPreparationError_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NotebookPreparationError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ErrorMessage’:
+	// Set property "ErrorMessage":
 	if typedInput.ErrorMessage != nil {
 		errorMessage := *typedInput.ErrorMessage
 		error.ErrorMessage = &errorMessage
 	}
 
-	// Set property ‘StatusCode’:
+	// Set property "StatusCode":
 	if typedInput.StatusCode != nil {
 		statusCode := *typedInput.StatusCode
 		error.StatusCode = &statusCode
@@ -4966,19 +4966,19 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId

--- a/v2/api/machinelearningservices/v1api20210701/workspaces_compute_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20210701/workspaces_compute_types_gen.go
@@ -350,7 +350,7 @@ func (compute *Workspaces_Compute_Spec) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &Workspaces_Compute_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if compute.Identity != nil {
 		identity_ARM, err := (*compute.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -360,16 +360,16 @@ func (compute *Workspaces_Compute_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if compute.Location != nil {
 		location := *compute.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if compute.Properties != nil {
 		properties_ARM, err := (*compute.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -379,7 +379,7 @@ func (compute *Workspaces_Compute_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties = &properties
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if compute.Sku != nil {
 		sku_ARM, err := (*compute.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -389,7 +389,7 @@ func (compute *Workspaces_Compute_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if compute.SystemData != nil {
 		systemData_ARM, err := (*compute.SystemData).ConvertToARM(resolved)
 		if err != nil {
@@ -399,7 +399,7 @@ func (compute *Workspaces_Compute_Spec) ConvertToARM(resolved genruntime.Convert
 		result.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if compute.Tags != nil {
 		result.Tags = make(map[string]string, len(compute.Tags))
 		for key, value := range compute.Tags {
@@ -421,10 +421,10 @@ func (compute *Workspaces_Compute_Spec) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspaces_Compute_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	compute.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -435,16 +435,16 @@ func (compute *Workspaces_Compute_Spec) PopulateFromARM(owner genruntime.Arbitra
 		compute.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		compute.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	compute.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 Compute
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -455,7 +455,7 @@ func (compute *Workspaces_Compute_Spec) PopulateFromARM(owner genruntime.Arbitra
 		compute.Properties = &properties
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -466,7 +466,7 @@ func (compute *Workspaces_Compute_Spec) PopulateFromARM(owner genruntime.Arbitra
 		compute.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -477,7 +477,7 @@ func (compute *Workspaces_Compute_Spec) PopulateFromARM(owner genruntime.Arbitra
 		compute.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		compute.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -861,15 +861,15 @@ func (compute *Workspaces_Compute_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspaces_Compute_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		compute.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -880,19 +880,19 @@ func (compute *Workspaces_Compute_STATUS) PopulateFromARM(owner genruntime.Arbit
 		compute.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		compute.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		compute.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 Compute_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -903,7 +903,7 @@ func (compute *Workspaces_Compute_STATUS) PopulateFromARM(owner genruntime.Arbit
 		compute.Properties = &properties
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -914,7 +914,7 @@ func (compute *Workspaces_Compute_STATUS) PopulateFromARM(owner genruntime.Arbit
 		compute.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -925,7 +925,7 @@ func (compute *Workspaces_Compute_STATUS) PopulateFromARM(owner genruntime.Arbit
 		compute.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		compute.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -933,7 +933,7 @@ func (compute *Workspaces_Compute_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		compute.Type = &typeVar
@@ -1139,7 +1139,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Compute_ARM{}
 
-	// Set property ‘AKS’:
+	// Set property "AKS":
 	if compute.AKS != nil {
 		aks_ARM, err := (*compute.AKS).ConvertToARM(resolved)
 		if err != nil {
@@ -1149,7 +1149,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.AKS = &aks
 	}
 
-	// Set property ‘AmlCompute’:
+	// Set property "AmlCompute":
 	if compute.AmlCompute != nil {
 		amlCompute_ARM, err := (*compute.AmlCompute).ConvertToARM(resolved)
 		if err != nil {
@@ -1159,7 +1159,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.AmlCompute = &amlCompute
 	}
 
-	// Set property ‘ComputeInstance’:
+	// Set property "ComputeInstance":
 	if compute.ComputeInstance != nil {
 		computeInstance_ARM, err := (*compute.ComputeInstance).ConvertToARM(resolved)
 		if err != nil {
@@ -1169,7 +1169,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.ComputeInstance = &computeInstance
 	}
 
-	// Set property ‘DataFactory’:
+	// Set property "DataFactory":
 	if compute.DataFactory != nil {
 		dataFactory_ARM, err := (*compute.DataFactory).ConvertToARM(resolved)
 		if err != nil {
@@ -1179,7 +1179,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.DataFactory = &dataFactory
 	}
 
-	// Set property ‘DataLakeAnalytics’:
+	// Set property "DataLakeAnalytics":
 	if compute.DataLakeAnalytics != nil {
 		dataLakeAnalytics_ARM, err := (*compute.DataLakeAnalytics).ConvertToARM(resolved)
 		if err != nil {
@@ -1189,7 +1189,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.DataLakeAnalytics = &dataLakeAnalytics
 	}
 
-	// Set property ‘Databricks’:
+	// Set property "Databricks":
 	if compute.Databricks != nil {
 		databricks_ARM, err := (*compute.Databricks).ConvertToARM(resolved)
 		if err != nil {
@@ -1199,7 +1199,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.Databricks = &databricks
 	}
 
-	// Set property ‘HDInsight’:
+	// Set property "HDInsight":
 	if compute.HDInsight != nil {
 		hdInsight_ARM, err := (*compute.HDInsight).ConvertToARM(resolved)
 		if err != nil {
@@ -1209,7 +1209,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.HDInsight = &hdInsight
 	}
 
-	// Set property ‘Kubernetes’:
+	// Set property "Kubernetes":
 	if compute.Kubernetes != nil {
 		kubernetes_ARM, err := (*compute.Kubernetes).ConvertToARM(resolved)
 		if err != nil {
@@ -1219,7 +1219,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.Kubernetes = &kubernetes
 	}
 
-	// Set property ‘SynapseSpark’:
+	// Set property "SynapseSpark":
 	if compute.SynapseSpark != nil {
 		synapseSpark_ARM, err := (*compute.SynapseSpark).ConvertToARM(resolved)
 		if err != nil {
@@ -1229,7 +1229,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.SynapseSpark = &synapseSpark
 	}
 
-	// Set property ‘VirtualMachine’:
+	// Set property "VirtualMachine":
 	if compute.VirtualMachine != nil {
 		virtualMachine_ARM, err := (*compute.VirtualMachine).ConvertToARM(resolved)
 		if err != nil {
@@ -1253,7 +1253,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Compute_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AKS’:
+	// Set property "AKS":
 	if typedInput.AKS != nil {
 		var aks1 AKS
 		err := aks1.PopulateFromARM(owner, *typedInput.AKS)
@@ -1264,7 +1264,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.AKS = &aks
 	}
 
-	// Set property ‘AmlCompute’:
+	// Set property "AmlCompute":
 	if typedInput.AmlCompute != nil {
 		var amlCompute1 AmlCompute
 		err := amlCompute1.PopulateFromARM(owner, *typedInput.AmlCompute)
@@ -1275,7 +1275,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.AmlCompute = &amlCompute
 	}
 
-	// Set property ‘ComputeInstance’:
+	// Set property "ComputeInstance":
 	if typedInput.ComputeInstance != nil {
 		var computeInstance1 ComputeInstance
 		err := computeInstance1.PopulateFromARM(owner, *typedInput.ComputeInstance)
@@ -1286,7 +1286,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.ComputeInstance = &computeInstance
 	}
 
-	// Set property ‘DataFactory’:
+	// Set property "DataFactory":
 	if typedInput.DataFactory != nil {
 		var dataFactory1 DataFactory
 		err := dataFactory1.PopulateFromARM(owner, *typedInput.DataFactory)
@@ -1297,7 +1297,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.DataFactory = &dataFactory
 	}
 
-	// Set property ‘DataLakeAnalytics’:
+	// Set property "DataLakeAnalytics":
 	if typedInput.DataLakeAnalytics != nil {
 		var dataLakeAnalytics1 DataLakeAnalytics
 		err := dataLakeAnalytics1.PopulateFromARM(owner, *typedInput.DataLakeAnalytics)
@@ -1308,7 +1308,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.DataLakeAnalytics = &dataLakeAnalytics
 	}
 
-	// Set property ‘Databricks’:
+	// Set property "Databricks":
 	if typedInput.Databricks != nil {
 		var databricks1 Databricks
 		err := databricks1.PopulateFromARM(owner, *typedInput.Databricks)
@@ -1319,7 +1319,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.Databricks = &databricks
 	}
 
-	// Set property ‘HDInsight’:
+	// Set property "HDInsight":
 	if typedInput.HDInsight != nil {
 		var hdInsight1 HDInsight
 		err := hdInsight1.PopulateFromARM(owner, *typedInput.HDInsight)
@@ -1330,7 +1330,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.HDInsight = &hdInsight
 	}
 
-	// Set property ‘Kubernetes’:
+	// Set property "Kubernetes":
 	if typedInput.Kubernetes != nil {
 		var kubernetes1 Kubernetes
 		err := kubernetes1.PopulateFromARM(owner, *typedInput.Kubernetes)
@@ -1341,7 +1341,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.Kubernetes = &kubernetes
 	}
 
-	// Set property ‘SynapseSpark’:
+	// Set property "SynapseSpark":
 	if typedInput.SynapseSpark != nil {
 		var synapseSpark1 SynapseSpark
 		err := synapseSpark1.PopulateFromARM(owner, *typedInput.SynapseSpark)
@@ -1352,7 +1352,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.SynapseSpark = &synapseSpark
 	}
 
-	// Set property ‘VirtualMachine’:
+	// Set property "VirtualMachine":
 	if typedInput.VirtualMachine != nil {
 		var virtualMachine1 VirtualMachine
 		err := virtualMachine1.PopulateFromARM(owner, *typedInput.VirtualMachine)
@@ -1803,7 +1803,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Compute_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AKS’:
+	// Set property "AKS":
 	if typedInput.AKS != nil {
 		var aks1 AKS_STATUS
 		err := aks1.PopulateFromARM(owner, *typedInput.AKS)
@@ -1814,7 +1814,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.AKS = &aks
 	}
 
-	// Set property ‘AmlCompute’:
+	// Set property "AmlCompute":
 	if typedInput.AmlCompute != nil {
 		var amlCompute1 AmlCompute_STATUS
 		err := amlCompute1.PopulateFromARM(owner, *typedInput.AmlCompute)
@@ -1825,7 +1825,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.AmlCompute = &amlCompute
 	}
 
-	// Set property ‘ComputeInstance’:
+	// Set property "ComputeInstance":
 	if typedInput.ComputeInstance != nil {
 		var computeInstance1 ComputeInstance_STATUS
 		err := computeInstance1.PopulateFromARM(owner, *typedInput.ComputeInstance)
@@ -1836,7 +1836,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.ComputeInstance = &computeInstance
 	}
 
-	// Set property ‘DataFactory’:
+	// Set property "DataFactory":
 	if typedInput.DataFactory != nil {
 		var dataFactory1 DataFactory_STATUS
 		err := dataFactory1.PopulateFromARM(owner, *typedInput.DataFactory)
@@ -1847,7 +1847,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.DataFactory = &dataFactory
 	}
 
-	// Set property ‘DataLakeAnalytics’:
+	// Set property "DataLakeAnalytics":
 	if typedInput.DataLakeAnalytics != nil {
 		var dataLakeAnalytics1 DataLakeAnalytics_STATUS
 		err := dataLakeAnalytics1.PopulateFromARM(owner, *typedInput.DataLakeAnalytics)
@@ -1858,7 +1858,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.DataLakeAnalytics = &dataLakeAnalytics
 	}
 
-	// Set property ‘Databricks’:
+	// Set property "Databricks":
 	if typedInput.Databricks != nil {
 		var databricks1 Databricks_STATUS
 		err := databricks1.PopulateFromARM(owner, *typedInput.Databricks)
@@ -1869,7 +1869,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.Databricks = &databricks
 	}
 
-	// Set property ‘HDInsight’:
+	// Set property "HDInsight":
 	if typedInput.HDInsight != nil {
 		var hdInsight1 HDInsight_STATUS
 		err := hdInsight1.PopulateFromARM(owner, *typedInput.HDInsight)
@@ -1880,7 +1880,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.HDInsight = &hdInsight
 	}
 
-	// Set property ‘Kubernetes’:
+	// Set property "Kubernetes":
 	if typedInput.Kubernetes != nil {
 		var kubernetes1 Kubernetes_STATUS
 		err := kubernetes1.PopulateFromARM(owner, *typedInput.Kubernetes)
@@ -1891,7 +1891,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.Kubernetes = &kubernetes
 	}
 
-	// Set property ‘SynapseSpark’:
+	// Set property "SynapseSpark":
 	if typedInput.SynapseSpark != nil {
 		var synapseSpark1 SynapseSpark_STATUS
 		err := synapseSpark1.PopulateFromARM(owner, *typedInput.SynapseSpark)
@@ -1902,7 +1902,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.SynapseSpark = &synapseSpark
 	}
 
-	// Set property ‘VirtualMachine’:
+	// Set property "VirtualMachine":
 	if typedInput.VirtualMachine != nil {
 		var virtualMachine1 VirtualMachine_STATUS
 		err := virtualMachine1.PopulateFromARM(owner, *typedInput.VirtualMachine)
@@ -2211,30 +2211,30 @@ func (aks *AKS) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &AKS_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if aks.ComputeLocation != nil {
 		computeLocation := *aks.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if aks.ComputeType != nil {
 		result.ComputeType = *aks.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if aks.Description != nil {
 		description := *aks.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if aks.DisableLocalAuth != nil {
 		disableLocalAuth := *aks.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if aks.Properties != nil {
 		properties_ARM, err := (*aks.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -2244,7 +2244,7 @@ func (aks *AKS) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if aks.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*aks.ResourceReference)
 		if err != nil {
@@ -2268,28 +2268,28 @@ func (aks *AKS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AKS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		aks.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	aks.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		aks.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		aks.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 AKS_Properties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -2300,7 +2300,7 @@ func (aks *AKS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		aks.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -2514,46 +2514,46 @@ func (aks *AKS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AKS_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		aks.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	aks.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		aks.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		aks.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		aks.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		aks.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		aks.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 AKS_Properties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -2564,7 +2564,7 @@ func (aks *AKS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		aks.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2574,13 +2574,13 @@ func (aks *AKS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		aks.ProvisioningErrors = append(aks.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		aks.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		aks.ResourceId = &resourceId
@@ -2798,30 +2798,30 @@ func (compute *AmlCompute) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &AmlCompute_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if compute.ComputeLocation != nil {
 		computeLocation := *compute.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if compute.ComputeType != nil {
 		result.ComputeType = *compute.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if compute.Description != nil {
 		description := *compute.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if compute.DisableLocalAuth != nil {
 		disableLocalAuth := *compute.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if compute.Properties != nil {
 		properties_ARM, err := (*compute.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -2831,7 +2831,7 @@ func (compute *AmlCompute) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if compute.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*compute.ResourceReference)
 		if err != nil {
@@ -2855,28 +2855,28 @@ func (compute *AmlCompute) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AmlCompute_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		compute.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	compute.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		compute.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		compute.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 AmlComputeProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -2887,7 +2887,7 @@ func (compute *AmlCompute) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		compute.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -3101,46 +3101,46 @@ func (compute *AmlCompute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AmlCompute_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		compute.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	compute.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		compute.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		compute.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		compute.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		compute.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		compute.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 AmlComputeProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -3151,7 +3151,7 @@ func (compute *AmlCompute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		compute.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3161,13 +3161,13 @@ func (compute *AmlCompute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		compute.ProvisioningErrors = append(compute.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		compute.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		compute.ResourceId = &resourceId
@@ -3385,30 +3385,30 @@ func (instance *ComputeInstance) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ComputeInstance_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if instance.ComputeLocation != nil {
 		computeLocation := *instance.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if instance.ComputeType != nil {
 		result.ComputeType = *instance.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if instance.Description != nil {
 		description := *instance.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if instance.DisableLocalAuth != nil {
 		disableLocalAuth := *instance.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if instance.Properties != nil {
 		properties_ARM, err := (*instance.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -3418,7 +3418,7 @@ func (instance *ComputeInstance) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if instance.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*instance.ResourceReference)
 		if err != nil {
@@ -3442,28 +3442,28 @@ func (instance *ComputeInstance) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstance_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		instance.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	instance.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		instance.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		instance.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 ComputeInstanceProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -3474,7 +3474,7 @@ func (instance *ComputeInstance) PopulateFromARM(owner genruntime.ArbitraryOwner
 		instance.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -3688,46 +3688,46 @@ func (instance *ComputeInstance_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstance_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		instance.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	instance.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		instance.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		instance.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		instance.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		instance.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		instance.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 ComputeInstanceProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -3738,7 +3738,7 @@ func (instance *ComputeInstance_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		instance.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3748,13 +3748,13 @@ func (instance *ComputeInstance_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		instance.ProvisioningErrors = append(instance.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		instance.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		instance.ResourceId = &resourceId
@@ -3972,30 +3972,30 @@ func (databricks *Databricks) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Databricks_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if databricks.ComputeLocation != nil {
 		computeLocation := *databricks.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if databricks.ComputeType != nil {
 		result.ComputeType = *databricks.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if databricks.Description != nil {
 		description := *databricks.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if databricks.DisableLocalAuth != nil {
 		disableLocalAuth := *databricks.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if databricks.Properties != nil {
 		properties_ARM, err := (*databricks.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -4005,7 +4005,7 @@ func (databricks *Databricks) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if databricks.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*databricks.ResourceReference)
 		if err != nil {
@@ -4029,28 +4029,28 @@ func (databricks *Databricks) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Databricks_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		databricks.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	databricks.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		databricks.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		databricks.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 DatabricksProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -4061,7 +4061,7 @@ func (databricks *Databricks) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		databricks.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -4275,46 +4275,46 @@ func (databricks *Databricks_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Databricks_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		databricks.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	databricks.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		databricks.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		databricks.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		databricks.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		databricks.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		databricks.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 DatabricksProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -4325,7 +4325,7 @@ func (databricks *Databricks_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		databricks.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4335,13 +4335,13 @@ func (databricks *Databricks_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		databricks.ProvisioningErrors = append(databricks.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		databricks.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		databricks.ResourceId = &resourceId
@@ -4556,30 +4556,30 @@ func (factory *DataFactory) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &DataFactory_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if factory.ComputeLocation != nil {
 		computeLocation := *factory.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if factory.ComputeType != nil {
 		result.ComputeType = *factory.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if factory.Description != nil {
 		description := *factory.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if factory.DisableLocalAuth != nil {
 		disableLocalAuth := *factory.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if factory.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*factory.ResourceReference)
 		if err != nil {
@@ -4603,28 +4603,28 @@ func (factory *DataFactory) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataFactory_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		factory.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	factory.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		factory.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		factory.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -4799,46 +4799,46 @@ func (factory *DataFactory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataFactory_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		factory.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	factory.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		factory.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		factory.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		factory.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		factory.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		factory.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4848,13 +4848,13 @@ func (factory *DataFactory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		factory.ProvisioningErrors = append(factory.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		factory.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		factory.ResourceId = &resourceId
@@ -5046,30 +5046,30 @@ func (analytics *DataLakeAnalytics) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &DataLakeAnalytics_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if analytics.ComputeLocation != nil {
 		computeLocation := *analytics.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if analytics.ComputeType != nil {
 		result.ComputeType = *analytics.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if analytics.Description != nil {
 		description := *analytics.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if analytics.DisableLocalAuth != nil {
 		disableLocalAuth := *analytics.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if analytics.Properties != nil {
 		properties_ARM, err := (*analytics.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -5079,7 +5079,7 @@ func (analytics *DataLakeAnalytics) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if analytics.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*analytics.ResourceReference)
 		if err != nil {
@@ -5103,28 +5103,28 @@ func (analytics *DataLakeAnalytics) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataLakeAnalytics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		analytics.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	analytics.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		analytics.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		analytics.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 DataLakeAnalytics_Properties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -5135,7 +5135,7 @@ func (analytics *DataLakeAnalytics) PopulateFromARM(owner genruntime.ArbitraryOw
 		analytics.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -5347,46 +5347,46 @@ func (analytics *DataLakeAnalytics_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataLakeAnalytics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		analytics.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	analytics.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		analytics.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		analytics.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		analytics.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		analytics.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		analytics.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 DataLakeAnalytics_Properties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -5397,7 +5397,7 @@ func (analytics *DataLakeAnalytics_STATUS) PopulateFromARM(owner genruntime.Arbi
 		analytics.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5407,13 +5407,13 @@ func (analytics *DataLakeAnalytics_STATUS) PopulateFromARM(owner genruntime.Arbi
 		analytics.ProvisioningErrors = append(analytics.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		analytics.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		analytics.ResourceId = &resourceId
@@ -5631,30 +5631,30 @@ func (insight *HDInsight) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &HDInsight_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if insight.ComputeLocation != nil {
 		computeLocation := *insight.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if insight.ComputeType != nil {
 		result.ComputeType = *insight.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if insight.Description != nil {
 		description := *insight.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if insight.DisableLocalAuth != nil {
 		disableLocalAuth := *insight.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if insight.Properties != nil {
 		properties_ARM, err := (*insight.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -5664,7 +5664,7 @@ func (insight *HDInsight) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if insight.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*insight.ResourceReference)
 		if err != nil {
@@ -5688,28 +5688,28 @@ func (insight *HDInsight) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HDInsight_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		insight.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	insight.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		insight.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		insight.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 HDInsightProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -5720,7 +5720,7 @@ func (insight *HDInsight) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		insight.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -5934,46 +5934,46 @@ func (insight *HDInsight_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HDInsight_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		insight.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	insight.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		insight.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		insight.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		insight.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		insight.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		insight.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 HDInsightProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -5984,7 +5984,7 @@ func (insight *HDInsight_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		insight.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5994,13 +5994,13 @@ func (insight *HDInsight_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		insight.ProvisioningErrors = append(insight.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		insight.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		insight.ResourceId = &resourceId
@@ -6218,30 +6218,30 @@ func (kubernetes *Kubernetes) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Kubernetes_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if kubernetes.ComputeLocation != nil {
 		computeLocation := *kubernetes.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if kubernetes.ComputeType != nil {
 		result.ComputeType = *kubernetes.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if kubernetes.Description != nil {
 		description := *kubernetes.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if kubernetes.DisableLocalAuth != nil {
 		disableLocalAuth := *kubernetes.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if kubernetes.Properties != nil {
 		properties_ARM, err := (*kubernetes.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -6251,7 +6251,7 @@ func (kubernetes *Kubernetes) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if kubernetes.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*kubernetes.ResourceReference)
 		if err != nil {
@@ -6275,28 +6275,28 @@ func (kubernetes *Kubernetes) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Kubernetes_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		kubernetes.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	kubernetes.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		kubernetes.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		kubernetes.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 KubernetesProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -6307,7 +6307,7 @@ func (kubernetes *Kubernetes) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		kubernetes.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -6521,46 +6521,46 @@ func (kubernetes *Kubernetes_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Kubernetes_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		kubernetes.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	kubernetes.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		kubernetes.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		kubernetes.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		kubernetes.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		kubernetes.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		kubernetes.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 KubernetesProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -6571,7 +6571,7 @@ func (kubernetes *Kubernetes_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		kubernetes.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6581,13 +6581,13 @@ func (kubernetes *Kubernetes_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		kubernetes.ProvisioningErrors = append(kubernetes.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		kubernetes.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		kubernetes.ResourceId = &resourceId
@@ -6803,30 +6803,30 @@ func (spark *SynapseSpark) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &SynapseSpark_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if spark.ComputeLocation != nil {
 		computeLocation := *spark.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if spark.ComputeType != nil {
 		result.ComputeType = *spark.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if spark.Description != nil {
 		description := *spark.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if spark.DisableLocalAuth != nil {
 		disableLocalAuth := *spark.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if spark.Properties != nil {
 		properties_ARM, err := (*spark.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -6836,7 +6836,7 @@ func (spark *SynapseSpark) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if spark.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*spark.ResourceReference)
 		if err != nil {
@@ -6860,28 +6860,28 @@ func (spark *SynapseSpark) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SynapseSpark_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		spark.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	spark.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		spark.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		spark.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 SynapseSpark_Properties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -6892,7 +6892,7 @@ func (spark *SynapseSpark) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		spark.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -7104,46 +7104,46 @@ func (spark *SynapseSpark_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SynapseSpark_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		spark.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	spark.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		spark.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		spark.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		spark.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		spark.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		spark.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 SynapseSpark_Properties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -7154,7 +7154,7 @@ func (spark *SynapseSpark_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		spark.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7164,13 +7164,13 @@ func (spark *SynapseSpark_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		spark.ProvisioningErrors = append(spark.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		spark.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		spark.ResourceId = &resourceId
@@ -7386,30 +7386,30 @@ func (machine *VirtualMachine) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &VirtualMachine_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if machine.ComputeLocation != nil {
 		computeLocation := *machine.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if machine.ComputeType != nil {
 		result.ComputeType = *machine.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if machine.Description != nil {
 		description := *machine.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if machine.DisableLocalAuth != nil {
 		disableLocalAuth := *machine.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if machine.Properties != nil {
 		properties_ARM, err := (*machine.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -7419,7 +7419,7 @@ func (machine *VirtualMachine) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if machine.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*machine.ResourceReference)
 		if err != nil {
@@ -7443,28 +7443,28 @@ func (machine *VirtualMachine) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		machine.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	machine.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		machine.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		machine.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 VirtualMachine_Properties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -7475,7 +7475,7 @@ func (machine *VirtualMachine) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		machine.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -7687,46 +7687,46 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		machine.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	machine.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		machine.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		machine.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		machine.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		machine.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		machine.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 VirtualMachine_Properties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -7737,7 +7737,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7747,13 +7747,13 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.ProvisioningErrors = append(machine.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		machine.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		machine.ResourceId = &resourceId
@@ -7976,19 +7976,19 @@ func (properties *AKS_Properties) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &AKS_Properties_ARM{}
 
-	// Set property ‘AgentCount’:
+	// Set property "AgentCount":
 	if properties.AgentCount != nil {
 		agentCount := *properties.AgentCount
 		result.AgentCount = &agentCount
 	}
 
-	// Set property ‘AgentVmSize’:
+	// Set property "AgentVmSize":
 	if properties.AgentVmSize != nil {
 		agentVmSize := *properties.AgentVmSize
 		result.AgentVmSize = &agentVmSize
 	}
 
-	// Set property ‘AksNetworkingConfiguration’:
+	// Set property "AksNetworkingConfiguration":
 	if properties.AksNetworkingConfiguration != nil {
 		aksNetworkingConfiguration_ARM, err := (*properties.AksNetworkingConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -7998,31 +7998,31 @@ func (properties *AKS_Properties) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.AksNetworkingConfiguration = &aksNetworkingConfiguration
 	}
 
-	// Set property ‘ClusterFqdn’:
+	// Set property "ClusterFqdn":
 	if properties.ClusterFqdn != nil {
 		clusterFqdn := *properties.ClusterFqdn
 		result.ClusterFqdn = &clusterFqdn
 	}
 
-	// Set property ‘ClusterPurpose’:
+	// Set property "ClusterPurpose":
 	if properties.ClusterPurpose != nil {
 		clusterPurpose := *properties.ClusterPurpose
 		result.ClusterPurpose = &clusterPurpose
 	}
 
-	// Set property ‘LoadBalancerSubnet’:
+	// Set property "LoadBalancerSubnet":
 	if properties.LoadBalancerSubnet != nil {
 		loadBalancerSubnet := *properties.LoadBalancerSubnet
 		result.LoadBalancerSubnet = &loadBalancerSubnet
 	}
 
-	// Set property ‘LoadBalancerType’:
+	// Set property "LoadBalancerType":
 	if properties.LoadBalancerType != nil {
 		loadBalancerType := *properties.LoadBalancerType
 		result.LoadBalancerType = &loadBalancerType
 	}
 
-	// Set property ‘SslConfiguration’:
+	// Set property "SslConfiguration":
 	if properties.SslConfiguration != nil {
 		sslConfiguration_ARM, err := (*properties.SslConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -8046,19 +8046,19 @@ func (properties *AKS_Properties) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AKS_Properties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AgentCount’:
+	// Set property "AgentCount":
 	if typedInput.AgentCount != nil {
 		agentCount := *typedInput.AgentCount
 		properties.AgentCount = &agentCount
 	}
 
-	// Set property ‘AgentVmSize’:
+	// Set property "AgentVmSize":
 	if typedInput.AgentVmSize != nil {
 		agentVmSize := *typedInput.AgentVmSize
 		properties.AgentVmSize = &agentVmSize
 	}
 
-	// Set property ‘AksNetworkingConfiguration’:
+	// Set property "AksNetworkingConfiguration":
 	if typedInput.AksNetworkingConfiguration != nil {
 		var aksNetworkingConfiguration1 AksNetworkingConfiguration
 		err := aksNetworkingConfiguration1.PopulateFromARM(owner, *typedInput.AksNetworkingConfiguration)
@@ -8069,31 +8069,31 @@ func (properties *AKS_Properties) PopulateFromARM(owner genruntime.ArbitraryOwne
 		properties.AksNetworkingConfiguration = &aksNetworkingConfiguration
 	}
 
-	// Set property ‘ClusterFqdn’:
+	// Set property "ClusterFqdn":
 	if typedInput.ClusterFqdn != nil {
 		clusterFqdn := *typedInput.ClusterFqdn
 		properties.ClusterFqdn = &clusterFqdn
 	}
 
-	// Set property ‘ClusterPurpose’:
+	// Set property "ClusterPurpose":
 	if typedInput.ClusterPurpose != nil {
 		clusterPurpose := *typedInput.ClusterPurpose
 		properties.ClusterPurpose = &clusterPurpose
 	}
 
-	// Set property ‘LoadBalancerSubnet’:
+	// Set property "LoadBalancerSubnet":
 	if typedInput.LoadBalancerSubnet != nil {
 		loadBalancerSubnet := *typedInput.LoadBalancerSubnet
 		properties.LoadBalancerSubnet = &loadBalancerSubnet
 	}
 
-	// Set property ‘LoadBalancerType’:
+	// Set property "LoadBalancerType":
 	if typedInput.LoadBalancerType != nil {
 		loadBalancerType := *typedInput.LoadBalancerType
 		properties.LoadBalancerType = &loadBalancerType
 	}
 
-	// Set property ‘SslConfiguration’:
+	// Set property "SslConfiguration":
 	if typedInput.SslConfiguration != nil {
 		var sslConfiguration1 SslConfiguration
 		err := sslConfiguration1.PopulateFromARM(owner, *typedInput.SslConfiguration)
@@ -8352,19 +8352,19 @@ func (properties *AKS_Properties_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AKS_Properties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AgentCount’:
+	// Set property "AgentCount":
 	if typedInput.AgentCount != nil {
 		agentCount := *typedInput.AgentCount
 		properties.AgentCount = &agentCount
 	}
 
-	// Set property ‘AgentVmSize’:
+	// Set property "AgentVmSize":
 	if typedInput.AgentVmSize != nil {
 		agentVmSize := *typedInput.AgentVmSize
 		properties.AgentVmSize = &agentVmSize
 	}
 
-	// Set property ‘AksNetworkingConfiguration’:
+	// Set property "AksNetworkingConfiguration":
 	if typedInput.AksNetworkingConfiguration != nil {
 		var aksNetworkingConfiguration1 AksNetworkingConfiguration_STATUS
 		err := aksNetworkingConfiguration1.PopulateFromARM(owner, *typedInput.AksNetworkingConfiguration)
@@ -8375,31 +8375,31 @@ func (properties *AKS_Properties_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		properties.AksNetworkingConfiguration = &aksNetworkingConfiguration
 	}
 
-	// Set property ‘ClusterFqdn’:
+	// Set property "ClusterFqdn":
 	if typedInput.ClusterFqdn != nil {
 		clusterFqdn := *typedInput.ClusterFqdn
 		properties.ClusterFqdn = &clusterFqdn
 	}
 
-	// Set property ‘ClusterPurpose’:
+	// Set property "ClusterPurpose":
 	if typedInput.ClusterPurpose != nil {
 		clusterPurpose := *typedInput.ClusterPurpose
 		properties.ClusterPurpose = &clusterPurpose
 	}
 
-	// Set property ‘LoadBalancerSubnet’:
+	// Set property "LoadBalancerSubnet":
 	if typedInput.LoadBalancerSubnet != nil {
 		loadBalancerSubnet := *typedInput.LoadBalancerSubnet
 		properties.LoadBalancerSubnet = &loadBalancerSubnet
 	}
 
-	// Set property ‘LoadBalancerType’:
+	// Set property "LoadBalancerType":
 	if typedInput.LoadBalancerType != nil {
 		loadBalancerType := *typedInput.LoadBalancerType
 		properties.LoadBalancerType = &loadBalancerType
 	}
 
-	// Set property ‘SslConfiguration’:
+	// Set property "SslConfiguration":
 	if typedInput.SslConfiguration != nil {
 		var sslConfiguration1 SslConfiguration_STATUS
 		err := sslConfiguration1.PopulateFromARM(owner, *typedInput.SslConfiguration)
@@ -8410,7 +8410,7 @@ func (properties *AKS_Properties_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		properties.SslConfiguration = &sslConfiguration
 	}
 
-	// Set property ‘SystemServices’:
+	// Set property "SystemServices":
 	for _, item := range typedInput.SystemServices {
 		var item1 SystemService_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8635,31 +8635,31 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &AmlComputeProperties_ARM{}
 
-	// Set property ‘EnableNodePublicIp’:
+	// Set property "EnableNodePublicIp":
 	if properties.EnableNodePublicIp != nil {
 		enableNodePublicIp := *properties.EnableNodePublicIp
 		result.EnableNodePublicIp = &enableNodePublicIp
 	}
 
-	// Set property ‘IsolatedNetwork’:
+	// Set property "IsolatedNetwork":
 	if properties.IsolatedNetwork != nil {
 		isolatedNetwork := *properties.IsolatedNetwork
 		result.IsolatedNetwork = &isolatedNetwork
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if properties.OsType != nil {
 		osType := *properties.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘RemoteLoginPortPublicAccess’:
+	// Set property "RemoteLoginPortPublicAccess":
 	if properties.RemoteLoginPortPublicAccess != nil {
 		remoteLoginPortPublicAccess := *properties.RemoteLoginPortPublicAccess
 		result.RemoteLoginPortPublicAccess = &remoteLoginPortPublicAccess
 	}
 
-	// Set property ‘ScaleSettings’:
+	// Set property "ScaleSettings":
 	if properties.ScaleSettings != nil {
 		scaleSettings_ARM, err := (*properties.ScaleSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -8669,7 +8669,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 		result.ScaleSettings = &scaleSettings
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if properties.Subnet != nil {
 		subnet_ARM, err := (*properties.Subnet).ConvertToARM(resolved)
 		if err != nil {
@@ -8679,7 +8679,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 		result.Subnet = &subnet
 	}
 
-	// Set property ‘UserAccountCredentials’:
+	// Set property "UserAccountCredentials":
 	if properties.UserAccountCredentials != nil {
 		userAccountCredentials_ARM, err := (*properties.UserAccountCredentials).ConvertToARM(resolved)
 		if err != nil {
@@ -8689,7 +8689,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 		result.UserAccountCredentials = &userAccountCredentials
 	}
 
-	// Set property ‘VirtualMachineImage’:
+	// Set property "VirtualMachineImage":
 	if properties.VirtualMachineImage != nil {
 		virtualMachineImage_ARM, err := (*properties.VirtualMachineImage).ConvertToARM(resolved)
 		if err != nil {
@@ -8699,13 +8699,13 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 		result.VirtualMachineImage = &virtualMachineImage
 	}
 
-	// Set property ‘VmPriority’:
+	// Set property "VmPriority":
 	if properties.VmPriority != nil {
 		vmPriority := *properties.VmPriority
 		result.VmPriority = &vmPriority
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if properties.VmSize != nil {
 		vmSize := *properties.VmSize
 		result.VmSize = &vmSize
@@ -8725,31 +8725,31 @@ func (properties *AmlComputeProperties) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AmlComputeProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableNodePublicIp’:
+	// Set property "EnableNodePublicIp":
 	if typedInput.EnableNodePublicIp != nil {
 		enableNodePublicIp := *typedInput.EnableNodePublicIp
 		properties.EnableNodePublicIp = &enableNodePublicIp
 	}
 
-	// Set property ‘IsolatedNetwork’:
+	// Set property "IsolatedNetwork":
 	if typedInput.IsolatedNetwork != nil {
 		isolatedNetwork := *typedInput.IsolatedNetwork
 		properties.IsolatedNetwork = &isolatedNetwork
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		properties.OsType = &osType
 	}
 
-	// Set property ‘RemoteLoginPortPublicAccess’:
+	// Set property "RemoteLoginPortPublicAccess":
 	if typedInput.RemoteLoginPortPublicAccess != nil {
 		remoteLoginPortPublicAccess := *typedInput.RemoteLoginPortPublicAccess
 		properties.RemoteLoginPortPublicAccess = &remoteLoginPortPublicAccess
 	}
 
-	// Set property ‘ScaleSettings’:
+	// Set property "ScaleSettings":
 	if typedInput.ScaleSettings != nil {
 		var scaleSettings1 ScaleSettings
 		err := scaleSettings1.PopulateFromARM(owner, *typedInput.ScaleSettings)
@@ -8760,7 +8760,7 @@ func (properties *AmlComputeProperties) PopulateFromARM(owner genruntime.Arbitra
 		properties.ScaleSettings = &scaleSettings
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if typedInput.Subnet != nil {
 		var subnet1 ResourceId
 		err := subnet1.PopulateFromARM(owner, *typedInput.Subnet)
@@ -8771,7 +8771,7 @@ func (properties *AmlComputeProperties) PopulateFromARM(owner genruntime.Arbitra
 		properties.Subnet = &subnet
 	}
 
-	// Set property ‘UserAccountCredentials’:
+	// Set property "UserAccountCredentials":
 	if typedInput.UserAccountCredentials != nil {
 		var userAccountCredentials1 UserAccountCredentials
 		err := userAccountCredentials1.PopulateFromARM(owner, *typedInput.UserAccountCredentials)
@@ -8782,7 +8782,7 @@ func (properties *AmlComputeProperties) PopulateFromARM(owner genruntime.Arbitra
 		properties.UserAccountCredentials = &userAccountCredentials
 	}
 
-	// Set property ‘VirtualMachineImage’:
+	// Set property "VirtualMachineImage":
 	if typedInput.VirtualMachineImage != nil {
 		var virtualMachineImage1 VirtualMachineImage
 		err := virtualMachineImage1.PopulateFromARM(owner, *typedInput.VirtualMachineImage)
@@ -8793,13 +8793,13 @@ func (properties *AmlComputeProperties) PopulateFromARM(owner genruntime.Arbitra
 		properties.VirtualMachineImage = &virtualMachineImage
 	}
 
-	// Set property ‘VmPriority’:
+	// Set property "VmPriority":
 	if typedInput.VmPriority != nil {
 		vmPriority := *typedInput.VmPriority
 		properties.VmPriority = &vmPriority
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		properties.VmSize = &vmSize
@@ -9188,31 +9188,31 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AmlComputeProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocationState’:
+	// Set property "AllocationState":
 	if typedInput.AllocationState != nil {
 		allocationState := *typedInput.AllocationState
 		properties.AllocationState = &allocationState
 	}
 
-	// Set property ‘AllocationStateTransitionTime’:
+	// Set property "AllocationStateTransitionTime":
 	if typedInput.AllocationStateTransitionTime != nil {
 		allocationStateTransitionTime := *typedInput.AllocationStateTransitionTime
 		properties.AllocationStateTransitionTime = &allocationStateTransitionTime
 	}
 
-	// Set property ‘CurrentNodeCount’:
+	// Set property "CurrentNodeCount":
 	if typedInput.CurrentNodeCount != nil {
 		currentNodeCount := *typedInput.CurrentNodeCount
 		properties.CurrentNodeCount = &currentNodeCount
 	}
 
-	// Set property ‘EnableNodePublicIp’:
+	// Set property "EnableNodePublicIp":
 	if typedInput.EnableNodePublicIp != nil {
 		enableNodePublicIp := *typedInput.EnableNodePublicIp
 		properties.EnableNodePublicIp = &enableNodePublicIp
 	}
 
-	// Set property ‘Errors’:
+	// Set property "Errors":
 	for _, item := range typedInput.Errors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -9222,13 +9222,13 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		properties.Errors = append(properties.Errors, item1)
 	}
 
-	// Set property ‘IsolatedNetwork’:
+	// Set property "IsolatedNetwork":
 	if typedInput.IsolatedNetwork != nil {
 		isolatedNetwork := *typedInput.IsolatedNetwork
 		properties.IsolatedNetwork = &isolatedNetwork
 	}
 
-	// Set property ‘NodeStateCounts’:
+	// Set property "NodeStateCounts":
 	if typedInput.NodeStateCounts != nil {
 		var nodeStateCounts1 NodeStateCounts_STATUS
 		err := nodeStateCounts1.PopulateFromARM(owner, *typedInput.NodeStateCounts)
@@ -9239,19 +9239,19 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		properties.NodeStateCounts = &nodeStateCounts
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		properties.OsType = &osType
 	}
 
-	// Set property ‘RemoteLoginPortPublicAccess’:
+	// Set property "RemoteLoginPortPublicAccess":
 	if typedInput.RemoteLoginPortPublicAccess != nil {
 		remoteLoginPortPublicAccess := *typedInput.RemoteLoginPortPublicAccess
 		properties.RemoteLoginPortPublicAccess = &remoteLoginPortPublicAccess
 	}
 
-	// Set property ‘ScaleSettings’:
+	// Set property "ScaleSettings":
 	if typedInput.ScaleSettings != nil {
 		var scaleSettings1 ScaleSettings_STATUS
 		err := scaleSettings1.PopulateFromARM(owner, *typedInput.ScaleSettings)
@@ -9262,7 +9262,7 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		properties.ScaleSettings = &scaleSettings
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if typedInput.Subnet != nil {
 		var subnet1 ResourceId_STATUS
 		err := subnet1.PopulateFromARM(owner, *typedInput.Subnet)
@@ -9273,13 +9273,13 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		properties.Subnet = &subnet
 	}
 
-	// Set property ‘TargetNodeCount’:
+	// Set property "TargetNodeCount":
 	if typedInput.TargetNodeCount != nil {
 		targetNodeCount := *typedInput.TargetNodeCount
 		properties.TargetNodeCount = &targetNodeCount
 	}
 
-	// Set property ‘UserAccountCredentials’:
+	// Set property "UserAccountCredentials":
 	if typedInput.UserAccountCredentials != nil {
 		var userAccountCredentials1 UserAccountCredentials_STATUS
 		err := userAccountCredentials1.PopulateFromARM(owner, *typedInput.UserAccountCredentials)
@@ -9290,7 +9290,7 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		properties.UserAccountCredentials = &userAccountCredentials
 	}
 
-	// Set property ‘VirtualMachineImage’:
+	// Set property "VirtualMachineImage":
 	if typedInput.VirtualMachineImage != nil {
 		var virtualMachineImage1 VirtualMachineImage_STATUS
 		err := virtualMachineImage1.PopulateFromARM(owner, *typedInput.VirtualMachineImage)
@@ -9301,13 +9301,13 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		properties.VirtualMachineImage = &virtualMachineImage
 	}
 
-	// Set property ‘VmPriority’:
+	// Set property "VmPriority":
 	if typedInput.VmPriority != nil {
 		vmPriority := *typedInput.VmPriority
 		properties.VmPriority = &vmPriority
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		properties.VmSize = &vmSize
@@ -9651,19 +9651,19 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ComputeInstanceProperties_ARM{}
 
-	// Set property ‘ApplicationSharingPolicy’:
+	// Set property "ApplicationSharingPolicy":
 	if properties.ApplicationSharingPolicy != nil {
 		applicationSharingPolicy := *properties.ApplicationSharingPolicy
 		result.ApplicationSharingPolicy = &applicationSharingPolicy
 	}
 
-	// Set property ‘ComputeInstanceAuthorizationType’:
+	// Set property "ComputeInstanceAuthorizationType":
 	if properties.ComputeInstanceAuthorizationType != nil {
 		computeInstanceAuthorizationType := *properties.ComputeInstanceAuthorizationType
 		result.ComputeInstanceAuthorizationType = &computeInstanceAuthorizationType
 	}
 
-	// Set property ‘PersonalComputeInstanceSettings’:
+	// Set property "PersonalComputeInstanceSettings":
 	if properties.PersonalComputeInstanceSettings != nil {
 		personalComputeInstanceSettings_ARM, err := (*properties.PersonalComputeInstanceSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -9673,7 +9673,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 		result.PersonalComputeInstanceSettings = &personalComputeInstanceSettings
 	}
 
-	// Set property ‘SetupScripts’:
+	// Set property "SetupScripts":
 	if properties.SetupScripts != nil {
 		setupScripts_ARM, err := (*properties.SetupScripts).ConvertToARM(resolved)
 		if err != nil {
@@ -9683,7 +9683,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 		result.SetupScripts = &setupScripts
 	}
 
-	// Set property ‘SshSettings’:
+	// Set property "SshSettings":
 	if properties.SshSettings != nil {
 		sshSettings_ARM, err := (*properties.SshSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -9693,7 +9693,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 		result.SshSettings = &sshSettings
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if properties.Subnet != nil {
 		subnet_ARM, err := (*properties.Subnet).ConvertToARM(resolved)
 		if err != nil {
@@ -9703,7 +9703,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 		result.Subnet = &subnet
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if properties.VmSize != nil {
 		vmSize := *properties.VmSize
 		result.VmSize = &vmSize
@@ -9723,19 +9723,19 @@ func (properties *ComputeInstanceProperties) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationSharingPolicy’:
+	// Set property "ApplicationSharingPolicy":
 	if typedInput.ApplicationSharingPolicy != nil {
 		applicationSharingPolicy := *typedInput.ApplicationSharingPolicy
 		properties.ApplicationSharingPolicy = &applicationSharingPolicy
 	}
 
-	// Set property ‘ComputeInstanceAuthorizationType’:
+	// Set property "ComputeInstanceAuthorizationType":
 	if typedInput.ComputeInstanceAuthorizationType != nil {
 		computeInstanceAuthorizationType := *typedInput.ComputeInstanceAuthorizationType
 		properties.ComputeInstanceAuthorizationType = &computeInstanceAuthorizationType
 	}
 
-	// Set property ‘PersonalComputeInstanceSettings’:
+	// Set property "PersonalComputeInstanceSettings":
 	if typedInput.PersonalComputeInstanceSettings != nil {
 		var personalComputeInstanceSettings1 PersonalComputeInstanceSettings
 		err := personalComputeInstanceSettings1.PopulateFromARM(owner, *typedInput.PersonalComputeInstanceSettings)
@@ -9746,7 +9746,7 @@ func (properties *ComputeInstanceProperties) PopulateFromARM(owner genruntime.Ar
 		properties.PersonalComputeInstanceSettings = &personalComputeInstanceSettings
 	}
 
-	// Set property ‘SetupScripts’:
+	// Set property "SetupScripts":
 	if typedInput.SetupScripts != nil {
 		var setupScripts1 SetupScripts
 		err := setupScripts1.PopulateFromARM(owner, *typedInput.SetupScripts)
@@ -9757,7 +9757,7 @@ func (properties *ComputeInstanceProperties) PopulateFromARM(owner genruntime.Ar
 		properties.SetupScripts = &setupScripts
 	}
 
-	// Set property ‘SshSettings’:
+	// Set property "SshSettings":
 	if typedInput.SshSettings != nil {
 		var sshSettings1 ComputeInstanceSshSettings
 		err := sshSettings1.PopulateFromARM(owner, *typedInput.SshSettings)
@@ -9768,7 +9768,7 @@ func (properties *ComputeInstanceProperties) PopulateFromARM(owner genruntime.Ar
 		properties.SshSettings = &sshSettings
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if typedInput.Subnet != nil {
 		var subnet1 ResourceId
 		err := subnet1.PopulateFromARM(owner, *typedInput.Subnet)
@@ -9779,7 +9779,7 @@ func (properties *ComputeInstanceProperties) PopulateFromARM(owner genruntime.Ar
 		properties.Subnet = &subnet
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		properties.VmSize = &vmSize
@@ -10078,13 +10078,13 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationSharingPolicy’:
+	// Set property "ApplicationSharingPolicy":
 	if typedInput.ApplicationSharingPolicy != nil {
 		applicationSharingPolicy := *typedInput.ApplicationSharingPolicy
 		properties.ApplicationSharingPolicy = &applicationSharingPolicy
 	}
 
-	// Set property ‘Applications’:
+	// Set property "Applications":
 	for _, item := range typedInput.Applications {
 		var item1 ComputeInstanceApplication_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10094,13 +10094,13 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.Applications = append(properties.Applications, item1)
 	}
 
-	// Set property ‘ComputeInstanceAuthorizationType’:
+	// Set property "ComputeInstanceAuthorizationType":
 	if typedInput.ComputeInstanceAuthorizationType != nil {
 		computeInstanceAuthorizationType := *typedInput.ComputeInstanceAuthorizationType
 		properties.ComputeInstanceAuthorizationType = &computeInstanceAuthorizationType
 	}
 
-	// Set property ‘ConnectivityEndpoints’:
+	// Set property "ConnectivityEndpoints":
 	if typedInput.ConnectivityEndpoints != nil {
 		var connectivityEndpoints1 ComputeInstanceConnectivityEndpoints_STATUS
 		err := connectivityEndpoints1.PopulateFromARM(owner, *typedInput.ConnectivityEndpoints)
@@ -10111,7 +10111,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.ConnectivityEndpoints = &connectivityEndpoints
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		var createdBy1 ComputeInstanceCreatedBy_STATUS
 		err := createdBy1.PopulateFromARM(owner, *typedInput.CreatedBy)
@@ -10122,7 +10122,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.CreatedBy = &createdBy
 	}
 
-	// Set property ‘Errors’:
+	// Set property "Errors":
 	for _, item := range typedInput.Errors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10132,7 +10132,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.Errors = append(properties.Errors, item1)
 	}
 
-	// Set property ‘LastOperation’:
+	// Set property "LastOperation":
 	if typedInput.LastOperation != nil {
 		var lastOperation1 ComputeInstanceLastOperation_STATUS
 		err := lastOperation1.PopulateFromARM(owner, *typedInput.LastOperation)
@@ -10143,7 +10143,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.LastOperation = &lastOperation
 	}
 
-	// Set property ‘PersonalComputeInstanceSettings’:
+	// Set property "PersonalComputeInstanceSettings":
 	if typedInput.PersonalComputeInstanceSettings != nil {
 		var personalComputeInstanceSettings1 PersonalComputeInstanceSettings_STATUS
 		err := personalComputeInstanceSettings1.PopulateFromARM(owner, *typedInput.PersonalComputeInstanceSettings)
@@ -10154,7 +10154,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.PersonalComputeInstanceSettings = &personalComputeInstanceSettings
 	}
 
-	// Set property ‘SetupScripts’:
+	// Set property "SetupScripts":
 	if typedInput.SetupScripts != nil {
 		var setupScripts1 SetupScripts_STATUS
 		err := setupScripts1.PopulateFromARM(owner, *typedInput.SetupScripts)
@@ -10165,7 +10165,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.SetupScripts = &setupScripts
 	}
 
-	// Set property ‘SshSettings’:
+	// Set property "SshSettings":
 	if typedInput.SshSettings != nil {
 		var sshSettings1 ComputeInstanceSshSettings_STATUS
 		err := sshSettings1.PopulateFromARM(owner, *typedInput.SshSettings)
@@ -10176,13 +10176,13 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.SshSettings = &sshSettings
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		properties.State = &state
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if typedInput.Subnet != nil {
 		var subnet1 ResourceId_STATUS
 		err := subnet1.PopulateFromARM(owner, *typedInput.Subnet)
@@ -10193,7 +10193,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.Subnet = &subnet
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		properties.VmSize = &vmSize
@@ -10538,13 +10538,13 @@ func (properties *DatabricksProperties) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &DatabricksProperties_ARM{}
 
-	// Set property ‘DatabricksAccessToken’:
+	// Set property "DatabricksAccessToken":
 	if properties.DatabricksAccessToken != nil {
 		databricksAccessToken := *properties.DatabricksAccessToken
 		result.DatabricksAccessToken = &databricksAccessToken
 	}
 
-	// Set property ‘WorkspaceUrl’:
+	// Set property "WorkspaceUrl":
 	if properties.WorkspaceUrl != nil {
 		workspaceUrl := *properties.WorkspaceUrl
 		result.WorkspaceUrl = &workspaceUrl
@@ -10564,13 +10564,13 @@ func (properties *DatabricksProperties) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabricksProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DatabricksAccessToken’:
+	// Set property "DatabricksAccessToken":
 	if typedInput.DatabricksAccessToken != nil {
 		databricksAccessToken := *typedInput.DatabricksAccessToken
 		properties.DatabricksAccessToken = &databricksAccessToken
 	}
 
-	// Set property ‘WorkspaceUrl’:
+	// Set property "WorkspaceUrl":
 	if typedInput.WorkspaceUrl != nil {
 		workspaceUrl := *typedInput.WorkspaceUrl
 		properties.WorkspaceUrl = &workspaceUrl
@@ -10651,13 +10651,13 @@ func (properties *DatabricksProperties_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabricksProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DatabricksAccessToken’:
+	// Set property "DatabricksAccessToken":
 	if typedInput.DatabricksAccessToken != nil {
 		databricksAccessToken := *typedInput.DatabricksAccessToken
 		properties.DatabricksAccessToken = &databricksAccessToken
 	}
 
-	// Set property ‘WorkspaceUrl’:
+	// Set property "WorkspaceUrl":
 	if typedInput.WorkspaceUrl != nil {
 		workspaceUrl := *typedInput.WorkspaceUrl
 		properties.WorkspaceUrl = &workspaceUrl
@@ -10716,7 +10716,7 @@ func (properties *DataLakeAnalytics_Properties) ConvertToARM(resolved genruntime
 	}
 	result := &DataLakeAnalytics_Properties_ARM{}
 
-	// Set property ‘DataLakeStoreAccountName’:
+	// Set property "DataLakeStoreAccountName":
 	if properties.DataLakeStoreAccountName != nil {
 		dataLakeStoreAccountName := *properties.DataLakeStoreAccountName
 		result.DataLakeStoreAccountName = &dataLakeStoreAccountName
@@ -10736,7 +10736,7 @@ func (properties *DataLakeAnalytics_Properties) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataLakeAnalytics_Properties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataLakeStoreAccountName’:
+	// Set property "DataLakeStoreAccountName":
 	if typedInput.DataLakeStoreAccountName != nil {
 		dataLakeStoreAccountName := *typedInput.DataLakeStoreAccountName
 		properties.DataLakeStoreAccountName = &dataLakeStoreAccountName
@@ -10804,7 +10804,7 @@ func (properties *DataLakeAnalytics_Properties_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataLakeAnalytics_Properties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataLakeStoreAccountName’:
+	// Set property "DataLakeStoreAccountName":
 	if typedInput.DataLakeStoreAccountName != nil {
 		dataLakeStoreAccountName := *typedInput.DataLakeStoreAccountName
 		properties.DataLakeStoreAccountName = &dataLakeStoreAccountName
@@ -10864,7 +10864,7 @@ func (response *ErrorResponse_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ErrorResponse_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ErrorDetail_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -10947,13 +10947,13 @@ func (properties *HDInsightProperties) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &HDInsightProperties_ARM{}
 
-	// Set property ‘Address’:
+	// Set property "Address":
 	if properties.Address != nil {
 		address := *properties.Address
 		result.Address = &address
 	}
 
-	// Set property ‘AdministratorAccount’:
+	// Set property "AdministratorAccount":
 	if properties.AdministratorAccount != nil {
 		administratorAccount_ARM, err := (*properties.AdministratorAccount).ConvertToARM(resolved)
 		if err != nil {
@@ -10963,7 +10963,7 @@ func (properties *HDInsightProperties) ConvertToARM(resolved genruntime.ConvertT
 		result.AdministratorAccount = &administratorAccount
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if properties.SshPort != nil {
 		sshPort := *properties.SshPort
 		result.SshPort = &sshPort
@@ -10983,13 +10983,13 @@ func (properties *HDInsightProperties) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HDInsightProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Address’:
+	// Set property "Address":
 	if typedInput.Address != nil {
 		address := *typedInput.Address
 		properties.Address = &address
 	}
 
-	// Set property ‘AdministratorAccount’:
+	// Set property "AdministratorAccount":
 	if typedInput.AdministratorAccount != nil {
 		var administratorAccount1 VirtualMachineSshCredentials
 		err := administratorAccount1.PopulateFromARM(owner, *typedInput.AdministratorAccount)
@@ -11000,7 +11000,7 @@ func (properties *HDInsightProperties) PopulateFromARM(owner genruntime.Arbitrar
 		properties.AdministratorAccount = &administratorAccount
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if typedInput.SshPort != nil {
 		sshPort := *typedInput.SshPort
 		properties.SshPort = &sshPort
@@ -11120,13 +11120,13 @@ func (properties *HDInsightProperties_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HDInsightProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Address’:
+	// Set property "Address":
 	if typedInput.Address != nil {
 		address := *typedInput.Address
 		properties.Address = &address
 	}
 
-	// Set property ‘AdministratorAccount’:
+	// Set property "AdministratorAccount":
 	if typedInput.AdministratorAccount != nil {
 		var administratorAccount1 VirtualMachineSshCredentials_STATUS
 		err := administratorAccount1.PopulateFromARM(owner, *typedInput.AdministratorAccount)
@@ -11137,7 +11137,7 @@ func (properties *HDInsightProperties_STATUS) PopulateFromARM(owner genruntime.A
 		properties.AdministratorAccount = &administratorAccount
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if typedInput.SshPort != nil {
 		sshPort := *typedInput.SshPort
 		properties.SshPort = &sshPort
@@ -11242,25 +11242,25 @@ func (properties *KubernetesProperties) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &KubernetesProperties_ARM{}
 
-	// Set property ‘DefaultInstanceType’:
+	// Set property "DefaultInstanceType":
 	if properties.DefaultInstanceType != nil {
 		defaultInstanceType := *properties.DefaultInstanceType
 		result.DefaultInstanceType = &defaultInstanceType
 	}
 
-	// Set property ‘ExtensionInstanceReleaseTrain’:
+	// Set property "ExtensionInstanceReleaseTrain":
 	if properties.ExtensionInstanceReleaseTrain != nil {
 		extensionInstanceReleaseTrain := *properties.ExtensionInstanceReleaseTrain
 		result.ExtensionInstanceReleaseTrain = &extensionInstanceReleaseTrain
 	}
 
-	// Set property ‘ExtensionPrincipalId’:
+	// Set property "ExtensionPrincipalId":
 	if properties.ExtensionPrincipalId != nil {
 		extensionPrincipalId := *properties.ExtensionPrincipalId
 		result.ExtensionPrincipalId = &extensionPrincipalId
 	}
 
-	// Set property ‘InstanceTypes’:
+	// Set property "InstanceTypes":
 	if properties.InstanceTypes != nil {
 		result.InstanceTypes = make(map[string]InstanceTypeSchema_ARM, len(properties.InstanceTypes))
 		for key, value := range properties.InstanceTypes {
@@ -11272,13 +11272,13 @@ func (properties *KubernetesProperties) ConvertToARM(resolved genruntime.Convert
 		}
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if properties.Namespace != nil {
 		namespace := *properties.Namespace
 		result.Namespace = &namespace
 	}
 
-	// Set property ‘RelayConnectionString’:
+	// Set property "RelayConnectionString":
 	if properties.RelayConnectionString != nil {
 		relayConnectionStringSecret, err := resolved.ResolvedSecrets.Lookup(*properties.RelayConnectionString)
 		if err != nil {
@@ -11288,7 +11288,7 @@ func (properties *KubernetesProperties) ConvertToARM(resolved genruntime.Convert
 		result.RelayConnectionString = &relayConnectionString
 	}
 
-	// Set property ‘ServiceBusConnectionString’:
+	// Set property "ServiceBusConnectionString":
 	if properties.ServiceBusConnectionString != nil {
 		serviceBusConnectionStringSecret, err := resolved.ResolvedSecrets.Lookup(*properties.ServiceBusConnectionString)
 		if err != nil {
@@ -11298,7 +11298,7 @@ func (properties *KubernetesProperties) ConvertToARM(resolved genruntime.Convert
 		result.ServiceBusConnectionString = &serviceBusConnectionString
 	}
 
-	// Set property ‘VcName’:
+	// Set property "VcName":
 	if properties.VcName != nil {
 		vcName := *properties.VcName
 		result.VcName = &vcName
@@ -11318,25 +11318,25 @@ func (properties *KubernetesProperties) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubernetesProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultInstanceType’:
+	// Set property "DefaultInstanceType":
 	if typedInput.DefaultInstanceType != nil {
 		defaultInstanceType := *typedInput.DefaultInstanceType
 		properties.DefaultInstanceType = &defaultInstanceType
 	}
 
-	// Set property ‘ExtensionInstanceReleaseTrain’:
+	// Set property "ExtensionInstanceReleaseTrain":
 	if typedInput.ExtensionInstanceReleaseTrain != nil {
 		extensionInstanceReleaseTrain := *typedInput.ExtensionInstanceReleaseTrain
 		properties.ExtensionInstanceReleaseTrain = &extensionInstanceReleaseTrain
 	}
 
-	// Set property ‘ExtensionPrincipalId’:
+	// Set property "ExtensionPrincipalId":
 	if typedInput.ExtensionPrincipalId != nil {
 		extensionPrincipalId := *typedInput.ExtensionPrincipalId
 		properties.ExtensionPrincipalId = &extensionPrincipalId
 	}
 
-	// Set property ‘InstanceTypes’:
+	// Set property "InstanceTypes":
 	if typedInput.InstanceTypes != nil {
 		properties.InstanceTypes = make(map[string]InstanceTypeSchema, len(typedInput.InstanceTypes))
 		for key, value := range typedInput.InstanceTypes {
@@ -11349,17 +11349,17 @@ func (properties *KubernetesProperties) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		properties.Namespace = &namespace
 	}
 
-	// no assignment for property ‘RelayConnectionString’
+	// no assignment for property "RelayConnectionString"
 
-	// no assignment for property ‘ServiceBusConnectionString’
+	// no assignment for property "ServiceBusConnectionString"
 
-	// Set property ‘VcName’:
+	// Set property "VcName":
 	if typedInput.VcName != nil {
 		vcName := *typedInput.VcName
 		properties.VcName = &vcName
@@ -11565,25 +11565,25 @@ func (properties *KubernetesProperties_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubernetesProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultInstanceType’:
+	// Set property "DefaultInstanceType":
 	if typedInput.DefaultInstanceType != nil {
 		defaultInstanceType := *typedInput.DefaultInstanceType
 		properties.DefaultInstanceType = &defaultInstanceType
 	}
 
-	// Set property ‘ExtensionInstanceReleaseTrain’:
+	// Set property "ExtensionInstanceReleaseTrain":
 	if typedInput.ExtensionInstanceReleaseTrain != nil {
 		extensionInstanceReleaseTrain := *typedInput.ExtensionInstanceReleaseTrain
 		properties.ExtensionInstanceReleaseTrain = &extensionInstanceReleaseTrain
 	}
 
-	// Set property ‘ExtensionPrincipalId’:
+	// Set property "ExtensionPrincipalId":
 	if typedInput.ExtensionPrincipalId != nil {
 		extensionPrincipalId := *typedInput.ExtensionPrincipalId
 		properties.ExtensionPrincipalId = &extensionPrincipalId
 	}
 
-	// Set property ‘InstanceTypes’:
+	// Set property "InstanceTypes":
 	if typedInput.InstanceTypes != nil {
 		properties.InstanceTypes = make(map[string]InstanceTypeSchema_STATUS, len(typedInput.InstanceTypes))
 		for key, value := range typedInput.InstanceTypes {
@@ -11596,13 +11596,13 @@ func (properties *KubernetesProperties_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		properties.Namespace = &namespace
 	}
 
-	// Set property ‘VcName’:
+	// Set property "VcName":
 	if typedInput.VcName != nil {
 		vcName := *typedInput.VcName
 		properties.VcName = &vcName
@@ -11742,7 +11742,7 @@ func (properties *SynapseSpark_Properties) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &SynapseSpark_Properties_ARM{}
 
-	// Set property ‘AutoPauseProperties’:
+	// Set property "AutoPauseProperties":
 	if properties.AutoPauseProperties != nil {
 		autoPauseProperties_ARM, err := (*properties.AutoPauseProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -11752,7 +11752,7 @@ func (properties *SynapseSpark_Properties) ConvertToARM(resolved genruntime.Conv
 		result.AutoPauseProperties = &autoPauseProperties
 	}
 
-	// Set property ‘AutoScaleProperties’:
+	// Set property "AutoScaleProperties":
 	if properties.AutoScaleProperties != nil {
 		autoScaleProperties_ARM, err := (*properties.AutoScaleProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -11762,49 +11762,49 @@ func (properties *SynapseSpark_Properties) ConvertToARM(resolved genruntime.Conv
 		result.AutoScaleProperties = &autoScaleProperties
 	}
 
-	// Set property ‘NodeCount’:
+	// Set property "NodeCount":
 	if properties.NodeCount != nil {
 		nodeCount := *properties.NodeCount
 		result.NodeCount = &nodeCount
 	}
 
-	// Set property ‘NodeSize’:
+	// Set property "NodeSize":
 	if properties.NodeSize != nil {
 		nodeSize := *properties.NodeSize
 		result.NodeSize = &nodeSize
 	}
 
-	// Set property ‘NodeSizeFamily’:
+	// Set property "NodeSizeFamily":
 	if properties.NodeSizeFamily != nil {
 		nodeSizeFamily := *properties.NodeSizeFamily
 		result.NodeSizeFamily = &nodeSizeFamily
 	}
 
-	// Set property ‘PoolName’:
+	// Set property "PoolName":
 	if properties.PoolName != nil {
 		poolName := *properties.PoolName
 		result.PoolName = &poolName
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if properties.ResourceGroup != nil {
 		resourceGroup := *properties.ResourceGroup
 		result.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SparkVersion’:
+	// Set property "SparkVersion":
 	if properties.SparkVersion != nil {
 		sparkVersion := *properties.SparkVersion
 		result.SparkVersion = &sparkVersion
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if properties.SubscriptionId != nil {
 		subscriptionId := *properties.SubscriptionId
 		result.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘WorkspaceName’:
+	// Set property "WorkspaceName":
 	if properties.WorkspaceName != nil {
 		workspaceName := *properties.WorkspaceName
 		result.WorkspaceName = &workspaceName
@@ -11824,7 +11824,7 @@ func (properties *SynapseSpark_Properties) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SynapseSpark_Properties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoPauseProperties’:
+	// Set property "AutoPauseProperties":
 	if typedInput.AutoPauseProperties != nil {
 		var autoPauseProperties1 AutoPauseProperties
 		err := autoPauseProperties1.PopulateFromARM(owner, *typedInput.AutoPauseProperties)
@@ -11835,7 +11835,7 @@ func (properties *SynapseSpark_Properties) PopulateFromARM(owner genruntime.Arbi
 		properties.AutoPauseProperties = &autoPauseProperties
 	}
 
-	// Set property ‘AutoScaleProperties’:
+	// Set property "AutoScaleProperties":
 	if typedInput.AutoScaleProperties != nil {
 		var autoScaleProperties1 AutoScaleProperties
 		err := autoScaleProperties1.PopulateFromARM(owner, *typedInput.AutoScaleProperties)
@@ -11846,49 +11846,49 @@ func (properties *SynapseSpark_Properties) PopulateFromARM(owner genruntime.Arbi
 		properties.AutoScaleProperties = &autoScaleProperties
 	}
 
-	// Set property ‘NodeCount’:
+	// Set property "NodeCount":
 	if typedInput.NodeCount != nil {
 		nodeCount := *typedInput.NodeCount
 		properties.NodeCount = &nodeCount
 	}
 
-	// Set property ‘NodeSize’:
+	// Set property "NodeSize":
 	if typedInput.NodeSize != nil {
 		nodeSize := *typedInput.NodeSize
 		properties.NodeSize = &nodeSize
 	}
 
-	// Set property ‘NodeSizeFamily’:
+	// Set property "NodeSizeFamily":
 	if typedInput.NodeSizeFamily != nil {
 		nodeSizeFamily := *typedInput.NodeSizeFamily
 		properties.NodeSizeFamily = &nodeSizeFamily
 	}
 
-	// Set property ‘PoolName’:
+	// Set property "PoolName":
 	if typedInput.PoolName != nil {
 		poolName := *typedInput.PoolName
 		properties.PoolName = &poolName
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if typedInput.ResourceGroup != nil {
 		resourceGroup := *typedInput.ResourceGroup
 		properties.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SparkVersion’:
+	// Set property "SparkVersion":
 	if typedInput.SparkVersion != nil {
 		sparkVersion := *typedInput.SparkVersion
 		properties.SparkVersion = &sparkVersion
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘WorkspaceName’:
+	// Set property "WorkspaceName":
 	if typedInput.WorkspaceName != nil {
 		workspaceName := *typedInput.WorkspaceName
 		properties.WorkspaceName = &workspaceName
@@ -12118,7 +12118,7 @@ func (properties *SynapseSpark_Properties_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SynapseSpark_Properties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoPauseProperties’:
+	// Set property "AutoPauseProperties":
 	if typedInput.AutoPauseProperties != nil {
 		var autoPauseProperties1 AutoPauseProperties_STATUS
 		err := autoPauseProperties1.PopulateFromARM(owner, *typedInput.AutoPauseProperties)
@@ -12129,7 +12129,7 @@ func (properties *SynapseSpark_Properties_STATUS) PopulateFromARM(owner genrunti
 		properties.AutoPauseProperties = &autoPauseProperties
 	}
 
-	// Set property ‘AutoScaleProperties’:
+	// Set property "AutoScaleProperties":
 	if typedInput.AutoScaleProperties != nil {
 		var autoScaleProperties1 AutoScaleProperties_STATUS
 		err := autoScaleProperties1.PopulateFromARM(owner, *typedInput.AutoScaleProperties)
@@ -12140,49 +12140,49 @@ func (properties *SynapseSpark_Properties_STATUS) PopulateFromARM(owner genrunti
 		properties.AutoScaleProperties = &autoScaleProperties
 	}
 
-	// Set property ‘NodeCount’:
+	// Set property "NodeCount":
 	if typedInput.NodeCount != nil {
 		nodeCount := *typedInput.NodeCount
 		properties.NodeCount = &nodeCount
 	}
 
-	// Set property ‘NodeSize’:
+	// Set property "NodeSize":
 	if typedInput.NodeSize != nil {
 		nodeSize := *typedInput.NodeSize
 		properties.NodeSize = &nodeSize
 	}
 
-	// Set property ‘NodeSizeFamily’:
+	// Set property "NodeSizeFamily":
 	if typedInput.NodeSizeFamily != nil {
 		nodeSizeFamily := *typedInput.NodeSizeFamily
 		properties.NodeSizeFamily = &nodeSizeFamily
 	}
 
-	// Set property ‘PoolName’:
+	// Set property "PoolName":
 	if typedInput.PoolName != nil {
 		poolName := *typedInput.PoolName
 		properties.PoolName = &poolName
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if typedInput.ResourceGroup != nil {
 		resourceGroup := *typedInput.ResourceGroup
 		properties.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SparkVersion’:
+	// Set property "SparkVersion":
 	if typedInput.SparkVersion != nil {
 		sparkVersion := *typedInput.SparkVersion
 		properties.SparkVersion = &sparkVersion
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘WorkspaceName’:
+	// Set property "WorkspaceName":
 	if typedInput.WorkspaceName != nil {
 		workspaceName := *typedInput.WorkspaceName
 		properties.WorkspaceName = &workspaceName
@@ -12337,13 +12337,13 @@ func (properties *VirtualMachine_Properties) ConvertToARM(resolved genruntime.Co
 	}
 	result := &VirtualMachine_Properties_ARM{}
 
-	// Set property ‘Address’:
+	// Set property "Address":
 	if properties.Address != nil {
 		address := *properties.Address
 		result.Address = &address
 	}
 
-	// Set property ‘AdministratorAccount’:
+	// Set property "AdministratorAccount":
 	if properties.AdministratorAccount != nil {
 		administratorAccount_ARM, err := (*properties.AdministratorAccount).ConvertToARM(resolved)
 		if err != nil {
@@ -12353,19 +12353,19 @@ func (properties *VirtualMachine_Properties) ConvertToARM(resolved genruntime.Co
 		result.AdministratorAccount = &administratorAccount
 	}
 
-	// Set property ‘IsNotebookInstanceCompute’:
+	// Set property "IsNotebookInstanceCompute":
 	if properties.IsNotebookInstanceCompute != nil {
 		isNotebookInstanceCompute := *properties.IsNotebookInstanceCompute
 		result.IsNotebookInstanceCompute = &isNotebookInstanceCompute
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if properties.SshPort != nil {
 		sshPort := *properties.SshPort
 		result.SshPort = &sshPort
 	}
 
-	// Set property ‘VirtualMachineSize’:
+	// Set property "VirtualMachineSize":
 	if properties.VirtualMachineSize != nil {
 		virtualMachineSize := *properties.VirtualMachineSize
 		result.VirtualMachineSize = &virtualMachineSize
@@ -12385,13 +12385,13 @@ func (properties *VirtualMachine_Properties) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_Properties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Address’:
+	// Set property "Address":
 	if typedInput.Address != nil {
 		address := *typedInput.Address
 		properties.Address = &address
 	}
 
-	// Set property ‘AdministratorAccount’:
+	// Set property "AdministratorAccount":
 	if typedInput.AdministratorAccount != nil {
 		var administratorAccount1 VirtualMachineSshCredentials
 		err := administratorAccount1.PopulateFromARM(owner, *typedInput.AdministratorAccount)
@@ -12402,19 +12402,19 @@ func (properties *VirtualMachine_Properties) PopulateFromARM(owner genruntime.Ar
 		properties.AdministratorAccount = &administratorAccount
 	}
 
-	// Set property ‘IsNotebookInstanceCompute’:
+	// Set property "IsNotebookInstanceCompute":
 	if typedInput.IsNotebookInstanceCompute != nil {
 		isNotebookInstanceCompute := *typedInput.IsNotebookInstanceCompute
 		properties.IsNotebookInstanceCompute = &isNotebookInstanceCompute
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if typedInput.SshPort != nil {
 		sshPort := *typedInput.SshPort
 		properties.SshPort = &sshPort
 	}
 
-	// Set property ‘VirtualMachineSize’:
+	// Set property "VirtualMachineSize":
 	if typedInput.VirtualMachineSize != nil {
 		virtualMachineSize := *typedInput.VirtualMachineSize
 		properties.VirtualMachineSize = &virtualMachineSize
@@ -12572,13 +12572,13 @@ func (properties *VirtualMachine_Properties_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_Properties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Address’:
+	// Set property "Address":
 	if typedInput.Address != nil {
 		address := *typedInput.Address
 		properties.Address = &address
 	}
 
-	// Set property ‘AdministratorAccount’:
+	// Set property "AdministratorAccount":
 	if typedInput.AdministratorAccount != nil {
 		var administratorAccount1 VirtualMachineSshCredentials_STATUS
 		err := administratorAccount1.PopulateFromARM(owner, *typedInput.AdministratorAccount)
@@ -12589,19 +12589,19 @@ func (properties *VirtualMachine_Properties_STATUS) PopulateFromARM(owner genrun
 		properties.AdministratorAccount = &administratorAccount
 	}
 
-	// Set property ‘IsNotebookInstanceCompute’:
+	// Set property "IsNotebookInstanceCompute":
 	if typedInput.IsNotebookInstanceCompute != nil {
 		isNotebookInstanceCompute := *typedInput.IsNotebookInstanceCompute
 		properties.IsNotebookInstanceCompute = &isNotebookInstanceCompute
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if typedInput.SshPort != nil {
 		sshPort := *typedInput.SshPort
 		properties.SshPort = &sshPort
 	}
 
-	// Set property ‘VirtualMachineSize’:
+	// Set property "VirtualMachineSize":
 	if typedInput.VirtualMachineSize != nil {
 		virtualMachineSize := *typedInput.VirtualMachineSize
 		properties.VirtualMachineSize = &virtualMachineSize
@@ -12722,25 +12722,25 @@ func (configuration *AksNetworkingConfiguration) ConvertToARM(resolved genruntim
 	}
 	result := &AksNetworkingConfiguration_ARM{}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if configuration.DnsServiceIP != nil {
 		dnsServiceIP := *configuration.DnsServiceIP
 		result.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if configuration.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *configuration.DockerBridgeCidr
 		result.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if configuration.ServiceCidr != nil {
 		serviceCidr := *configuration.ServiceCidr
 		result.ServiceCidr = &serviceCidr
 	}
 
-	// Set property ‘SubnetId’:
+	// Set property "SubnetId":
 	if configuration.SubnetReference != nil {
 		subnetReferenceARMID, err := resolved.ResolvedReferences.Lookup(*configuration.SubnetReference)
 		if err != nil {
@@ -12764,25 +12764,25 @@ func (configuration *AksNetworkingConfiguration) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AksNetworkingConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if typedInput.DnsServiceIP != nil {
 		dnsServiceIP := *typedInput.DnsServiceIP
 		configuration.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if typedInput.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *typedInput.DockerBridgeCidr
 		configuration.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if typedInput.ServiceCidr != nil {
 		serviceCidr := *typedInput.ServiceCidr
 		configuration.ServiceCidr = &serviceCidr
 	}
 
-	// no assignment for property ‘SubnetReference’
+	// no assignment for property "SubnetReference"
 
 	// No error
 	return nil
@@ -12946,25 +12946,25 @@ func (configuration *AksNetworkingConfiguration_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AksNetworkingConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if typedInput.DnsServiceIP != nil {
 		dnsServiceIP := *typedInput.DnsServiceIP
 		configuration.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if typedInput.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *typedInput.DockerBridgeCidr
 		configuration.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if typedInput.ServiceCidr != nil {
 		serviceCidr := *typedInput.ServiceCidr
 		configuration.ServiceCidr = &serviceCidr
 	}
 
-	// Set property ‘SubnetId’:
+	// Set property "SubnetId":
 	if typedInput.SubnetId != nil {
 		subnetId := *typedInput.SubnetId
 		configuration.SubnetId = &subnetId
@@ -13036,13 +13036,13 @@ func (properties *AutoPauseProperties) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &AutoPauseProperties_ARM{}
 
-	// Set property ‘DelayInMinutes’:
+	// Set property "DelayInMinutes":
 	if properties.DelayInMinutes != nil {
 		delayInMinutes := *properties.DelayInMinutes
 		result.DelayInMinutes = &delayInMinutes
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if properties.Enabled != nil {
 		enabled := *properties.Enabled
 		result.Enabled = &enabled
@@ -13062,13 +13062,13 @@ func (properties *AutoPauseProperties) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoPauseProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DelayInMinutes’:
+	// Set property "DelayInMinutes":
 	if typedInput.DelayInMinutes != nil {
 		delayInMinutes := *typedInput.DelayInMinutes
 		properties.DelayInMinutes = &delayInMinutes
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
@@ -13161,13 +13161,13 @@ func (properties *AutoPauseProperties_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoPauseProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DelayInMinutes’:
+	// Set property "DelayInMinutes":
 	if typedInput.DelayInMinutes != nil {
 		delayInMinutes := *typedInput.DelayInMinutes
 		properties.DelayInMinutes = &delayInMinutes
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
@@ -13238,19 +13238,19 @@ func (properties *AutoScaleProperties) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &AutoScaleProperties_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if properties.Enabled != nil {
 		enabled := *properties.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if properties.MaxNodeCount != nil {
 		maxNodeCount := *properties.MaxNodeCount
 		result.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if properties.MinNodeCount != nil {
 		minNodeCount := *properties.MinNodeCount
 		result.MinNodeCount = &minNodeCount
@@ -13270,19 +13270,19 @@ func (properties *AutoScaleProperties) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoScaleProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
 	}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if typedInput.MaxNodeCount != nil {
 		maxNodeCount := *typedInput.MaxNodeCount
 		properties.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if typedInput.MinNodeCount != nil {
 		minNodeCount := *typedInput.MinNodeCount
 		properties.MinNodeCount = &minNodeCount
@@ -13385,19 +13385,19 @@ func (properties *AutoScaleProperties_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoScaleProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
 	}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if typedInput.MaxNodeCount != nil {
 		maxNodeCount := *typedInput.MaxNodeCount
 		properties.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if typedInput.MinNodeCount != nil {
 		minNodeCount := *typedInput.MinNodeCount
 		properties.MinNodeCount = &minNodeCount
@@ -13481,13 +13481,13 @@ func (application *ComputeInstanceApplication_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceApplication_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisplayName’:
+	// Set property "DisplayName":
 	if typedInput.DisplayName != nil {
 		displayName := *typedInput.DisplayName
 		application.DisplayName = &displayName
 	}
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if typedInput.EndpointUri != nil {
 		endpointUri := *typedInput.EndpointUri
 		application.EndpointUri = &endpointUri
@@ -13556,13 +13556,13 @@ func (endpoints *ComputeInstanceConnectivityEndpoints_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceConnectivityEndpoints_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrivateIpAddress’:
+	// Set property "PrivateIpAddress":
 	if typedInput.PrivateIpAddress != nil {
 		privateIpAddress := *typedInput.PrivateIpAddress
 		endpoints.PrivateIpAddress = &privateIpAddress
 	}
 
-	// Set property ‘PublicIpAddress’:
+	// Set property "PublicIpAddress":
 	if typedInput.PublicIpAddress != nil {
 		publicIpAddress := *typedInput.PublicIpAddress
 		endpoints.PublicIpAddress = &publicIpAddress
@@ -13633,19 +13633,19 @@ func (createdBy *ComputeInstanceCreatedBy_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceCreatedBy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserId’:
+	// Set property "UserId":
 	if typedInput.UserId != nil {
 		userId := *typedInput.UserId
 		createdBy.UserId = &userId
 	}
 
-	// Set property ‘UserName’:
+	// Set property "UserName":
 	if typedInput.UserName != nil {
 		userName := *typedInput.UserName
 		createdBy.UserName = &userName
 	}
 
-	// Set property ‘UserOrgId’:
+	// Set property "UserOrgId":
 	if typedInput.UserOrgId != nil {
 		userOrgId := *typedInput.UserOrgId
 		createdBy.UserOrgId = &userOrgId
@@ -13722,19 +13722,19 @@ func (operation *ComputeInstanceLastOperation_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceLastOperation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘OperationName’:
+	// Set property "OperationName":
 	if typedInput.OperationName != nil {
 		operationName := *typedInput.OperationName
 		operation.OperationName = &operationName
 	}
 
-	// Set property ‘OperationStatus’:
+	// Set property "OperationStatus":
 	if typedInput.OperationStatus != nil {
 		operationStatus := *typedInput.OperationStatus
 		operation.OperationStatus = &operationStatus
 	}
 
-	// Set property ‘OperationTime’:
+	// Set property "OperationTime":
 	if typedInput.OperationTime != nil {
 		operationTime := *typedInput.OperationTime
 		operation.OperationTime = &operationTime
@@ -13826,13 +13826,13 @@ func (settings *ComputeInstanceSshSettings) ConvertToARM(resolved genruntime.Con
 	}
 	result := &ComputeInstanceSshSettings_ARM{}
 
-	// Set property ‘AdminPublicKey’:
+	// Set property "AdminPublicKey":
 	if settings.AdminPublicKey != nil {
 		adminPublicKey := *settings.AdminPublicKey
 		result.AdminPublicKey = &adminPublicKey
 	}
 
-	// Set property ‘SshPublicAccess’:
+	// Set property "SshPublicAccess":
 	if settings.SshPublicAccess != nil {
 		sshPublicAccess := *settings.SshPublicAccess
 		result.SshPublicAccess = &sshPublicAccess
@@ -13852,13 +13852,13 @@ func (settings *ComputeInstanceSshSettings) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceSshSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminPublicKey’:
+	// Set property "AdminPublicKey":
 	if typedInput.AdminPublicKey != nil {
 		adminPublicKey := *typedInput.AdminPublicKey
 		settings.AdminPublicKey = &adminPublicKey
 	}
 
-	// Set property ‘SshPublicAccess’:
+	// Set property "SshPublicAccess":
 	if typedInput.SshPublicAccess != nil {
 		sshPublicAccess := *typedInput.SshPublicAccess
 		settings.SshPublicAccess = &sshPublicAccess
@@ -13963,25 +13963,25 @@ func (settings *ComputeInstanceSshSettings_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceSshSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminPublicKey’:
+	// Set property "AdminPublicKey":
 	if typedInput.AdminPublicKey != nil {
 		adminPublicKey := *typedInput.AdminPublicKey
 		settings.AdminPublicKey = &adminPublicKey
 	}
 
-	// Set property ‘AdminUserName’:
+	// Set property "AdminUserName":
 	if typedInput.AdminUserName != nil {
 		adminUserName := *typedInput.AdminUserName
 		settings.AdminUserName = &adminUserName
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if typedInput.SshPort != nil {
 		sshPort := *typedInput.SshPort
 		settings.SshPort = &sshPort
 	}
 
-	// Set property ‘SshPublicAccess’:
+	// Set property "SshPublicAccess":
 	if typedInput.SshPublicAccess != nil {
 		sshPublicAccess := *typedInput.SshPublicAccess
 		settings.SshPublicAccess = &sshPublicAccess
@@ -14080,7 +14080,7 @@ func (detail *ErrorDetail_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ErrorDetail_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalInfo’:
+	// Set property "AdditionalInfo":
 	for _, item := range typedInput.AdditionalInfo {
 		var item1 ErrorAdditionalInfo_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -14090,13 +14090,13 @@ func (detail *ErrorDetail_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		detail.AdditionalInfo = append(detail.AdditionalInfo, item1)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		detail.Code = &code
 	}
 
-	// Set property ‘Details’:
+	// Set property "Details":
 	for _, item := range typedInput.Details {
 		var item1 ErrorDetail_STATUS_Unrolled
 		err := item1.PopulateFromARM(owner, item)
@@ -14106,13 +14106,13 @@ func (detail *ErrorDetail_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		detail.Details = append(detail.Details, item1)
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		detail.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		detail.Target = &target
@@ -14253,7 +14253,7 @@ func (schema *InstanceTypeSchema) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &InstanceTypeSchema_ARM{}
 
-	// Set property ‘NodeSelector’:
+	// Set property "NodeSelector":
 	if schema.NodeSelector != nil {
 		result.NodeSelector = make(map[string]string, len(schema.NodeSelector))
 		for key, value := range schema.NodeSelector {
@@ -14261,7 +14261,7 @@ func (schema *InstanceTypeSchema) ConvertToARM(resolved genruntime.ConvertToARMR
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	if schema.Resources != nil {
 		resources_ARM, err := (*schema.Resources).ConvertToARM(resolved)
 		if err != nil {
@@ -14285,7 +14285,7 @@ func (schema *InstanceTypeSchema) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InstanceTypeSchema_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NodeSelector’:
+	// Set property "NodeSelector":
 	if typedInput.NodeSelector != nil {
 		schema.NodeSelector = make(map[string]string, len(typedInput.NodeSelector))
 		for key, value := range typedInput.NodeSelector {
@@ -14293,7 +14293,7 @@ func (schema *InstanceTypeSchema) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	if typedInput.Resources != nil {
 		var resources1 InstanceTypeSchema_Resources
 		err := resources1.PopulateFromARM(owner, *typedInput.Resources)
@@ -14406,7 +14406,7 @@ func (schema *InstanceTypeSchema_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InstanceTypeSchema_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NodeSelector’:
+	// Set property "NodeSelector":
 	if typedInput.NodeSelector != nil {
 		schema.NodeSelector = make(map[string]string, len(typedInput.NodeSelector))
 		for key, value := range typedInput.NodeSelector {
@@ -14414,7 +14414,7 @@ func (schema *InstanceTypeSchema_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	if typedInput.Resources != nil {
 		var resources1 InstanceTypeSchema_Resources_STATUS
 		err := resources1.PopulateFromARM(owner, *typedInput.Resources)
@@ -14517,37 +14517,37 @@ func (counts *NodeStateCounts_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NodeStateCounts_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IdleNodeCount’:
+	// Set property "IdleNodeCount":
 	if typedInput.IdleNodeCount != nil {
 		idleNodeCount := *typedInput.IdleNodeCount
 		counts.IdleNodeCount = &idleNodeCount
 	}
 
-	// Set property ‘LeavingNodeCount’:
+	// Set property "LeavingNodeCount":
 	if typedInput.LeavingNodeCount != nil {
 		leavingNodeCount := *typedInput.LeavingNodeCount
 		counts.LeavingNodeCount = &leavingNodeCount
 	}
 
-	// Set property ‘PreemptedNodeCount’:
+	// Set property "PreemptedNodeCount":
 	if typedInput.PreemptedNodeCount != nil {
 		preemptedNodeCount := *typedInput.PreemptedNodeCount
 		counts.PreemptedNodeCount = &preemptedNodeCount
 	}
 
-	// Set property ‘PreparingNodeCount’:
+	// Set property "PreparingNodeCount":
 	if typedInput.PreparingNodeCount != nil {
 		preparingNodeCount := *typedInput.PreparingNodeCount
 		counts.PreparingNodeCount = &preparingNodeCount
 	}
 
-	// Set property ‘RunningNodeCount’:
+	// Set property "RunningNodeCount":
 	if typedInput.RunningNodeCount != nil {
 		runningNodeCount := *typedInput.RunningNodeCount
 		counts.RunningNodeCount = &runningNodeCount
 	}
 
-	// Set property ‘UnusableNodeCount’:
+	// Set property "UnusableNodeCount":
 	if typedInput.UnusableNodeCount != nil {
 		unusableNodeCount := *typedInput.UnusableNodeCount
 		counts.UnusableNodeCount = &unusableNodeCount
@@ -14631,7 +14631,7 @@ func (settings *PersonalComputeInstanceSettings) ConvertToARM(resolved genruntim
 	}
 	result := &PersonalComputeInstanceSettings_ARM{}
 
-	// Set property ‘AssignedUser’:
+	// Set property "AssignedUser":
 	if settings.AssignedUser != nil {
 		assignedUser_ARM, err := (*settings.AssignedUser).ConvertToARM(resolved)
 		if err != nil {
@@ -14655,7 +14655,7 @@ func (settings *PersonalComputeInstanceSettings) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PersonalComputeInstanceSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssignedUser’:
+	// Set property "AssignedUser":
 	if typedInput.AssignedUser != nil {
 		var assignedUser1 AssignedUser
 		err := assignedUser1.PopulateFromARM(owner, *typedInput.AssignedUser)
@@ -14756,7 +14756,7 @@ func (settings *PersonalComputeInstanceSettings_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PersonalComputeInstanceSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssignedUser’:
+	// Set property "AssignedUser":
 	if typedInput.AssignedUser != nil {
 		var assignedUser1 AssignedUser_STATUS
 		err := assignedUser1.PopulateFromARM(owner, *typedInput.AssignedUser)
@@ -14834,7 +14834,7 @@ func (resourceId *ResourceId) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &ResourceId_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resourceId.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resourceId.Reference)
 		if err != nil {
@@ -14858,7 +14858,7 @@ func (resourceId *ResourceId) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceId_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -14938,7 +14938,7 @@ func (resourceId *ResourceId_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceId_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resourceId.Id = &id
@@ -14999,19 +14999,19 @@ func (settings *ScaleSettings) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &ScaleSettings_ARM{}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if settings.MaxNodeCount != nil {
 		maxNodeCount := *settings.MaxNodeCount
 		result.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if settings.MinNodeCount != nil {
 		minNodeCount := *settings.MinNodeCount
 		result.MinNodeCount = &minNodeCount
 	}
 
-	// Set property ‘NodeIdleTimeBeforeScaleDown’:
+	// Set property "NodeIdleTimeBeforeScaleDown":
 	if settings.NodeIdleTimeBeforeScaleDown != nil {
 		nodeIdleTimeBeforeScaleDown := *settings.NodeIdleTimeBeforeScaleDown
 		result.NodeIdleTimeBeforeScaleDown = &nodeIdleTimeBeforeScaleDown
@@ -15031,19 +15031,19 @@ func (settings *ScaleSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScaleSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if typedInput.MaxNodeCount != nil {
 		maxNodeCount := *typedInput.MaxNodeCount
 		settings.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if typedInput.MinNodeCount != nil {
 		minNodeCount := *typedInput.MinNodeCount
 		settings.MinNodeCount = &minNodeCount
 	}
 
-	// Set property ‘NodeIdleTimeBeforeScaleDown’:
+	// Set property "NodeIdleTimeBeforeScaleDown":
 	if typedInput.NodeIdleTimeBeforeScaleDown != nil {
 		nodeIdleTimeBeforeScaleDown := *typedInput.NodeIdleTimeBeforeScaleDown
 		settings.NodeIdleTimeBeforeScaleDown = &nodeIdleTimeBeforeScaleDown
@@ -15136,19 +15136,19 @@ func (settings *ScaleSettings_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScaleSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if typedInput.MaxNodeCount != nil {
 		maxNodeCount := *typedInput.MaxNodeCount
 		settings.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if typedInput.MinNodeCount != nil {
 		minNodeCount := *typedInput.MinNodeCount
 		settings.MinNodeCount = &minNodeCount
 	}
 
-	// Set property ‘NodeIdleTimeBeforeScaleDown’:
+	// Set property "NodeIdleTimeBeforeScaleDown":
 	if typedInput.NodeIdleTimeBeforeScaleDown != nil {
 		nodeIdleTimeBeforeScaleDown := *typedInput.NodeIdleTimeBeforeScaleDown
 		settings.NodeIdleTimeBeforeScaleDown = &nodeIdleTimeBeforeScaleDown
@@ -15214,7 +15214,7 @@ func (scripts *SetupScripts) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SetupScripts_ARM{}
 
-	// Set property ‘Scripts’:
+	// Set property "Scripts":
 	if scripts.Scripts != nil {
 		scripts_ARM, err := (*scripts.Scripts).ConvertToARM(resolved)
 		if err != nil {
@@ -15238,7 +15238,7 @@ func (scripts *SetupScripts) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SetupScripts_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Scripts’:
+	// Set property "Scripts":
 	if typedInput.Scripts != nil {
 		var scripts2 ScriptsToExecute
 		err := scripts2.PopulateFromARM(owner, *typedInput.Scripts)
@@ -15339,7 +15339,7 @@ func (scripts *SetupScripts_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SetupScripts_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Scripts’:
+	// Set property "Scripts":
 	if typedInput.Scripts != nil {
 		var scripts2 ScriptsToExecute_STATUS
 		err := scripts2.PopulateFromARM(owner, *typedInput.Scripts)
@@ -15431,37 +15431,37 @@ func (configuration *SslConfiguration) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &SslConfiguration_ARM{}
 
-	// Set property ‘Cert’:
+	// Set property "Cert":
 	if configuration.Cert != nil {
 		cert := *configuration.Cert
 		result.Cert = &cert
 	}
 
-	// Set property ‘Cname’:
+	// Set property "Cname":
 	if configuration.Cname != nil {
 		cname := *configuration.Cname
 		result.Cname = &cname
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if configuration.Key != nil {
 		key := *configuration.Key
 		result.Key = &key
 	}
 
-	// Set property ‘LeafDomainLabel’:
+	// Set property "LeafDomainLabel":
 	if configuration.LeafDomainLabel != nil {
 		leafDomainLabel := *configuration.LeafDomainLabel
 		result.LeafDomainLabel = &leafDomainLabel
 	}
 
-	// Set property ‘OverwriteExistingDomain’:
+	// Set property "OverwriteExistingDomain":
 	if configuration.OverwriteExistingDomain != nil {
 		overwriteExistingDomain := *configuration.OverwriteExistingDomain
 		result.OverwriteExistingDomain = &overwriteExistingDomain
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if configuration.Status != nil {
 		status := *configuration.Status
 		result.Status = &status
@@ -15481,37 +15481,37 @@ func (configuration *SslConfiguration) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SslConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cert’:
+	// Set property "Cert":
 	if typedInput.Cert != nil {
 		cert := *typedInput.Cert
 		configuration.Cert = &cert
 	}
 
-	// Set property ‘Cname’:
+	// Set property "Cname":
 	if typedInput.Cname != nil {
 		cname := *typedInput.Cname
 		configuration.Cname = &cname
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		configuration.Key = &key
 	}
 
-	// Set property ‘LeafDomainLabel’:
+	// Set property "LeafDomainLabel":
 	if typedInput.LeafDomainLabel != nil {
 		leafDomainLabel := *typedInput.LeafDomainLabel
 		configuration.LeafDomainLabel = &leafDomainLabel
 	}
 
-	// Set property ‘OverwriteExistingDomain’:
+	// Set property "OverwriteExistingDomain":
 	if typedInput.OverwriteExistingDomain != nil {
 		overwriteExistingDomain := *typedInput.OverwriteExistingDomain
 		configuration.OverwriteExistingDomain = &overwriteExistingDomain
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		configuration.Status = &status
@@ -15670,37 +15670,37 @@ func (configuration *SslConfiguration_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SslConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cert’:
+	// Set property "Cert":
 	if typedInput.Cert != nil {
 		cert := *typedInput.Cert
 		configuration.Cert = &cert
 	}
 
-	// Set property ‘Cname’:
+	// Set property "Cname":
 	if typedInput.Cname != nil {
 		cname := *typedInput.Cname
 		configuration.Cname = &cname
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		configuration.Key = &key
 	}
 
-	// Set property ‘LeafDomainLabel’:
+	// Set property "LeafDomainLabel":
 	if typedInput.LeafDomainLabel != nil {
 		leafDomainLabel := *typedInput.LeafDomainLabel
 		configuration.LeafDomainLabel = &leafDomainLabel
 	}
 
-	// Set property ‘OverwriteExistingDomain’:
+	// Set property "OverwriteExistingDomain":
 	if typedInput.OverwriteExistingDomain != nil {
 		overwriteExistingDomain := *typedInput.OverwriteExistingDomain
 		configuration.OverwriteExistingDomain = &overwriteExistingDomain
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		configuration.Status = &status
@@ -15815,19 +15815,19 @@ func (service *SystemService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemService_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIpAddress’:
+	// Set property "PublicIpAddress":
 	if typedInput.PublicIpAddress != nil {
 		publicIpAddress := *typedInput.PublicIpAddress
 		service.PublicIpAddress = &publicIpAddress
 	}
 
-	// Set property ‘SystemServiceType’:
+	// Set property "SystemServiceType":
 	if typedInput.SystemServiceType != nil {
 		systemServiceType := *typedInput.SystemServiceType
 		service.SystemServiceType = &systemServiceType
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		service.Version = &version
@@ -15900,13 +15900,13 @@ func (credentials *UserAccountCredentials) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &UserAccountCredentials_ARM{}
 
-	// Set property ‘AdminUserName’:
+	// Set property "AdminUserName":
 	if credentials.AdminUserName != nil {
 		adminUserName := *credentials.AdminUserName
 		result.AdminUserName = &adminUserName
 	}
 
-	// Set property ‘AdminUserPassword’:
+	// Set property "AdminUserPassword":
 	if credentials.AdminUserPassword != nil {
 		adminUserPasswordSecret, err := resolved.ResolvedSecrets.Lookup(*credentials.AdminUserPassword)
 		if err != nil {
@@ -15916,7 +15916,7 @@ func (credentials *UserAccountCredentials) ConvertToARM(resolved genruntime.Conv
 		result.AdminUserPassword = &adminUserPassword
 	}
 
-	// Set property ‘AdminUserSshPublicKey’:
+	// Set property "AdminUserSshPublicKey":
 	if credentials.AdminUserSshPublicKey != nil {
 		adminUserSshPublicKeySecret, err := resolved.ResolvedSecrets.Lookup(*credentials.AdminUserSshPublicKey)
 		if err != nil {
@@ -15940,15 +15940,15 @@ func (credentials *UserAccountCredentials) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAccountCredentials_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUserName’:
+	// Set property "AdminUserName":
 	if typedInput.AdminUserName != nil {
 		adminUserName := *typedInput.AdminUserName
 		credentials.AdminUserName = &adminUserName
 	}
 
-	// no assignment for property ‘AdminUserPassword’
+	// no assignment for property "AdminUserPassword"
 
-	// no assignment for property ‘AdminUserSshPublicKey’
+	// no assignment for property "AdminUserSshPublicKey"
 
 	// No error
 	return nil
@@ -16045,7 +16045,7 @@ func (credentials *UserAccountCredentials_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAccountCredentials_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUserName’:
+	// Set property "AdminUserName":
 	if typedInput.AdminUserName != nil {
 		adminUserName := *typedInput.AdminUserName
 		credentials.AdminUserName = &adminUserName
@@ -16100,7 +16100,7 @@ func (image *VirtualMachineImage) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &VirtualMachineImage_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if image.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*image.Reference)
 		if err != nil {
@@ -16124,7 +16124,7 @@ func (image *VirtualMachineImage) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineImage_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -16204,7 +16204,7 @@ func (image *VirtualMachineImage_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineImage_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		image.Id = &id
@@ -16267,7 +16267,7 @@ func (credentials *VirtualMachineSshCredentials) ConvertToARM(resolved genruntim
 	}
 	result := &VirtualMachineSshCredentials_ARM{}
 
-	// Set property ‘Password’:
+	// Set property "Password":
 	if credentials.Password != nil {
 		passwordSecret, err := resolved.ResolvedSecrets.Lookup(*credentials.Password)
 		if err != nil {
@@ -16277,19 +16277,19 @@ func (credentials *VirtualMachineSshCredentials) ConvertToARM(resolved genruntim
 		result.Password = &password
 	}
 
-	// Set property ‘PrivateKeyData’:
+	// Set property "PrivateKeyData":
 	if credentials.PrivateKeyData != nil {
 		privateKeyData := *credentials.PrivateKeyData
 		result.PrivateKeyData = &privateKeyData
 	}
 
-	// Set property ‘PublicKeyData’:
+	// Set property "PublicKeyData":
 	if credentials.PublicKeyData != nil {
 		publicKeyData := *credentials.PublicKeyData
 		result.PublicKeyData = &publicKeyData
 	}
 
-	// Set property ‘Username’:
+	// Set property "Username":
 	if credentials.Username != nil {
 		username := *credentials.Username
 		result.Username = &username
@@ -16309,21 +16309,21 @@ func (credentials *VirtualMachineSshCredentials) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineSshCredentials_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Password’
+	// no assignment for property "Password"
 
-	// Set property ‘PrivateKeyData’:
+	// Set property "PrivateKeyData":
 	if typedInput.PrivateKeyData != nil {
 		privateKeyData := *typedInput.PrivateKeyData
 		credentials.PrivateKeyData = &privateKeyData
 	}
 
-	// Set property ‘PublicKeyData’:
+	// Set property "PublicKeyData":
 	if typedInput.PublicKeyData != nil {
 		publicKeyData := *typedInput.PublicKeyData
 		credentials.PublicKeyData = &publicKeyData
 	}
 
-	// Set property ‘Username’:
+	// Set property "Username":
 	if typedInput.Username != nil {
 		username := *typedInput.Username
 		credentials.Username = &username
@@ -16432,19 +16432,19 @@ func (credentials *VirtualMachineSshCredentials_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineSshCredentials_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrivateKeyData’:
+	// Set property "PrivateKeyData":
 	if typedInput.PrivateKeyData != nil {
 		privateKeyData := *typedInput.PrivateKeyData
 		credentials.PrivateKeyData = &privateKeyData
 	}
 
-	// Set property ‘PublicKeyData’:
+	// Set property "PublicKeyData":
 	if typedInput.PublicKeyData != nil {
 		publicKeyData := *typedInput.PublicKeyData
 		credentials.PublicKeyData = &publicKeyData
 	}
 
-	// Set property ‘Username’:
+	// Set property "Username":
 	if typedInput.Username != nil {
 		username := *typedInput.Username
 		credentials.Username = &username
@@ -16515,13 +16515,13 @@ func (user *AssignedUser) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &AssignedUser_ARM{}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if user.ObjectId != nil {
 		objectId := *user.ObjectId
 		result.ObjectId = &objectId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if user.TenantId != nil {
 		tenantId := *user.TenantId
 		result.TenantId = &tenantId
@@ -16541,13 +16541,13 @@ func (user *AssignedUser) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AssignedUser_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		user.ObjectId = &objectId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		user.TenantId = &tenantId
@@ -16628,13 +16628,13 @@ func (user *AssignedUser_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AssignedUser_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		user.ObjectId = &objectId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		user.TenantId = &tenantId
@@ -16702,7 +16702,7 @@ func (info *ErrorAdditionalInfo_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ErrorAdditionalInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Info’:
+	// Set property "Info":
 	if typedInput.Info != nil {
 		info.Info = make(map[string]v1.JSON, len(typedInput.Info))
 		for key, value := range typedInput.Info {
@@ -16710,7 +16710,7 @@ func (info *ErrorAdditionalInfo_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		info.Type = &typeVar
@@ -16803,7 +16803,7 @@ func (unrolled *ErrorDetail_STATUS_Unrolled) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ErrorDetail_STATUS_Unrolled_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalInfo’:
+	// Set property "AdditionalInfo":
 	for _, item := range typedInput.AdditionalInfo {
 		var item1 ErrorAdditionalInfo_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -16813,19 +16813,19 @@ func (unrolled *ErrorDetail_STATUS_Unrolled) PopulateFromARM(owner genruntime.Ar
 		unrolled.AdditionalInfo = append(unrolled.AdditionalInfo, item1)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		unrolled.Code = &code
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		unrolled.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		unrolled.Target = &target
@@ -16929,7 +16929,7 @@ func (resources *InstanceTypeSchema_Resources) ConvertToARM(resolved genruntime.
 	}
 	result := &InstanceTypeSchema_Resources_ARM{}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if resources.Limits != nil {
 		result.Limits = make(map[string]string, len(resources.Limits))
 		for key, value := range resources.Limits {
@@ -16937,7 +16937,7 @@ func (resources *InstanceTypeSchema_Resources) ConvertToARM(resolved genruntime.
 		}
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if resources.Requests != nil {
 		result.Requests = make(map[string]string, len(resources.Requests))
 		for key, value := range resources.Requests {
@@ -16959,7 +16959,7 @@ func (resources *InstanceTypeSchema_Resources) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InstanceTypeSchema_Resources_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if typedInput.Limits != nil {
 		resources.Limits = make(map[string]string, len(typedInput.Limits))
 		for key, value := range typedInput.Limits {
@@ -16967,7 +16967,7 @@ func (resources *InstanceTypeSchema_Resources) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if typedInput.Requests != nil {
 		resources.Requests = make(map[string]string, len(typedInput.Requests))
 		for key, value := range typedInput.Requests {
@@ -17049,7 +17049,7 @@ func (resources *InstanceTypeSchema_Resources_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InstanceTypeSchema_Resources_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if typedInput.Limits != nil {
 		resources.Limits = make(map[string]string, len(typedInput.Limits))
 		for key, value := range typedInput.Limits {
@@ -17057,7 +17057,7 @@ func (resources *InstanceTypeSchema_Resources_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if typedInput.Requests != nil {
 		resources.Requests = make(map[string]string, len(typedInput.Requests))
 		for key, value := range typedInput.Requests {
@@ -17122,7 +17122,7 @@ func (execute *ScriptsToExecute) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ScriptsToExecute_ARM{}
 
-	// Set property ‘CreationScript’:
+	// Set property "CreationScript":
 	if execute.CreationScript != nil {
 		creationScript_ARM, err := (*execute.CreationScript).ConvertToARM(resolved)
 		if err != nil {
@@ -17132,7 +17132,7 @@ func (execute *ScriptsToExecute) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.CreationScript = &creationScript
 	}
 
-	// Set property ‘StartupScript’:
+	// Set property "StartupScript":
 	if execute.StartupScript != nil {
 		startupScript_ARM, err := (*execute.StartupScript).ConvertToARM(resolved)
 		if err != nil {
@@ -17156,7 +17156,7 @@ func (execute *ScriptsToExecute) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScriptsToExecute_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreationScript’:
+	// Set property "CreationScript":
 	if typedInput.CreationScript != nil {
 		var creationScript1 ScriptReference
 		err := creationScript1.PopulateFromARM(owner, *typedInput.CreationScript)
@@ -17167,7 +17167,7 @@ func (execute *ScriptsToExecute) PopulateFromARM(owner genruntime.ArbitraryOwner
 		execute.CreationScript = &creationScript
 	}
 
-	// Set property ‘StartupScript’:
+	// Set property "StartupScript":
 	if typedInput.StartupScript != nil {
 		var startupScript1 ScriptReference
 		err := startupScript1.PopulateFromARM(owner, *typedInput.StartupScript)
@@ -17307,7 +17307,7 @@ func (execute *ScriptsToExecute_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScriptsToExecute_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreationScript’:
+	// Set property "CreationScript":
 	if typedInput.CreationScript != nil {
 		var creationScript1 ScriptReference_STATUS
 		err := creationScript1.PopulateFromARM(owner, *typedInput.CreationScript)
@@ -17318,7 +17318,7 @@ func (execute *ScriptsToExecute_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		execute.CreationScript = &creationScript
 	}
 
-	// Set property ‘StartupScript’:
+	// Set property "StartupScript":
 	if typedInput.StartupScript != nil {
 		var startupScript1 ScriptReference_STATUS
 		err := startupScript1.PopulateFromARM(owner, *typedInput.StartupScript)
@@ -17428,25 +17428,25 @@ func (reference *ScriptReference) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ScriptReference_ARM{}
 
-	// Set property ‘ScriptArguments’:
+	// Set property "ScriptArguments":
 	if reference.ScriptArguments != nil {
 		scriptArguments := *reference.ScriptArguments
 		result.ScriptArguments = &scriptArguments
 	}
 
-	// Set property ‘ScriptData’:
+	// Set property "ScriptData":
 	if reference.ScriptData != nil {
 		scriptData := *reference.ScriptData
 		result.ScriptData = &scriptData
 	}
 
-	// Set property ‘ScriptSource’:
+	// Set property "ScriptSource":
 	if reference.ScriptSource != nil {
 		scriptSource := *reference.ScriptSource
 		result.ScriptSource = &scriptSource
 	}
 
-	// Set property ‘Timeout’:
+	// Set property "Timeout":
 	if reference.Timeout != nil {
 		timeout := *reference.Timeout
 		result.Timeout = &timeout
@@ -17466,25 +17466,25 @@ func (reference *ScriptReference) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScriptReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ScriptArguments’:
+	// Set property "ScriptArguments":
 	if typedInput.ScriptArguments != nil {
 		scriptArguments := *typedInput.ScriptArguments
 		reference.ScriptArguments = &scriptArguments
 	}
 
-	// Set property ‘ScriptData’:
+	// Set property "ScriptData":
 	if typedInput.ScriptData != nil {
 		scriptData := *typedInput.ScriptData
 		reference.ScriptData = &scriptData
 	}
 
-	// Set property ‘ScriptSource’:
+	// Set property "ScriptSource":
 	if typedInput.ScriptSource != nil {
 		scriptSource := *typedInput.ScriptSource
 		reference.ScriptSource = &scriptSource
 	}
 
-	// Set property ‘Timeout’:
+	// Set property "Timeout":
 	if typedInput.Timeout != nil {
 		timeout := *typedInput.Timeout
 		reference.Timeout = &timeout
@@ -17589,25 +17589,25 @@ func (reference *ScriptReference_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScriptReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ScriptArguments’:
+	// Set property "ScriptArguments":
 	if typedInput.ScriptArguments != nil {
 		scriptArguments := *typedInput.ScriptArguments
 		reference.ScriptArguments = &scriptArguments
 	}
 
-	// Set property ‘ScriptData’:
+	// Set property "ScriptData":
 	if typedInput.ScriptData != nil {
 		scriptData := *typedInput.ScriptData
 		reference.ScriptData = &scriptData
 	}
 
-	// Set property ‘ScriptSource’:
+	// Set property "ScriptSource":
 	if typedInput.ScriptSource != nil {
 		scriptSource := *typedInput.ScriptSource
 		reference.ScriptSource = &scriptSource
 	}
 
-	// Set property ‘Timeout’:
+	// Set property "Timeout":
 	if typedInput.Timeout != nil {
 		timeout := *typedInput.Timeout
 		reference.Timeout = &timeout

--- a/v2/api/machinelearningservices/v1api20210701/workspaces_connection_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20210701/workspaces_connection_types_gen.go
@@ -346,10 +346,10 @@ func (connection *Workspaces_Connection_Spec) ConvertToARM(resolved genruntime.C
 	}
 	result := &Workspaces_Connection_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if connection.AuthType != nil ||
 		connection.Category != nil ||
 		connection.Target != nil ||
@@ -392,7 +392,7 @@ func (connection *Workspaces_Connection_Spec) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspaces_Connection_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthType’:
+	// Set property "AuthType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AuthType != nil {
@@ -401,10 +401,10 @@ func (connection *Workspaces_Connection_Spec) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	connection.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Category’:
+	// Set property "Category":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Category != nil {
@@ -413,10 +413,10 @@ func (connection *Workspaces_Connection_Spec) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	connection.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Target != nil {
@@ -425,7 +425,7 @@ func (connection *Workspaces_Connection_Spec) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {
@@ -434,7 +434,7 @@ func (connection *Workspaces_Connection_Spec) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ValueFormat’:
+	// Set property "ValueFormat":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ValueFormat != nil {
@@ -715,7 +715,7 @@ func (connection *Workspaces_Connection_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspaces_Connection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthType’:
+	// Set property "AuthType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AuthType != nil {
@@ -724,7 +724,7 @@ func (connection *Workspaces_Connection_STATUS) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// Set property ‘Category’:
+	// Set property "Category":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Category != nil {
@@ -733,21 +733,21 @@ func (connection *Workspaces_Connection_STATUS) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		connection.Name = &name
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Target != nil {
@@ -756,13 +756,13 @@ func (connection *Workspaces_Connection_STATUS) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		connection.Type = &typeVar
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {
@@ -771,7 +771,7 @@ func (connection *Workspaces_Connection_STATUS) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// Set property ‘ValueFormat’:
+	// Set property "ValueFormat":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ValueFormat != nil {

--- a/v2/api/machinelearningservices/v1beta20210701/workspace_types_gen.go
+++ b/v2/api/machinelearningservices/v1beta20210701/workspace_types_gen.go
@@ -385,7 +385,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &Workspace_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if workspace.Identity != nil {
 		identity_ARM, err := (*workspace.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -395,16 +395,16 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if workspace.Location != nil {
 		location := *workspace.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if workspace.AllowPublicAccessWhenBehindVnet != nil ||
 		workspace.ApplicationInsightsReference != nil ||
 		workspace.ContainerRegistryReference != nil ||
@@ -514,7 +514,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.StorageAccount = &storageAccount
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if workspace.Sku != nil {
 		sku_ARM, err := (*workspace.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -524,7 +524,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if workspace.SystemData != nil {
 		systemData_ARM, err := (*workspace.SystemData).ConvertToARM(resolved)
 		if err != nil {
@@ -534,7 +534,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if workspace.Tags != nil {
 		result.Tags = make(map[string]string, len(workspace.Tags))
 		for key, value := range workspace.Tags {
@@ -556,7 +556,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspace_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowPublicAccessWhenBehindVnet’:
+	// Set property "AllowPublicAccessWhenBehindVnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowPublicAccessWhenBehindVnet != nil {
@@ -565,14 +565,14 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// no assignment for property ‘ApplicationInsightsReference’
+	// no assignment for property "ApplicationInsightsReference"
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	workspace.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// no assignment for property ‘ContainerRegistryReference’
+	// no assignment for property "ContainerRegistryReference"
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -581,7 +581,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DiscoveryUrl’:
+	// Set property "DiscoveryUrl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiscoveryUrl != nil {
@@ -590,7 +590,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -604,7 +604,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘FriendlyName’:
+	// Set property "FriendlyName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FriendlyName != nil {
@@ -613,7 +613,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘HbiWorkspace’:
+	// Set property "HbiWorkspace":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HbiWorkspace != nil {
@@ -622,7 +622,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -633,7 +633,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		workspace.Identity = &identity
 	}
 
-	// Set property ‘ImageBuildCompute’:
+	// Set property "ImageBuildCompute":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImageBuildCompute != nil {
@@ -642,22 +642,22 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// no assignment for property ‘KeyVaultReference’
+	// no assignment for property "KeyVaultReference"
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		workspace.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	workspace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// no assignment for property ‘PrimaryUserAssignedIdentityReference’
+	// no assignment for property "PrimaryUserAssignedIdentityReference"
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -666,7 +666,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ServiceManagedResourcesSettings’:
+	// Set property "ServiceManagedResourcesSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceManagedResourcesSettings != nil {
@@ -680,7 +680,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘SharedPrivateLinkResources’:
+	// Set property "SharedPrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SharedPrivateLinkResources {
@@ -693,7 +693,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -704,9 +704,9 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		workspace.Sku = &sku
 	}
 
-	// no assignment for property ‘StorageAccountReference’
+	// no assignment for property "StorageAccountReference"
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -717,7 +717,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		workspace.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		workspace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1282,7 +1282,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspace_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowPublicAccessWhenBehindVnet’:
+	// Set property "AllowPublicAccessWhenBehindVnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowPublicAccessWhenBehindVnet != nil {
@@ -1291,7 +1291,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ApplicationInsights’:
+	// Set property "ApplicationInsights":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApplicationInsights != nil {
@@ -1300,9 +1300,9 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ContainerRegistry’:
+	// Set property "ContainerRegistry":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ContainerRegistry != nil {
@@ -1311,7 +1311,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -1320,7 +1320,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘DiscoveryUrl’:
+	// Set property "DiscoveryUrl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiscoveryUrl != nil {
@@ -1329,7 +1329,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1343,7 +1343,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘FriendlyName’:
+	// Set property "FriendlyName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FriendlyName != nil {
@@ -1352,7 +1352,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HbiWorkspace’:
+	// Set property "HbiWorkspace":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HbiWorkspace != nil {
@@ -1361,13 +1361,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		workspace.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1378,7 +1378,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		workspace.Identity = &identity
 	}
 
-	// Set property ‘ImageBuildCompute’:
+	// Set property "ImageBuildCompute":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImageBuildCompute != nil {
@@ -1387,7 +1387,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘KeyVault’:
+	// Set property "KeyVault":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVault != nil {
@@ -1396,13 +1396,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		workspace.Location = &location
 	}
 
-	// Set property ‘MlFlowTrackingUri’:
+	// Set property "MlFlowTrackingUri":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MlFlowTrackingUri != nil {
@@ -1411,13 +1411,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		workspace.Name = &name
 	}
 
-	// Set property ‘NotebookInfo’:
+	// Set property "NotebookInfo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NotebookInfo != nil {
@@ -1431,7 +1431,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PrimaryUserAssignedIdentity’:
+	// Set property "PrimaryUserAssignedIdentity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrimaryUserAssignedIdentity != nil {
@@ -1440,7 +1440,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1453,7 +1453,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PrivateLinkCount’:
+	// Set property "PrivateLinkCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkCount != nil {
@@ -1462,7 +1462,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1471,7 +1471,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1480,7 +1480,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ServiceManagedResourcesSettings’:
+	// Set property "ServiceManagedResourcesSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceManagedResourcesSettings != nil {
@@ -1494,7 +1494,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ServiceProvisionedResourceGroup’:
+	// Set property "ServiceProvisionedResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceProvisionedResourceGroup != nil {
@@ -1503,7 +1503,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SharedPrivateLinkResources’:
+	// Set property "SharedPrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SharedPrivateLinkResources {
@@ -1516,7 +1516,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1527,7 +1527,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		workspace.Sku = &sku
 	}
 
-	// Set property ‘StorageAccount’:
+	// Set property "StorageAccount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageAccount != nil {
@@ -1536,7 +1536,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘StorageHnsEnabled’:
+	// Set property "StorageHnsEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageHnsEnabled != nil {
@@ -1545,7 +1545,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1556,7 +1556,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		workspace.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		workspace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1564,7 +1564,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantId != nil {
@@ -1573,13 +1573,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		workspace.Type = &typeVar
 	}
 
-	// Set property ‘WorkspaceId’:
+	// Set property "WorkspaceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkspaceId != nil {
@@ -2051,7 +2051,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &EncryptionProperty_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if property.Identity != nil {
 		identity_ARM, err := (*property.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -2061,7 +2061,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Identity = &identity
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if property.KeyVaultProperties != nil {
 		keyVaultProperties_ARM, err := (*property.KeyVaultProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -2071,7 +2071,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 		result.KeyVaultProperties = &keyVaultProperties
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if property.Status != nil {
 		status := *property.Status
 		result.Status = &status
@@ -2091,7 +2091,7 @@ func (property *EncryptionProperty) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperty_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 IdentityForCmk
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2102,7 +2102,7 @@ func (property *EncryptionProperty) PopulateFromARM(owner genruntime.ArbitraryOw
 		property.Identity = &identity
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -2113,7 +2113,7 @@ func (property *EncryptionProperty) PopulateFromARM(owner genruntime.ArbitraryOw
 		property.KeyVaultProperties = &keyVaultProperties
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		property.Status = &status
@@ -2231,7 +2231,7 @@ func (property *EncryptionProperty_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 IdentityForCmk_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2242,7 +2242,7 @@ func (property *EncryptionProperty_STATUS) PopulateFromARM(owner genruntime.Arbi
 		property.Identity = &identity
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	if typedInput.KeyVaultProperties != nil {
 		var keyVaultProperties1 KeyVaultProperties_STATUS
 		err := keyVaultProperties1.PopulateFromARM(owner, *typedInput.KeyVaultProperties)
@@ -2253,7 +2253,7 @@ func (property *EncryptionProperty_STATUS) PopulateFromARM(owner genruntime.Arbi
 		property.KeyVaultProperties = &keyVaultProperties
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		property.Status = &status
@@ -2365,13 +2365,13 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Identity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -2396,13 +2396,13 @@ func (identity *Identity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -2505,25 +2505,25 @@ func (identity *Identity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2648,13 +2648,13 @@ func (info *NotebookResourceInfo_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NotebookResourceInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	if typedInput.Fqdn != nil {
 		fqdn := *typedInput.Fqdn
 		info.Fqdn = &fqdn
 	}
 
-	// Set property ‘NotebookPreparationError’:
+	// Set property "NotebookPreparationError":
 	if typedInput.NotebookPreparationError != nil {
 		var notebookPreparationError1 NotebookPreparationError_STATUS
 		err := notebookPreparationError1.PopulateFromARM(owner, *typedInput.NotebookPreparationError)
@@ -2665,7 +2665,7 @@ func (info *NotebookResourceInfo_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		info.NotebookPreparationError = &notebookPreparationError
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		info.ResourceId = &resourceId
@@ -2753,7 +2753,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -2806,7 +2806,7 @@ func (settings *ServiceManagedResourcesSettings) ConvertToARM(resolved genruntim
 	}
 	result := &ServiceManagedResourcesSettings_ARM{}
 
-	// Set property ‘CosmosDb’:
+	// Set property "CosmosDb":
 	if settings.CosmosDb != nil {
 		cosmosDb_ARM, err := (*settings.CosmosDb).ConvertToARM(resolved)
 		if err != nil {
@@ -2830,7 +2830,7 @@ func (settings *ServiceManagedResourcesSettings) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceManagedResourcesSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CosmosDb’:
+	// Set property "CosmosDb":
 	if typedInput.CosmosDb != nil {
 		var cosmosDb1 CosmosDbSettings
 		err := cosmosDb1.PopulateFromARM(owner, *typedInput.CosmosDb)
@@ -2911,7 +2911,7 @@ func (settings *ServiceManagedResourcesSettings_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceManagedResourcesSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CosmosDb’:
+	// Set property "CosmosDb":
 	if typedInput.CosmosDb != nil {
 		var cosmosDb1 CosmosDbSettings_STATUS
 		err := cosmosDb1.PopulateFromARM(owner, *typedInput.CosmosDb)
@@ -2991,13 +2991,13 @@ func (resource *SharedPrivateLinkResource) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &SharedPrivateLinkResource_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if resource.Name != nil {
 		name := *resource.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if resource.GroupId != nil ||
 		resource.PrivateLinkResourceReference != nil ||
 		resource.RequestMessage != nil ||
@@ -3039,7 +3039,7 @@ func (resource *SharedPrivateLinkResource) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SharedPrivateLinkResource_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GroupId != nil {
@@ -3048,15 +3048,15 @@ func (resource *SharedPrivateLinkResource) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resource.Name = &name
 	}
 
-	// no assignment for property ‘PrivateLinkResourceReference’
+	// no assignment for property "PrivateLinkResourceReference"
 
-	// Set property ‘RequestMessage’:
+	// Set property "RequestMessage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequestMessage != nil {
@@ -3065,7 +3065,7 @@ func (resource *SharedPrivateLinkResource) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -3174,7 +3174,7 @@ func (resource *SharedPrivateLinkResource_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SharedPrivateLinkResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GroupId != nil {
@@ -3183,13 +3183,13 @@ func (resource *SharedPrivateLinkResource_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resource.Name = &name
 	}
 
-	// Set property ‘PrivateLinkResourceId’:
+	// Set property "PrivateLinkResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkResourceId != nil {
@@ -3198,7 +3198,7 @@ func (resource *SharedPrivateLinkResource_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘RequestMessage’:
+	// Set property "RequestMessage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequestMessage != nil {
@@ -3207,7 +3207,7 @@ func (resource *SharedPrivateLinkResource_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -3298,13 +3298,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -3324,13 +3324,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3395,13 +3395,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3465,37 +3465,37 @@ func (data *SystemData) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &SystemData_ARM{}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if data.CreatedAt != nil {
 		createdAt := *data.CreatedAt
 		result.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if data.CreatedBy != nil {
 		createdBy := *data.CreatedBy
 		result.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if data.CreatedByType != nil {
 		createdByType := *data.CreatedByType
 		result.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if data.LastModifiedAt != nil {
 		lastModifiedAt := *data.LastModifiedAt
 		result.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if data.LastModifiedBy != nil {
 		lastModifiedBy := *data.LastModifiedBy
 		result.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if data.LastModifiedByType != nil {
 		lastModifiedByType := *data.LastModifiedByType
 		result.LastModifiedByType = &lastModifiedByType
@@ -3515,37 +3515,37 @@ func (data *SystemData) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -3658,37 +3658,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -3877,7 +3877,7 @@ func (settings *CosmosDbSettings) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &CosmosDbSettings_ARM{}
 
-	// Set property ‘CollectionsThroughput’:
+	// Set property "CollectionsThroughput":
 	if settings.CollectionsThroughput != nil {
 		collectionsThroughput := *settings.CollectionsThroughput
 		result.CollectionsThroughput = &collectionsThroughput
@@ -3897,7 +3897,7 @@ func (settings *CosmosDbSettings) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CosmosDbSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CollectionsThroughput’:
+	// Set property "CollectionsThroughput":
 	if typedInput.CollectionsThroughput != nil {
 		collectionsThroughput := *typedInput.CollectionsThroughput
 		settings.CollectionsThroughput = &collectionsThroughput
@@ -3955,7 +3955,7 @@ func (settings *CosmosDbSettings_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CosmosDbSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CollectionsThroughput’:
+	// Set property "CollectionsThroughput":
 	if typedInput.CollectionsThroughput != nil {
 		collectionsThroughput := *typedInput.CollectionsThroughput
 		settings.CollectionsThroughput = &collectionsThroughput
@@ -4025,7 +4025,7 @@ func (forCmk *IdentityForCmk) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &IdentityForCmk_ARM{}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if forCmk.UserAssignedIdentity != nil {
 		userAssignedIdentity := *forCmk.UserAssignedIdentity
 		result.UserAssignedIdentity = &userAssignedIdentity
@@ -4045,7 +4045,7 @@ func (forCmk *IdentityForCmk) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IdentityForCmk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		forCmk.UserAssignedIdentity = &userAssignedIdentity
@@ -4103,7 +4103,7 @@ func (forCmk *IdentityForCmk_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IdentityForCmk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		forCmk.UserAssignedIdentity = &userAssignedIdentity
@@ -4162,19 +4162,19 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘IdentityClientId’:
+	// Set property "IdentityClientId":
 	if properties.IdentityClientId != nil {
 		identityClientId := *properties.IdentityClientId
 		result.IdentityClientId = &identityClientId
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if properties.KeyIdentifier != nil {
 		keyIdentifier := *properties.KeyIdentifier
 		result.KeyIdentifier = &keyIdentifier
 	}
 
-	// Set property ‘KeyVaultArmId’:
+	// Set property "KeyVaultArmId":
 	if properties.KeyVaultArmId != nil {
 		keyVaultArmId := *properties.KeyVaultArmId
 		result.KeyVaultArmId = &keyVaultArmId
@@ -4194,19 +4194,19 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IdentityClientId’:
+	// Set property "IdentityClientId":
 	if typedInput.IdentityClientId != nil {
 		identityClientId := *typedInput.IdentityClientId
 		properties.IdentityClientId = &identityClientId
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
 	}
 
-	// Set property ‘KeyVaultArmId’:
+	// Set property "KeyVaultArmId":
 	if typedInput.KeyVaultArmId != nil {
 		keyVaultArmId := *typedInput.KeyVaultArmId
 		properties.KeyVaultArmId = &keyVaultArmId
@@ -4278,19 +4278,19 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IdentityClientId’:
+	// Set property "IdentityClientId":
 	if typedInput.IdentityClientId != nil {
 		identityClientId := *typedInput.IdentityClientId
 		properties.IdentityClientId = &identityClientId
 	}
 
-	// Set property ‘KeyIdentifier’:
+	// Set property "KeyIdentifier":
 	if typedInput.KeyIdentifier != nil {
 		keyIdentifier := *typedInput.KeyIdentifier
 		properties.KeyIdentifier = &keyIdentifier
 	}
 
-	// Set property ‘KeyVaultArmId’:
+	// Set property "KeyVaultArmId":
 	if typedInput.KeyVaultArmId != nil {
 		keyVaultArmId := *typedInput.KeyVaultArmId
 		properties.KeyVaultArmId = &keyVaultArmId
@@ -4361,13 +4361,13 @@ func (error *NotebookPreparationError_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NotebookPreparationError_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ErrorMessage’:
+	// Set property "ErrorMessage":
 	if typedInput.ErrorMessage != nil {
 		errorMessage := *typedInput.ErrorMessage
 		error.ErrorMessage = &errorMessage
 	}
 
-	// Set property ‘StatusCode’:
+	// Set property "StatusCode":
 	if typedInput.StatusCode != nil {
 		statusCode := *typedInput.StatusCode
 		error.StatusCode = &statusCode
@@ -4458,19 +4458,19 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId

--- a/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_types_gen.go
+++ b/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_types_gen.go
@@ -337,7 +337,7 @@ func (compute *Workspaces_Compute_Spec) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &Workspaces_Compute_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if compute.Identity != nil {
 		identity_ARM, err := (*compute.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -347,16 +347,16 @@ func (compute *Workspaces_Compute_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if compute.Location != nil {
 		location := *compute.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if compute.Properties != nil {
 		properties_ARM, err := (*compute.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -366,7 +366,7 @@ func (compute *Workspaces_Compute_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties = &properties
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if compute.Sku != nil {
 		sku_ARM, err := (*compute.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -376,7 +376,7 @@ func (compute *Workspaces_Compute_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if compute.SystemData != nil {
 		systemData_ARM, err := (*compute.SystemData).ConvertToARM(resolved)
 		if err != nil {
@@ -386,7 +386,7 @@ func (compute *Workspaces_Compute_Spec) ConvertToARM(resolved genruntime.Convert
 		result.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if compute.Tags != nil {
 		result.Tags = make(map[string]string, len(compute.Tags))
 		for key, value := range compute.Tags {
@@ -408,10 +408,10 @@ func (compute *Workspaces_Compute_Spec) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspaces_Compute_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	compute.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -422,16 +422,16 @@ func (compute *Workspaces_Compute_Spec) PopulateFromARM(owner genruntime.Arbitra
 		compute.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		compute.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	compute.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 Compute
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -442,7 +442,7 @@ func (compute *Workspaces_Compute_Spec) PopulateFromARM(owner genruntime.Arbitra
 		compute.Properties = &properties
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -453,7 +453,7 @@ func (compute *Workspaces_Compute_Spec) PopulateFromARM(owner genruntime.Arbitra
 		compute.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -464,7 +464,7 @@ func (compute *Workspaces_Compute_Spec) PopulateFromARM(owner genruntime.Arbitra
 		compute.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		compute.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -769,15 +769,15 @@ func (compute *Workspaces_Compute_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspaces_Compute_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		compute.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -788,19 +788,19 @@ func (compute *Workspaces_Compute_STATUS) PopulateFromARM(owner genruntime.Arbit
 		compute.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		compute.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		compute.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 Compute_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -811,7 +811,7 @@ func (compute *Workspaces_Compute_STATUS) PopulateFromARM(owner genruntime.Arbit
 		compute.Properties = &properties
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -822,7 +822,7 @@ func (compute *Workspaces_Compute_STATUS) PopulateFromARM(owner genruntime.Arbit
 		compute.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -833,7 +833,7 @@ func (compute *Workspaces_Compute_STATUS) PopulateFromARM(owner genruntime.Arbit
 		compute.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		compute.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -841,7 +841,7 @@ func (compute *Workspaces_Compute_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		compute.Type = &typeVar
@@ -1029,7 +1029,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &Compute_ARM{}
 
-	// Set property ‘AKS’:
+	// Set property "AKS":
 	if compute.AKS != nil {
 		aks_ARM, err := (*compute.AKS).ConvertToARM(resolved)
 		if err != nil {
@@ -1039,7 +1039,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.AKS = &aks
 	}
 
-	// Set property ‘AmlCompute’:
+	// Set property "AmlCompute":
 	if compute.AmlCompute != nil {
 		amlCompute_ARM, err := (*compute.AmlCompute).ConvertToARM(resolved)
 		if err != nil {
@@ -1049,7 +1049,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.AmlCompute = &amlCompute
 	}
 
-	// Set property ‘ComputeInstance’:
+	// Set property "ComputeInstance":
 	if compute.ComputeInstance != nil {
 		computeInstance_ARM, err := (*compute.ComputeInstance).ConvertToARM(resolved)
 		if err != nil {
@@ -1059,7 +1059,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.ComputeInstance = &computeInstance
 	}
 
-	// Set property ‘DataFactory’:
+	// Set property "DataFactory":
 	if compute.DataFactory != nil {
 		dataFactory_ARM, err := (*compute.DataFactory).ConvertToARM(resolved)
 		if err != nil {
@@ -1069,7 +1069,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.DataFactory = &dataFactory
 	}
 
-	// Set property ‘DataLakeAnalytics’:
+	// Set property "DataLakeAnalytics":
 	if compute.DataLakeAnalytics != nil {
 		dataLakeAnalytics_ARM, err := (*compute.DataLakeAnalytics).ConvertToARM(resolved)
 		if err != nil {
@@ -1079,7 +1079,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.DataLakeAnalytics = &dataLakeAnalytics
 	}
 
-	// Set property ‘Databricks’:
+	// Set property "Databricks":
 	if compute.Databricks != nil {
 		databricks_ARM, err := (*compute.Databricks).ConvertToARM(resolved)
 		if err != nil {
@@ -1089,7 +1089,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.Databricks = &databricks
 	}
 
-	// Set property ‘HDInsight’:
+	// Set property "HDInsight":
 	if compute.HDInsight != nil {
 		hdInsight_ARM, err := (*compute.HDInsight).ConvertToARM(resolved)
 		if err != nil {
@@ -1099,7 +1099,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.HDInsight = &hdInsight
 	}
 
-	// Set property ‘Kubernetes’:
+	// Set property "Kubernetes":
 	if compute.Kubernetes != nil {
 		kubernetes_ARM, err := (*compute.Kubernetes).ConvertToARM(resolved)
 		if err != nil {
@@ -1109,7 +1109,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.Kubernetes = &kubernetes
 	}
 
-	// Set property ‘SynapseSpark’:
+	// Set property "SynapseSpark":
 	if compute.SynapseSpark != nil {
 		synapseSpark_ARM, err := (*compute.SynapseSpark).ConvertToARM(resolved)
 		if err != nil {
@@ -1119,7 +1119,7 @@ func (compute *Compute) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		result.SynapseSpark = &synapseSpark
 	}
 
-	// Set property ‘VirtualMachine’:
+	// Set property "VirtualMachine":
 	if compute.VirtualMachine != nil {
 		virtualMachine_ARM, err := (*compute.VirtualMachine).ConvertToARM(resolved)
 		if err != nil {
@@ -1143,7 +1143,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Compute_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AKS’:
+	// Set property "AKS":
 	if typedInput.AKS != nil {
 		var aks1 AKS
 		err := aks1.PopulateFromARM(owner, *typedInput.AKS)
@@ -1154,7 +1154,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.AKS = &aks
 	}
 
-	// Set property ‘AmlCompute’:
+	// Set property "AmlCompute":
 	if typedInput.AmlCompute != nil {
 		var amlCompute1 AmlCompute
 		err := amlCompute1.PopulateFromARM(owner, *typedInput.AmlCompute)
@@ -1165,7 +1165,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.AmlCompute = &amlCompute
 	}
 
-	// Set property ‘ComputeInstance’:
+	// Set property "ComputeInstance":
 	if typedInput.ComputeInstance != nil {
 		var computeInstance1 ComputeInstance
 		err := computeInstance1.PopulateFromARM(owner, *typedInput.ComputeInstance)
@@ -1176,7 +1176,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.ComputeInstance = &computeInstance
 	}
 
-	// Set property ‘DataFactory’:
+	// Set property "DataFactory":
 	if typedInput.DataFactory != nil {
 		var dataFactory1 DataFactory
 		err := dataFactory1.PopulateFromARM(owner, *typedInput.DataFactory)
@@ -1187,7 +1187,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.DataFactory = &dataFactory
 	}
 
-	// Set property ‘DataLakeAnalytics’:
+	// Set property "DataLakeAnalytics":
 	if typedInput.DataLakeAnalytics != nil {
 		var dataLakeAnalytics1 DataLakeAnalytics
 		err := dataLakeAnalytics1.PopulateFromARM(owner, *typedInput.DataLakeAnalytics)
@@ -1198,7 +1198,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.DataLakeAnalytics = &dataLakeAnalytics
 	}
 
-	// Set property ‘Databricks’:
+	// Set property "Databricks":
 	if typedInput.Databricks != nil {
 		var databricks1 Databricks
 		err := databricks1.PopulateFromARM(owner, *typedInput.Databricks)
@@ -1209,7 +1209,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.Databricks = &databricks
 	}
 
-	// Set property ‘HDInsight’:
+	// Set property "HDInsight":
 	if typedInput.HDInsight != nil {
 		var hdInsight1 HDInsight
 		err := hdInsight1.PopulateFromARM(owner, *typedInput.HDInsight)
@@ -1220,7 +1220,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.HDInsight = &hdInsight
 	}
 
-	// Set property ‘Kubernetes’:
+	// Set property "Kubernetes":
 	if typedInput.Kubernetes != nil {
 		var kubernetes1 Kubernetes
 		err := kubernetes1.PopulateFromARM(owner, *typedInput.Kubernetes)
@@ -1231,7 +1231,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.Kubernetes = &kubernetes
 	}
 
-	// Set property ‘SynapseSpark’:
+	// Set property "SynapseSpark":
 	if typedInput.SynapseSpark != nil {
 		var synapseSpark1 SynapseSpark
 		err := synapseSpark1.PopulateFromARM(owner, *typedInput.SynapseSpark)
@@ -1242,7 +1242,7 @@ func (compute *Compute) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		compute.SynapseSpark = &synapseSpark
 	}
 
-	// Set property ‘VirtualMachine’:
+	// Set property "VirtualMachine":
 	if typedInput.VirtualMachine != nil {
 		var virtualMachine1 VirtualMachine
 		err := virtualMachine1.PopulateFromARM(owner, *typedInput.VirtualMachine)
@@ -1548,7 +1548,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Compute_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AKS’:
+	// Set property "AKS":
 	if typedInput.AKS != nil {
 		var aks1 AKS_STATUS
 		err := aks1.PopulateFromARM(owner, *typedInput.AKS)
@@ -1559,7 +1559,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.AKS = &aks
 	}
 
-	// Set property ‘AmlCompute’:
+	// Set property "AmlCompute":
 	if typedInput.AmlCompute != nil {
 		var amlCompute1 AmlCompute_STATUS
 		err := amlCompute1.PopulateFromARM(owner, *typedInput.AmlCompute)
@@ -1570,7 +1570,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.AmlCompute = &amlCompute
 	}
 
-	// Set property ‘ComputeInstance’:
+	// Set property "ComputeInstance":
 	if typedInput.ComputeInstance != nil {
 		var computeInstance1 ComputeInstance_STATUS
 		err := computeInstance1.PopulateFromARM(owner, *typedInput.ComputeInstance)
@@ -1581,7 +1581,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.ComputeInstance = &computeInstance
 	}
 
-	// Set property ‘DataFactory’:
+	// Set property "DataFactory":
 	if typedInput.DataFactory != nil {
 		var dataFactory1 DataFactory_STATUS
 		err := dataFactory1.PopulateFromARM(owner, *typedInput.DataFactory)
@@ -1592,7 +1592,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.DataFactory = &dataFactory
 	}
 
-	// Set property ‘DataLakeAnalytics’:
+	// Set property "DataLakeAnalytics":
 	if typedInput.DataLakeAnalytics != nil {
 		var dataLakeAnalytics1 DataLakeAnalytics_STATUS
 		err := dataLakeAnalytics1.PopulateFromARM(owner, *typedInput.DataLakeAnalytics)
@@ -1603,7 +1603,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.DataLakeAnalytics = &dataLakeAnalytics
 	}
 
-	// Set property ‘Databricks’:
+	// Set property "Databricks":
 	if typedInput.Databricks != nil {
 		var databricks1 Databricks_STATUS
 		err := databricks1.PopulateFromARM(owner, *typedInput.Databricks)
@@ -1614,7 +1614,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.Databricks = &databricks
 	}
 
-	// Set property ‘HDInsight’:
+	// Set property "HDInsight":
 	if typedInput.HDInsight != nil {
 		var hdInsight1 HDInsight_STATUS
 		err := hdInsight1.PopulateFromARM(owner, *typedInput.HDInsight)
@@ -1625,7 +1625,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.HDInsight = &hdInsight
 	}
 
-	// Set property ‘Kubernetes’:
+	// Set property "Kubernetes":
 	if typedInput.Kubernetes != nil {
 		var kubernetes1 Kubernetes_STATUS
 		err := kubernetes1.PopulateFromARM(owner, *typedInput.Kubernetes)
@@ -1636,7 +1636,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.Kubernetes = &kubernetes
 	}
 
-	// Set property ‘SynapseSpark’:
+	// Set property "SynapseSpark":
 	if typedInput.SynapseSpark != nil {
 		var synapseSpark1 SynapseSpark_STATUS
 		err := synapseSpark1.PopulateFromARM(owner, *typedInput.SynapseSpark)
@@ -1647,7 +1647,7 @@ func (compute *Compute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		compute.SynapseSpark = &synapseSpark
 	}
 
-	// Set property ‘VirtualMachine’:
+	// Set property "VirtualMachine":
 	if typedInput.VirtualMachine != nil {
 		var virtualMachine1 VirtualMachine_STATUS
 		err := virtualMachine1.PopulateFromARM(owner, *typedInput.VirtualMachine)
@@ -1946,30 +1946,30 @@ func (aks *AKS) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &AKS_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if aks.ComputeLocation != nil {
 		computeLocation := *aks.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if aks.ComputeType != nil {
 		result.ComputeType = *aks.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if aks.Description != nil {
 		description := *aks.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if aks.DisableLocalAuth != nil {
 		disableLocalAuth := *aks.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if aks.Properties != nil {
 		properties_ARM, err := (*aks.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -1979,7 +1979,7 @@ func (aks *AKS) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if aks.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*aks.ResourceReference)
 		if err != nil {
@@ -2003,28 +2003,28 @@ func (aks *AKS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AKS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		aks.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	aks.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		aks.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		aks.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 AKS_Properties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -2035,7 +2035,7 @@ func (aks *AKS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		aks.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -2177,46 +2177,46 @@ func (aks *AKS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AKS_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		aks.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	aks.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		aks.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		aks.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		aks.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		aks.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		aks.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 AKS_Properties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -2227,7 +2227,7 @@ func (aks *AKS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		aks.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2237,13 +2237,13 @@ func (aks *AKS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		aks.ProvisioningErrors = append(aks.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		aks.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		aks.ResourceId = &resourceId
@@ -2451,30 +2451,30 @@ func (compute *AmlCompute) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &AmlCompute_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if compute.ComputeLocation != nil {
 		computeLocation := *compute.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if compute.ComputeType != nil {
 		result.ComputeType = *compute.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if compute.Description != nil {
 		description := *compute.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if compute.DisableLocalAuth != nil {
 		disableLocalAuth := *compute.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if compute.Properties != nil {
 		properties_ARM, err := (*compute.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -2484,7 +2484,7 @@ func (compute *AmlCompute) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if compute.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*compute.ResourceReference)
 		if err != nil {
@@ -2508,28 +2508,28 @@ func (compute *AmlCompute) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AmlCompute_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		compute.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	compute.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		compute.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		compute.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 AmlComputeProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -2540,7 +2540,7 @@ func (compute *AmlCompute) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		compute.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -2682,46 +2682,46 @@ func (compute *AmlCompute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AmlCompute_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		compute.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	compute.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		compute.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		compute.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		compute.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		compute.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		compute.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 AmlComputeProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -2732,7 +2732,7 @@ func (compute *AmlCompute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		compute.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2742,13 +2742,13 @@ func (compute *AmlCompute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		compute.ProvisioningErrors = append(compute.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		compute.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		compute.ResourceId = &resourceId
@@ -2956,30 +2956,30 @@ func (instance *ComputeInstance) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ComputeInstance_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if instance.ComputeLocation != nil {
 		computeLocation := *instance.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if instance.ComputeType != nil {
 		result.ComputeType = *instance.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if instance.Description != nil {
 		description := *instance.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if instance.DisableLocalAuth != nil {
 		disableLocalAuth := *instance.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if instance.Properties != nil {
 		properties_ARM, err := (*instance.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -2989,7 +2989,7 @@ func (instance *ComputeInstance) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if instance.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*instance.ResourceReference)
 		if err != nil {
@@ -3013,28 +3013,28 @@ func (instance *ComputeInstance) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstance_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		instance.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	instance.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		instance.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		instance.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 ComputeInstanceProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -3045,7 +3045,7 @@ func (instance *ComputeInstance) PopulateFromARM(owner genruntime.ArbitraryOwner
 		instance.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -3187,46 +3187,46 @@ func (instance *ComputeInstance_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstance_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		instance.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	instance.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		instance.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		instance.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		instance.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		instance.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		instance.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 ComputeInstanceProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -3237,7 +3237,7 @@ func (instance *ComputeInstance_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		instance.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3247,13 +3247,13 @@ func (instance *ComputeInstance_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		instance.ProvisioningErrors = append(instance.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		instance.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		instance.ResourceId = &resourceId
@@ -3461,30 +3461,30 @@ func (databricks *Databricks) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Databricks_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if databricks.ComputeLocation != nil {
 		computeLocation := *databricks.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if databricks.ComputeType != nil {
 		result.ComputeType = *databricks.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if databricks.Description != nil {
 		description := *databricks.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if databricks.DisableLocalAuth != nil {
 		disableLocalAuth := *databricks.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if databricks.Properties != nil {
 		properties_ARM, err := (*databricks.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -3494,7 +3494,7 @@ func (databricks *Databricks) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if databricks.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*databricks.ResourceReference)
 		if err != nil {
@@ -3518,28 +3518,28 @@ func (databricks *Databricks) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Databricks_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		databricks.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	databricks.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		databricks.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		databricks.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 DatabricksProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -3550,7 +3550,7 @@ func (databricks *Databricks) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		databricks.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -3692,46 +3692,46 @@ func (databricks *Databricks_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Databricks_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		databricks.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	databricks.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		databricks.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		databricks.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		databricks.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		databricks.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		databricks.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 DatabricksProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -3742,7 +3742,7 @@ func (databricks *Databricks_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		databricks.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3752,13 +3752,13 @@ func (databricks *Databricks_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		databricks.ProvisioningErrors = append(databricks.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		databricks.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		databricks.ResourceId = &resourceId
@@ -3965,30 +3965,30 @@ func (factory *DataFactory) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &DataFactory_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if factory.ComputeLocation != nil {
 		computeLocation := *factory.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if factory.ComputeType != nil {
 		result.ComputeType = *factory.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if factory.Description != nil {
 		description := *factory.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if factory.DisableLocalAuth != nil {
 		disableLocalAuth := *factory.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if factory.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*factory.ResourceReference)
 		if err != nil {
@@ -4012,28 +4012,28 @@ func (factory *DataFactory) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataFactory_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		factory.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	factory.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		factory.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		factory.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -4150,46 +4150,46 @@ func (factory *DataFactory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataFactory_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		factory.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	factory.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		factory.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		factory.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		factory.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		factory.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		factory.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4199,13 +4199,13 @@ func (factory *DataFactory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		factory.ProvisioningErrors = append(factory.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		factory.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		factory.ResourceId = &resourceId
@@ -4389,30 +4389,30 @@ func (analytics *DataLakeAnalytics) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &DataLakeAnalytics_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if analytics.ComputeLocation != nil {
 		computeLocation := *analytics.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if analytics.ComputeType != nil {
 		result.ComputeType = *analytics.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if analytics.Description != nil {
 		description := *analytics.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if analytics.DisableLocalAuth != nil {
 		disableLocalAuth := *analytics.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if analytics.Properties != nil {
 		properties_ARM, err := (*analytics.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -4422,7 +4422,7 @@ func (analytics *DataLakeAnalytics) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if analytics.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*analytics.ResourceReference)
 		if err != nil {
@@ -4446,28 +4446,28 @@ func (analytics *DataLakeAnalytics) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataLakeAnalytics_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		analytics.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	analytics.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		analytics.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		analytics.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 DataLakeAnalytics_Properties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -4478,7 +4478,7 @@ func (analytics *DataLakeAnalytics) PopulateFromARM(owner genruntime.ArbitraryOw
 		analytics.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -4620,46 +4620,46 @@ func (analytics *DataLakeAnalytics_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataLakeAnalytics_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		analytics.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	analytics.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		analytics.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		analytics.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		analytics.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		analytics.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		analytics.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 DataLakeAnalytics_Properties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -4670,7 +4670,7 @@ func (analytics *DataLakeAnalytics_STATUS) PopulateFromARM(owner genruntime.Arbi
 		analytics.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4680,13 +4680,13 @@ func (analytics *DataLakeAnalytics_STATUS) PopulateFromARM(owner genruntime.Arbi
 		analytics.ProvisioningErrors = append(analytics.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		analytics.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		analytics.ResourceId = &resourceId
@@ -4894,30 +4894,30 @@ func (insight *HDInsight) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &HDInsight_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if insight.ComputeLocation != nil {
 		computeLocation := *insight.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if insight.ComputeType != nil {
 		result.ComputeType = *insight.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if insight.Description != nil {
 		description := *insight.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if insight.DisableLocalAuth != nil {
 		disableLocalAuth := *insight.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if insight.Properties != nil {
 		properties_ARM, err := (*insight.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -4927,7 +4927,7 @@ func (insight *HDInsight) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if insight.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*insight.ResourceReference)
 		if err != nil {
@@ -4951,28 +4951,28 @@ func (insight *HDInsight) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HDInsight_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		insight.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	insight.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		insight.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		insight.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 HDInsightProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -4983,7 +4983,7 @@ func (insight *HDInsight) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		insight.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -5125,46 +5125,46 @@ func (insight *HDInsight_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HDInsight_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		insight.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	insight.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		insight.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		insight.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		insight.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		insight.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		insight.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 HDInsightProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -5175,7 +5175,7 @@ func (insight *HDInsight_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		insight.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5185,13 +5185,13 @@ func (insight *HDInsight_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		insight.ProvisioningErrors = append(insight.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		insight.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		insight.ResourceId = &resourceId
@@ -5399,30 +5399,30 @@ func (kubernetes *Kubernetes) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Kubernetes_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if kubernetes.ComputeLocation != nil {
 		computeLocation := *kubernetes.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if kubernetes.ComputeType != nil {
 		result.ComputeType = *kubernetes.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if kubernetes.Description != nil {
 		description := *kubernetes.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if kubernetes.DisableLocalAuth != nil {
 		disableLocalAuth := *kubernetes.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if kubernetes.Properties != nil {
 		properties_ARM, err := (*kubernetes.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -5432,7 +5432,7 @@ func (kubernetes *Kubernetes) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if kubernetes.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*kubernetes.ResourceReference)
 		if err != nil {
@@ -5456,28 +5456,28 @@ func (kubernetes *Kubernetes) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Kubernetes_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		kubernetes.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	kubernetes.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		kubernetes.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		kubernetes.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 KubernetesProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -5488,7 +5488,7 @@ func (kubernetes *Kubernetes) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		kubernetes.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -5630,46 +5630,46 @@ func (kubernetes *Kubernetes_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Kubernetes_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		kubernetes.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	kubernetes.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		kubernetes.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		kubernetes.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		kubernetes.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		kubernetes.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		kubernetes.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 KubernetesProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -5680,7 +5680,7 @@ func (kubernetes *Kubernetes_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		kubernetes.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5690,13 +5690,13 @@ func (kubernetes *Kubernetes_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		kubernetes.ProvisioningErrors = append(kubernetes.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		kubernetes.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		kubernetes.ResourceId = &resourceId
@@ -5904,30 +5904,30 @@ func (spark *SynapseSpark) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &SynapseSpark_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if spark.ComputeLocation != nil {
 		computeLocation := *spark.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if spark.ComputeType != nil {
 		result.ComputeType = *spark.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if spark.Description != nil {
 		description := *spark.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if spark.DisableLocalAuth != nil {
 		disableLocalAuth := *spark.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if spark.Properties != nil {
 		properties_ARM, err := (*spark.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -5937,7 +5937,7 @@ func (spark *SynapseSpark) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if spark.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*spark.ResourceReference)
 		if err != nil {
@@ -5961,28 +5961,28 @@ func (spark *SynapseSpark) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SynapseSpark_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		spark.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	spark.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		spark.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		spark.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 SynapseSpark_Properties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -5993,7 +5993,7 @@ func (spark *SynapseSpark) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		spark.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -6135,46 +6135,46 @@ func (spark *SynapseSpark_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SynapseSpark_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		spark.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	spark.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		spark.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		spark.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		spark.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		spark.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		spark.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 SynapseSpark_Properties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -6185,7 +6185,7 @@ func (spark *SynapseSpark_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		spark.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6195,13 +6195,13 @@ func (spark *SynapseSpark_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		spark.ProvisioningErrors = append(spark.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		spark.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		spark.ResourceId = &resourceId
@@ -6409,30 +6409,30 @@ func (machine *VirtualMachine) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &VirtualMachine_ARM{}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if machine.ComputeLocation != nil {
 		computeLocation := *machine.ComputeLocation
 		result.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	if machine.ComputeType != nil {
 		result.ComputeType = *machine.ComputeType
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if machine.Description != nil {
 		description := *machine.Description
 		result.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if machine.DisableLocalAuth != nil {
 		disableLocalAuth := *machine.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if machine.Properties != nil {
 		properties_ARM, err := (*machine.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -6442,7 +6442,7 @@ func (machine *VirtualMachine) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.Properties = &properties
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if machine.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*machine.ResourceReference)
 		if err != nil {
@@ -6466,28 +6466,28 @@ func (machine *VirtualMachine) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		machine.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	machine.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		machine.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		machine.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 VirtualMachine_Properties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -6498,7 +6498,7 @@ func (machine *VirtualMachine) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		machine.Properties = &properties
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -6640,46 +6640,46 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeLocation’:
+	// Set property "ComputeLocation":
 	if typedInput.ComputeLocation != nil {
 		computeLocation := *typedInput.ComputeLocation
 		machine.ComputeLocation = &computeLocation
 	}
 
-	// Set property ‘ComputeType’:
+	// Set property "ComputeType":
 	machine.ComputeType = &typedInput.ComputeType
 
-	// Set property ‘CreatedOn’:
+	// Set property "CreatedOn":
 	if typedInput.CreatedOn != nil {
 		createdOn := *typedInput.CreatedOn
 		machine.CreatedOn = &createdOn
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		machine.Description = &description
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		machine.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘IsAttachedCompute’:
+	// Set property "IsAttachedCompute":
 	if typedInput.IsAttachedCompute != nil {
 		isAttachedCompute := *typedInput.IsAttachedCompute
 		machine.IsAttachedCompute = &isAttachedCompute
 	}
 
-	// Set property ‘ModifiedOn’:
+	// Set property "ModifiedOn":
 	if typedInput.ModifiedOn != nil {
 		modifiedOn := *typedInput.ModifiedOn
 		machine.ModifiedOn = &modifiedOn
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 VirtualMachine_Properties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -6690,7 +6690,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.Properties = &properties
 	}
 
-	// Set property ‘ProvisioningErrors’:
+	// Set property "ProvisioningErrors":
 	for _, item := range typedInput.ProvisioningErrors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6700,13 +6700,13 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		machine.ProvisioningErrors = append(machine.ProvisioningErrors, item1)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		machine.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		machine.ResourceId = &resourceId
@@ -6915,19 +6915,19 @@ func (properties *AKS_Properties) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &AKS_Properties_ARM{}
 
-	// Set property ‘AgentCount’:
+	// Set property "AgentCount":
 	if properties.AgentCount != nil {
 		agentCount := *properties.AgentCount
 		result.AgentCount = &agentCount
 	}
 
-	// Set property ‘AgentVmSize’:
+	// Set property "AgentVmSize":
 	if properties.AgentVmSize != nil {
 		agentVmSize := *properties.AgentVmSize
 		result.AgentVmSize = &agentVmSize
 	}
 
-	// Set property ‘AksNetworkingConfiguration’:
+	// Set property "AksNetworkingConfiguration":
 	if properties.AksNetworkingConfiguration != nil {
 		aksNetworkingConfiguration_ARM, err := (*properties.AksNetworkingConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -6937,31 +6937,31 @@ func (properties *AKS_Properties) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.AksNetworkingConfiguration = &aksNetworkingConfiguration
 	}
 
-	// Set property ‘ClusterFqdn’:
+	// Set property "ClusterFqdn":
 	if properties.ClusterFqdn != nil {
 		clusterFqdn := *properties.ClusterFqdn
 		result.ClusterFqdn = &clusterFqdn
 	}
 
-	// Set property ‘ClusterPurpose’:
+	// Set property "ClusterPurpose":
 	if properties.ClusterPurpose != nil {
 		clusterPurpose := *properties.ClusterPurpose
 		result.ClusterPurpose = &clusterPurpose
 	}
 
-	// Set property ‘LoadBalancerSubnet’:
+	// Set property "LoadBalancerSubnet":
 	if properties.LoadBalancerSubnet != nil {
 		loadBalancerSubnet := *properties.LoadBalancerSubnet
 		result.LoadBalancerSubnet = &loadBalancerSubnet
 	}
 
-	// Set property ‘LoadBalancerType’:
+	// Set property "LoadBalancerType":
 	if properties.LoadBalancerType != nil {
 		loadBalancerType := *properties.LoadBalancerType
 		result.LoadBalancerType = &loadBalancerType
 	}
 
-	// Set property ‘SslConfiguration’:
+	// Set property "SslConfiguration":
 	if properties.SslConfiguration != nil {
 		sslConfiguration_ARM, err := (*properties.SslConfiguration).ConvertToARM(resolved)
 		if err != nil {
@@ -6985,19 +6985,19 @@ func (properties *AKS_Properties) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AKS_Properties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AgentCount’:
+	// Set property "AgentCount":
 	if typedInput.AgentCount != nil {
 		agentCount := *typedInput.AgentCount
 		properties.AgentCount = &agentCount
 	}
 
-	// Set property ‘AgentVmSize’:
+	// Set property "AgentVmSize":
 	if typedInput.AgentVmSize != nil {
 		agentVmSize := *typedInput.AgentVmSize
 		properties.AgentVmSize = &agentVmSize
 	}
 
-	// Set property ‘AksNetworkingConfiguration’:
+	// Set property "AksNetworkingConfiguration":
 	if typedInput.AksNetworkingConfiguration != nil {
 		var aksNetworkingConfiguration1 AksNetworkingConfiguration
 		err := aksNetworkingConfiguration1.PopulateFromARM(owner, *typedInput.AksNetworkingConfiguration)
@@ -7008,31 +7008,31 @@ func (properties *AKS_Properties) PopulateFromARM(owner genruntime.ArbitraryOwne
 		properties.AksNetworkingConfiguration = &aksNetworkingConfiguration
 	}
 
-	// Set property ‘ClusterFqdn’:
+	// Set property "ClusterFqdn":
 	if typedInput.ClusterFqdn != nil {
 		clusterFqdn := *typedInput.ClusterFqdn
 		properties.ClusterFqdn = &clusterFqdn
 	}
 
-	// Set property ‘ClusterPurpose’:
+	// Set property "ClusterPurpose":
 	if typedInput.ClusterPurpose != nil {
 		clusterPurpose := *typedInput.ClusterPurpose
 		properties.ClusterPurpose = &clusterPurpose
 	}
 
-	// Set property ‘LoadBalancerSubnet’:
+	// Set property "LoadBalancerSubnet":
 	if typedInput.LoadBalancerSubnet != nil {
 		loadBalancerSubnet := *typedInput.LoadBalancerSubnet
 		properties.LoadBalancerSubnet = &loadBalancerSubnet
 	}
 
-	// Set property ‘LoadBalancerType’:
+	// Set property "LoadBalancerType":
 	if typedInput.LoadBalancerType != nil {
 		loadBalancerType := *typedInput.LoadBalancerType
 		properties.LoadBalancerType = &loadBalancerType
 	}
 
-	// Set property ‘SslConfiguration’:
+	// Set property "SslConfiguration":
 	if typedInput.SslConfiguration != nil {
 		var sslConfiguration1 SslConfiguration
 		err := sslConfiguration1.PopulateFromARM(owner, *typedInput.SslConfiguration)
@@ -7211,19 +7211,19 @@ func (properties *AKS_Properties_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AKS_Properties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AgentCount’:
+	// Set property "AgentCount":
 	if typedInput.AgentCount != nil {
 		agentCount := *typedInput.AgentCount
 		properties.AgentCount = &agentCount
 	}
 
-	// Set property ‘AgentVmSize’:
+	// Set property "AgentVmSize":
 	if typedInput.AgentVmSize != nil {
 		agentVmSize := *typedInput.AgentVmSize
 		properties.AgentVmSize = &agentVmSize
 	}
 
-	// Set property ‘AksNetworkingConfiguration’:
+	// Set property "AksNetworkingConfiguration":
 	if typedInput.AksNetworkingConfiguration != nil {
 		var aksNetworkingConfiguration1 AksNetworkingConfiguration_STATUS
 		err := aksNetworkingConfiguration1.PopulateFromARM(owner, *typedInput.AksNetworkingConfiguration)
@@ -7234,31 +7234,31 @@ func (properties *AKS_Properties_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		properties.AksNetworkingConfiguration = &aksNetworkingConfiguration
 	}
 
-	// Set property ‘ClusterFqdn’:
+	// Set property "ClusterFqdn":
 	if typedInput.ClusterFqdn != nil {
 		clusterFqdn := *typedInput.ClusterFqdn
 		properties.ClusterFqdn = &clusterFqdn
 	}
 
-	// Set property ‘ClusterPurpose’:
+	// Set property "ClusterPurpose":
 	if typedInput.ClusterPurpose != nil {
 		clusterPurpose := *typedInput.ClusterPurpose
 		properties.ClusterPurpose = &clusterPurpose
 	}
 
-	// Set property ‘LoadBalancerSubnet’:
+	// Set property "LoadBalancerSubnet":
 	if typedInput.LoadBalancerSubnet != nil {
 		loadBalancerSubnet := *typedInput.LoadBalancerSubnet
 		properties.LoadBalancerSubnet = &loadBalancerSubnet
 	}
 
-	// Set property ‘LoadBalancerType’:
+	// Set property "LoadBalancerType":
 	if typedInput.LoadBalancerType != nil {
 		loadBalancerType := *typedInput.LoadBalancerType
 		properties.LoadBalancerType = &loadBalancerType
 	}
 
-	// Set property ‘SslConfiguration’:
+	// Set property "SslConfiguration":
 	if typedInput.SslConfiguration != nil {
 		var sslConfiguration1 SslConfiguration_STATUS
 		err := sslConfiguration1.PopulateFromARM(owner, *typedInput.SslConfiguration)
@@ -7269,7 +7269,7 @@ func (properties *AKS_Properties_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		properties.SslConfiguration = &sslConfiguration
 	}
 
-	// Set property ‘SystemServices’:
+	// Set property "SystemServices":
 	for _, item := range typedInput.SystemServices {
 		var item1 SystemService_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7469,31 +7469,31 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &AmlComputeProperties_ARM{}
 
-	// Set property ‘EnableNodePublicIp’:
+	// Set property "EnableNodePublicIp":
 	if properties.EnableNodePublicIp != nil {
 		enableNodePublicIp := *properties.EnableNodePublicIp
 		result.EnableNodePublicIp = &enableNodePublicIp
 	}
 
-	// Set property ‘IsolatedNetwork’:
+	// Set property "IsolatedNetwork":
 	if properties.IsolatedNetwork != nil {
 		isolatedNetwork := *properties.IsolatedNetwork
 		result.IsolatedNetwork = &isolatedNetwork
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if properties.OsType != nil {
 		osType := *properties.OsType
 		result.OsType = &osType
 	}
 
-	// Set property ‘RemoteLoginPortPublicAccess’:
+	// Set property "RemoteLoginPortPublicAccess":
 	if properties.RemoteLoginPortPublicAccess != nil {
 		remoteLoginPortPublicAccess := *properties.RemoteLoginPortPublicAccess
 		result.RemoteLoginPortPublicAccess = &remoteLoginPortPublicAccess
 	}
 
-	// Set property ‘ScaleSettings’:
+	// Set property "ScaleSettings":
 	if properties.ScaleSettings != nil {
 		scaleSettings_ARM, err := (*properties.ScaleSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -7503,7 +7503,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 		result.ScaleSettings = &scaleSettings
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if properties.Subnet != nil {
 		subnet_ARM, err := (*properties.Subnet).ConvertToARM(resolved)
 		if err != nil {
@@ -7513,7 +7513,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 		result.Subnet = &subnet
 	}
 
-	// Set property ‘UserAccountCredentials’:
+	// Set property "UserAccountCredentials":
 	if properties.UserAccountCredentials != nil {
 		userAccountCredentials_ARM, err := (*properties.UserAccountCredentials).ConvertToARM(resolved)
 		if err != nil {
@@ -7523,7 +7523,7 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 		result.UserAccountCredentials = &userAccountCredentials
 	}
 
-	// Set property ‘VirtualMachineImage’:
+	// Set property "VirtualMachineImage":
 	if properties.VirtualMachineImage != nil {
 		virtualMachineImage_ARM, err := (*properties.VirtualMachineImage).ConvertToARM(resolved)
 		if err != nil {
@@ -7533,13 +7533,13 @@ func (properties *AmlComputeProperties) ConvertToARM(resolved genruntime.Convert
 		result.VirtualMachineImage = &virtualMachineImage
 	}
 
-	// Set property ‘VmPriority’:
+	// Set property "VmPriority":
 	if properties.VmPriority != nil {
 		vmPriority := *properties.VmPriority
 		result.VmPriority = &vmPriority
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if properties.VmSize != nil {
 		vmSize := *properties.VmSize
 		result.VmSize = &vmSize
@@ -7559,31 +7559,31 @@ func (properties *AmlComputeProperties) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AmlComputeProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EnableNodePublicIp’:
+	// Set property "EnableNodePublicIp":
 	if typedInput.EnableNodePublicIp != nil {
 		enableNodePublicIp := *typedInput.EnableNodePublicIp
 		properties.EnableNodePublicIp = &enableNodePublicIp
 	}
 
-	// Set property ‘IsolatedNetwork’:
+	// Set property "IsolatedNetwork":
 	if typedInput.IsolatedNetwork != nil {
 		isolatedNetwork := *typedInput.IsolatedNetwork
 		properties.IsolatedNetwork = &isolatedNetwork
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		properties.OsType = &osType
 	}
 
-	// Set property ‘RemoteLoginPortPublicAccess’:
+	// Set property "RemoteLoginPortPublicAccess":
 	if typedInput.RemoteLoginPortPublicAccess != nil {
 		remoteLoginPortPublicAccess := *typedInput.RemoteLoginPortPublicAccess
 		properties.RemoteLoginPortPublicAccess = &remoteLoginPortPublicAccess
 	}
 
-	// Set property ‘ScaleSettings’:
+	// Set property "ScaleSettings":
 	if typedInput.ScaleSettings != nil {
 		var scaleSettings1 ScaleSettings
 		err := scaleSettings1.PopulateFromARM(owner, *typedInput.ScaleSettings)
@@ -7594,7 +7594,7 @@ func (properties *AmlComputeProperties) PopulateFromARM(owner genruntime.Arbitra
 		properties.ScaleSettings = &scaleSettings
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if typedInput.Subnet != nil {
 		var subnet1 ResourceId
 		err := subnet1.PopulateFromARM(owner, *typedInput.Subnet)
@@ -7605,7 +7605,7 @@ func (properties *AmlComputeProperties) PopulateFromARM(owner genruntime.Arbitra
 		properties.Subnet = &subnet
 	}
 
-	// Set property ‘UserAccountCredentials’:
+	// Set property "UserAccountCredentials":
 	if typedInput.UserAccountCredentials != nil {
 		var userAccountCredentials1 UserAccountCredentials
 		err := userAccountCredentials1.PopulateFromARM(owner, *typedInput.UserAccountCredentials)
@@ -7616,7 +7616,7 @@ func (properties *AmlComputeProperties) PopulateFromARM(owner genruntime.Arbitra
 		properties.UserAccountCredentials = &userAccountCredentials
 	}
 
-	// Set property ‘VirtualMachineImage’:
+	// Set property "VirtualMachineImage":
 	if typedInput.VirtualMachineImage != nil {
 		var virtualMachineImage1 VirtualMachineImage
 		err := virtualMachineImage1.PopulateFromARM(owner, *typedInput.VirtualMachineImage)
@@ -7627,13 +7627,13 @@ func (properties *AmlComputeProperties) PopulateFromARM(owner genruntime.Arbitra
 		properties.VirtualMachineImage = &virtualMachineImage
 	}
 
-	// Set property ‘VmPriority’:
+	// Set property "VmPriority":
 	if typedInput.VmPriority != nil {
 		vmPriority := *typedInput.VmPriority
 		properties.VmPriority = &vmPriority
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		properties.VmSize = &vmSize
@@ -7882,31 +7882,31 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AmlComputeProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocationState’:
+	// Set property "AllocationState":
 	if typedInput.AllocationState != nil {
 		allocationState := *typedInput.AllocationState
 		properties.AllocationState = &allocationState
 	}
 
-	// Set property ‘AllocationStateTransitionTime’:
+	// Set property "AllocationStateTransitionTime":
 	if typedInput.AllocationStateTransitionTime != nil {
 		allocationStateTransitionTime := *typedInput.AllocationStateTransitionTime
 		properties.AllocationStateTransitionTime = &allocationStateTransitionTime
 	}
 
-	// Set property ‘CurrentNodeCount’:
+	// Set property "CurrentNodeCount":
 	if typedInput.CurrentNodeCount != nil {
 		currentNodeCount := *typedInput.CurrentNodeCount
 		properties.CurrentNodeCount = &currentNodeCount
 	}
 
-	// Set property ‘EnableNodePublicIp’:
+	// Set property "EnableNodePublicIp":
 	if typedInput.EnableNodePublicIp != nil {
 		enableNodePublicIp := *typedInput.EnableNodePublicIp
 		properties.EnableNodePublicIp = &enableNodePublicIp
 	}
 
-	// Set property ‘Errors’:
+	// Set property "Errors":
 	for _, item := range typedInput.Errors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7916,13 +7916,13 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		properties.Errors = append(properties.Errors, item1)
 	}
 
-	// Set property ‘IsolatedNetwork’:
+	// Set property "IsolatedNetwork":
 	if typedInput.IsolatedNetwork != nil {
 		isolatedNetwork := *typedInput.IsolatedNetwork
 		properties.IsolatedNetwork = &isolatedNetwork
 	}
 
-	// Set property ‘NodeStateCounts’:
+	// Set property "NodeStateCounts":
 	if typedInput.NodeStateCounts != nil {
 		var nodeStateCounts1 NodeStateCounts_STATUS
 		err := nodeStateCounts1.PopulateFromARM(owner, *typedInput.NodeStateCounts)
@@ -7933,19 +7933,19 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		properties.NodeStateCounts = &nodeStateCounts
 	}
 
-	// Set property ‘OsType’:
+	// Set property "OsType":
 	if typedInput.OsType != nil {
 		osType := *typedInput.OsType
 		properties.OsType = &osType
 	}
 
-	// Set property ‘RemoteLoginPortPublicAccess’:
+	// Set property "RemoteLoginPortPublicAccess":
 	if typedInput.RemoteLoginPortPublicAccess != nil {
 		remoteLoginPortPublicAccess := *typedInput.RemoteLoginPortPublicAccess
 		properties.RemoteLoginPortPublicAccess = &remoteLoginPortPublicAccess
 	}
 
-	// Set property ‘ScaleSettings’:
+	// Set property "ScaleSettings":
 	if typedInput.ScaleSettings != nil {
 		var scaleSettings1 ScaleSettings_STATUS
 		err := scaleSettings1.PopulateFromARM(owner, *typedInput.ScaleSettings)
@@ -7956,7 +7956,7 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		properties.ScaleSettings = &scaleSettings
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if typedInput.Subnet != nil {
 		var subnet1 ResourceId_STATUS
 		err := subnet1.PopulateFromARM(owner, *typedInput.Subnet)
@@ -7967,13 +7967,13 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		properties.Subnet = &subnet
 	}
 
-	// Set property ‘TargetNodeCount’:
+	// Set property "TargetNodeCount":
 	if typedInput.TargetNodeCount != nil {
 		targetNodeCount := *typedInput.TargetNodeCount
 		properties.TargetNodeCount = &targetNodeCount
 	}
 
-	// Set property ‘UserAccountCredentials’:
+	// Set property "UserAccountCredentials":
 	if typedInput.UserAccountCredentials != nil {
 		var userAccountCredentials1 UserAccountCredentials_STATUS
 		err := userAccountCredentials1.PopulateFromARM(owner, *typedInput.UserAccountCredentials)
@@ -7984,7 +7984,7 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		properties.UserAccountCredentials = &userAccountCredentials
 	}
 
-	// Set property ‘VirtualMachineImage’:
+	// Set property "VirtualMachineImage":
 	if typedInput.VirtualMachineImage != nil {
 		var virtualMachineImage1 VirtualMachineImage_STATUS
 		err := virtualMachineImage1.PopulateFromARM(owner, *typedInput.VirtualMachineImage)
@@ -7995,13 +7995,13 @@ func (properties *AmlComputeProperties_STATUS) PopulateFromARM(owner genruntime.
 		properties.VirtualMachineImage = &virtualMachineImage
 	}
 
-	// Set property ‘VmPriority’:
+	// Set property "VmPriority":
 	if typedInput.VmPriority != nil {
 		vmPriority := *typedInput.VmPriority
 		properties.VmPriority = &vmPriority
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		properties.VmSize = &vmSize
@@ -8330,19 +8330,19 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ComputeInstanceProperties_ARM{}
 
-	// Set property ‘ApplicationSharingPolicy’:
+	// Set property "ApplicationSharingPolicy":
 	if properties.ApplicationSharingPolicy != nil {
 		applicationSharingPolicy := *properties.ApplicationSharingPolicy
 		result.ApplicationSharingPolicy = &applicationSharingPolicy
 	}
 
-	// Set property ‘ComputeInstanceAuthorizationType’:
+	// Set property "ComputeInstanceAuthorizationType":
 	if properties.ComputeInstanceAuthorizationType != nil {
 		computeInstanceAuthorizationType := *properties.ComputeInstanceAuthorizationType
 		result.ComputeInstanceAuthorizationType = &computeInstanceAuthorizationType
 	}
 
-	// Set property ‘PersonalComputeInstanceSettings’:
+	// Set property "PersonalComputeInstanceSettings":
 	if properties.PersonalComputeInstanceSettings != nil {
 		personalComputeInstanceSettings_ARM, err := (*properties.PersonalComputeInstanceSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -8352,7 +8352,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 		result.PersonalComputeInstanceSettings = &personalComputeInstanceSettings
 	}
 
-	// Set property ‘SetupScripts’:
+	// Set property "SetupScripts":
 	if properties.SetupScripts != nil {
 		setupScripts_ARM, err := (*properties.SetupScripts).ConvertToARM(resolved)
 		if err != nil {
@@ -8362,7 +8362,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 		result.SetupScripts = &setupScripts
 	}
 
-	// Set property ‘SshSettings’:
+	// Set property "SshSettings":
 	if properties.SshSettings != nil {
 		sshSettings_ARM, err := (*properties.SshSettings).ConvertToARM(resolved)
 		if err != nil {
@@ -8372,7 +8372,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 		result.SshSettings = &sshSettings
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if properties.Subnet != nil {
 		subnet_ARM, err := (*properties.Subnet).ConvertToARM(resolved)
 		if err != nil {
@@ -8382,7 +8382,7 @@ func (properties *ComputeInstanceProperties) ConvertToARM(resolved genruntime.Co
 		result.Subnet = &subnet
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if properties.VmSize != nil {
 		vmSize := *properties.VmSize
 		result.VmSize = &vmSize
@@ -8402,19 +8402,19 @@ func (properties *ComputeInstanceProperties) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationSharingPolicy’:
+	// Set property "ApplicationSharingPolicy":
 	if typedInput.ApplicationSharingPolicy != nil {
 		applicationSharingPolicy := *typedInput.ApplicationSharingPolicy
 		properties.ApplicationSharingPolicy = &applicationSharingPolicy
 	}
 
-	// Set property ‘ComputeInstanceAuthorizationType’:
+	// Set property "ComputeInstanceAuthorizationType":
 	if typedInput.ComputeInstanceAuthorizationType != nil {
 		computeInstanceAuthorizationType := *typedInput.ComputeInstanceAuthorizationType
 		properties.ComputeInstanceAuthorizationType = &computeInstanceAuthorizationType
 	}
 
-	// Set property ‘PersonalComputeInstanceSettings’:
+	// Set property "PersonalComputeInstanceSettings":
 	if typedInput.PersonalComputeInstanceSettings != nil {
 		var personalComputeInstanceSettings1 PersonalComputeInstanceSettings
 		err := personalComputeInstanceSettings1.PopulateFromARM(owner, *typedInput.PersonalComputeInstanceSettings)
@@ -8425,7 +8425,7 @@ func (properties *ComputeInstanceProperties) PopulateFromARM(owner genruntime.Ar
 		properties.PersonalComputeInstanceSettings = &personalComputeInstanceSettings
 	}
 
-	// Set property ‘SetupScripts’:
+	// Set property "SetupScripts":
 	if typedInput.SetupScripts != nil {
 		var setupScripts1 SetupScripts
 		err := setupScripts1.PopulateFromARM(owner, *typedInput.SetupScripts)
@@ -8436,7 +8436,7 @@ func (properties *ComputeInstanceProperties) PopulateFromARM(owner genruntime.Ar
 		properties.SetupScripts = &setupScripts
 	}
 
-	// Set property ‘SshSettings’:
+	// Set property "SshSettings":
 	if typedInput.SshSettings != nil {
 		var sshSettings1 ComputeInstanceSshSettings
 		err := sshSettings1.PopulateFromARM(owner, *typedInput.SshSettings)
@@ -8447,7 +8447,7 @@ func (properties *ComputeInstanceProperties) PopulateFromARM(owner genruntime.Ar
 		properties.SshSettings = &sshSettings
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if typedInput.Subnet != nil {
 		var subnet1 ResourceId
 		err := subnet1.PopulateFromARM(owner, *typedInput.Subnet)
@@ -8458,7 +8458,7 @@ func (properties *ComputeInstanceProperties) PopulateFromARM(owner genruntime.Ar
 		properties.Subnet = &subnet
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		properties.VmSize = &vmSize
@@ -8656,13 +8656,13 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationSharingPolicy’:
+	// Set property "ApplicationSharingPolicy":
 	if typedInput.ApplicationSharingPolicy != nil {
 		applicationSharingPolicy := *typedInput.ApplicationSharingPolicy
 		properties.ApplicationSharingPolicy = &applicationSharingPolicy
 	}
 
-	// Set property ‘Applications’:
+	// Set property "Applications":
 	for _, item := range typedInput.Applications {
 		var item1 ComputeInstanceApplication_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8672,13 +8672,13 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.Applications = append(properties.Applications, item1)
 	}
 
-	// Set property ‘ComputeInstanceAuthorizationType’:
+	// Set property "ComputeInstanceAuthorizationType":
 	if typedInput.ComputeInstanceAuthorizationType != nil {
 		computeInstanceAuthorizationType := *typedInput.ComputeInstanceAuthorizationType
 		properties.ComputeInstanceAuthorizationType = &computeInstanceAuthorizationType
 	}
 
-	// Set property ‘ConnectivityEndpoints’:
+	// Set property "ConnectivityEndpoints":
 	if typedInput.ConnectivityEndpoints != nil {
 		var connectivityEndpoints1 ComputeInstanceConnectivityEndpoints_STATUS
 		err := connectivityEndpoints1.PopulateFromARM(owner, *typedInput.ConnectivityEndpoints)
@@ -8689,7 +8689,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.ConnectivityEndpoints = &connectivityEndpoints
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		var createdBy1 ComputeInstanceCreatedBy_STATUS
 		err := createdBy1.PopulateFromARM(owner, *typedInput.CreatedBy)
@@ -8700,7 +8700,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.CreatedBy = &createdBy
 	}
 
-	// Set property ‘Errors’:
+	// Set property "Errors":
 	for _, item := range typedInput.Errors {
 		var item1 ErrorResponse_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8710,7 +8710,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.Errors = append(properties.Errors, item1)
 	}
 
-	// Set property ‘LastOperation’:
+	// Set property "LastOperation":
 	if typedInput.LastOperation != nil {
 		var lastOperation1 ComputeInstanceLastOperation_STATUS
 		err := lastOperation1.PopulateFromARM(owner, *typedInput.LastOperation)
@@ -8721,7 +8721,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.LastOperation = &lastOperation
 	}
 
-	// Set property ‘PersonalComputeInstanceSettings’:
+	// Set property "PersonalComputeInstanceSettings":
 	if typedInput.PersonalComputeInstanceSettings != nil {
 		var personalComputeInstanceSettings1 PersonalComputeInstanceSettings_STATUS
 		err := personalComputeInstanceSettings1.PopulateFromARM(owner, *typedInput.PersonalComputeInstanceSettings)
@@ -8732,7 +8732,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.PersonalComputeInstanceSettings = &personalComputeInstanceSettings
 	}
 
-	// Set property ‘SetupScripts’:
+	// Set property "SetupScripts":
 	if typedInput.SetupScripts != nil {
 		var setupScripts1 SetupScripts_STATUS
 		err := setupScripts1.PopulateFromARM(owner, *typedInput.SetupScripts)
@@ -8743,7 +8743,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.SetupScripts = &setupScripts
 	}
 
-	// Set property ‘SshSettings’:
+	// Set property "SshSettings":
 	if typedInput.SshSettings != nil {
 		var sshSettings1 ComputeInstanceSshSettings_STATUS
 		err := sshSettings1.PopulateFromARM(owner, *typedInput.SshSettings)
@@ -8754,13 +8754,13 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.SshSettings = &sshSettings
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		properties.State = &state
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if typedInput.Subnet != nil {
 		var subnet1 ResourceId_STATUS
 		err := subnet1.PopulateFromARM(owner, *typedInput.Subnet)
@@ -8771,7 +8771,7 @@ func (properties *ComputeInstanceProperties_STATUS) PopulateFromARM(owner genrun
 		properties.Subnet = &subnet
 	}
 
-	// Set property ‘VmSize’:
+	// Set property "VmSize":
 	if typedInput.VmSize != nil {
 		vmSize := *typedInput.VmSize
 		properties.VmSize = &vmSize
@@ -9113,13 +9113,13 @@ func (properties *DatabricksProperties) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &DatabricksProperties_ARM{}
 
-	// Set property ‘DatabricksAccessToken’:
+	// Set property "DatabricksAccessToken":
 	if properties.DatabricksAccessToken != nil {
 		databricksAccessToken := *properties.DatabricksAccessToken
 		result.DatabricksAccessToken = &databricksAccessToken
 	}
 
-	// Set property ‘WorkspaceUrl’:
+	// Set property "WorkspaceUrl":
 	if properties.WorkspaceUrl != nil {
 		workspaceUrl := *properties.WorkspaceUrl
 		result.WorkspaceUrl = &workspaceUrl
@@ -9139,13 +9139,13 @@ func (properties *DatabricksProperties) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabricksProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DatabricksAccessToken’:
+	// Set property "DatabricksAccessToken":
 	if typedInput.DatabricksAccessToken != nil {
 		databricksAccessToken := *typedInput.DatabricksAccessToken
 		properties.DatabricksAccessToken = &databricksAccessToken
 	}
 
-	// Set property ‘WorkspaceUrl’:
+	// Set property "WorkspaceUrl":
 	if typedInput.WorkspaceUrl != nil {
 		workspaceUrl := *typedInput.WorkspaceUrl
 		properties.WorkspaceUrl = &workspaceUrl
@@ -9210,13 +9210,13 @@ func (properties *DatabricksProperties_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabricksProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DatabricksAccessToken’:
+	// Set property "DatabricksAccessToken":
 	if typedInput.DatabricksAccessToken != nil {
 		databricksAccessToken := *typedInput.DatabricksAccessToken
 		properties.DatabricksAccessToken = &databricksAccessToken
 	}
 
-	// Set property ‘WorkspaceUrl’:
+	// Set property "WorkspaceUrl":
 	if typedInput.WorkspaceUrl != nil {
 		workspaceUrl := *typedInput.WorkspaceUrl
 		properties.WorkspaceUrl = &workspaceUrl
@@ -9275,7 +9275,7 @@ func (properties *DataLakeAnalytics_Properties) ConvertToARM(resolved genruntime
 	}
 	result := &DataLakeAnalytics_Properties_ARM{}
 
-	// Set property ‘DataLakeStoreAccountName’:
+	// Set property "DataLakeStoreAccountName":
 	if properties.DataLakeStoreAccountName != nil {
 		dataLakeStoreAccountName := *properties.DataLakeStoreAccountName
 		result.DataLakeStoreAccountName = &dataLakeStoreAccountName
@@ -9295,7 +9295,7 @@ func (properties *DataLakeAnalytics_Properties) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataLakeAnalytics_Properties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataLakeStoreAccountName’:
+	// Set property "DataLakeStoreAccountName":
 	if typedInput.DataLakeStoreAccountName != nil {
 		dataLakeStoreAccountName := *typedInput.DataLakeStoreAccountName
 		properties.DataLakeStoreAccountName = &dataLakeStoreAccountName
@@ -9353,7 +9353,7 @@ func (properties *DataLakeAnalytics_Properties_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataLakeAnalytics_Properties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DataLakeStoreAccountName’:
+	// Set property "DataLakeStoreAccountName":
 	if typedInput.DataLakeStoreAccountName != nil {
 		dataLakeStoreAccountName := *typedInput.DataLakeStoreAccountName
 		properties.DataLakeStoreAccountName = &dataLakeStoreAccountName
@@ -9411,7 +9411,7 @@ func (response *ErrorResponse_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ErrorResponse_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Error’:
+	// Set property "Error":
 	if typedInput.Error != nil {
 		var error1 ErrorDetail_STATUS
 		err := error1.PopulateFromARM(owner, *typedInput.Error)
@@ -9489,13 +9489,13 @@ func (properties *HDInsightProperties) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &HDInsightProperties_ARM{}
 
-	// Set property ‘Address’:
+	// Set property "Address":
 	if properties.Address != nil {
 		address := *properties.Address
 		result.Address = &address
 	}
 
-	// Set property ‘AdministratorAccount’:
+	// Set property "AdministratorAccount":
 	if properties.AdministratorAccount != nil {
 		administratorAccount_ARM, err := (*properties.AdministratorAccount).ConvertToARM(resolved)
 		if err != nil {
@@ -9505,7 +9505,7 @@ func (properties *HDInsightProperties) ConvertToARM(resolved genruntime.ConvertT
 		result.AdministratorAccount = &administratorAccount
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if properties.SshPort != nil {
 		sshPort := *properties.SshPort
 		result.SshPort = &sshPort
@@ -9525,13 +9525,13 @@ func (properties *HDInsightProperties) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HDInsightProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Address’:
+	// Set property "Address":
 	if typedInput.Address != nil {
 		address := *typedInput.Address
 		properties.Address = &address
 	}
 
-	// Set property ‘AdministratorAccount’:
+	// Set property "AdministratorAccount":
 	if typedInput.AdministratorAccount != nil {
 		var administratorAccount1 VirtualMachineSshCredentials
 		err := administratorAccount1.PopulateFromARM(owner, *typedInput.AdministratorAccount)
@@ -9542,7 +9542,7 @@ func (properties *HDInsightProperties) PopulateFromARM(owner genruntime.Arbitrar
 		properties.AdministratorAccount = &administratorAccount
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if typedInput.SshPort != nil {
 		sshPort := *typedInput.SshPort
 		properties.SshPort = &sshPort
@@ -9632,13 +9632,13 @@ func (properties *HDInsightProperties_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HDInsightProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Address’:
+	// Set property "Address":
 	if typedInput.Address != nil {
 		address := *typedInput.Address
 		properties.Address = &address
 	}
 
-	// Set property ‘AdministratorAccount’:
+	// Set property "AdministratorAccount":
 	if typedInput.AdministratorAccount != nil {
 		var administratorAccount1 VirtualMachineSshCredentials_STATUS
 		err := administratorAccount1.PopulateFromARM(owner, *typedInput.AdministratorAccount)
@@ -9649,7 +9649,7 @@ func (properties *HDInsightProperties_STATUS) PopulateFromARM(owner genruntime.A
 		properties.AdministratorAccount = &administratorAccount
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if typedInput.SshPort != nil {
 		sshPort := *typedInput.SshPort
 		properties.SshPort = &sshPort
@@ -9739,25 +9739,25 @@ func (properties *KubernetesProperties) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &KubernetesProperties_ARM{}
 
-	// Set property ‘DefaultInstanceType’:
+	// Set property "DefaultInstanceType":
 	if properties.DefaultInstanceType != nil {
 		defaultInstanceType := *properties.DefaultInstanceType
 		result.DefaultInstanceType = &defaultInstanceType
 	}
 
-	// Set property ‘ExtensionInstanceReleaseTrain’:
+	// Set property "ExtensionInstanceReleaseTrain":
 	if properties.ExtensionInstanceReleaseTrain != nil {
 		extensionInstanceReleaseTrain := *properties.ExtensionInstanceReleaseTrain
 		result.ExtensionInstanceReleaseTrain = &extensionInstanceReleaseTrain
 	}
 
-	// Set property ‘ExtensionPrincipalId’:
+	// Set property "ExtensionPrincipalId":
 	if properties.ExtensionPrincipalId != nil {
 		extensionPrincipalId := *properties.ExtensionPrincipalId
 		result.ExtensionPrincipalId = &extensionPrincipalId
 	}
 
-	// Set property ‘InstanceTypes’:
+	// Set property "InstanceTypes":
 	if properties.InstanceTypes != nil {
 		result.InstanceTypes = make(map[string]InstanceTypeSchema_ARM, len(properties.InstanceTypes))
 		for key, value := range properties.InstanceTypes {
@@ -9769,13 +9769,13 @@ func (properties *KubernetesProperties) ConvertToARM(resolved genruntime.Convert
 		}
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if properties.Namespace != nil {
 		namespace := *properties.Namespace
 		result.Namespace = &namespace
 	}
 
-	// Set property ‘RelayConnectionString’:
+	// Set property "RelayConnectionString":
 	if properties.RelayConnectionString != nil {
 		relayConnectionStringSecret, err := resolved.ResolvedSecrets.Lookup(*properties.RelayConnectionString)
 		if err != nil {
@@ -9785,7 +9785,7 @@ func (properties *KubernetesProperties) ConvertToARM(resolved genruntime.Convert
 		result.RelayConnectionString = &relayConnectionString
 	}
 
-	// Set property ‘ServiceBusConnectionString’:
+	// Set property "ServiceBusConnectionString":
 	if properties.ServiceBusConnectionString != nil {
 		serviceBusConnectionStringSecret, err := resolved.ResolvedSecrets.Lookup(*properties.ServiceBusConnectionString)
 		if err != nil {
@@ -9795,7 +9795,7 @@ func (properties *KubernetesProperties) ConvertToARM(resolved genruntime.Convert
 		result.ServiceBusConnectionString = &serviceBusConnectionString
 	}
 
-	// Set property ‘VcName’:
+	// Set property "VcName":
 	if properties.VcName != nil {
 		vcName := *properties.VcName
 		result.VcName = &vcName
@@ -9815,25 +9815,25 @@ func (properties *KubernetesProperties) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubernetesProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultInstanceType’:
+	// Set property "DefaultInstanceType":
 	if typedInput.DefaultInstanceType != nil {
 		defaultInstanceType := *typedInput.DefaultInstanceType
 		properties.DefaultInstanceType = &defaultInstanceType
 	}
 
-	// Set property ‘ExtensionInstanceReleaseTrain’:
+	// Set property "ExtensionInstanceReleaseTrain":
 	if typedInput.ExtensionInstanceReleaseTrain != nil {
 		extensionInstanceReleaseTrain := *typedInput.ExtensionInstanceReleaseTrain
 		properties.ExtensionInstanceReleaseTrain = &extensionInstanceReleaseTrain
 	}
 
-	// Set property ‘ExtensionPrincipalId’:
+	// Set property "ExtensionPrincipalId":
 	if typedInput.ExtensionPrincipalId != nil {
 		extensionPrincipalId := *typedInput.ExtensionPrincipalId
 		properties.ExtensionPrincipalId = &extensionPrincipalId
 	}
 
-	// Set property ‘InstanceTypes’:
+	// Set property "InstanceTypes":
 	if typedInput.InstanceTypes != nil {
 		properties.InstanceTypes = make(map[string]InstanceTypeSchema, len(typedInput.InstanceTypes))
 		for key, value := range typedInput.InstanceTypes {
@@ -9846,17 +9846,17 @@ func (properties *KubernetesProperties) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		properties.Namespace = &namespace
 	}
 
-	// no assignment for property ‘RelayConnectionString’
+	// no assignment for property "RelayConnectionString"
 
-	// no assignment for property ‘ServiceBusConnectionString’
+	// no assignment for property "ServiceBusConnectionString"
 
-	// Set property ‘VcName’:
+	// Set property "VcName":
 	if typedInput.VcName != nil {
 		vcName := *typedInput.VcName
 		properties.VcName = &vcName
@@ -10011,25 +10011,25 @@ func (properties *KubernetesProperties_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubernetesProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultInstanceType’:
+	// Set property "DefaultInstanceType":
 	if typedInput.DefaultInstanceType != nil {
 		defaultInstanceType := *typedInput.DefaultInstanceType
 		properties.DefaultInstanceType = &defaultInstanceType
 	}
 
-	// Set property ‘ExtensionInstanceReleaseTrain’:
+	// Set property "ExtensionInstanceReleaseTrain":
 	if typedInput.ExtensionInstanceReleaseTrain != nil {
 		extensionInstanceReleaseTrain := *typedInput.ExtensionInstanceReleaseTrain
 		properties.ExtensionInstanceReleaseTrain = &extensionInstanceReleaseTrain
 	}
 
-	// Set property ‘ExtensionPrincipalId’:
+	// Set property "ExtensionPrincipalId":
 	if typedInput.ExtensionPrincipalId != nil {
 		extensionPrincipalId := *typedInput.ExtensionPrincipalId
 		properties.ExtensionPrincipalId = &extensionPrincipalId
 	}
 
-	// Set property ‘InstanceTypes’:
+	// Set property "InstanceTypes":
 	if typedInput.InstanceTypes != nil {
 		properties.InstanceTypes = make(map[string]InstanceTypeSchema_STATUS, len(typedInput.InstanceTypes))
 		for key, value := range typedInput.InstanceTypes {
@@ -10042,13 +10042,13 @@ func (properties *KubernetesProperties_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Namespace’:
+	// Set property "Namespace":
 	if typedInput.Namespace != nil {
 		namespace := *typedInput.Namespace
 		properties.Namespace = &namespace
 	}
 
-	// Set property ‘VcName’:
+	// Set property "VcName":
 	if typedInput.VcName != nil {
 		vcName := *typedInput.VcName
 		properties.VcName = &vcName
@@ -10170,7 +10170,7 @@ func (properties *SynapseSpark_Properties) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &SynapseSpark_Properties_ARM{}
 
-	// Set property ‘AutoPauseProperties’:
+	// Set property "AutoPauseProperties":
 	if properties.AutoPauseProperties != nil {
 		autoPauseProperties_ARM, err := (*properties.AutoPauseProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -10180,7 +10180,7 @@ func (properties *SynapseSpark_Properties) ConvertToARM(resolved genruntime.Conv
 		result.AutoPauseProperties = &autoPauseProperties
 	}
 
-	// Set property ‘AutoScaleProperties’:
+	// Set property "AutoScaleProperties":
 	if properties.AutoScaleProperties != nil {
 		autoScaleProperties_ARM, err := (*properties.AutoScaleProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -10190,49 +10190,49 @@ func (properties *SynapseSpark_Properties) ConvertToARM(resolved genruntime.Conv
 		result.AutoScaleProperties = &autoScaleProperties
 	}
 
-	// Set property ‘NodeCount’:
+	// Set property "NodeCount":
 	if properties.NodeCount != nil {
 		nodeCount := *properties.NodeCount
 		result.NodeCount = &nodeCount
 	}
 
-	// Set property ‘NodeSize’:
+	// Set property "NodeSize":
 	if properties.NodeSize != nil {
 		nodeSize := *properties.NodeSize
 		result.NodeSize = &nodeSize
 	}
 
-	// Set property ‘NodeSizeFamily’:
+	// Set property "NodeSizeFamily":
 	if properties.NodeSizeFamily != nil {
 		nodeSizeFamily := *properties.NodeSizeFamily
 		result.NodeSizeFamily = &nodeSizeFamily
 	}
 
-	// Set property ‘PoolName’:
+	// Set property "PoolName":
 	if properties.PoolName != nil {
 		poolName := *properties.PoolName
 		result.PoolName = &poolName
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if properties.ResourceGroup != nil {
 		resourceGroup := *properties.ResourceGroup
 		result.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SparkVersion’:
+	// Set property "SparkVersion":
 	if properties.SparkVersion != nil {
 		sparkVersion := *properties.SparkVersion
 		result.SparkVersion = &sparkVersion
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if properties.SubscriptionId != nil {
 		subscriptionId := *properties.SubscriptionId
 		result.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘WorkspaceName’:
+	// Set property "WorkspaceName":
 	if properties.WorkspaceName != nil {
 		workspaceName := *properties.WorkspaceName
 		result.WorkspaceName = &workspaceName
@@ -10252,7 +10252,7 @@ func (properties *SynapseSpark_Properties) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SynapseSpark_Properties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoPauseProperties’:
+	// Set property "AutoPauseProperties":
 	if typedInput.AutoPauseProperties != nil {
 		var autoPauseProperties1 AutoPauseProperties
 		err := autoPauseProperties1.PopulateFromARM(owner, *typedInput.AutoPauseProperties)
@@ -10263,7 +10263,7 @@ func (properties *SynapseSpark_Properties) PopulateFromARM(owner genruntime.Arbi
 		properties.AutoPauseProperties = &autoPauseProperties
 	}
 
-	// Set property ‘AutoScaleProperties’:
+	// Set property "AutoScaleProperties":
 	if typedInput.AutoScaleProperties != nil {
 		var autoScaleProperties1 AutoScaleProperties
 		err := autoScaleProperties1.PopulateFromARM(owner, *typedInput.AutoScaleProperties)
@@ -10274,49 +10274,49 @@ func (properties *SynapseSpark_Properties) PopulateFromARM(owner genruntime.Arbi
 		properties.AutoScaleProperties = &autoScaleProperties
 	}
 
-	// Set property ‘NodeCount’:
+	// Set property "NodeCount":
 	if typedInput.NodeCount != nil {
 		nodeCount := *typedInput.NodeCount
 		properties.NodeCount = &nodeCount
 	}
 
-	// Set property ‘NodeSize’:
+	// Set property "NodeSize":
 	if typedInput.NodeSize != nil {
 		nodeSize := *typedInput.NodeSize
 		properties.NodeSize = &nodeSize
 	}
 
-	// Set property ‘NodeSizeFamily’:
+	// Set property "NodeSizeFamily":
 	if typedInput.NodeSizeFamily != nil {
 		nodeSizeFamily := *typedInput.NodeSizeFamily
 		properties.NodeSizeFamily = &nodeSizeFamily
 	}
 
-	// Set property ‘PoolName’:
+	// Set property "PoolName":
 	if typedInput.PoolName != nil {
 		poolName := *typedInput.PoolName
 		properties.PoolName = &poolName
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if typedInput.ResourceGroup != nil {
 		resourceGroup := *typedInput.ResourceGroup
 		properties.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SparkVersion’:
+	// Set property "SparkVersion":
 	if typedInput.SparkVersion != nil {
 		sparkVersion := *typedInput.SparkVersion
 		properties.SparkVersion = &sparkVersion
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘WorkspaceName’:
+	// Set property "WorkspaceName":
 	if typedInput.WorkspaceName != nil {
 		workspaceName := *typedInput.WorkspaceName
 		properties.WorkspaceName = &workspaceName
@@ -10473,7 +10473,7 @@ func (properties *SynapseSpark_Properties_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SynapseSpark_Properties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoPauseProperties’:
+	// Set property "AutoPauseProperties":
 	if typedInput.AutoPauseProperties != nil {
 		var autoPauseProperties1 AutoPauseProperties_STATUS
 		err := autoPauseProperties1.PopulateFromARM(owner, *typedInput.AutoPauseProperties)
@@ -10484,7 +10484,7 @@ func (properties *SynapseSpark_Properties_STATUS) PopulateFromARM(owner genrunti
 		properties.AutoPauseProperties = &autoPauseProperties
 	}
 
-	// Set property ‘AutoScaleProperties’:
+	// Set property "AutoScaleProperties":
 	if typedInput.AutoScaleProperties != nil {
 		var autoScaleProperties1 AutoScaleProperties_STATUS
 		err := autoScaleProperties1.PopulateFromARM(owner, *typedInput.AutoScaleProperties)
@@ -10495,49 +10495,49 @@ func (properties *SynapseSpark_Properties_STATUS) PopulateFromARM(owner genrunti
 		properties.AutoScaleProperties = &autoScaleProperties
 	}
 
-	// Set property ‘NodeCount’:
+	// Set property "NodeCount":
 	if typedInput.NodeCount != nil {
 		nodeCount := *typedInput.NodeCount
 		properties.NodeCount = &nodeCount
 	}
 
-	// Set property ‘NodeSize’:
+	// Set property "NodeSize":
 	if typedInput.NodeSize != nil {
 		nodeSize := *typedInput.NodeSize
 		properties.NodeSize = &nodeSize
 	}
 
-	// Set property ‘NodeSizeFamily’:
+	// Set property "NodeSizeFamily":
 	if typedInput.NodeSizeFamily != nil {
 		nodeSizeFamily := *typedInput.NodeSizeFamily
 		properties.NodeSizeFamily = &nodeSizeFamily
 	}
 
-	// Set property ‘PoolName’:
+	// Set property "PoolName":
 	if typedInput.PoolName != nil {
 		poolName := *typedInput.PoolName
 		properties.PoolName = &poolName
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	if typedInput.ResourceGroup != nil {
 		resourceGroup := *typedInput.ResourceGroup
 		properties.ResourceGroup = &resourceGroup
 	}
 
-	// Set property ‘SparkVersion’:
+	// Set property "SparkVersion":
 	if typedInput.SparkVersion != nil {
 		sparkVersion := *typedInput.SparkVersion
 		properties.SparkVersion = &sparkVersion
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘WorkspaceName’:
+	// Set property "WorkspaceName":
 	if typedInput.WorkspaceName != nil {
 		workspaceName := *typedInput.WorkspaceName
 		properties.WorkspaceName = &workspaceName
@@ -10684,13 +10684,13 @@ func (properties *VirtualMachine_Properties) ConvertToARM(resolved genruntime.Co
 	}
 	result := &VirtualMachine_Properties_ARM{}
 
-	// Set property ‘Address’:
+	// Set property "Address":
 	if properties.Address != nil {
 		address := *properties.Address
 		result.Address = &address
 	}
 
-	// Set property ‘AdministratorAccount’:
+	// Set property "AdministratorAccount":
 	if properties.AdministratorAccount != nil {
 		administratorAccount_ARM, err := (*properties.AdministratorAccount).ConvertToARM(resolved)
 		if err != nil {
@@ -10700,19 +10700,19 @@ func (properties *VirtualMachine_Properties) ConvertToARM(resolved genruntime.Co
 		result.AdministratorAccount = &administratorAccount
 	}
 
-	// Set property ‘IsNotebookInstanceCompute’:
+	// Set property "IsNotebookInstanceCompute":
 	if properties.IsNotebookInstanceCompute != nil {
 		isNotebookInstanceCompute := *properties.IsNotebookInstanceCompute
 		result.IsNotebookInstanceCompute = &isNotebookInstanceCompute
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if properties.SshPort != nil {
 		sshPort := *properties.SshPort
 		result.SshPort = &sshPort
 	}
 
-	// Set property ‘VirtualMachineSize’:
+	// Set property "VirtualMachineSize":
 	if properties.VirtualMachineSize != nil {
 		virtualMachineSize := *properties.VirtualMachineSize
 		result.VirtualMachineSize = &virtualMachineSize
@@ -10732,13 +10732,13 @@ func (properties *VirtualMachine_Properties) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_Properties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Address’:
+	// Set property "Address":
 	if typedInput.Address != nil {
 		address := *typedInput.Address
 		properties.Address = &address
 	}
 
-	// Set property ‘AdministratorAccount’:
+	// Set property "AdministratorAccount":
 	if typedInput.AdministratorAccount != nil {
 		var administratorAccount1 VirtualMachineSshCredentials
 		err := administratorAccount1.PopulateFromARM(owner, *typedInput.AdministratorAccount)
@@ -10749,19 +10749,19 @@ func (properties *VirtualMachine_Properties) PopulateFromARM(owner genruntime.Ar
 		properties.AdministratorAccount = &administratorAccount
 	}
 
-	// Set property ‘IsNotebookInstanceCompute’:
+	// Set property "IsNotebookInstanceCompute":
 	if typedInput.IsNotebookInstanceCompute != nil {
 		isNotebookInstanceCompute := *typedInput.IsNotebookInstanceCompute
 		properties.IsNotebookInstanceCompute = &isNotebookInstanceCompute
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if typedInput.SshPort != nil {
 		sshPort := *typedInput.SshPort
 		properties.SshPort = &sshPort
 	}
 
-	// Set property ‘VirtualMachineSize’:
+	// Set property "VirtualMachineSize":
 	if typedInput.VirtualMachineSize != nil {
 		virtualMachineSize := *typedInput.VirtualMachineSize
 		properties.VirtualMachineSize = &virtualMachineSize
@@ -10875,13 +10875,13 @@ func (properties *VirtualMachine_Properties_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachine_Properties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Address’:
+	// Set property "Address":
 	if typedInput.Address != nil {
 		address := *typedInput.Address
 		properties.Address = &address
 	}
 
-	// Set property ‘AdministratorAccount’:
+	// Set property "AdministratorAccount":
 	if typedInput.AdministratorAccount != nil {
 		var administratorAccount1 VirtualMachineSshCredentials_STATUS
 		err := administratorAccount1.PopulateFromARM(owner, *typedInput.AdministratorAccount)
@@ -10892,19 +10892,19 @@ func (properties *VirtualMachine_Properties_STATUS) PopulateFromARM(owner genrun
 		properties.AdministratorAccount = &administratorAccount
 	}
 
-	// Set property ‘IsNotebookInstanceCompute’:
+	// Set property "IsNotebookInstanceCompute":
 	if typedInput.IsNotebookInstanceCompute != nil {
 		isNotebookInstanceCompute := *typedInput.IsNotebookInstanceCompute
 		properties.IsNotebookInstanceCompute = &isNotebookInstanceCompute
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if typedInput.SshPort != nil {
 		sshPort := *typedInput.SshPort
 		properties.SshPort = &sshPort
 	}
 
-	// Set property ‘VirtualMachineSize’:
+	// Set property "VirtualMachineSize":
 	if typedInput.VirtualMachineSize != nil {
 		virtualMachineSize := *typedInput.VirtualMachineSize
 		properties.VirtualMachineSize = &virtualMachineSize
@@ -11017,25 +11017,25 @@ func (configuration *AksNetworkingConfiguration) ConvertToARM(resolved genruntim
 	}
 	result := &AksNetworkingConfiguration_ARM{}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if configuration.DnsServiceIP != nil {
 		dnsServiceIP := *configuration.DnsServiceIP
 		result.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if configuration.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *configuration.DockerBridgeCidr
 		result.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if configuration.ServiceCidr != nil {
 		serviceCidr := *configuration.ServiceCidr
 		result.ServiceCidr = &serviceCidr
 	}
 
-	// Set property ‘SubnetId’:
+	// Set property "SubnetId":
 	if configuration.SubnetReference != nil {
 		subnetReferenceARMID, err := resolved.ResolvedReferences.Lookup(*configuration.SubnetReference)
 		if err != nil {
@@ -11059,25 +11059,25 @@ func (configuration *AksNetworkingConfiguration) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AksNetworkingConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if typedInput.DnsServiceIP != nil {
 		dnsServiceIP := *typedInput.DnsServiceIP
 		configuration.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if typedInput.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *typedInput.DockerBridgeCidr
 		configuration.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if typedInput.ServiceCidr != nil {
 		serviceCidr := *typedInput.ServiceCidr
 		configuration.ServiceCidr = &serviceCidr
 	}
 
-	// no assignment for property ‘SubnetReference’
+	// no assignment for property "SubnetReference"
 
 	// No error
 	return nil
@@ -11192,25 +11192,25 @@ func (configuration *AksNetworkingConfiguration_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AksNetworkingConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServiceIP’:
+	// Set property "DnsServiceIP":
 	if typedInput.DnsServiceIP != nil {
 		dnsServiceIP := *typedInput.DnsServiceIP
 		configuration.DnsServiceIP = &dnsServiceIP
 	}
 
-	// Set property ‘DockerBridgeCidr’:
+	// Set property "DockerBridgeCidr":
 	if typedInput.DockerBridgeCidr != nil {
 		dockerBridgeCidr := *typedInput.DockerBridgeCidr
 		configuration.DockerBridgeCidr = &dockerBridgeCidr
 	}
 
-	// Set property ‘ServiceCidr’:
+	// Set property "ServiceCidr":
 	if typedInput.ServiceCidr != nil {
 		serviceCidr := *typedInput.ServiceCidr
 		configuration.ServiceCidr = &serviceCidr
 	}
 
-	// Set property ‘SubnetId’:
+	// Set property "SubnetId":
 	if typedInput.SubnetId != nil {
 		subnetId := *typedInput.SubnetId
 		configuration.SubnetId = &subnetId
@@ -11282,13 +11282,13 @@ func (properties *AutoPauseProperties) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &AutoPauseProperties_ARM{}
 
-	// Set property ‘DelayInMinutes’:
+	// Set property "DelayInMinutes":
 	if properties.DelayInMinutes != nil {
 		delayInMinutes := *properties.DelayInMinutes
 		result.DelayInMinutes = &delayInMinutes
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if properties.Enabled != nil {
 		enabled := *properties.Enabled
 		result.Enabled = &enabled
@@ -11308,13 +11308,13 @@ func (properties *AutoPauseProperties) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoPauseProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DelayInMinutes’:
+	// Set property "DelayInMinutes":
 	if typedInput.DelayInMinutes != nil {
 		delayInMinutes := *typedInput.DelayInMinutes
 		properties.DelayInMinutes = &delayInMinutes
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
@@ -11389,13 +11389,13 @@ func (properties *AutoPauseProperties_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoPauseProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DelayInMinutes’:
+	// Set property "DelayInMinutes":
 	if typedInput.DelayInMinutes != nil {
 		delayInMinutes := *typedInput.DelayInMinutes
 		properties.DelayInMinutes = &delayInMinutes
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
@@ -11466,19 +11466,19 @@ func (properties *AutoScaleProperties) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &AutoScaleProperties_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if properties.Enabled != nil {
 		enabled := *properties.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if properties.MaxNodeCount != nil {
 		maxNodeCount := *properties.MaxNodeCount
 		result.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if properties.MinNodeCount != nil {
 		minNodeCount := *properties.MinNodeCount
 		result.MinNodeCount = &minNodeCount
@@ -11498,19 +11498,19 @@ func (properties *AutoScaleProperties) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoScaleProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
 	}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if typedInput.MaxNodeCount != nil {
 		maxNodeCount := *typedInput.MaxNodeCount
 		properties.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if typedInput.MinNodeCount != nil {
 		minNodeCount := *typedInput.MinNodeCount
 		properties.MinNodeCount = &minNodeCount
@@ -11592,19 +11592,19 @@ func (properties *AutoScaleProperties_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoScaleProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
 	}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if typedInput.MaxNodeCount != nil {
 		maxNodeCount := *typedInput.MaxNodeCount
 		properties.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if typedInput.MinNodeCount != nil {
 		minNodeCount := *typedInput.MinNodeCount
 		properties.MinNodeCount = &minNodeCount
@@ -11685,13 +11685,13 @@ func (application *ComputeInstanceApplication_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceApplication_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisplayName’:
+	// Set property "DisplayName":
 	if typedInput.DisplayName != nil {
 		displayName := *typedInput.DisplayName
 		application.DisplayName = &displayName
 	}
 
-	// Set property ‘EndpointUri’:
+	// Set property "EndpointUri":
 	if typedInput.EndpointUri != nil {
 		endpointUri := *typedInput.EndpointUri
 		application.EndpointUri = &endpointUri
@@ -11756,13 +11756,13 @@ func (endpoints *ComputeInstanceConnectivityEndpoints_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceConnectivityEndpoints_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrivateIpAddress’:
+	// Set property "PrivateIpAddress":
 	if typedInput.PrivateIpAddress != nil {
 		privateIpAddress := *typedInput.PrivateIpAddress
 		endpoints.PrivateIpAddress = &privateIpAddress
 	}
 
-	// Set property ‘PublicIpAddress’:
+	// Set property "PublicIpAddress":
 	if typedInput.PublicIpAddress != nil {
 		publicIpAddress := *typedInput.PublicIpAddress
 		endpoints.PublicIpAddress = &publicIpAddress
@@ -11828,19 +11828,19 @@ func (createdBy *ComputeInstanceCreatedBy_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceCreatedBy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserId’:
+	// Set property "UserId":
 	if typedInput.UserId != nil {
 		userId := *typedInput.UserId
 		createdBy.UserId = &userId
 	}
 
-	// Set property ‘UserName’:
+	// Set property "UserName":
 	if typedInput.UserName != nil {
 		userName := *typedInput.UserName
 		createdBy.UserName = &userName
 	}
 
-	// Set property ‘UserOrgId’:
+	// Set property "UserOrgId":
 	if typedInput.UserOrgId != nil {
 		userOrgId := *typedInput.UserOrgId
 		createdBy.UserOrgId = &userOrgId
@@ -11912,19 +11912,19 @@ func (operation *ComputeInstanceLastOperation_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceLastOperation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘OperationName’:
+	// Set property "OperationName":
 	if typedInput.OperationName != nil {
 		operationName := *typedInput.OperationName
 		operation.OperationName = &operationName
 	}
 
-	// Set property ‘OperationStatus’:
+	// Set property "OperationStatus":
 	if typedInput.OperationStatus != nil {
 		operationStatus := *typedInput.OperationStatus
 		operation.OperationStatus = &operationStatus
 	}
 
-	// Set property ‘OperationTime’:
+	// Set property "OperationTime":
 	if typedInput.OperationTime != nil {
 		operationTime := *typedInput.OperationTime
 		operation.OperationTime = &operationTime
@@ -12010,13 +12010,13 @@ func (settings *ComputeInstanceSshSettings) ConvertToARM(resolved genruntime.Con
 	}
 	result := &ComputeInstanceSshSettings_ARM{}
 
-	// Set property ‘AdminPublicKey’:
+	// Set property "AdminPublicKey":
 	if settings.AdminPublicKey != nil {
 		adminPublicKey := *settings.AdminPublicKey
 		result.AdminPublicKey = &adminPublicKey
 	}
 
-	// Set property ‘SshPublicAccess’:
+	// Set property "SshPublicAccess":
 	if settings.SshPublicAccess != nil {
 		sshPublicAccess := *settings.SshPublicAccess
 		result.SshPublicAccess = &sshPublicAccess
@@ -12036,13 +12036,13 @@ func (settings *ComputeInstanceSshSettings) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceSshSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminPublicKey’:
+	// Set property "AdminPublicKey":
 	if typedInput.AdminPublicKey != nil {
 		adminPublicKey := *typedInput.AdminPublicKey
 		settings.AdminPublicKey = &adminPublicKey
 	}
 
-	// Set property ‘SshPublicAccess’:
+	// Set property "SshPublicAccess":
 	if typedInput.SshPublicAccess != nil {
 		sshPublicAccess := *typedInput.SshPublicAccess
 		settings.SshPublicAccess = &sshPublicAccess
@@ -12119,25 +12119,25 @@ func (settings *ComputeInstanceSshSettings_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ComputeInstanceSshSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminPublicKey’:
+	// Set property "AdminPublicKey":
 	if typedInput.AdminPublicKey != nil {
 		adminPublicKey := *typedInput.AdminPublicKey
 		settings.AdminPublicKey = &adminPublicKey
 	}
 
-	// Set property ‘AdminUserName’:
+	// Set property "AdminUserName":
 	if typedInput.AdminUserName != nil {
 		adminUserName := *typedInput.AdminUserName
 		settings.AdminUserName = &adminUserName
 	}
 
-	// Set property ‘SshPort’:
+	// Set property "SshPort":
 	if typedInput.SshPort != nil {
 		sshPort := *typedInput.SshPort
 		settings.SshPort = &sshPort
 	}
 
-	// Set property ‘SshPublicAccess’:
+	// Set property "SshPublicAccess":
 	if typedInput.SshPublicAccess != nil {
 		sshPublicAccess := *typedInput.SshPublicAccess
 		settings.SshPublicAccess = &sshPublicAccess
@@ -12227,7 +12227,7 @@ func (detail *ErrorDetail_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ErrorDetail_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalInfo’:
+	// Set property "AdditionalInfo":
 	for _, item := range typedInput.AdditionalInfo {
 		var item1 ErrorAdditionalInfo_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -12237,13 +12237,13 @@ func (detail *ErrorDetail_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		detail.AdditionalInfo = append(detail.AdditionalInfo, item1)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		detail.Code = &code
 	}
 
-	// Set property ‘Details’:
+	// Set property "Details":
 	for _, item := range typedInput.Details {
 		var item1 ErrorDetail_STATUS_Unrolled
 		err := item1.PopulateFromARM(owner, item)
@@ -12253,13 +12253,13 @@ func (detail *ErrorDetail_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		detail.Details = append(detail.Details, item1)
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		detail.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		detail.Target = &target
@@ -12397,7 +12397,7 @@ func (schema *InstanceTypeSchema) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &InstanceTypeSchema_ARM{}
 
-	// Set property ‘NodeSelector’:
+	// Set property "NodeSelector":
 	if schema.NodeSelector != nil {
 		result.NodeSelector = make(map[string]string, len(schema.NodeSelector))
 		for key, value := range schema.NodeSelector {
@@ -12405,7 +12405,7 @@ func (schema *InstanceTypeSchema) ConvertToARM(resolved genruntime.ConvertToARMR
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	if schema.Resources != nil {
 		resources_ARM, err := (*schema.Resources).ConvertToARM(resolved)
 		if err != nil {
@@ -12429,7 +12429,7 @@ func (schema *InstanceTypeSchema) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InstanceTypeSchema_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NodeSelector’:
+	// Set property "NodeSelector":
 	if typedInput.NodeSelector != nil {
 		schema.NodeSelector = make(map[string]string, len(typedInput.NodeSelector))
 		for key, value := range typedInput.NodeSelector {
@@ -12437,7 +12437,7 @@ func (schema *InstanceTypeSchema) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	if typedInput.Resources != nil {
 		var resources1 InstanceTypeSchema_Resources
 		err := resources1.PopulateFromARM(owner, *typedInput.Resources)
@@ -12525,7 +12525,7 @@ func (schema *InstanceTypeSchema_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InstanceTypeSchema_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘NodeSelector’:
+	// Set property "NodeSelector":
 	if typedInput.NodeSelector != nil {
 		schema.NodeSelector = make(map[string]string, len(typedInput.NodeSelector))
 		for key, value := range typedInput.NodeSelector {
@@ -12533,7 +12533,7 @@ func (schema *InstanceTypeSchema_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Resources’:
+	// Set property "Resources":
 	if typedInput.Resources != nil {
 		var resources1 InstanceTypeSchema_Resources_STATUS
 		err := resources1.PopulateFromARM(owner, *typedInput.Resources)
@@ -12625,37 +12625,37 @@ func (counts *NodeStateCounts_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NodeStateCounts_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IdleNodeCount’:
+	// Set property "IdleNodeCount":
 	if typedInput.IdleNodeCount != nil {
 		idleNodeCount := *typedInput.IdleNodeCount
 		counts.IdleNodeCount = &idleNodeCount
 	}
 
-	// Set property ‘LeavingNodeCount’:
+	// Set property "LeavingNodeCount":
 	if typedInput.LeavingNodeCount != nil {
 		leavingNodeCount := *typedInput.LeavingNodeCount
 		counts.LeavingNodeCount = &leavingNodeCount
 	}
 
-	// Set property ‘PreemptedNodeCount’:
+	// Set property "PreemptedNodeCount":
 	if typedInput.PreemptedNodeCount != nil {
 		preemptedNodeCount := *typedInput.PreemptedNodeCount
 		counts.PreemptedNodeCount = &preemptedNodeCount
 	}
 
-	// Set property ‘PreparingNodeCount’:
+	// Set property "PreparingNodeCount":
 	if typedInput.PreparingNodeCount != nil {
 		preparingNodeCount := *typedInput.PreparingNodeCount
 		counts.PreparingNodeCount = &preparingNodeCount
 	}
 
-	// Set property ‘RunningNodeCount’:
+	// Set property "RunningNodeCount":
 	if typedInput.RunningNodeCount != nil {
 		runningNodeCount := *typedInput.RunningNodeCount
 		counts.RunningNodeCount = &runningNodeCount
 	}
 
-	// Set property ‘UnusableNodeCount’:
+	// Set property "UnusableNodeCount":
 	if typedInput.UnusableNodeCount != nil {
 		unusableNodeCount := *typedInput.UnusableNodeCount
 		counts.UnusableNodeCount = &unusableNodeCount
@@ -12738,7 +12738,7 @@ func (settings *PersonalComputeInstanceSettings) ConvertToARM(resolved genruntim
 	}
 	result := &PersonalComputeInstanceSettings_ARM{}
 
-	// Set property ‘AssignedUser’:
+	// Set property "AssignedUser":
 	if settings.AssignedUser != nil {
 		assignedUser_ARM, err := (*settings.AssignedUser).ConvertToARM(resolved)
 		if err != nil {
@@ -12762,7 +12762,7 @@ func (settings *PersonalComputeInstanceSettings) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PersonalComputeInstanceSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssignedUser’:
+	// Set property "AssignedUser":
 	if typedInput.AssignedUser != nil {
 		var assignedUser1 AssignedUser
 		err := assignedUser1.PopulateFromARM(owner, *typedInput.AssignedUser)
@@ -12843,7 +12843,7 @@ func (settings *PersonalComputeInstanceSettings_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PersonalComputeInstanceSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AssignedUser’:
+	// Set property "AssignedUser":
 	if typedInput.AssignedUser != nil {
 		var assignedUser1 AssignedUser_STATUS
 		err := assignedUser1.PopulateFromARM(owner, *typedInput.AssignedUser)
@@ -12920,7 +12920,7 @@ func (resourceId *ResourceId) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &ResourceId_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resourceId.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resourceId.Reference)
 		if err != nil {
@@ -12944,7 +12944,7 @@ func (resourceId *ResourceId) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceId_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -13008,7 +13008,7 @@ func (resourceId *ResourceId_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceId_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resourceId.Id = &id
@@ -13064,19 +13064,19 @@ func (settings *ScaleSettings) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &ScaleSettings_ARM{}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if settings.MaxNodeCount != nil {
 		maxNodeCount := *settings.MaxNodeCount
 		result.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if settings.MinNodeCount != nil {
 		minNodeCount := *settings.MinNodeCount
 		result.MinNodeCount = &minNodeCount
 	}
 
-	// Set property ‘NodeIdleTimeBeforeScaleDown’:
+	// Set property "NodeIdleTimeBeforeScaleDown":
 	if settings.NodeIdleTimeBeforeScaleDown != nil {
 		nodeIdleTimeBeforeScaleDown := *settings.NodeIdleTimeBeforeScaleDown
 		result.NodeIdleTimeBeforeScaleDown = &nodeIdleTimeBeforeScaleDown
@@ -13096,19 +13096,19 @@ func (settings *ScaleSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScaleSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if typedInput.MaxNodeCount != nil {
 		maxNodeCount := *typedInput.MaxNodeCount
 		settings.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if typedInput.MinNodeCount != nil {
 		minNodeCount := *typedInput.MinNodeCount
 		settings.MinNodeCount = &minNodeCount
 	}
 
-	// Set property ‘NodeIdleTimeBeforeScaleDown’:
+	// Set property "NodeIdleTimeBeforeScaleDown":
 	if typedInput.NodeIdleTimeBeforeScaleDown != nil {
 		nodeIdleTimeBeforeScaleDown := *typedInput.NodeIdleTimeBeforeScaleDown
 		settings.NodeIdleTimeBeforeScaleDown = &nodeIdleTimeBeforeScaleDown
@@ -13180,19 +13180,19 @@ func (settings *ScaleSettings_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScaleSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if typedInput.MaxNodeCount != nil {
 		maxNodeCount := *typedInput.MaxNodeCount
 		settings.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if typedInput.MinNodeCount != nil {
 		minNodeCount := *typedInput.MinNodeCount
 		settings.MinNodeCount = &minNodeCount
 	}
 
-	// Set property ‘NodeIdleTimeBeforeScaleDown’:
+	// Set property "NodeIdleTimeBeforeScaleDown":
 	if typedInput.NodeIdleTimeBeforeScaleDown != nil {
 		nodeIdleTimeBeforeScaleDown := *typedInput.NodeIdleTimeBeforeScaleDown
 		settings.NodeIdleTimeBeforeScaleDown = &nodeIdleTimeBeforeScaleDown
@@ -13257,7 +13257,7 @@ func (scripts *SetupScripts) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SetupScripts_ARM{}
 
-	// Set property ‘Scripts’:
+	// Set property "Scripts":
 	if scripts.Scripts != nil {
 		scripts_ARM, err := (*scripts.Scripts).ConvertToARM(resolved)
 		if err != nil {
@@ -13281,7 +13281,7 @@ func (scripts *SetupScripts) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SetupScripts_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Scripts’:
+	// Set property "Scripts":
 	if typedInput.Scripts != nil {
 		var scripts2 ScriptsToExecute
 		err := scripts2.PopulateFromARM(owner, *typedInput.Scripts)
@@ -13362,7 +13362,7 @@ func (scripts *SetupScripts_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SetupScripts_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Scripts’:
+	// Set property "Scripts":
 	if typedInput.Scripts != nil {
 		var scripts2 ScriptsToExecute_STATUS
 		err := scripts2.PopulateFromARM(owner, *typedInput.Scripts)
@@ -13443,37 +13443,37 @@ func (configuration *SslConfiguration) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &SslConfiguration_ARM{}
 
-	// Set property ‘Cert’:
+	// Set property "Cert":
 	if configuration.Cert != nil {
 		cert := *configuration.Cert
 		result.Cert = &cert
 	}
 
-	// Set property ‘Cname’:
+	// Set property "Cname":
 	if configuration.Cname != nil {
 		cname := *configuration.Cname
 		result.Cname = &cname
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if configuration.Key != nil {
 		key := *configuration.Key
 		result.Key = &key
 	}
 
-	// Set property ‘LeafDomainLabel’:
+	// Set property "LeafDomainLabel":
 	if configuration.LeafDomainLabel != nil {
 		leafDomainLabel := *configuration.LeafDomainLabel
 		result.LeafDomainLabel = &leafDomainLabel
 	}
 
-	// Set property ‘OverwriteExistingDomain’:
+	// Set property "OverwriteExistingDomain":
 	if configuration.OverwriteExistingDomain != nil {
 		overwriteExistingDomain := *configuration.OverwriteExistingDomain
 		result.OverwriteExistingDomain = &overwriteExistingDomain
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if configuration.Status != nil {
 		status := *configuration.Status
 		result.Status = &status
@@ -13493,37 +13493,37 @@ func (configuration *SslConfiguration) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SslConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cert’:
+	// Set property "Cert":
 	if typedInput.Cert != nil {
 		cert := *typedInput.Cert
 		configuration.Cert = &cert
 	}
 
-	// Set property ‘Cname’:
+	// Set property "Cname":
 	if typedInput.Cname != nil {
 		cname := *typedInput.Cname
 		configuration.Cname = &cname
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		configuration.Key = &key
 	}
 
-	// Set property ‘LeafDomainLabel’:
+	// Set property "LeafDomainLabel":
 	if typedInput.LeafDomainLabel != nil {
 		leafDomainLabel := *typedInput.LeafDomainLabel
 		configuration.LeafDomainLabel = &leafDomainLabel
 	}
 
-	// Set property ‘OverwriteExistingDomain’:
+	// Set property "OverwriteExistingDomain":
 	if typedInput.OverwriteExistingDomain != nil {
 		overwriteExistingDomain := *typedInput.OverwriteExistingDomain
 		configuration.OverwriteExistingDomain = &overwriteExistingDomain
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		configuration.Status = &status
@@ -13636,37 +13636,37 @@ func (configuration *SslConfiguration_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SslConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cert’:
+	// Set property "Cert":
 	if typedInput.Cert != nil {
 		cert := *typedInput.Cert
 		configuration.Cert = &cert
 	}
 
-	// Set property ‘Cname’:
+	// Set property "Cname":
 	if typedInput.Cname != nil {
 		cname := *typedInput.Cname
 		configuration.Cname = &cname
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		key := *typedInput.Key
 		configuration.Key = &key
 	}
 
-	// Set property ‘LeafDomainLabel’:
+	// Set property "LeafDomainLabel":
 	if typedInput.LeafDomainLabel != nil {
 		leafDomainLabel := *typedInput.LeafDomainLabel
 		configuration.LeafDomainLabel = &leafDomainLabel
 	}
 
-	// Set property ‘OverwriteExistingDomain’:
+	// Set property "OverwriteExistingDomain":
 	if typedInput.OverwriteExistingDomain != nil {
 		overwriteExistingDomain := *typedInput.OverwriteExistingDomain
 		configuration.OverwriteExistingDomain = &overwriteExistingDomain
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		configuration.Status = &status
@@ -13776,19 +13776,19 @@ func (service *SystemService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemService_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublicIpAddress’:
+	// Set property "PublicIpAddress":
 	if typedInput.PublicIpAddress != nil {
 		publicIpAddress := *typedInput.PublicIpAddress
 		service.PublicIpAddress = &publicIpAddress
 	}
 
-	// Set property ‘SystemServiceType’:
+	// Set property "SystemServiceType":
 	if typedInput.SystemServiceType != nil {
 		systemServiceType := *typedInput.SystemServiceType
 		service.SystemServiceType = &systemServiceType
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		version := *typedInput.Version
 		service.Version = &version
@@ -13856,13 +13856,13 @@ func (credentials *UserAccountCredentials) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &UserAccountCredentials_ARM{}
 
-	// Set property ‘AdminUserName’:
+	// Set property "AdminUserName":
 	if credentials.AdminUserName != nil {
 		adminUserName := *credentials.AdminUserName
 		result.AdminUserName = &adminUserName
 	}
 
-	// Set property ‘AdminUserPassword’:
+	// Set property "AdminUserPassword":
 	if credentials.AdminUserPassword != nil {
 		adminUserPasswordSecret, err := resolved.ResolvedSecrets.Lookup(*credentials.AdminUserPassword)
 		if err != nil {
@@ -13872,7 +13872,7 @@ func (credentials *UserAccountCredentials) ConvertToARM(resolved genruntime.Conv
 		result.AdminUserPassword = &adminUserPassword
 	}
 
-	// Set property ‘AdminUserSshPublicKey’:
+	// Set property "AdminUserSshPublicKey":
 	if credentials.AdminUserSshPublicKey != nil {
 		adminUserSshPublicKeySecret, err := resolved.ResolvedSecrets.Lookup(*credentials.AdminUserSshPublicKey)
 		if err != nil {
@@ -13896,15 +13896,15 @@ func (credentials *UserAccountCredentials) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAccountCredentials_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUserName’:
+	// Set property "AdminUserName":
 	if typedInput.AdminUserName != nil {
 		adminUserName := *typedInput.AdminUserName
 		credentials.AdminUserName = &adminUserName
 	}
 
-	// no assignment for property ‘AdminUserPassword’
+	// no assignment for property "AdminUserPassword"
 
-	// no assignment for property ‘AdminUserSshPublicKey’
+	// no assignment for property "AdminUserSshPublicKey"
 
 	// No error
 	return nil
@@ -13990,7 +13990,7 @@ func (credentials *UserAccountCredentials_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAccountCredentials_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdminUserName’:
+	// Set property "AdminUserName":
 	if typedInput.AdminUserName != nil {
 		adminUserName := *typedInput.AdminUserName
 		credentials.AdminUserName = &adminUserName
@@ -14044,7 +14044,7 @@ func (image *VirtualMachineImage) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &VirtualMachineImage_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if image.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*image.Reference)
 		if err != nil {
@@ -14068,7 +14068,7 @@ func (image *VirtualMachineImage) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineImage_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -14132,7 +14132,7 @@ func (image *VirtualMachineImage_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineImage_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		image.Id = &id
@@ -14188,7 +14188,7 @@ func (credentials *VirtualMachineSshCredentials) ConvertToARM(resolved genruntim
 	}
 	result := &VirtualMachineSshCredentials_ARM{}
 
-	// Set property ‘Password’:
+	// Set property "Password":
 	if credentials.Password != nil {
 		passwordSecret, err := resolved.ResolvedSecrets.Lookup(*credentials.Password)
 		if err != nil {
@@ -14198,19 +14198,19 @@ func (credentials *VirtualMachineSshCredentials) ConvertToARM(resolved genruntim
 		result.Password = &password
 	}
 
-	// Set property ‘PrivateKeyData’:
+	// Set property "PrivateKeyData":
 	if credentials.PrivateKeyData != nil {
 		privateKeyData := *credentials.PrivateKeyData
 		result.PrivateKeyData = &privateKeyData
 	}
 
-	// Set property ‘PublicKeyData’:
+	// Set property "PublicKeyData":
 	if credentials.PublicKeyData != nil {
 		publicKeyData := *credentials.PublicKeyData
 		result.PublicKeyData = &publicKeyData
 	}
 
-	// Set property ‘Username’:
+	// Set property "Username":
 	if credentials.Username != nil {
 		username := *credentials.Username
 		result.Username = &username
@@ -14230,21 +14230,21 @@ func (credentials *VirtualMachineSshCredentials) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineSshCredentials_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Password’
+	// no assignment for property "Password"
 
-	// Set property ‘PrivateKeyData’:
+	// Set property "PrivateKeyData":
 	if typedInput.PrivateKeyData != nil {
 		privateKeyData := *typedInput.PrivateKeyData
 		credentials.PrivateKeyData = &privateKeyData
 	}
 
-	// Set property ‘PublicKeyData’:
+	// Set property "PublicKeyData":
 	if typedInput.PublicKeyData != nil {
 		publicKeyData := *typedInput.PublicKeyData
 		credentials.PublicKeyData = &publicKeyData
 	}
 
-	// Set property ‘Username’:
+	// Set property "Username":
 	if typedInput.Username != nil {
 		username := *typedInput.Username
 		credentials.Username = &username
@@ -14332,19 +14332,19 @@ func (credentials *VirtualMachineSshCredentials_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualMachineSshCredentials_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrivateKeyData’:
+	// Set property "PrivateKeyData":
 	if typedInput.PrivateKeyData != nil {
 		privateKeyData := *typedInput.PrivateKeyData
 		credentials.PrivateKeyData = &privateKeyData
 	}
 
-	// Set property ‘PublicKeyData’:
+	// Set property "PublicKeyData":
 	if typedInput.PublicKeyData != nil {
 		publicKeyData := *typedInput.PublicKeyData
 		credentials.PublicKeyData = &publicKeyData
 	}
 
-	// Set property ‘Username’:
+	// Set property "Username":
 	if typedInput.Username != nil {
 		username := *typedInput.Username
 		credentials.Username = &username
@@ -14413,13 +14413,13 @@ func (user *AssignedUser) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &AssignedUser_ARM{}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if user.ObjectId != nil {
 		objectId := *user.ObjectId
 		result.ObjectId = &objectId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if user.TenantId != nil {
 		tenantId := *user.TenantId
 		result.TenantId = &tenantId
@@ -14439,13 +14439,13 @@ func (user *AssignedUser) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AssignedUser_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		user.ObjectId = &objectId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		user.TenantId = &tenantId
@@ -14510,13 +14510,13 @@ func (user *AssignedUser_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AssignedUser_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectId’:
+	// Set property "ObjectId":
 	if typedInput.ObjectId != nil {
 		objectId := *typedInput.ObjectId
 		user.ObjectId = &objectId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		user.TenantId = &tenantId
@@ -14581,7 +14581,7 @@ func (info *ErrorAdditionalInfo_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ErrorAdditionalInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Info’:
+	// Set property "Info":
 	if typedInput.Info != nil {
 		info.Info = make(map[string]v1.JSON, len(typedInput.Info))
 		for key, value := range typedInput.Info {
@@ -14589,7 +14589,7 @@ func (info *ErrorAdditionalInfo_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		info.Type = &typeVar
@@ -14676,7 +14676,7 @@ func (unrolled *ErrorDetail_STATUS_Unrolled) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ErrorDetail_STATUS_Unrolled_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalInfo’:
+	// Set property "AdditionalInfo":
 	for _, item := range typedInput.AdditionalInfo {
 		var item1 ErrorAdditionalInfo_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -14686,19 +14686,19 @@ func (unrolled *ErrorDetail_STATUS_Unrolled) PopulateFromARM(owner genruntime.Ar
 		unrolled.AdditionalInfo = append(unrolled.AdditionalInfo, item1)
 	}
 
-	// Set property ‘Code’:
+	// Set property "Code":
 	if typedInput.Code != nil {
 		code := *typedInput.Code
 		unrolled.Code = &code
 	}
 
-	// Set property ‘Message’:
+	// Set property "Message":
 	if typedInput.Message != nil {
 		message := *typedInput.Message
 		unrolled.Message = &message
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		unrolled.Target = &target
@@ -14800,7 +14800,7 @@ func (resources *InstanceTypeSchema_Resources) ConvertToARM(resolved genruntime.
 	}
 	result := &InstanceTypeSchema_Resources_ARM{}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if resources.Limits != nil {
 		result.Limits = make(map[string]string, len(resources.Limits))
 		for key, value := range resources.Limits {
@@ -14808,7 +14808,7 @@ func (resources *InstanceTypeSchema_Resources) ConvertToARM(resolved genruntime.
 		}
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if resources.Requests != nil {
 		result.Requests = make(map[string]string, len(resources.Requests))
 		for key, value := range resources.Requests {
@@ -14830,7 +14830,7 @@ func (resources *InstanceTypeSchema_Resources) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InstanceTypeSchema_Resources_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if typedInput.Limits != nil {
 		resources.Limits = make(map[string]string, len(typedInput.Limits))
 		for key, value := range typedInput.Limits {
@@ -14838,7 +14838,7 @@ func (resources *InstanceTypeSchema_Resources) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if typedInput.Requests != nil {
 		resources.Requests = make(map[string]string, len(typedInput.Requests))
 		for key, value := range typedInput.Requests {
@@ -14905,7 +14905,7 @@ func (resources *InstanceTypeSchema_Resources_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InstanceTypeSchema_Resources_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if typedInput.Limits != nil {
 		resources.Limits = make(map[string]string, len(typedInput.Limits))
 		for key, value := range typedInput.Limits {
@@ -14913,7 +14913,7 @@ func (resources *InstanceTypeSchema_Resources_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if typedInput.Requests != nil {
 		resources.Requests = make(map[string]string, len(typedInput.Requests))
 		for key, value := range typedInput.Requests {
@@ -14975,7 +14975,7 @@ func (execute *ScriptsToExecute) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ScriptsToExecute_ARM{}
 
-	// Set property ‘CreationScript’:
+	// Set property "CreationScript":
 	if execute.CreationScript != nil {
 		creationScript_ARM, err := (*execute.CreationScript).ConvertToARM(resolved)
 		if err != nil {
@@ -14985,7 +14985,7 @@ func (execute *ScriptsToExecute) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.CreationScript = &creationScript
 	}
 
-	// Set property ‘StartupScript’:
+	// Set property "StartupScript":
 	if execute.StartupScript != nil {
 		startupScript_ARM, err := (*execute.StartupScript).ConvertToARM(resolved)
 		if err != nil {
@@ -15009,7 +15009,7 @@ func (execute *ScriptsToExecute) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScriptsToExecute_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreationScript’:
+	// Set property "CreationScript":
 	if typedInput.CreationScript != nil {
 		var creationScript1 ScriptReference
 		err := creationScript1.PopulateFromARM(owner, *typedInput.CreationScript)
@@ -15020,7 +15020,7 @@ func (execute *ScriptsToExecute) PopulateFromARM(owner genruntime.ArbitraryOwner
 		execute.CreationScript = &creationScript
 	}
 
-	// Set property ‘StartupScript’:
+	// Set property "StartupScript":
 	if typedInput.StartupScript != nil {
 		var startupScript1 ScriptReference
 		err := startupScript1.PopulateFromARM(owner, *typedInput.StartupScript)
@@ -15126,7 +15126,7 @@ func (execute *ScriptsToExecute_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScriptsToExecute_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreationScript’:
+	// Set property "CreationScript":
 	if typedInput.CreationScript != nil {
 		var creationScript1 ScriptReference_STATUS
 		err := creationScript1.PopulateFromARM(owner, *typedInput.CreationScript)
@@ -15137,7 +15137,7 @@ func (execute *ScriptsToExecute_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		execute.CreationScript = &creationScript
 	}
 
-	// Set property ‘StartupScript’:
+	// Set property "StartupScript":
 	if typedInput.StartupScript != nil {
 		var startupScript1 ScriptReference_STATUS
 		err := startupScript1.PopulateFromARM(owner, *typedInput.StartupScript)
@@ -15240,25 +15240,25 @@ func (reference *ScriptReference) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ScriptReference_ARM{}
 
-	// Set property ‘ScriptArguments’:
+	// Set property "ScriptArguments":
 	if reference.ScriptArguments != nil {
 		scriptArguments := *reference.ScriptArguments
 		result.ScriptArguments = &scriptArguments
 	}
 
-	// Set property ‘ScriptData’:
+	// Set property "ScriptData":
 	if reference.ScriptData != nil {
 		scriptData := *reference.ScriptData
 		result.ScriptData = &scriptData
 	}
 
-	// Set property ‘ScriptSource’:
+	// Set property "ScriptSource":
 	if reference.ScriptSource != nil {
 		scriptSource := *reference.ScriptSource
 		result.ScriptSource = &scriptSource
 	}
 
-	// Set property ‘Timeout’:
+	// Set property "Timeout":
 	if reference.Timeout != nil {
 		timeout := *reference.Timeout
 		result.Timeout = &timeout
@@ -15278,25 +15278,25 @@ func (reference *ScriptReference) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScriptReference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ScriptArguments’:
+	// Set property "ScriptArguments":
 	if typedInput.ScriptArguments != nil {
 		scriptArguments := *typedInput.ScriptArguments
 		reference.ScriptArguments = &scriptArguments
 	}
 
-	// Set property ‘ScriptData’:
+	// Set property "ScriptData":
 	if typedInput.ScriptData != nil {
 		scriptData := *typedInput.ScriptData
 		reference.ScriptData = &scriptData
 	}
 
-	// Set property ‘ScriptSource’:
+	// Set property "ScriptSource":
 	if typedInput.ScriptSource != nil {
 		scriptSource := *typedInput.ScriptSource
 		reference.ScriptSource = &scriptSource
 	}
 
-	// Set property ‘Timeout’:
+	// Set property "Timeout":
 	if typedInput.Timeout != nil {
 		timeout := *typedInput.Timeout
 		reference.Timeout = &timeout
@@ -15375,25 +15375,25 @@ func (reference *ScriptReference_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ScriptReference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ScriptArguments’:
+	// Set property "ScriptArguments":
 	if typedInput.ScriptArguments != nil {
 		scriptArguments := *typedInput.ScriptArguments
 		reference.ScriptArguments = &scriptArguments
 	}
 
-	// Set property ‘ScriptData’:
+	// Set property "ScriptData":
 	if typedInput.ScriptData != nil {
 		scriptData := *typedInput.ScriptData
 		reference.ScriptData = &scriptData
 	}
 
-	// Set property ‘ScriptSource’:
+	// Set property "ScriptSource":
 	if typedInput.ScriptSource != nil {
 		scriptSource := *typedInput.ScriptSource
 		reference.ScriptSource = &scriptSource
 	}
 
-	// Set property ‘Timeout’:
+	// Set property "Timeout":
 	if typedInput.Timeout != nil {
 		timeout := *typedInput.Timeout
 		reference.Timeout = &timeout

--- a/v2/api/machinelearningservices/v1beta20210701/workspaces_connection_types_gen.go
+++ b/v2/api/machinelearningservices/v1beta20210701/workspaces_connection_types_gen.go
@@ -336,10 +336,10 @@ func (connection *Workspaces_Connection_Spec) ConvertToARM(resolved genruntime.C
 	}
 	result := &Workspaces_Connection_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if connection.AuthType != nil ||
 		connection.Category != nil ||
 		connection.Target != nil ||
@@ -382,7 +382,7 @@ func (connection *Workspaces_Connection_Spec) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspaces_Connection_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthType’:
+	// Set property "AuthType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AuthType != nil {
@@ -391,10 +391,10 @@ func (connection *Workspaces_Connection_Spec) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	connection.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Category’:
+	// Set property "Category":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Category != nil {
@@ -403,10 +403,10 @@ func (connection *Workspaces_Connection_Spec) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	connection.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Target != nil {
@@ -415,7 +415,7 @@ func (connection *Workspaces_Connection_Spec) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {
@@ -424,7 +424,7 @@ func (connection *Workspaces_Connection_Spec) PopulateFromARM(owner genruntime.A
 		}
 	}
 
-	// Set property ‘ValueFormat’:
+	// Set property "ValueFormat":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ValueFormat != nil {
@@ -664,7 +664,7 @@ func (connection *Workspaces_Connection_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspaces_Connection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthType’:
+	// Set property "AuthType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AuthType != nil {
@@ -673,7 +673,7 @@ func (connection *Workspaces_Connection_STATUS) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// Set property ‘Category’:
+	// Set property "Category":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Category != nil {
@@ -682,21 +682,21 @@ func (connection *Workspaces_Connection_STATUS) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		connection.Name = &name
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Target != nil {
@@ -705,13 +705,13 @@ func (connection *Workspaces_Connection_STATUS) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		connection.Type = &typeVar
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Value != nil {
@@ -720,7 +720,7 @@ func (connection *Workspaces_Connection_STATUS) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// Set property ‘ValueFormat’:
+	// Set property "ValueFormat":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ValueFormat != nil {

--- a/v2/api/managedidentity/v1api20181130/user_assigned_identity_types_gen.go
+++ b/v2/api/managedidentity/v1api20181130/user_assigned_identity_types_gen.go
@@ -399,16 +399,16 @@ func (identity *UserAssignedIdentity_Spec) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &UserAssignedIdentity_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if identity.Location != nil {
 		location := *identity.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if identity.Tags != nil {
 		result.Tags = make(map[string]string, len(identity.Tags))
 		for key, value := range identity.Tags {
@@ -430,21 +430,21 @@ func (identity *UserAssignedIdentity_Spec) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	identity.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		identity.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	identity.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		identity.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -707,7 +707,7 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientId != nil {
@@ -716,27 +716,27 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		identity.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		identity.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		identity.Name = &name
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalId != nil {
@@ -745,7 +745,7 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		identity.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -753,7 +753,7 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantId != nil {
@@ -762,7 +762,7 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar

--- a/v2/api/managedidentity/v1api20220131preview/federated_identity_credential_types_gen.go
+++ b/v2/api/managedidentity/v1api20220131preview/federated_identity_credential_types_gen.go
@@ -365,10 +365,10 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Conve
 	}
 	result := &UserAssignedIdentities_FederatedIdentityCredential_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if credential.Audiences != nil ||
 		credential.Issuer != nil ||
 		credential.IssuerFromConfig != nil ||
@@ -418,7 +418,7 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Popul
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentities_FederatedIdentityCredential_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Audiences’:
+	// Set property "Audiences":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Audiences {
@@ -426,10 +426,10 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Popul
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	credential.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Issuer’:
+	// Set property "Issuer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Issuer != nil {
@@ -438,12 +438,12 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Popul
 		}
 	}
 
-	// no assignment for property ‘IssuerFromConfig’
+	// no assignment for property "IssuerFromConfig"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	credential.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Subject’:
+	// Set property "Subject":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subject != nil {
@@ -452,7 +452,7 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Popul
 		}
 	}
 
-	// no assignment for property ‘SubjectFromConfig’
+	// no assignment for property "SubjectFromConfig"
 
 	// No error
 	return nil
@@ -720,7 +720,7 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_STATUS) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentities_FederatedIdentityCredential_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Audiences’:
+	// Set property "Audiences":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Audiences {
@@ -728,15 +728,15 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_STATUS) Pop
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		credential.Id = &id
 	}
 
-	// Set property ‘Issuer’:
+	// Set property "Issuer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Issuer != nil {
@@ -745,13 +745,13 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_STATUS) Pop
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		credential.Name = &name
 	}
 
-	// Set property ‘Subject’:
+	// Set property "Subject":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subject != nil {
@@ -760,7 +760,7 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_STATUS) Pop
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		credential.Type = &typeVar

--- a/v2/api/managedidentity/v1beta20181130/user_assigned_identity_types_gen.go
+++ b/v2/api/managedidentity/v1beta20181130/user_assigned_identity_types_gen.go
@@ -396,16 +396,16 @@ func (identity *UserAssignedIdentity_Spec) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &UserAssignedIdentity_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if identity.Location != nil {
 		location := *identity.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if identity.Tags != nil {
 		result.Tags = make(map[string]string, len(identity.Tags))
 		for key, value := range identity.Tags {
@@ -427,21 +427,21 @@ func (identity *UserAssignedIdentity_Spec) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	identity.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		identity.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	identity.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		identity.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -676,7 +676,7 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientId != nil {
@@ -685,27 +685,27 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		identity.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		identity.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		identity.Name = &name
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrincipalId != nil {
@@ -714,7 +714,7 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		identity.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -722,7 +722,7 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantId != nil {
@@ -731,7 +731,7 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar

--- a/v2/api/managedidentity/v1beta20220131preview/federated_identity_credential_types_gen.go
+++ b/v2/api/managedidentity/v1beta20220131preview/federated_identity_credential_types_gen.go
@@ -356,10 +356,10 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Conve
 	}
 	result := &UserAssignedIdentities_FederatedIdentityCredential_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if credential.Audiences != nil ||
 		credential.Issuer != nil ||
 		credential.IssuerFromConfig != nil ||
@@ -409,7 +409,7 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Popul
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentities_FederatedIdentityCredential_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Audiences’:
+	// Set property "Audiences":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Audiences {
@@ -417,10 +417,10 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Popul
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	credential.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Issuer’:
+	// Set property "Issuer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Issuer != nil {
@@ -429,12 +429,12 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Popul
 		}
 	}
 
-	// no assignment for property ‘IssuerFromConfig’
+	// no assignment for property "IssuerFromConfig"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	credential.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Subject’:
+	// Set property "Subject":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subject != nil {
@@ -443,7 +443,7 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Popul
 		}
 	}
 
-	// no assignment for property ‘SubjectFromConfig’
+	// no assignment for property "SubjectFromConfig"
 
 	// No error
 	return nil
@@ -684,7 +684,7 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_STATUS) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentities_FederatedIdentityCredential_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Audiences’:
+	// Set property "Audiences":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Audiences {
@@ -692,15 +692,15 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_STATUS) Pop
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		credential.Id = &id
 	}
 
-	// Set property ‘Issuer’:
+	// Set property "Issuer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Issuer != nil {
@@ -709,13 +709,13 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_STATUS) Pop
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		credential.Name = &name
 	}
 
-	// Set property ‘Subject’:
+	// Set property "Subject":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subject != nil {
@@ -724,7 +724,7 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_STATUS) Pop
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		credential.Type = &typeVar

--- a/v2/api/network/v1api20180501/dns_zone_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zone_types_gen.go
@@ -354,16 +354,16 @@ func (zone *DnsZone_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &DnsZone_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if zone.Location != nil {
 		location := *zone.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if zone.RegistrationVirtualNetworks != nil ||
 		zone.ResolutionVirtualNetworks != nil ||
 		zone.ZoneType != nil {
@@ -388,7 +388,7 @@ func (zone *DnsZone_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Properties.ZoneType = &zoneType
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if zone.Tags != nil {
 		result.Tags = make(map[string]string, len(zone.Tags))
 		for key, value := range zone.Tags {
@@ -410,19 +410,19 @@ func (zone *DnsZone_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZone_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zone.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		zone.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zone.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RegistrationVirtualNetworks’:
+	// Set property "RegistrationVirtualNetworks":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.RegistrationVirtualNetworks {
@@ -435,7 +435,7 @@ func (zone *DnsZone_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘ResolutionVirtualNetworks’:
+	// Set property "ResolutionVirtualNetworks":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ResolutionVirtualNetworks {
@@ -448,7 +448,7 @@ func (zone *DnsZone_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		zone.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -456,7 +456,7 @@ func (zone *DnsZone_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘ZoneType’:
+	// Set property "ZoneType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneType != nil {
@@ -846,27 +846,27 @@ func (zone *DnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZone_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zone.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zone.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		zone.Location = &location
 	}
 
-	// Set property ‘MaxNumberOfRecordSets’:
+	// Set property "MaxNumberOfRecordSets":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxNumberOfRecordSets != nil {
@@ -875,7 +875,7 @@ func (zone *DnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘MaxNumberOfRecordsPerRecordSet’:
+	// Set property "MaxNumberOfRecordsPerRecordSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxNumberOfRecordsPerRecordSet != nil {
@@ -884,13 +884,13 @@ func (zone *DnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zone.Name = &name
 	}
 
-	// Set property ‘NameServers’:
+	// Set property "NameServers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NameServers {
@@ -898,7 +898,7 @@ func (zone *DnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘NumberOfRecordSets’:
+	// Set property "NumberOfRecordSets":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfRecordSets != nil {
@@ -907,7 +907,7 @@ func (zone *DnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘RegistrationVirtualNetworks’:
+	// Set property "RegistrationVirtualNetworks":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.RegistrationVirtualNetworks {
@@ -920,7 +920,7 @@ func (zone *DnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘ResolutionVirtualNetworks’:
+	// Set property "ResolutionVirtualNetworks":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ResolutionVirtualNetworks {
@@ -933,7 +933,7 @@ func (zone *DnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		zone.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -941,13 +941,13 @@ func (zone *DnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zone.Type = &typeVar
 	}
 
-	// Set property ‘ZoneType’:
+	// Set property "ZoneType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneType != nil {
@@ -1152,7 +1152,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -1176,7 +1176,7 @@ func (resource *SubResource) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1256,7 +1256,7 @@ func (resource *SubResource_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id

--- a/v2/api/network/v1api20180501/dns_zones_a_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_a_record_types_gen.go
@@ -373,16 +373,16 @@ func (zonesA *DnsZones_A_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &DnsZones_A_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if zonesA.Etag != nil {
 		etag := *zonesA.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if zonesA.AAAARecords != nil ||
 		zonesA.ARecords != nil ||
 		zonesA.CNAMERecord != nil ||
@@ -503,7 +503,7 @@ func (zonesA *DnsZones_A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_A_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -516,7 +516,7 @@ func (zonesA *DnsZones_A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -529,10 +529,10 @@ func (zonesA *DnsZones_A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zonesA.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -546,7 +546,7 @@ func (zonesA *DnsZones_A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -559,13 +559,13 @@ func (zonesA *DnsZones_A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesA.Etag = &etag
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -578,7 +578,7 @@ func (zonesA *DnsZones_A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -589,7 +589,7 @@ func (zonesA *DnsZones_A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -602,10 +602,10 @@ func (zonesA *DnsZones_A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zonesA.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -618,7 +618,7 @@ func (zonesA *DnsZones_A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -632,7 +632,7 @@ func (zonesA *DnsZones_A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -645,7 +645,7 @@ func (zonesA *DnsZones_A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -654,7 +654,7 @@ func (zonesA *DnsZones_A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -667,7 +667,7 @@ func (zonesA *DnsZones_A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1491,7 +1491,7 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_A_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -1504,7 +1504,7 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1517,7 +1517,7 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -1531,7 +1531,7 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -1544,15 +1544,15 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesA.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1561,13 +1561,13 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zonesA.Id = &id
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -1580,7 +1580,7 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1591,7 +1591,7 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -1604,13 +1604,13 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zonesA.Name = &name
 	}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -1623,7 +1623,7 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1632,7 +1632,7 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -1646,7 +1646,7 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -1659,7 +1659,7 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -1668,7 +1668,7 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -1681,7 +1681,7 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1695,7 +1695,7 @@ func (zonesA *DnsZones_A_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zonesA.Type = &typeVar

--- a/v2/api/network/v1api20180501/dns_zones_aaaa_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_aaaa_record_types_gen.go
@@ -370,10 +370,10 @@ func (aaaa *DnsZones_AAAA_Spec) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &DnsZones_AAAA_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if aaaa.AAAARecords != nil ||
 		aaaa.ARecords != nil ||
 		aaaa.CNAMERecord != nil ||
@@ -494,7 +494,7 @@ func (aaaa *DnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_AAAA_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -507,7 +507,7 @@ func (aaaa *DnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -520,10 +520,10 @@ func (aaaa *DnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	aaaa.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -537,7 +537,7 @@ func (aaaa *DnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -550,7 +550,7 @@ func (aaaa *DnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -563,7 +563,7 @@ func (aaaa *DnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -574,7 +574,7 @@ func (aaaa *DnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -587,10 +587,10 @@ func (aaaa *DnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	aaaa.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -603,7 +603,7 @@ func (aaaa *DnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -617,7 +617,7 @@ func (aaaa *DnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -630,7 +630,7 @@ func (aaaa *DnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -639,7 +639,7 @@ func (aaaa *DnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -652,7 +652,7 @@ func (aaaa *DnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1467,7 +1467,7 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_AAAA_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -1480,7 +1480,7 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1493,7 +1493,7 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -1507,7 +1507,7 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -1520,15 +1520,15 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		aaaa.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1537,13 +1537,13 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		aaaa.Id = &id
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -1556,7 +1556,7 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1567,7 +1567,7 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -1580,13 +1580,13 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		aaaa.Name = &name
 	}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -1599,7 +1599,7 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1608,7 +1608,7 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -1622,7 +1622,7 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -1635,7 +1635,7 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -1644,7 +1644,7 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -1657,7 +1657,7 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1671,7 +1671,7 @@ func (aaaa *DnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		aaaa.Type = &typeVar
@@ -2133,7 +2133,7 @@ func (record *AaaaRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &AaaaRecord_ARM{}
 
-	// Set property ‘Ipv6Address’:
+	// Set property "Ipv6Address":
 	if record.Ipv6Address != nil {
 		ipv6Address := *record.Ipv6Address
 		result.Ipv6Address = &ipv6Address
@@ -2153,7 +2153,7 @@ func (record *AaaaRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AaaaRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Ipv6Address’:
+	// Set property "Ipv6Address":
 	if typedInput.Ipv6Address != nil {
 		ipv6Address := *typedInput.Ipv6Address
 		record.Ipv6Address = &ipv6Address
@@ -2222,7 +2222,7 @@ func (record *AaaaRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AaaaRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Ipv6Address’:
+	// Set property "Ipv6Address":
 	if typedInput.Ipv6Address != nil {
 		ipv6Address := *typedInput.Ipv6Address
 		record.Ipv6Address = &ipv6Address
@@ -2276,7 +2276,7 @@ func (record *ARecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 	}
 	result := &ARecord_ARM{}
 
-	// Set property ‘Ipv4Address’:
+	// Set property "Ipv4Address":
 	if record.Ipv4Address != nil {
 		ipv4Address := *record.Ipv4Address
 		result.Ipv4Address = &ipv4Address
@@ -2296,7 +2296,7 @@ func (record *ARecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ARecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Ipv4Address’:
+	// Set property "Ipv4Address":
 	if typedInput.Ipv4Address != nil {
 		ipv4Address := *typedInput.Ipv4Address
 		record.Ipv4Address = &ipv4Address
@@ -2365,7 +2365,7 @@ func (record *ARecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ARecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Ipv4Address’:
+	// Set property "Ipv4Address":
 	if typedInput.Ipv4Address != nil {
 		ipv4Address := *typedInput.Ipv4Address
 		record.Ipv4Address = &ipv4Address
@@ -2425,19 +2425,19 @@ func (record *CaaRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &CaaRecord_ARM{}
 
-	// Set property ‘Flags’:
+	// Set property "Flags":
 	if record.Flags != nil {
 		flags := *record.Flags
 		result.Flags = &flags
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if record.Tag != nil {
 		tag := *record.Tag
 		result.Tag = &tag
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if record.Value != nil {
 		value := *record.Value
 		result.Value = &value
@@ -2457,19 +2457,19 @@ func (record *CaaRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CaaRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Flags’:
+	// Set property "Flags":
 	if typedInput.Flags != nil {
 		flags := *typedInput.Flags
 		record.Flags = &flags
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		record.Tag = &tag
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		record.Value = &value
@@ -2562,19 +2562,19 @@ func (record *CaaRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CaaRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Flags’:
+	// Set property "Flags":
 	if typedInput.Flags != nil {
 		flags := *typedInput.Flags
 		record.Flags = &flags
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		record.Tag = &tag
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		record.Value = &value
@@ -2640,7 +2640,7 @@ func (record *CnameRecord) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &CnameRecord_ARM{}
 
-	// Set property ‘Cname’:
+	// Set property "Cname":
 	if record.Cname != nil {
 		cname := *record.Cname
 		result.Cname = &cname
@@ -2660,7 +2660,7 @@ func (record *CnameRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CnameRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cname’:
+	// Set property "Cname":
 	if typedInput.Cname != nil {
 		cname := *typedInput.Cname
 		record.Cname = &cname
@@ -2729,7 +2729,7 @@ func (record *CnameRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CnameRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cname’:
+	// Set property "Cname":
 	if typedInput.Cname != nil {
 		cname := *typedInput.Cname
 		record.Cname = &cname
@@ -2786,13 +2786,13 @@ func (record *MxRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &MxRecord_ARM{}
 
-	// Set property ‘Exchange’:
+	// Set property "Exchange":
 	if record.Exchange != nil {
 		exchange := *record.Exchange
 		result.Exchange = &exchange
 	}
 
-	// Set property ‘Preference’:
+	// Set property "Preference":
 	if record.Preference != nil {
 		preference := *record.Preference
 		result.Preference = &preference
@@ -2812,13 +2812,13 @@ func (record *MxRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MxRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Exchange’:
+	// Set property "Exchange":
 	if typedInput.Exchange != nil {
 		exchange := *typedInput.Exchange
 		record.Exchange = &exchange
 	}
 
-	// Set property ‘Preference’:
+	// Set property "Preference":
 	if typedInput.Preference != nil {
 		preference := *typedInput.Preference
 		record.Preference = &preference
@@ -2899,13 +2899,13 @@ func (record *MxRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MxRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Exchange’:
+	// Set property "Exchange":
 	if typedInput.Exchange != nil {
 		exchange := *typedInput.Exchange
 		record.Exchange = &exchange
 	}
 
-	// Set property ‘Preference’:
+	// Set property "Preference":
 	if typedInput.Preference != nil {
 		preference := *typedInput.Preference
 		record.Preference = &preference
@@ -2965,7 +2965,7 @@ func (record *NsRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &NsRecord_ARM{}
 
-	// Set property ‘Nsdname’:
+	// Set property "Nsdname":
 	if record.Nsdname != nil {
 		nsdname := *record.Nsdname
 		result.Nsdname = &nsdname
@@ -2985,7 +2985,7 @@ func (record *NsRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NsRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Nsdname’:
+	// Set property "Nsdname":
 	if typedInput.Nsdname != nil {
 		nsdname := *typedInput.Nsdname
 		record.Nsdname = &nsdname
@@ -3054,7 +3054,7 @@ func (record *NsRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NsRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Nsdname’:
+	// Set property "Nsdname":
 	if typedInput.Nsdname != nil {
 		nsdname := *typedInput.Nsdname
 		record.Nsdname = &nsdname
@@ -3108,7 +3108,7 @@ func (record *PtrRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &PtrRecord_ARM{}
 
-	// Set property ‘Ptrdname’:
+	// Set property "Ptrdname":
 	if record.Ptrdname != nil {
 		ptrdname := *record.Ptrdname
 		result.Ptrdname = &ptrdname
@@ -3128,7 +3128,7 @@ func (record *PtrRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PtrRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Ptrdname’:
+	// Set property "Ptrdname":
 	if typedInput.Ptrdname != nil {
 		ptrdname := *typedInput.Ptrdname
 		record.Ptrdname = &ptrdname
@@ -3197,7 +3197,7 @@ func (record *PtrRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PtrRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Ptrdname’:
+	// Set property "Ptrdname":
 	if typedInput.Ptrdname != nil {
 		ptrdname := *typedInput.Ptrdname
 		record.Ptrdname = &ptrdname
@@ -3269,43 +3269,43 @@ func (record *SoaRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &SoaRecord_ARM{}
 
-	// Set property ‘Email’:
+	// Set property "Email":
 	if record.Email != nil {
 		email := *record.Email
 		result.Email = &email
 	}
 
-	// Set property ‘ExpireTime’:
+	// Set property "ExpireTime":
 	if record.ExpireTime != nil {
 		expireTime := *record.ExpireTime
 		result.ExpireTime = &expireTime
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	if record.Host != nil {
 		host := *record.Host
 		result.Host = &host
 	}
 
-	// Set property ‘MinimumTTL’:
+	// Set property "MinimumTTL":
 	if record.MinimumTTL != nil {
 		minimumTTL := *record.MinimumTTL
 		result.MinimumTTL = &minimumTTL
 	}
 
-	// Set property ‘RefreshTime’:
+	// Set property "RefreshTime":
 	if record.RefreshTime != nil {
 		refreshTime := *record.RefreshTime
 		result.RefreshTime = &refreshTime
 	}
 
-	// Set property ‘RetryTime’:
+	// Set property "RetryTime":
 	if record.RetryTime != nil {
 		retryTime := *record.RetryTime
 		result.RetryTime = &retryTime
 	}
 
-	// Set property ‘SerialNumber’:
+	// Set property "SerialNumber":
 	if record.SerialNumber != nil {
 		serialNumber := *record.SerialNumber
 		result.SerialNumber = &serialNumber
@@ -3325,43 +3325,43 @@ func (record *SoaRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SoaRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Email’:
+	// Set property "Email":
 	if typedInput.Email != nil {
 		email := *typedInput.Email
 		record.Email = &email
 	}
 
-	// Set property ‘ExpireTime’:
+	// Set property "ExpireTime":
 	if typedInput.ExpireTime != nil {
 		expireTime := *typedInput.ExpireTime
 		record.ExpireTime = &expireTime
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	if typedInput.Host != nil {
 		host := *typedInput.Host
 		record.Host = &host
 	}
 
-	// Set property ‘MinimumTTL’:
+	// Set property "MinimumTTL":
 	if typedInput.MinimumTTL != nil {
 		minimumTTL := *typedInput.MinimumTTL
 		record.MinimumTTL = &minimumTTL
 	}
 
-	// Set property ‘RefreshTime’:
+	// Set property "RefreshTime":
 	if typedInput.RefreshTime != nil {
 		refreshTime := *typedInput.RefreshTime
 		record.RefreshTime = &refreshTime
 	}
 
-	// Set property ‘RetryTime’:
+	// Set property "RetryTime":
 	if typedInput.RetryTime != nil {
 		retryTime := *typedInput.RetryTime
 		record.RetryTime = &retryTime
 	}
 
-	// Set property ‘SerialNumber’:
+	// Set property "SerialNumber":
 	if typedInput.SerialNumber != nil {
 		serialNumber := *typedInput.SerialNumber
 		record.SerialNumber = &serialNumber
@@ -3502,43 +3502,43 @@ func (record *SoaRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SoaRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Email’:
+	// Set property "Email":
 	if typedInput.Email != nil {
 		email := *typedInput.Email
 		record.Email = &email
 	}
 
-	// Set property ‘ExpireTime’:
+	// Set property "ExpireTime":
 	if typedInput.ExpireTime != nil {
 		expireTime := *typedInput.ExpireTime
 		record.ExpireTime = &expireTime
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	if typedInput.Host != nil {
 		host := *typedInput.Host
 		record.Host = &host
 	}
 
-	// Set property ‘MinimumTTL’:
+	// Set property "MinimumTTL":
 	if typedInput.MinimumTTL != nil {
 		minimumTTL := *typedInput.MinimumTTL
 		record.MinimumTTL = &minimumTTL
 	}
 
-	// Set property ‘RefreshTime’:
+	// Set property "RefreshTime":
 	if typedInput.RefreshTime != nil {
 		refreshTime := *typedInput.RefreshTime
 		record.RefreshTime = &refreshTime
 	}
 
-	// Set property ‘RetryTime’:
+	// Set property "RetryTime":
 	if typedInput.RetryTime != nil {
 		retryTime := *typedInput.RetryTime
 		record.RetryTime = &retryTime
 	}
 
-	// Set property ‘SerialNumber’:
+	// Set property "SerialNumber":
 	if typedInput.SerialNumber != nil {
 		serialNumber := *typedInput.SerialNumber
 		record.SerialNumber = &serialNumber
@@ -3637,25 +3637,25 @@ func (record *SrvRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &SrvRecord_ARM{}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if record.Port != nil {
 		port := *record.Port
 		result.Port = &port
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if record.Priority != nil {
 		priority := *record.Priority
 		result.Priority = &priority
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if record.Target != nil {
 		target := *record.Target
 		result.Target = &target
 	}
 
-	// Set property ‘Weight’:
+	// Set property "Weight":
 	if record.Weight != nil {
 		weight := *record.Weight
 		result.Weight = &weight
@@ -3675,25 +3675,25 @@ func (record *SrvRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SrvRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port := *typedInput.Port
 		record.Port = &port
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		record.Priority = &priority
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		record.Target = &target
 	}
 
-	// Set property ‘Weight’:
+	// Set property "Weight":
 	if typedInput.Weight != nil {
 		weight := *typedInput.Weight
 		record.Weight = &weight
@@ -3798,25 +3798,25 @@ func (record *SrvRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SrvRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port := *typedInput.Port
 		record.Port = &port
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		record.Priority = &priority
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		record.Target = &target
 	}
 
-	// Set property ‘Weight’:
+	// Set property "Weight":
 	if typedInput.Weight != nil {
 		weight := *typedInput.Weight
 		record.Weight = &weight
@@ -3888,7 +3888,7 @@ func (record *TxtRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &TxtRecord_ARM{}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	for _, item := range record.Value {
 		result.Value = append(result.Value, item)
 	}
@@ -3907,7 +3907,7 @@ func (record *TxtRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TxtRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	for _, item := range typedInput.Value {
 		record.Value = append(record.Value, item)
 	}
@@ -3975,7 +3975,7 @@ func (record *TxtRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TxtRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	for _, item := range typedInput.Value {
 		record.Value = append(record.Value, item)
 	}

--- a/v2/api/network/v1api20180501/dns_zones_caa_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_caa_record_types_gen.go
@@ -370,10 +370,10 @@ func (zonesCAA *DnsZones_CAA_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &DnsZones_CAA_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if zonesCAA.AAAARecords != nil ||
 		zonesCAA.ARecords != nil ||
 		zonesCAA.CNAMERecord != nil ||
@@ -494,7 +494,7 @@ func (zonesCAA *DnsZones_CAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_CAA_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -507,7 +507,7 @@ func (zonesCAA *DnsZones_CAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -520,10 +520,10 @@ func (zonesCAA *DnsZones_CAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zonesCAA.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -537,7 +537,7 @@ func (zonesCAA *DnsZones_CAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -550,7 +550,7 @@ func (zonesCAA *DnsZones_CAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -563,7 +563,7 @@ func (zonesCAA *DnsZones_CAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -574,7 +574,7 @@ func (zonesCAA *DnsZones_CAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -587,10 +587,10 @@ func (zonesCAA *DnsZones_CAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zonesCAA.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -603,7 +603,7 @@ func (zonesCAA *DnsZones_CAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -617,7 +617,7 @@ func (zonesCAA *DnsZones_CAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -630,7 +630,7 @@ func (zonesCAA *DnsZones_CAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -639,7 +639,7 @@ func (zonesCAA *DnsZones_CAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -652,7 +652,7 @@ func (zonesCAA *DnsZones_CAA_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1467,7 +1467,7 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_CAA_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -1480,7 +1480,7 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1493,7 +1493,7 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -1507,7 +1507,7 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -1520,15 +1520,15 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesCAA.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1537,13 +1537,13 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zonesCAA.Id = &id
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -1556,7 +1556,7 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1567,7 +1567,7 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -1580,13 +1580,13 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zonesCAA.Name = &name
 	}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -1599,7 +1599,7 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1608,7 +1608,7 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -1622,7 +1622,7 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -1635,7 +1635,7 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -1644,7 +1644,7 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -1657,7 +1657,7 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1671,7 +1671,7 @@ func (zonesCAA *DnsZones_CAA_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zonesCAA.Type = &typeVar

--- a/v2/api/network/v1api20180501/dns_zones_cname_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_cname_record_types_gen.go
@@ -370,10 +370,10 @@ func (cname *DnsZones_CNAME_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &DnsZones_CNAME_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if cname.AAAARecords != nil ||
 		cname.ARecords != nil ||
 		cname.CNAMERecord != nil ||
@@ -494,7 +494,7 @@ func (cname *DnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_CNAME_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -507,7 +507,7 @@ func (cname *DnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -520,10 +520,10 @@ func (cname *DnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	cname.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -537,7 +537,7 @@ func (cname *DnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -550,7 +550,7 @@ func (cname *DnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -563,7 +563,7 @@ func (cname *DnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -574,7 +574,7 @@ func (cname *DnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -587,10 +587,10 @@ func (cname *DnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	cname.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -603,7 +603,7 @@ func (cname *DnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -617,7 +617,7 @@ func (cname *DnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -630,7 +630,7 @@ func (cname *DnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -639,7 +639,7 @@ func (cname *DnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -652,7 +652,7 @@ func (cname *DnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1467,7 +1467,7 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_CNAME_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -1480,7 +1480,7 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1493,7 +1493,7 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -1507,7 +1507,7 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -1520,15 +1520,15 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		cname.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1537,13 +1537,13 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		cname.Id = &id
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -1556,7 +1556,7 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1567,7 +1567,7 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -1580,13 +1580,13 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		cname.Name = &name
 	}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -1599,7 +1599,7 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1608,7 +1608,7 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -1622,7 +1622,7 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -1635,7 +1635,7 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -1644,7 +1644,7 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -1657,7 +1657,7 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1671,7 +1671,7 @@ func (cname *DnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		cname.Type = &typeVar

--- a/v2/api/network/v1api20180501/dns_zones_mx_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_mx_record_types_gen.go
@@ -370,10 +370,10 @@ func (zonesMX *DnsZones_MX_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &DnsZones_MX_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if zonesMX.AAAARecords != nil ||
 		zonesMX.ARecords != nil ||
 		zonesMX.CNAMERecord != nil ||
@@ -494,7 +494,7 @@ func (zonesMX *DnsZones_MX_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_MX_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -507,7 +507,7 @@ func (zonesMX *DnsZones_MX_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -520,10 +520,10 @@ func (zonesMX *DnsZones_MX_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zonesMX.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -537,7 +537,7 @@ func (zonesMX *DnsZones_MX_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -550,7 +550,7 @@ func (zonesMX *DnsZones_MX_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -563,7 +563,7 @@ func (zonesMX *DnsZones_MX_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -574,7 +574,7 @@ func (zonesMX *DnsZones_MX_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -587,10 +587,10 @@ func (zonesMX *DnsZones_MX_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zonesMX.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -603,7 +603,7 @@ func (zonesMX *DnsZones_MX_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -617,7 +617,7 @@ func (zonesMX *DnsZones_MX_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -630,7 +630,7 @@ func (zonesMX *DnsZones_MX_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -639,7 +639,7 @@ func (zonesMX *DnsZones_MX_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -652,7 +652,7 @@ func (zonesMX *DnsZones_MX_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1467,7 +1467,7 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_MX_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -1480,7 +1480,7 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1493,7 +1493,7 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -1507,7 +1507,7 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -1520,15 +1520,15 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesMX.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1537,13 +1537,13 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zonesMX.Id = &id
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -1556,7 +1556,7 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1567,7 +1567,7 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -1580,13 +1580,13 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zonesMX.Name = &name
 	}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -1599,7 +1599,7 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1608,7 +1608,7 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -1622,7 +1622,7 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -1635,7 +1635,7 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -1644,7 +1644,7 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -1657,7 +1657,7 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1671,7 +1671,7 @@ func (zonesMX *DnsZones_MX_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zonesMX.Type = &typeVar

--- a/v2/api/network/v1api20180501/dns_zones_ns_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_ns_record_types_gen.go
@@ -370,10 +370,10 @@ func (zonesNS *DnsZones_NS_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &DnsZones_NS_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if zonesNS.AAAARecords != nil ||
 		zonesNS.ARecords != nil ||
 		zonesNS.CNAMERecord != nil ||
@@ -494,7 +494,7 @@ func (zonesNS *DnsZones_NS_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_NS_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -507,7 +507,7 @@ func (zonesNS *DnsZones_NS_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -520,10 +520,10 @@ func (zonesNS *DnsZones_NS_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zonesNS.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -537,7 +537,7 @@ func (zonesNS *DnsZones_NS_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -550,7 +550,7 @@ func (zonesNS *DnsZones_NS_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -563,7 +563,7 @@ func (zonesNS *DnsZones_NS_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -574,7 +574,7 @@ func (zonesNS *DnsZones_NS_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -587,10 +587,10 @@ func (zonesNS *DnsZones_NS_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zonesNS.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -603,7 +603,7 @@ func (zonesNS *DnsZones_NS_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -617,7 +617,7 @@ func (zonesNS *DnsZones_NS_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -630,7 +630,7 @@ func (zonesNS *DnsZones_NS_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -639,7 +639,7 @@ func (zonesNS *DnsZones_NS_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -652,7 +652,7 @@ func (zonesNS *DnsZones_NS_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1467,7 +1467,7 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_NS_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -1480,7 +1480,7 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1493,7 +1493,7 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -1507,7 +1507,7 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -1520,15 +1520,15 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesNS.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1537,13 +1537,13 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zonesNS.Id = &id
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -1556,7 +1556,7 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1567,7 +1567,7 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -1580,13 +1580,13 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zonesNS.Name = &name
 	}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -1599,7 +1599,7 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1608,7 +1608,7 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -1622,7 +1622,7 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -1635,7 +1635,7 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -1644,7 +1644,7 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -1657,7 +1657,7 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1671,7 +1671,7 @@ func (zonesNS *DnsZones_NS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zonesNS.Type = &typeVar

--- a/v2/api/network/v1api20180501/dns_zones_ptr_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_ptr_record_types_gen.go
@@ -370,10 +370,10 @@ func (zonesPTR *DnsZones_PTR_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &DnsZones_PTR_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if zonesPTR.AAAARecords != nil ||
 		zonesPTR.ARecords != nil ||
 		zonesPTR.CNAMERecord != nil ||
@@ -494,7 +494,7 @@ func (zonesPTR *DnsZones_PTR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_PTR_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -507,7 +507,7 @@ func (zonesPTR *DnsZones_PTR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -520,10 +520,10 @@ func (zonesPTR *DnsZones_PTR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zonesPTR.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -537,7 +537,7 @@ func (zonesPTR *DnsZones_PTR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -550,7 +550,7 @@ func (zonesPTR *DnsZones_PTR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -563,7 +563,7 @@ func (zonesPTR *DnsZones_PTR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -574,7 +574,7 @@ func (zonesPTR *DnsZones_PTR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -587,10 +587,10 @@ func (zonesPTR *DnsZones_PTR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zonesPTR.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -603,7 +603,7 @@ func (zonesPTR *DnsZones_PTR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -617,7 +617,7 @@ func (zonesPTR *DnsZones_PTR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -630,7 +630,7 @@ func (zonesPTR *DnsZones_PTR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -639,7 +639,7 @@ func (zonesPTR *DnsZones_PTR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -652,7 +652,7 @@ func (zonesPTR *DnsZones_PTR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1467,7 +1467,7 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_PTR_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -1480,7 +1480,7 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1493,7 +1493,7 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -1507,7 +1507,7 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -1520,15 +1520,15 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesPTR.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1537,13 +1537,13 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zonesPTR.Id = &id
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -1556,7 +1556,7 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1567,7 +1567,7 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -1580,13 +1580,13 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zonesPTR.Name = &name
 	}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -1599,7 +1599,7 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1608,7 +1608,7 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -1622,7 +1622,7 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -1635,7 +1635,7 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -1644,7 +1644,7 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -1657,7 +1657,7 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1671,7 +1671,7 @@ func (zonesPTR *DnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zonesPTR.Type = &typeVar

--- a/v2/api/network/v1api20180501/dns_zones_srv_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_srv_record_types_gen.go
@@ -370,10 +370,10 @@ func (zonesSRV *DnsZones_SRV_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &DnsZones_SRV_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if zonesSRV.AAAARecords != nil ||
 		zonesSRV.ARecords != nil ||
 		zonesSRV.CNAMERecord != nil ||
@@ -494,7 +494,7 @@ func (zonesSRV *DnsZones_SRV_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_SRV_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -507,7 +507,7 @@ func (zonesSRV *DnsZones_SRV_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -520,10 +520,10 @@ func (zonesSRV *DnsZones_SRV_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zonesSRV.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -537,7 +537,7 @@ func (zonesSRV *DnsZones_SRV_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -550,7 +550,7 @@ func (zonesSRV *DnsZones_SRV_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -563,7 +563,7 @@ func (zonesSRV *DnsZones_SRV_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -574,7 +574,7 @@ func (zonesSRV *DnsZones_SRV_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -587,10 +587,10 @@ func (zonesSRV *DnsZones_SRV_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zonesSRV.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -603,7 +603,7 @@ func (zonesSRV *DnsZones_SRV_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -617,7 +617,7 @@ func (zonesSRV *DnsZones_SRV_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -630,7 +630,7 @@ func (zonesSRV *DnsZones_SRV_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -639,7 +639,7 @@ func (zonesSRV *DnsZones_SRV_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -652,7 +652,7 @@ func (zonesSRV *DnsZones_SRV_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1467,7 +1467,7 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_SRV_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -1480,7 +1480,7 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1493,7 +1493,7 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -1507,7 +1507,7 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -1520,15 +1520,15 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesSRV.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1537,13 +1537,13 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zonesSRV.Id = &id
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -1556,7 +1556,7 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1567,7 +1567,7 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -1580,13 +1580,13 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zonesSRV.Name = &name
 	}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -1599,7 +1599,7 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1608,7 +1608,7 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -1622,7 +1622,7 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -1635,7 +1635,7 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -1644,7 +1644,7 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -1657,7 +1657,7 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1671,7 +1671,7 @@ func (zonesSRV *DnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zonesSRV.Type = &typeVar

--- a/v2/api/network/v1api20180501/dns_zones_txt_record_types_gen.go
+++ b/v2/api/network/v1api20180501/dns_zones_txt_record_types_gen.go
@@ -370,10 +370,10 @@ func (zonesTXT *DnsZones_TXT_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &DnsZones_TXT_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if zonesTXT.AAAARecords != nil ||
 		zonesTXT.ARecords != nil ||
 		zonesTXT.CNAMERecord != nil ||
@@ -494,7 +494,7 @@ func (zonesTXT *DnsZones_TXT_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_TXT_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -507,7 +507,7 @@ func (zonesTXT *DnsZones_TXT_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -520,10 +520,10 @@ func (zonesTXT *DnsZones_TXT_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zonesTXT.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -537,7 +537,7 @@ func (zonesTXT *DnsZones_TXT_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -550,7 +550,7 @@ func (zonesTXT *DnsZones_TXT_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -563,7 +563,7 @@ func (zonesTXT *DnsZones_TXT_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -574,7 +574,7 @@ func (zonesTXT *DnsZones_TXT_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -587,10 +587,10 @@ func (zonesTXT *DnsZones_TXT_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zonesTXT.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -603,7 +603,7 @@ func (zonesTXT *DnsZones_TXT_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -617,7 +617,7 @@ func (zonesTXT *DnsZones_TXT_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -630,7 +630,7 @@ func (zonesTXT *DnsZones_TXT_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -639,7 +639,7 @@ func (zonesTXT *DnsZones_TXT_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -652,7 +652,7 @@ func (zonesTXT *DnsZones_TXT_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1467,7 +1467,7 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsZones_TXT_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AAAARecords’:
+	// Set property "AAAARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AAAARecords {
@@ -1480,7 +1480,7 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1493,7 +1493,7 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘CNAMERecord’:
+	// Set property "CNAMERecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CNAMERecord != nil {
@@ -1507,7 +1507,7 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘CaaRecords’:
+	// Set property "CaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CaaRecords {
@@ -1520,15 +1520,15 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesTXT.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1537,13 +1537,13 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zonesTXT.Id = &id
 	}
 
-	// Set property ‘MXRecords’:
+	// Set property "MXRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MXRecords {
@@ -1556,7 +1556,7 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1567,7 +1567,7 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NSRecords’:
+	// Set property "NSRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NSRecords {
@@ -1580,13 +1580,13 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zonesTXT.Name = &name
 	}
 
-	// Set property ‘PTRRecords’:
+	// Set property "PTRRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PTRRecords {
@@ -1599,7 +1599,7 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1608,7 +1608,7 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SOARecord’:
+	// Set property "SOARecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SOARecord != nil {
@@ -1622,7 +1622,7 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SRVRecords’:
+	// Set property "SRVRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SRVRecords {
@@ -1635,7 +1635,7 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TTL’:
+	// Set property "TTL":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TTL != nil {
@@ -1644,7 +1644,7 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TXTRecords’:
+	// Set property "TXTRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TXTRecords {
@@ -1657,7 +1657,7 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TargetResource’:
+	// Set property "TargetResource":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetResource != nil {
@@ -1671,7 +1671,7 @@ func (zonesTXT *DnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zonesTXT.Type = &typeVar

--- a/v2/api/network/v1api20180901/private_dns_zone_types_gen.go
+++ b/v2/api/network/v1api20180901/private_dns_zone_types_gen.go
@@ -345,22 +345,22 @@ func (zone *PrivateDnsZone_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &PrivateDnsZone_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if zone.Etag != nil {
 		etag := *zone.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if zone.Location != nil {
 		location := *zone.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if zone.Tags != nil {
 		result.Tags = make(map[string]string, len(zone.Tags))
 		for key, value := range zone.Tags {
@@ -382,25 +382,25 @@ func (zone *PrivateDnsZone_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZone_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zone.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zone.Etag = &etag
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		zone.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zone.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		zone.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -669,27 +669,27 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZone_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zone.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zone.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		zone.Location = &location
 	}
 
-	// Set property ‘MaxNumberOfRecordSets’:
+	// Set property "MaxNumberOfRecordSets":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxNumberOfRecordSets != nil {
@@ -698,7 +698,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MaxNumberOfVirtualNetworkLinks’:
+	// Set property "MaxNumberOfVirtualNetworkLinks":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxNumberOfVirtualNetworkLinks != nil {
@@ -707,7 +707,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MaxNumberOfVirtualNetworkLinksWithRegistration’:
+	// Set property "MaxNumberOfVirtualNetworkLinksWithRegistration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxNumberOfVirtualNetworkLinksWithRegistration != nil {
@@ -716,13 +716,13 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zone.Name = &name
 	}
 
-	// Set property ‘NumberOfRecordSets’:
+	// Set property "NumberOfRecordSets":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfRecordSets != nil {
@@ -731,7 +731,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘NumberOfVirtualNetworkLinks’:
+	// Set property "NumberOfVirtualNetworkLinks":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfVirtualNetworkLinks != nil {
@@ -740,7 +740,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘NumberOfVirtualNetworkLinksWithRegistration’:
+	// Set property "NumberOfVirtualNetworkLinksWithRegistration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfVirtualNetworkLinksWithRegistration != nil {
@@ -749,7 +749,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -758,7 +758,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		zone.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -766,7 +766,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zone.Type = &typeVar

--- a/v2/api/network/v1api20200601/private_dns_zones_a_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_a_record_types_gen.go
@@ -364,16 +364,16 @@ func (zonesA *PrivateDnsZones_A_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &PrivateDnsZones_A_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if zonesA.Etag != nil {
 		etag := *zonesA.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if zonesA.ARecords != nil ||
 		zonesA.AaaaRecords != nil ||
 		zonesA.CnameRecord != nil ||
@@ -469,7 +469,7 @@ func (zonesA *PrivateDnsZones_A_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_A_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -482,7 +482,7 @@ func (zonesA *PrivateDnsZones_A_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -495,10 +495,10 @@ func (zonesA *PrivateDnsZones_A_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zonesA.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -512,13 +512,13 @@ func (zonesA *PrivateDnsZones_A_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesA.Etag = &etag
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -529,7 +529,7 @@ func (zonesA *PrivateDnsZones_A_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -542,10 +542,10 @@ func (zonesA *PrivateDnsZones_A_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zonesA.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -558,7 +558,7 @@ func (zonesA *PrivateDnsZones_A_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -572,7 +572,7 @@ func (zonesA *PrivateDnsZones_A_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -585,7 +585,7 @@ func (zonesA *PrivateDnsZones_A_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -594,7 +594,7 @@ func (zonesA *PrivateDnsZones_A_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1265,7 +1265,7 @@ func (zonesA *PrivateDnsZones_A_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_A_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1278,7 +1278,7 @@ func (zonesA *PrivateDnsZones_A_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -1291,7 +1291,7 @@ func (zonesA *PrivateDnsZones_A_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -1305,15 +1305,15 @@ func (zonesA *PrivateDnsZones_A_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesA.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1322,13 +1322,13 @@ func (zonesA *PrivateDnsZones_A_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zonesA.Id = &id
 	}
 
-	// Set property ‘IsAutoRegistered’:
+	// Set property "IsAutoRegistered":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAutoRegistered != nil {
@@ -1337,7 +1337,7 @@ func (zonesA *PrivateDnsZones_A_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1348,7 +1348,7 @@ func (zonesA *PrivateDnsZones_A_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -1361,13 +1361,13 @@ func (zonesA *PrivateDnsZones_A_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zonesA.Name = &name
 	}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -1380,7 +1380,7 @@ func (zonesA *PrivateDnsZones_A_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -1394,7 +1394,7 @@ func (zonesA *PrivateDnsZones_A_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -1407,7 +1407,7 @@ func (zonesA *PrivateDnsZones_A_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -1416,7 +1416,7 @@ func (zonesA *PrivateDnsZones_A_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1429,7 +1429,7 @@ func (zonesA *PrivateDnsZones_A_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zonesA.Type = &typeVar

--- a/v2/api/network/v1api20200601/private_dns_zones_aaaa_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_aaaa_record_types_gen.go
@@ -369,16 +369,16 @@ func (aaaa *PrivateDnsZones_AAAA_Spec) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &PrivateDnsZones_AAAA_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if aaaa.Etag != nil {
 		etag := *aaaa.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if aaaa.ARecords != nil ||
 		aaaa.AaaaRecords != nil ||
 		aaaa.CnameRecord != nil ||
@@ -474,7 +474,7 @@ func (aaaa *PrivateDnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_AAAA_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -487,7 +487,7 @@ func (aaaa *PrivateDnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -500,10 +500,10 @@ func (aaaa *PrivateDnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	aaaa.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -517,13 +517,13 @@ func (aaaa *PrivateDnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		aaaa.Etag = &etag
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -534,7 +534,7 @@ func (aaaa *PrivateDnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -547,10 +547,10 @@ func (aaaa *PrivateDnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	aaaa.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -563,7 +563,7 @@ func (aaaa *PrivateDnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -577,7 +577,7 @@ func (aaaa *PrivateDnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -590,7 +590,7 @@ func (aaaa *PrivateDnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -599,7 +599,7 @@ func (aaaa *PrivateDnsZones_AAAA_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1270,7 +1270,7 @@ func (aaaa *PrivateDnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_AAAA_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1283,7 +1283,7 @@ func (aaaa *PrivateDnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -1296,7 +1296,7 @@ func (aaaa *PrivateDnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -1310,15 +1310,15 @@ func (aaaa *PrivateDnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		aaaa.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1327,13 +1327,13 @@ func (aaaa *PrivateDnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		aaaa.Id = &id
 	}
 
-	// Set property ‘IsAutoRegistered’:
+	// Set property "IsAutoRegistered":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAutoRegistered != nil {
@@ -1342,7 +1342,7 @@ func (aaaa *PrivateDnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1353,7 +1353,7 @@ func (aaaa *PrivateDnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -1366,13 +1366,13 @@ func (aaaa *PrivateDnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		aaaa.Name = &name
 	}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -1385,7 +1385,7 @@ func (aaaa *PrivateDnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -1399,7 +1399,7 @@ func (aaaa *PrivateDnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -1412,7 +1412,7 @@ func (aaaa *PrivateDnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -1421,7 +1421,7 @@ func (aaaa *PrivateDnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1434,7 +1434,7 @@ func (aaaa *PrivateDnsZones_AAAA_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		aaaa.Type = &typeVar
@@ -1810,7 +1810,7 @@ func (record *AaaaRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &AaaaRecord_ARM{}
 
-	// Set property ‘Ipv6Address’:
+	// Set property "Ipv6Address":
 	if record.Ipv6Address != nil {
 		ipv6Address := *record.Ipv6Address
 		result.Ipv6Address = &ipv6Address
@@ -1830,7 +1830,7 @@ func (record *AaaaRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AaaaRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Ipv6Address’:
+	// Set property "Ipv6Address":
 	if typedInput.Ipv6Address != nil {
 		ipv6Address := *typedInput.Ipv6Address
 		record.Ipv6Address = &ipv6Address
@@ -1899,7 +1899,7 @@ func (record *AaaaRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AaaaRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Ipv6Address’:
+	// Set property "Ipv6Address":
 	if typedInput.Ipv6Address != nil {
 		ipv6Address := *typedInput.Ipv6Address
 		record.Ipv6Address = &ipv6Address
@@ -1953,7 +1953,7 @@ func (record *ARecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 	}
 	result := &ARecord_ARM{}
 
-	// Set property ‘Ipv4Address’:
+	// Set property "Ipv4Address":
 	if record.Ipv4Address != nil {
 		ipv4Address := *record.Ipv4Address
 		result.Ipv4Address = &ipv4Address
@@ -1973,7 +1973,7 @@ func (record *ARecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ARecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Ipv4Address’:
+	// Set property "Ipv4Address":
 	if typedInput.Ipv4Address != nil {
 		ipv4Address := *typedInput.Ipv4Address
 		record.Ipv4Address = &ipv4Address
@@ -2042,7 +2042,7 @@ func (record *ARecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ARecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Ipv4Address’:
+	// Set property "Ipv4Address":
 	if typedInput.Ipv4Address != nil {
 		ipv4Address := *typedInput.Ipv4Address
 		record.Ipv4Address = &ipv4Address
@@ -2096,7 +2096,7 @@ func (record *CnameRecord) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &CnameRecord_ARM{}
 
-	// Set property ‘Cname’:
+	// Set property "Cname":
 	if record.Cname != nil {
 		cname := *record.Cname
 		result.Cname = &cname
@@ -2116,7 +2116,7 @@ func (record *CnameRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CnameRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cname’:
+	// Set property "Cname":
 	if typedInput.Cname != nil {
 		cname := *typedInput.Cname
 		record.Cname = &cname
@@ -2185,7 +2185,7 @@ func (record *CnameRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CnameRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cname’:
+	// Set property "Cname":
 	if typedInput.Cname != nil {
 		cname := *typedInput.Cname
 		record.Cname = &cname
@@ -2242,13 +2242,13 @@ func (record *MxRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &MxRecord_ARM{}
 
-	// Set property ‘Exchange’:
+	// Set property "Exchange":
 	if record.Exchange != nil {
 		exchange := *record.Exchange
 		result.Exchange = &exchange
 	}
 
-	// Set property ‘Preference’:
+	// Set property "Preference":
 	if record.Preference != nil {
 		preference := *record.Preference
 		result.Preference = &preference
@@ -2268,13 +2268,13 @@ func (record *MxRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MxRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Exchange’:
+	// Set property "Exchange":
 	if typedInput.Exchange != nil {
 		exchange := *typedInput.Exchange
 		record.Exchange = &exchange
 	}
 
-	// Set property ‘Preference’:
+	// Set property "Preference":
 	if typedInput.Preference != nil {
 		preference := *typedInput.Preference
 		record.Preference = &preference
@@ -2355,13 +2355,13 @@ func (record *MxRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MxRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Exchange’:
+	// Set property "Exchange":
 	if typedInput.Exchange != nil {
 		exchange := *typedInput.Exchange
 		record.Exchange = &exchange
 	}
 
-	// Set property ‘Preference’:
+	// Set property "Preference":
 	if typedInput.Preference != nil {
 		preference := *typedInput.Preference
 		record.Preference = &preference
@@ -2421,7 +2421,7 @@ func (record *PtrRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &PtrRecord_ARM{}
 
-	// Set property ‘Ptrdname’:
+	// Set property "Ptrdname":
 	if record.Ptrdname != nil {
 		ptrdname := *record.Ptrdname
 		result.Ptrdname = &ptrdname
@@ -2441,7 +2441,7 @@ func (record *PtrRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PtrRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Ptrdname’:
+	// Set property "Ptrdname":
 	if typedInput.Ptrdname != nil {
 		ptrdname := *typedInput.Ptrdname
 		record.Ptrdname = &ptrdname
@@ -2510,7 +2510,7 @@ func (record *PtrRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PtrRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Ptrdname’:
+	// Set property "Ptrdname":
 	if typedInput.Ptrdname != nil {
 		ptrdname := *typedInput.Ptrdname
 		record.Ptrdname = &ptrdname
@@ -2582,43 +2582,43 @@ func (record *SoaRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &SoaRecord_ARM{}
 
-	// Set property ‘Email’:
+	// Set property "Email":
 	if record.Email != nil {
 		email := *record.Email
 		result.Email = &email
 	}
 
-	// Set property ‘ExpireTime’:
+	// Set property "ExpireTime":
 	if record.ExpireTime != nil {
 		expireTime := *record.ExpireTime
 		result.ExpireTime = &expireTime
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	if record.Host != nil {
 		host := *record.Host
 		result.Host = &host
 	}
 
-	// Set property ‘MinimumTtl’:
+	// Set property "MinimumTtl":
 	if record.MinimumTtl != nil {
 		minimumTtl := *record.MinimumTtl
 		result.MinimumTtl = &minimumTtl
 	}
 
-	// Set property ‘RefreshTime’:
+	// Set property "RefreshTime":
 	if record.RefreshTime != nil {
 		refreshTime := *record.RefreshTime
 		result.RefreshTime = &refreshTime
 	}
 
-	// Set property ‘RetryTime’:
+	// Set property "RetryTime":
 	if record.RetryTime != nil {
 		retryTime := *record.RetryTime
 		result.RetryTime = &retryTime
 	}
 
-	// Set property ‘SerialNumber’:
+	// Set property "SerialNumber":
 	if record.SerialNumber != nil {
 		serialNumber := *record.SerialNumber
 		result.SerialNumber = &serialNumber
@@ -2638,43 +2638,43 @@ func (record *SoaRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SoaRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Email’:
+	// Set property "Email":
 	if typedInput.Email != nil {
 		email := *typedInput.Email
 		record.Email = &email
 	}
 
-	// Set property ‘ExpireTime’:
+	// Set property "ExpireTime":
 	if typedInput.ExpireTime != nil {
 		expireTime := *typedInput.ExpireTime
 		record.ExpireTime = &expireTime
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	if typedInput.Host != nil {
 		host := *typedInput.Host
 		record.Host = &host
 	}
 
-	// Set property ‘MinimumTtl’:
+	// Set property "MinimumTtl":
 	if typedInput.MinimumTtl != nil {
 		minimumTtl := *typedInput.MinimumTtl
 		record.MinimumTtl = &minimumTtl
 	}
 
-	// Set property ‘RefreshTime’:
+	// Set property "RefreshTime":
 	if typedInput.RefreshTime != nil {
 		refreshTime := *typedInput.RefreshTime
 		record.RefreshTime = &refreshTime
 	}
 
-	// Set property ‘RetryTime’:
+	// Set property "RetryTime":
 	if typedInput.RetryTime != nil {
 		retryTime := *typedInput.RetryTime
 		record.RetryTime = &retryTime
 	}
 
-	// Set property ‘SerialNumber’:
+	// Set property "SerialNumber":
 	if typedInput.SerialNumber != nil {
 		serialNumber := *typedInput.SerialNumber
 		record.SerialNumber = &serialNumber
@@ -2815,43 +2815,43 @@ func (record *SoaRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SoaRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Email’:
+	// Set property "Email":
 	if typedInput.Email != nil {
 		email := *typedInput.Email
 		record.Email = &email
 	}
 
-	// Set property ‘ExpireTime’:
+	// Set property "ExpireTime":
 	if typedInput.ExpireTime != nil {
 		expireTime := *typedInput.ExpireTime
 		record.ExpireTime = &expireTime
 	}
 
-	// Set property ‘Host’:
+	// Set property "Host":
 	if typedInput.Host != nil {
 		host := *typedInput.Host
 		record.Host = &host
 	}
 
-	// Set property ‘MinimumTtl’:
+	// Set property "MinimumTtl":
 	if typedInput.MinimumTtl != nil {
 		minimumTtl := *typedInput.MinimumTtl
 		record.MinimumTtl = &minimumTtl
 	}
 
-	// Set property ‘RefreshTime’:
+	// Set property "RefreshTime":
 	if typedInput.RefreshTime != nil {
 		refreshTime := *typedInput.RefreshTime
 		record.RefreshTime = &refreshTime
 	}
 
-	// Set property ‘RetryTime’:
+	// Set property "RetryTime":
 	if typedInput.RetryTime != nil {
 		retryTime := *typedInput.RetryTime
 		record.RetryTime = &retryTime
 	}
 
-	// Set property ‘SerialNumber’:
+	// Set property "SerialNumber":
 	if typedInput.SerialNumber != nil {
 		serialNumber := *typedInput.SerialNumber
 		record.SerialNumber = &serialNumber
@@ -2950,25 +2950,25 @@ func (record *SrvRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &SrvRecord_ARM{}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if record.Port != nil {
 		port := *record.Port
 		result.Port = &port
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if record.Priority != nil {
 		priority := *record.Priority
 		result.Priority = &priority
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if record.Target != nil {
 		target := *record.Target
 		result.Target = &target
 	}
 
-	// Set property ‘Weight’:
+	// Set property "Weight":
 	if record.Weight != nil {
 		weight := *record.Weight
 		result.Weight = &weight
@@ -2988,25 +2988,25 @@ func (record *SrvRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SrvRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port := *typedInput.Port
 		record.Port = &port
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		record.Priority = &priority
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		record.Target = &target
 	}
 
-	// Set property ‘Weight’:
+	// Set property "Weight":
 	if typedInput.Weight != nil {
 		weight := *typedInput.Weight
 		record.Weight = &weight
@@ -3111,25 +3111,25 @@ func (record *SrvRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SrvRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port := *typedInput.Port
 		record.Port = &port
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		record.Priority = &priority
 	}
 
-	// Set property ‘Target’:
+	// Set property "Target":
 	if typedInput.Target != nil {
 		target := *typedInput.Target
 		record.Target = &target
 	}
 
-	// Set property ‘Weight’:
+	// Set property "Weight":
 	if typedInput.Weight != nil {
 		weight := *typedInput.Weight
 		record.Weight = &weight
@@ -3201,7 +3201,7 @@ func (record *TxtRecord) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &TxtRecord_ARM{}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	for _, item := range record.Value {
 		result.Value = append(result.Value, item)
 	}
@@ -3220,7 +3220,7 @@ func (record *TxtRecord) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TxtRecord_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	for _, item := range typedInput.Value {
 		record.Value = append(record.Value, item)
 	}
@@ -3288,7 +3288,7 @@ func (record *TxtRecord_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TxtRecord_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	for _, item := range typedInput.Value {
 		record.Value = append(record.Value, item)
 	}

--- a/v2/api/network/v1api20200601/private_dns_zones_cname_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_cname_record_types_gen.go
@@ -364,16 +364,16 @@ func (cname *PrivateDnsZones_CNAME_Spec) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &PrivateDnsZones_CNAME_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if cname.Etag != nil {
 		etag := *cname.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if cname.ARecords != nil ||
 		cname.AaaaRecords != nil ||
 		cname.CnameRecord != nil ||
@@ -469,7 +469,7 @@ func (cname *PrivateDnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_CNAME_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -482,7 +482,7 @@ func (cname *PrivateDnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -495,10 +495,10 @@ func (cname *PrivateDnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	cname.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -512,13 +512,13 @@ func (cname *PrivateDnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		cname.Etag = &etag
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -529,7 +529,7 @@ func (cname *PrivateDnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -542,10 +542,10 @@ func (cname *PrivateDnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	cname.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -558,7 +558,7 @@ func (cname *PrivateDnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -572,7 +572,7 @@ func (cname *PrivateDnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -585,7 +585,7 @@ func (cname *PrivateDnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -594,7 +594,7 @@ func (cname *PrivateDnsZones_CNAME_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1265,7 +1265,7 @@ func (cname *PrivateDnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_CNAME_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1278,7 +1278,7 @@ func (cname *PrivateDnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -1291,7 +1291,7 @@ func (cname *PrivateDnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -1305,15 +1305,15 @@ func (cname *PrivateDnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		cname.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1322,13 +1322,13 @@ func (cname *PrivateDnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		cname.Id = &id
 	}
 
-	// Set property ‘IsAutoRegistered’:
+	// Set property "IsAutoRegistered":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAutoRegistered != nil {
@@ -1337,7 +1337,7 @@ func (cname *PrivateDnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1348,7 +1348,7 @@ func (cname *PrivateDnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -1361,13 +1361,13 @@ func (cname *PrivateDnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		cname.Name = &name
 	}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -1380,7 +1380,7 @@ func (cname *PrivateDnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -1394,7 +1394,7 @@ func (cname *PrivateDnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -1407,7 +1407,7 @@ func (cname *PrivateDnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -1416,7 +1416,7 @@ func (cname *PrivateDnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1429,7 +1429,7 @@ func (cname *PrivateDnsZones_CNAME_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		cname.Type = &typeVar

--- a/v2/api/network/v1api20200601/private_dns_zones_mx_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_mx_record_types_gen.go
@@ -364,16 +364,16 @@ func (zonesMX *PrivateDnsZones_MX_Spec) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &PrivateDnsZones_MX_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if zonesMX.Etag != nil {
 		etag := *zonesMX.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if zonesMX.ARecords != nil ||
 		zonesMX.AaaaRecords != nil ||
 		zonesMX.CnameRecord != nil ||
@@ -469,7 +469,7 @@ func (zonesMX *PrivateDnsZones_MX_Spec) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_MX_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -482,7 +482,7 @@ func (zonesMX *PrivateDnsZones_MX_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -495,10 +495,10 @@ func (zonesMX *PrivateDnsZones_MX_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zonesMX.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -512,13 +512,13 @@ func (zonesMX *PrivateDnsZones_MX_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesMX.Etag = &etag
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -529,7 +529,7 @@ func (zonesMX *PrivateDnsZones_MX_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -542,10 +542,10 @@ func (zonesMX *PrivateDnsZones_MX_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zonesMX.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -558,7 +558,7 @@ func (zonesMX *PrivateDnsZones_MX_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -572,7 +572,7 @@ func (zonesMX *PrivateDnsZones_MX_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -585,7 +585,7 @@ func (zonesMX *PrivateDnsZones_MX_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -594,7 +594,7 @@ func (zonesMX *PrivateDnsZones_MX_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1265,7 +1265,7 @@ func (zonesMX *PrivateDnsZones_MX_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_MX_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1278,7 +1278,7 @@ func (zonesMX *PrivateDnsZones_MX_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -1291,7 +1291,7 @@ func (zonesMX *PrivateDnsZones_MX_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -1305,15 +1305,15 @@ func (zonesMX *PrivateDnsZones_MX_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesMX.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1322,13 +1322,13 @@ func (zonesMX *PrivateDnsZones_MX_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zonesMX.Id = &id
 	}
 
-	// Set property ‘IsAutoRegistered’:
+	// Set property "IsAutoRegistered":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAutoRegistered != nil {
@@ -1337,7 +1337,7 @@ func (zonesMX *PrivateDnsZones_MX_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1348,7 +1348,7 @@ func (zonesMX *PrivateDnsZones_MX_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -1361,13 +1361,13 @@ func (zonesMX *PrivateDnsZones_MX_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zonesMX.Name = &name
 	}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -1380,7 +1380,7 @@ func (zonesMX *PrivateDnsZones_MX_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -1394,7 +1394,7 @@ func (zonesMX *PrivateDnsZones_MX_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -1407,7 +1407,7 @@ func (zonesMX *PrivateDnsZones_MX_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -1416,7 +1416,7 @@ func (zonesMX *PrivateDnsZones_MX_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1429,7 +1429,7 @@ func (zonesMX *PrivateDnsZones_MX_STATUS) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zonesMX.Type = &typeVar

--- a/v2/api/network/v1api20200601/private_dns_zones_ptr_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_ptr_record_types_gen.go
@@ -364,16 +364,16 @@ func (zonesPTR *PrivateDnsZones_PTR_Spec) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &PrivateDnsZones_PTR_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if zonesPTR.Etag != nil {
 		etag := *zonesPTR.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if zonesPTR.ARecords != nil ||
 		zonesPTR.AaaaRecords != nil ||
 		zonesPTR.CnameRecord != nil ||
@@ -469,7 +469,7 @@ func (zonesPTR *PrivateDnsZones_PTR_Spec) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_PTR_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -482,7 +482,7 @@ func (zonesPTR *PrivateDnsZones_PTR_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -495,10 +495,10 @@ func (zonesPTR *PrivateDnsZones_PTR_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zonesPTR.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -512,13 +512,13 @@ func (zonesPTR *PrivateDnsZones_PTR_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesPTR.Etag = &etag
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -529,7 +529,7 @@ func (zonesPTR *PrivateDnsZones_PTR_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -542,10 +542,10 @@ func (zonesPTR *PrivateDnsZones_PTR_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zonesPTR.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -558,7 +558,7 @@ func (zonesPTR *PrivateDnsZones_PTR_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -572,7 +572,7 @@ func (zonesPTR *PrivateDnsZones_PTR_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -585,7 +585,7 @@ func (zonesPTR *PrivateDnsZones_PTR_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -594,7 +594,7 @@ func (zonesPTR *PrivateDnsZones_PTR_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1267,7 +1267,7 @@ func (zonesPTR *PrivateDnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_PTR_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1280,7 +1280,7 @@ func (zonesPTR *PrivateDnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -1293,7 +1293,7 @@ func (zonesPTR *PrivateDnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -1307,15 +1307,15 @@ func (zonesPTR *PrivateDnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesPTR.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1324,13 +1324,13 @@ func (zonesPTR *PrivateDnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zonesPTR.Id = &id
 	}
 
-	// Set property ‘IsAutoRegistered’:
+	// Set property "IsAutoRegistered":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAutoRegistered != nil {
@@ -1339,7 +1339,7 @@ func (zonesPTR *PrivateDnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1350,7 +1350,7 @@ func (zonesPTR *PrivateDnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -1363,13 +1363,13 @@ func (zonesPTR *PrivateDnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zonesPTR.Name = &name
 	}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -1382,7 +1382,7 @@ func (zonesPTR *PrivateDnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -1396,7 +1396,7 @@ func (zonesPTR *PrivateDnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -1409,7 +1409,7 @@ func (zonesPTR *PrivateDnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -1418,7 +1418,7 @@ func (zonesPTR *PrivateDnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1431,7 +1431,7 @@ func (zonesPTR *PrivateDnsZones_PTR_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zonesPTR.Type = &typeVar

--- a/v2/api/network/v1api20200601/private_dns_zones_srv_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_srv_record_types_gen.go
@@ -364,16 +364,16 @@ func (zonesSRV *PrivateDnsZones_SRV_Spec) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &PrivateDnsZones_SRV_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if zonesSRV.Etag != nil {
 		etag := *zonesSRV.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if zonesSRV.ARecords != nil ||
 		zonesSRV.AaaaRecords != nil ||
 		zonesSRV.CnameRecord != nil ||
@@ -469,7 +469,7 @@ func (zonesSRV *PrivateDnsZones_SRV_Spec) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_SRV_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -482,7 +482,7 @@ func (zonesSRV *PrivateDnsZones_SRV_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -495,10 +495,10 @@ func (zonesSRV *PrivateDnsZones_SRV_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zonesSRV.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -512,13 +512,13 @@ func (zonesSRV *PrivateDnsZones_SRV_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesSRV.Etag = &etag
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -529,7 +529,7 @@ func (zonesSRV *PrivateDnsZones_SRV_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -542,10 +542,10 @@ func (zonesSRV *PrivateDnsZones_SRV_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zonesSRV.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -558,7 +558,7 @@ func (zonesSRV *PrivateDnsZones_SRV_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -572,7 +572,7 @@ func (zonesSRV *PrivateDnsZones_SRV_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -585,7 +585,7 @@ func (zonesSRV *PrivateDnsZones_SRV_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -594,7 +594,7 @@ func (zonesSRV *PrivateDnsZones_SRV_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1267,7 +1267,7 @@ func (zonesSRV *PrivateDnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_SRV_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1280,7 +1280,7 @@ func (zonesSRV *PrivateDnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -1293,7 +1293,7 @@ func (zonesSRV *PrivateDnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -1307,15 +1307,15 @@ func (zonesSRV *PrivateDnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesSRV.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1324,13 +1324,13 @@ func (zonesSRV *PrivateDnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zonesSRV.Id = &id
 	}
 
-	// Set property ‘IsAutoRegistered’:
+	// Set property "IsAutoRegistered":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAutoRegistered != nil {
@@ -1339,7 +1339,7 @@ func (zonesSRV *PrivateDnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1350,7 +1350,7 @@ func (zonesSRV *PrivateDnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -1363,13 +1363,13 @@ func (zonesSRV *PrivateDnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zonesSRV.Name = &name
 	}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -1382,7 +1382,7 @@ func (zonesSRV *PrivateDnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -1396,7 +1396,7 @@ func (zonesSRV *PrivateDnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -1409,7 +1409,7 @@ func (zonesSRV *PrivateDnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -1418,7 +1418,7 @@ func (zonesSRV *PrivateDnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1431,7 +1431,7 @@ func (zonesSRV *PrivateDnsZones_SRV_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zonesSRV.Type = &typeVar

--- a/v2/api/network/v1api20200601/private_dns_zones_txt_record_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_txt_record_types_gen.go
@@ -364,16 +364,16 @@ func (zonesTXT *PrivateDnsZones_TXT_Spec) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &PrivateDnsZones_TXT_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if zonesTXT.Etag != nil {
 		etag := *zonesTXT.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if zonesTXT.ARecords != nil ||
 		zonesTXT.AaaaRecords != nil ||
 		zonesTXT.CnameRecord != nil ||
@@ -469,7 +469,7 @@ func (zonesTXT *PrivateDnsZones_TXT_Spec) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_TXT_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -482,7 +482,7 @@ func (zonesTXT *PrivateDnsZones_TXT_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -495,10 +495,10 @@ func (zonesTXT *PrivateDnsZones_TXT_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zonesTXT.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -512,13 +512,13 @@ func (zonesTXT *PrivateDnsZones_TXT_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesTXT.Etag = &etag
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -529,7 +529,7 @@ func (zonesTXT *PrivateDnsZones_TXT_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -542,10 +542,10 @@ func (zonesTXT *PrivateDnsZones_TXT_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zonesTXT.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -558,7 +558,7 @@ func (zonesTXT *PrivateDnsZones_TXT_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -572,7 +572,7 @@ func (zonesTXT *PrivateDnsZones_TXT_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -585,7 +585,7 @@ func (zonesTXT *PrivateDnsZones_TXT_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -594,7 +594,7 @@ func (zonesTXT *PrivateDnsZones_TXT_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1267,7 +1267,7 @@ func (zonesTXT *PrivateDnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_TXT_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ARecords’:
+	// Set property "ARecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ARecords {
@@ -1280,7 +1280,7 @@ func (zonesTXT *PrivateDnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘AaaaRecords’:
+	// Set property "AaaaRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AaaaRecords {
@@ -1293,7 +1293,7 @@ func (zonesTXT *PrivateDnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘CnameRecord’:
+	// Set property "CnameRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CnameRecord != nil {
@@ -1307,15 +1307,15 @@ func (zonesTXT *PrivateDnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zonesTXT.Etag = &etag
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Fqdn != nil {
@@ -1324,13 +1324,13 @@ func (zonesTXT *PrivateDnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zonesTXT.Id = &id
 	}
 
-	// Set property ‘IsAutoRegistered’:
+	// Set property "IsAutoRegistered":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAutoRegistered != nil {
@@ -1339,7 +1339,7 @@ func (zonesTXT *PrivateDnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1350,7 +1350,7 @@ func (zonesTXT *PrivateDnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘MxRecords’:
+	// Set property "MxRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.MxRecords {
@@ -1363,13 +1363,13 @@ func (zonesTXT *PrivateDnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zonesTXT.Name = &name
 	}
 
-	// Set property ‘PtrRecords’:
+	// Set property "PtrRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PtrRecords {
@@ -1382,7 +1382,7 @@ func (zonesTXT *PrivateDnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘SoaRecord’:
+	// Set property "SoaRecord":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SoaRecord != nil {
@@ -1396,7 +1396,7 @@ func (zonesTXT *PrivateDnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘SrvRecords’:
+	// Set property "SrvRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SrvRecords {
@@ -1409,7 +1409,7 @@ func (zonesTXT *PrivateDnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Ttl != nil {
@@ -1418,7 +1418,7 @@ func (zonesTXT *PrivateDnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘TxtRecords’:
+	// Set property "TxtRecords":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TxtRecords {
@@ -1431,7 +1431,7 @@ func (zonesTXT *PrivateDnsZones_TXT_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zonesTXT.Type = &typeVar

--- a/v2/api/network/v1api20200601/private_dns_zones_virtual_network_link_types_gen.go
+++ b/v2/api/network/v1api20200601/private_dns_zones_virtual_network_link_types_gen.go
@@ -347,22 +347,22 @@ func (link *PrivateDnsZones_VirtualNetworkLink_Spec) ConvertToARM(resolved genru
 	}
 	result := &PrivateDnsZones_VirtualNetworkLink_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if link.Etag != nil {
 		etag := *link.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if link.Location != nil {
 		location := *link.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if link.RegistrationEnabled != nil || link.VirtualNetwork != nil {
 		result.Properties = &VirtualNetworkLinkProperties_ARM{}
 	}
@@ -379,7 +379,7 @@ func (link *PrivateDnsZones_VirtualNetworkLink_Spec) ConvertToARM(resolved genru
 		result.Properties.VirtualNetwork = &virtualNetwork
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if link.Tags != nil {
 		result.Tags = make(map[string]string, len(link.Tags))
 		for key, value := range link.Tags {
@@ -401,25 +401,25 @@ func (link *PrivateDnsZones_VirtualNetworkLink_Spec) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_VirtualNetworkLink_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	link.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		link.Etag = &etag
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		link.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	link.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RegistrationEnabled’:
+	// Set property "RegistrationEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RegistrationEnabled != nil {
@@ -428,7 +428,7 @@ func (link *PrivateDnsZones_VirtualNetworkLink_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		link.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -436,7 +436,7 @@ func (link *PrivateDnsZones_VirtualNetworkLink_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘VirtualNetwork’:
+	// Set property "VirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetwork != nil {
@@ -759,33 +759,33 @@ func (link *PrivateDnsZones_VirtualNetworkLink_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZones_VirtualNetworkLink_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		link.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		link.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		link.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		link.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -794,7 +794,7 @@ func (link *PrivateDnsZones_VirtualNetworkLink_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘RegistrationEnabled’:
+	// Set property "RegistrationEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RegistrationEnabled != nil {
@@ -803,7 +803,7 @@ func (link *PrivateDnsZones_VirtualNetworkLink_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		link.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -811,13 +811,13 @@ func (link *PrivateDnsZones_VirtualNetworkLink_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		link.Type = &typeVar
 	}
 
-	// Set property ‘VirtualNetwork’:
+	// Set property "VirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetwork != nil {
@@ -831,7 +831,7 @@ func (link *PrivateDnsZones_VirtualNetworkLink_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘VirtualNetworkLinkState’:
+	// Set property "VirtualNetworkLinkState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetworkLinkState != nil {
@@ -996,7 +996,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -1020,7 +1020,7 @@ func (resource *SubResource) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1100,7 +1100,7 @@ func (resource *SubResource_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id

--- a/v2/api/network/v1api20201101/load_balancer_types_gen.go
+++ b/v2/api/network/v1api20201101/load_balancer_types_gen.go
@@ -376,7 +376,7 @@ func (balancer *LoadBalancer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &LoadBalancer_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if balancer.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*balancer.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -386,16 +386,16 @@ func (balancer *LoadBalancer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if balancer.Location != nil {
 		location := *balancer.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if balancer.BackendAddressPools != nil ||
 		balancer.FrontendIPConfigurations != nil ||
 		balancer.InboundNatPools != nil ||
@@ -455,7 +455,7 @@ func (balancer *LoadBalancer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.Probes = append(result.Properties.Probes, *item_ARM.(*Probe_ARM))
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if balancer.Sku != nil {
 		sku_ARM, err := (*balancer.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -465,7 +465,7 @@ func (balancer *LoadBalancer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if balancer.Tags != nil {
 		result.Tags = make(map[string]string, len(balancer.Tags))
 		for key, value := range balancer.Tags {
@@ -487,10 +487,10 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancer_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	balancer.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BackendAddressPools’:
+	// Set property "BackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.BackendAddressPools {
@@ -503,7 +503,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -514,7 +514,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		balancer.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FrontendIPConfigurations’:
+	// Set property "FrontendIPConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.FrontendIPConfigurations {
@@ -527,7 +527,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘InboundNatPools’:
+	// Set property "InboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundNatPools {
@@ -540,7 +540,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘InboundNatRules’:
+	// Set property "InboundNatRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundNatRules {
@@ -553,7 +553,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘LoadBalancingRules’:
+	// Set property "LoadBalancingRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancingRules {
@@ -566,13 +566,13 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		balancer.Location = &location
 	}
 
-	// Set property ‘OutboundRules’:
+	// Set property "OutboundRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.OutboundRules {
@@ -585,10 +585,10 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	balancer.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Probes’:
+	// Set property "Probes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Probes {
@@ -601,7 +601,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 LoadBalancerSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -612,7 +612,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		balancer.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		balancer.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1333,7 +1333,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancer_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendAddressPools’:
+	// Set property "BackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.BackendAddressPools {
@@ -1346,15 +1346,15 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		balancer.Etag = &etag
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1365,7 +1365,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		balancer.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FrontendIPConfigurations’:
+	// Set property "FrontendIPConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.FrontendIPConfigurations {
@@ -1378,13 +1378,13 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		balancer.Id = &id
 	}
 
-	// Set property ‘InboundNatPools’:
+	// Set property "InboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundNatPools {
@@ -1397,7 +1397,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘InboundNatRules’:
+	// Set property "InboundNatRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundNatRules {
@@ -1410,7 +1410,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘LoadBalancingRules’:
+	// Set property "LoadBalancingRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancingRules {
@@ -1423,19 +1423,19 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		balancer.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		balancer.Name = &name
 	}
 
-	// Set property ‘OutboundRules’:
+	// Set property "OutboundRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.OutboundRules {
@@ -1448,7 +1448,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Probes’:
+	// Set property "Probes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Probes {
@@ -1461,7 +1461,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1470,7 +1470,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -1479,7 +1479,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 LoadBalancerSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1490,7 +1490,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		balancer.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		balancer.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1498,7 +1498,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		balancer.Type = &typeVar
@@ -1914,13 +1914,13 @@ func (embedded *BackendAddressPool_LoadBalancer_SubResourceEmbedded) ConvertToAR
 	}
 	result := &BackendAddressPool_LoadBalancer_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if embedded.Name != nil {
 		name := *embedded.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if embedded.LoadBalancerBackendAddresses != nil {
 		result.Properties = &BackendAddressPoolPropertiesFormat_ARM{}
 	}
@@ -1946,7 +1946,7 @@ func (embedded *BackendAddressPool_LoadBalancer_SubResourceEmbedded) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackendAddressPool_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LoadBalancerBackendAddresses’:
+	// Set property "LoadBalancerBackendAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddresses {
@@ -1959,7 +1959,7 @@ func (embedded *BackendAddressPool_LoadBalancer_SubResourceEmbedded) PopulateFro
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
@@ -2110,7 +2110,7 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendIPConfigurations’:
+	// Set property "BackendIPConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.BackendIPConfigurations {
@@ -2123,19 +2123,19 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘LoadBalancerBackendAddresses’:
+	// Set property "LoadBalancerBackendAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddresses {
@@ -2148,7 +2148,7 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘LoadBalancingRules’:
+	// Set property "LoadBalancingRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancingRules {
@@ -2161,13 +2161,13 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘OutboundRule’:
+	// Set property "OutboundRule":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OutboundRule != nil {
@@ -2181,7 +2181,7 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘OutboundRules’:
+	// Set property "OutboundRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.OutboundRules {
@@ -2194,7 +2194,7 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2203,7 +2203,7 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
@@ -2464,13 +2464,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -2490,13 +2490,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -2592,13 +2592,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -2690,13 +2690,13 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Conver
 	}
 	result := &FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if embedded.Name != nil {
 		name := *embedded.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if embedded.PrivateIPAddress != nil ||
 		embedded.PrivateIPAddressVersion != nil ||
 		embedded.PrivateIPAllocationMethod != nil ||
@@ -2742,7 +2742,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Conver
 		result.Properties.Subnet = &subnet
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range embedded.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -2761,13 +2761,13 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -2776,7 +2776,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -2785,7 +2785,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		}
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -2794,7 +2794,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		}
 	}
 
-	// Set property ‘PublicIPAddress’:
+	// Set property "PublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddress != nil {
@@ -2808,7 +2808,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -2822,7 +2822,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -2836,7 +2836,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		embedded.Zones = append(embedded.Zones, item)
 	}
@@ -3124,19 +3124,19 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘InboundNatPools’:
+	// Set property "InboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundNatPools {
@@ -3149,7 +3149,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘InboundNatRules’:
+	// Set property "InboundNatRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundNatRules {
@@ -3162,7 +3162,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘LoadBalancingRules’:
+	// Set property "LoadBalancingRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancingRules {
@@ -3175,13 +3175,13 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘OutboundRules’:
+	// Set property "OutboundRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.OutboundRules {
@@ -3194,7 +3194,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -3203,7 +3203,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -3212,7 +3212,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -3221,7 +3221,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -3230,7 +3230,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘PublicIPAddress’:
+	// Set property "PublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddress != nil {
@@ -3244,7 +3244,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -3258,7 +3258,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -3272,13 +3272,13 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		embedded.Zones = append(embedded.Zones, item)
 	}
@@ -3660,13 +3660,13 @@ func (pool *InboundNatPool) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &InboundNatPool_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if pool.Name != nil {
 		name := *pool.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if pool.BackendPort != nil ||
 		pool.EnableFloatingIP != nil ||
 		pool.EnableTcpReset != nil ||
@@ -3728,7 +3728,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundNatPool_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -3737,7 +3737,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -3746,7 +3746,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -3755,7 +3755,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -3769,7 +3769,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘FrontendPortRangeEnd’:
+	// Set property "FrontendPortRangeEnd":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPortRangeEnd != nil {
@@ -3778,7 +3778,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘FrontendPortRangeStart’:
+	// Set property "FrontendPortRangeStart":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPortRangeStart != nil {
@@ -3787,7 +3787,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -3796,13 +3796,13 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pool.Name = &name
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -4061,7 +4061,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundNatPool_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -4070,7 +4070,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -4079,7 +4079,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -4088,13 +4088,13 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		pool.Etag = &etag
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -4108,7 +4108,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘FrontendPortRangeEnd’:
+	// Set property "FrontendPortRangeEnd":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPortRangeEnd != nil {
@@ -4117,7 +4117,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘FrontendPortRangeStart’:
+	// Set property "FrontendPortRangeStart":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPortRangeStart != nil {
@@ -4126,13 +4126,13 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		pool.Id = &id
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -4141,13 +4141,13 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pool.Name = &name
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -4156,7 +4156,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -4165,7 +4165,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		pool.Type = &typeVar
@@ -4376,13 +4376,13 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) ConvertToARM(re
 	}
 	result := &InboundNatRule_LoadBalancer_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if embedded.Name != nil {
 		name := *embedded.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if embedded.BackendPort != nil ||
 		embedded.EnableFloatingIP != nil ||
 		embedded.EnableTcpReset != nil ||
@@ -4439,7 +4439,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundNatRule_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -4448,7 +4448,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -4457,7 +4457,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -4466,7 +4466,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		}
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -4480,7 +4480,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		}
 	}
 
-	// Set property ‘FrontendPort’:
+	// Set property "FrontendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPort != nil {
@@ -4489,7 +4489,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -4498,13 +4498,13 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -4754,7 +4754,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendIPConfiguration’:
+	// Set property "BackendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendIPConfiguration != nil {
@@ -4768,7 +4768,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -4777,7 +4777,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -4786,7 +4786,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -4795,13 +4795,13 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -4815,7 +4815,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘FrontendPort’:
+	// Set property "FrontendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPort != nil {
@@ -4824,13 +4824,13 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -4839,13 +4839,13 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -4854,7 +4854,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -4863,7 +4863,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
@@ -5068,13 +5068,13 @@ func (balancerSku *LoadBalancerSku) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &LoadBalancerSku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if balancerSku.Name != nil {
 		name := *balancerSku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if balancerSku.Tier != nil {
 		tier := *balancerSku.Tier
 		result.Tier = &tier
@@ -5094,13 +5094,13 @@ func (balancerSku *LoadBalancerSku) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancerSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		balancerSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		balancerSku.Tier = &tier
@@ -5211,13 +5211,13 @@ func (balancerSku *LoadBalancerSku_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancerSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		balancerSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		balancerSku.Tier = &tier
@@ -5341,13 +5341,13 @@ func (rule *LoadBalancingRule) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &LoadBalancingRule_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if rule.Name != nil {
 		name := *rule.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.BackendAddressPool != nil ||
 		rule.BackendPort != nil ||
 		rule.DisableOutboundSnat != nil ||
@@ -5432,7 +5432,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancingRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendAddressPool’:
+	// Set property "BackendAddressPool":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendAddressPool != nil {
@@ -5446,7 +5446,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -5455,7 +5455,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘DisableOutboundSnat’:
+	// Set property "DisableOutboundSnat":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableOutboundSnat != nil {
@@ -5464,7 +5464,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -5473,7 +5473,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -5482,7 +5482,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -5496,7 +5496,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘FrontendPort’:
+	// Set property "FrontendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPort != nil {
@@ -5505,7 +5505,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -5514,7 +5514,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘LoadDistribution’:
+	// Set property "LoadDistribution":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LoadDistribution != nil {
@@ -5523,13 +5523,13 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Probe’:
+	// Set property "Probe":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Probe != nil {
@@ -5543,7 +5543,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -5924,7 +5924,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancingRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendAddressPool’:
+	// Set property "BackendAddressPool":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendAddressPool != nil {
@@ -5938,7 +5938,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -5947,7 +5947,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DisableOutboundSnat’:
+	// Set property "DisableOutboundSnat":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableOutboundSnat != nil {
@@ -5956,7 +5956,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -5965,7 +5965,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -5974,13 +5974,13 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		rule.Etag = &etag
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -5994,7 +5994,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘FrontendPort’:
+	// Set property "FrontendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPort != nil {
@@ -6003,13 +6003,13 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -6018,7 +6018,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LoadDistribution’:
+	// Set property "LoadDistribution":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LoadDistribution != nil {
@@ -6027,13 +6027,13 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Probe’:
+	// Set property "Probe":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Probe != nil {
@@ -6047,7 +6047,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -6056,7 +6056,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -6065,7 +6065,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -6347,13 +6347,13 @@ func (rule *OutboundRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &OutboundRule_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if rule.Name != nil {
 		name := *rule.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.AllocatedOutboundPorts != nil ||
 		rule.BackendAddressPool != nil ||
 		rule.EnableTcpReset != nil ||
@@ -6408,7 +6408,7 @@ func (rule *OutboundRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OutboundRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllocatedOutboundPorts != nil {
@@ -6417,7 +6417,7 @@ func (rule *OutboundRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘BackendAddressPool’:
+	// Set property "BackendAddressPool":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendAddressPool != nil {
@@ -6431,7 +6431,7 @@ func (rule *OutboundRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -6440,7 +6440,7 @@ func (rule *OutboundRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘FrontendIPConfigurations’:
+	// Set property "FrontendIPConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.FrontendIPConfigurations {
@@ -6453,7 +6453,7 @@ func (rule *OutboundRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -6462,13 +6462,13 @@ func (rule *OutboundRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -6729,7 +6729,7 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OutboundRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllocatedOutboundPorts != nil {
@@ -6738,7 +6738,7 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘BackendAddressPool’:
+	// Set property "BackendAddressPool":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendAddressPool != nil {
@@ -6752,7 +6752,7 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -6761,13 +6761,13 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		rule.Etag = &etag
 	}
 
-	// Set property ‘FrontendIPConfigurations’:
+	// Set property "FrontendIPConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.FrontendIPConfigurations {
@@ -6780,13 +6780,13 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -6795,13 +6795,13 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -6810,7 +6810,7 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -6819,7 +6819,7 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -7036,13 +7036,13 @@ func (probe *Probe) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &Probe_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if probe.Name != nil {
 		name := *probe.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if probe.IntervalInSeconds != nil ||
 		probe.NumberOfProbes != nil ||
 		probe.Port != nil ||
@@ -7085,7 +7085,7 @@ func (probe *Probe) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Probe_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IntervalInSeconds’:
+	// Set property "IntervalInSeconds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IntervalInSeconds != nil {
@@ -7094,13 +7094,13 @@ func (probe *Probe) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		probe.Name = &name
 	}
 
-	// Set property ‘NumberOfProbes’:
+	// Set property "NumberOfProbes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfProbes != nil {
@@ -7109,7 +7109,7 @@ func (probe *Probe) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		}
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Port != nil {
@@ -7118,7 +7118,7 @@ func (probe *Probe) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		}
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -7127,7 +7127,7 @@ func (probe *Probe) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		}
 	}
 
-	// Set property ‘RequestPath’:
+	// Set property "RequestPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequestPath != nil {
@@ -7297,19 +7297,19 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Probe_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		probe.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		probe.Id = &id
 	}
 
-	// Set property ‘IntervalInSeconds’:
+	// Set property "IntervalInSeconds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IntervalInSeconds != nil {
@@ -7318,7 +7318,7 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘LoadBalancingRules’:
+	// Set property "LoadBalancingRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancingRules {
@@ -7331,13 +7331,13 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		probe.Name = &name
 	}
 
-	// Set property ‘NumberOfProbes’:
+	// Set property "NumberOfProbes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfProbes != nil {
@@ -7346,7 +7346,7 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Port != nil {
@@ -7355,7 +7355,7 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -7364,7 +7364,7 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -7373,7 +7373,7 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘RequestPath’:
+	// Set property "RequestPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequestPath != nil {
@@ -7382,7 +7382,7 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		probe.Type = &typeVar
@@ -7568,13 +7568,13 @@ func (address *LoadBalancerBackendAddress) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &LoadBalancerBackendAddress_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if address.Name != nil {
 		name := *address.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if address.IpAddress != nil ||
 		address.LoadBalancerFrontendIPConfiguration != nil ||
 		address.Subnet != nil ||
@@ -7624,7 +7624,7 @@ func (address *LoadBalancerBackendAddress) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancerBackendAddress_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpAddress != nil {
@@ -7633,7 +7633,7 @@ func (address *LoadBalancerBackendAddress) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘LoadBalancerFrontendIPConfiguration’:
+	// Set property "LoadBalancerFrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LoadBalancerFrontendIPConfiguration != nil {
@@ -7647,13 +7647,13 @@ func (address *LoadBalancerBackendAddress) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		address.Name = &name
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -7667,7 +7667,7 @@ func (address *LoadBalancerBackendAddress) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘VirtualNetwork’:
+	// Set property "VirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetwork != nil {
@@ -7876,7 +7876,7 @@ func (address *LoadBalancerBackendAddress_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancerBackendAddress_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpAddress != nil {
@@ -7885,7 +7885,7 @@ func (address *LoadBalancerBackendAddress_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘LoadBalancerFrontendIPConfiguration’:
+	// Set property "LoadBalancerFrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LoadBalancerFrontendIPConfiguration != nil {
@@ -7899,13 +7899,13 @@ func (address *LoadBalancerBackendAddress_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		address.Name = &name
 	}
 
-	// Set property ‘NetworkInterfaceIPConfiguration’:
+	// Set property "NetworkInterfaceIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkInterfaceIPConfiguration != nil {
@@ -7919,7 +7919,7 @@ func (address *LoadBalancerBackendAddress_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -7933,7 +7933,7 @@ func (address *LoadBalancerBackendAddress_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘VirtualNetwork’:
+	// Set property "VirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetwork != nil {
@@ -8119,7 +8119,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_LoadBalancer_SubResourceE
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -8212,7 +8212,7 @@ func (embedded *PublicIPAddress_STATUS_LoadBalancer_SubResourceEmbedded) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddress_STATUS_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -8266,7 +8266,7 @@ func (embedded *PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded) ConvertToA
 	}
 	result := &PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -8290,7 +8290,7 @@ func (embedded *PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -8365,7 +8365,7 @@ func (embedded *Subnet_LoadBalancer_SubResourceEmbedded) ConvertToARM(resolved g
 	}
 	result := &Subnet_LoadBalancer_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -8389,7 +8389,7 @@ func (embedded *Subnet_LoadBalancer_SubResourceEmbedded) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -8469,7 +8469,7 @@ func (embedded *Subnet_STATUS_LoadBalancer_SubResourceEmbedded) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_STATUS_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id

--- a/v2/api/network/v1api20201101/load_balancers_inbound_nat_rule_types_gen.go
+++ b/v2/api/network/v1api20201101/load_balancers_inbound_nat_rule_types_gen.go
@@ -357,10 +357,10 @@ func (rule *LoadBalancers_InboundNatRule_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &LoadBalancers_InboundNatRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.BackendPort != nil ||
 		rule.EnableFloatingIP != nil ||
 		rule.EnableTcpReset != nil ||
@@ -417,10 +417,10 @@ func (rule *LoadBalancers_InboundNatRule_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancers_InboundNatRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -429,7 +429,7 @@ func (rule *LoadBalancers_InboundNatRule_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -438,7 +438,7 @@ func (rule *LoadBalancers_InboundNatRule_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -447,7 +447,7 @@ func (rule *LoadBalancers_InboundNatRule_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -461,7 +461,7 @@ func (rule *LoadBalancers_InboundNatRule_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘FrontendPort’:
+	// Set property "FrontendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPort != nil {
@@ -470,7 +470,7 @@ func (rule *LoadBalancers_InboundNatRule_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -479,10 +479,10 @@ func (rule *LoadBalancers_InboundNatRule_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -860,7 +860,7 @@ func (rule *LoadBalancers_InboundNatRule_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancers_InboundNatRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendIPConfiguration’:
+	// Set property "BackendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendIPConfiguration != nil {
@@ -874,7 +874,7 @@ func (rule *LoadBalancers_InboundNatRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -883,9 +883,9 @@ func (rule *LoadBalancers_InboundNatRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -894,7 +894,7 @@ func (rule *LoadBalancers_InboundNatRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -903,13 +903,13 @@ func (rule *LoadBalancers_InboundNatRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		rule.Etag = &etag
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -923,7 +923,7 @@ func (rule *LoadBalancers_InboundNatRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘FrontendPort’:
+	// Set property "FrontendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPort != nil {
@@ -932,13 +932,13 @@ func (rule *LoadBalancers_InboundNatRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -947,13 +947,13 @@ func (rule *LoadBalancers_InboundNatRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -962,7 +962,7 @@ func (rule *LoadBalancers_InboundNatRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -971,7 +971,7 @@ func (rule *LoadBalancers_InboundNatRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -1184,7 +1184,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_LoadBalancers_InboundNatR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceIPConfiguration_STATUS_LoadBalancers_InboundNatRule_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -1238,7 +1238,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -1262,7 +1262,7 @@ func (resource *SubResource) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1342,7 +1342,7 @@ func (resource *SubResource_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id

--- a/v2/api/network/v1api20201101/network_interface_types_gen.go
+++ b/v2/api/network/v1api20201101/network_interface_types_gen.go
@@ -361,7 +361,7 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &NetworkInterface_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if networkInterface.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*networkInterface.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -371,16 +371,16 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if networkInterface.Location != nil {
 		location := *networkInterface.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if networkInterface.DnsSettings != nil ||
 		networkInterface.EnableAcceleratedNetworking != nil ||
 		networkInterface.EnableIPForwarding != nil ||
@@ -434,7 +434,7 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 		result.Properties.PrivateLinkService = &privateLinkService
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if networkInterface.Tags != nil {
 		result.Tags = make(map[string]string, len(networkInterface.Tags))
 		for key, value := range networkInterface.Tags {
@@ -456,10 +456,10 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterface_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	networkInterface.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -473,7 +473,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -482,7 +482,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -491,7 +491,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -502,7 +502,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		networkInterface.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -515,13 +515,13 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		networkInterface.Location = &location
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -535,7 +535,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘NicType’:
+	// Set property "NicType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NicType != nil {
@@ -544,10 +544,10 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	networkInterface.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PrivateLinkService’:
+	// Set property "PrivateLinkService":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkService != nil {
@@ -561,7 +561,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		networkInterface.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1118,9 +1118,9 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -1134,7 +1134,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘DscpConfiguration’:
+	// Set property "DscpConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DscpConfiguration != nil {
@@ -1148,7 +1148,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -1157,7 +1157,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -1166,13 +1166,13 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1183,7 +1183,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		embedded.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostedWorkloads’:
+	// Set property "HostedWorkloads":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.HostedWorkloads {
@@ -1191,13 +1191,13 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -1210,13 +1210,13 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		embedded.Location = &location
 	}
 
-	// Set property ‘MacAddress’:
+	// Set property "MacAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MacAddress != nil {
@@ -1225,7 +1225,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘MigrationPhase’:
+	// Set property "MigrationPhase":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MigrationPhase != nil {
@@ -1234,13 +1234,13 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -1254,7 +1254,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘NicType’:
+	// Set property "NicType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NicType != nil {
@@ -1263,7 +1263,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -1272,7 +1272,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘PrivateEndpoint’:
+	// Set property "PrivateEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateEndpoint != nil {
@@ -1286,7 +1286,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘PrivateLinkService’:
+	// Set property "PrivateLinkService":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkService != nil {
@@ -1300,7 +1300,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1309,7 +1309,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -1318,7 +1318,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		embedded.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1326,7 +1326,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘TapConfigurations’:
+	// Set property "TapConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TapConfigurations {
@@ -1339,13 +1339,13 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
 	}
 
-	// Set property ‘VirtualMachine’:
+	// Set property "VirtualMachine":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachine != nil {
@@ -1802,12 +1802,12 @@ func (settings *NetworkInterfaceDnsSettings) ConvertToARM(resolved genruntime.Co
 	}
 	result := &NetworkInterfaceDnsSettings_ARM{}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range settings.DnsServers {
 		result.DnsServers = append(result.DnsServers, item)
 	}
 
-	// Set property ‘InternalDnsNameLabel’:
+	// Set property "InternalDnsNameLabel":
 	if settings.InternalDnsNameLabel != nil {
 		internalDnsNameLabel := *settings.InternalDnsNameLabel
 		result.InternalDnsNameLabel = &internalDnsNameLabel
@@ -1827,12 +1827,12 @@ func (settings *NetworkInterfaceDnsSettings) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceDnsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		settings.DnsServers = append(settings.DnsServers, item)
 	}
 
-	// Set property ‘InternalDnsNameLabel’:
+	// Set property "InternalDnsNameLabel":
 	if typedInput.InternalDnsNameLabel != nil {
 		internalDnsNameLabel := *typedInput.InternalDnsNameLabel
 		settings.InternalDnsNameLabel = &internalDnsNameLabel
@@ -1927,29 +1927,29 @@ func (settings *NetworkInterfaceDnsSettings_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceDnsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AppliedDnsServers’:
+	// Set property "AppliedDnsServers":
 	for _, item := range typedInput.AppliedDnsServers {
 		settings.AppliedDnsServers = append(settings.AppliedDnsServers, item)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		settings.DnsServers = append(settings.DnsServers, item)
 	}
 
-	// Set property ‘InternalDnsNameLabel’:
+	// Set property "InternalDnsNameLabel":
 	if typedInput.InternalDnsNameLabel != nil {
 		internalDnsNameLabel := *typedInput.InternalDnsNameLabel
 		settings.InternalDnsNameLabel = &internalDnsNameLabel
 	}
 
-	// Set property ‘InternalDomainNameSuffix’:
+	// Set property "InternalDomainNameSuffix":
 	if typedInput.InternalDomainNameSuffix != nil {
 		internalDomainNameSuffix := *typedInput.InternalDomainNameSuffix
 		settings.InternalDomainNameSuffix = &internalDomainNameSuffix
 	}
 
-	// Set property ‘InternalFqdn’:
+	// Set property "InternalFqdn":
 	if typedInput.InternalFqdn != nil {
 		internalFqdn := *typedInput.InternalFqdn
 		settings.InternalFqdn = &internalFqdn
@@ -2060,13 +2060,13 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 	}
 	result := &NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if embedded.Name != nil {
 		name := *embedded.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if embedded.ApplicationGatewayBackendAddressPools != nil ||
 		embedded.ApplicationSecurityGroups != nil ||
 		embedded.LoadBalancerBackendAddressPools != nil ||
@@ -2162,7 +2162,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -2175,7 +2175,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -2188,7 +2188,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -2201,7 +2201,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘LoadBalancerInboundNatRules’:
+	// Set property "LoadBalancerInboundNatRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerInboundNatRules {
@@ -2214,13 +2214,13 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -2229,7 +2229,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -2238,7 +2238,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -2247,7 +2247,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -2256,7 +2256,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘PublicIPAddress’:
+	// Set property "PublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddress != nil {
@@ -2270,7 +2270,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -2284,7 +2284,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘VirtualNetworkTaps’:
+	// Set property "VirtualNetworkTaps":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VirtualNetworkTaps {
@@ -2831,7 +2831,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -2844,7 +2844,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -2857,19 +2857,19 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -2882,7 +2882,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘LoadBalancerInboundNatRules’:
+	// Set property "LoadBalancerInboundNatRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerInboundNatRules {
@@ -2895,13 +2895,13 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -2910,7 +2910,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -2919,7 +2919,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -2928,7 +2928,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -2937,7 +2937,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘PrivateLinkConnectionProperties’:
+	// Set property "PrivateLinkConnectionProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkConnectionProperties != nil {
@@ -2951,7 +2951,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2960,7 +2960,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘PublicIPAddress’:
+	// Set property "PublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddress != nil {
@@ -2974,7 +2974,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -2988,13 +2988,13 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
 	}
 
-	// Set property ‘VirtualNetworkTaps’:
+	// Set property "VirtualNetworkTaps":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VirtualNetworkTaps {
@@ -3425,7 +3425,7 @@ func (embedded *NetworkInterfaceTapConfiguration_STATUS_NetworkInterface_SubReso
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceTapConfiguration_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3484,7 +3484,7 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3538,7 +3538,7 @@ func (embedded *NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded) C
 	}
 	result := &NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -3562,7 +3562,7 @@ func (embedded *NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded) P
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3642,7 +3642,7 @@ func (embedded *PrivateEndpoint_STATUS_NetworkInterface_SubResourceEmbedded) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpoint_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3701,7 +3701,7 @@ func (embedded *PrivateLinkService_STATUS_NetworkInterface_SubResourceEmbedded) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkService_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3755,7 +3755,7 @@ func (service *PrivateLinkServiceSpec) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &PrivateLinkServiceSpec_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if service.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*service.Reference)
 		if err != nil {
@@ -3779,7 +3779,7 @@ func (service *PrivateLinkServiceSpec) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkServiceSpec_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3854,7 +3854,7 @@ func (embedded *ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourc
 	}
 	result := &ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -3878,7 +3878,7 @@ func (embedded *ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3958,7 +3958,7 @@ func (embedded *ApplicationGatewayBackendAddressPool_STATUS_NetworkInterface_Sub
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationGatewayBackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -4017,7 +4017,7 @@ func (embedded *ApplicationSecurityGroup_STATUS_NetworkInterface_SubResourceEmbe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -4071,7 +4071,7 @@ func (embedded *ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedde
 	}
 	result := &ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -4095,7 +4095,7 @@ func (embedded *ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedde
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -4170,7 +4170,7 @@ func (embedded *BackendAddressPool_NetworkInterface_SubResourceEmbedded) Convert
 	}
 	result := &BackendAddressPool_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -4194,7 +4194,7 @@ func (embedded *BackendAddressPool_NetworkInterface_SubResourceEmbedded) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackendAddressPool_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -4274,7 +4274,7 @@ func (embedded *BackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -4328,7 +4328,7 @@ func (embedded *InboundNatRule_NetworkInterface_SubResourceEmbedded) ConvertToAR
 	}
 	result := &InboundNatRule_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -4352,7 +4352,7 @@ func (embedded *InboundNatRule_NetworkInterface_SubResourceEmbedded) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundNatRule_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -4432,7 +4432,7 @@ func (embedded *InboundNatRule_STATUS_NetworkInterface_SubResourceEmbedded) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundNatRule_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -4497,18 +4497,18 @@ func (properties *NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Fqdns’:
+	// Set property "Fqdns":
 	for _, item := range typedInput.Fqdns {
 		properties.Fqdns = append(properties.Fqdns, item)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if typedInput.GroupId != nil {
 		groupId := *typedInput.GroupId
 		properties.GroupId = &groupId
 	}
 
-	// Set property ‘RequiredMemberName’:
+	// Set property "RequiredMemberName":
 	if typedInput.RequiredMemberName != nil {
 		requiredMemberName := *typedInput.RequiredMemberName
 		properties.RequiredMemberName = &requiredMemberName
@@ -4579,7 +4579,7 @@ func (embedded *PublicIPAddress_STATUS_NetworkInterface_SubResourceEmbedded) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddress_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -4633,7 +4633,7 @@ func (embedded *PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded) Conver
 	}
 	result := &PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -4657,7 +4657,7 @@ func (embedded *PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded) Popula
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -4732,7 +4732,7 @@ func (embedded *Subnet_NetworkInterface_SubResourceEmbedded) ConvertToARM(resolv
 	}
 	result := &Subnet_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -4756,7 +4756,7 @@ func (embedded *Subnet_NetworkInterface_SubResourceEmbedded) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -4836,7 +4836,7 @@ func (embedded *Subnet_STATUS_NetworkInterface_SubResourceEmbedded) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -4895,7 +4895,7 @@ func (embedded *VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded) P
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -4949,7 +4949,7 @@ func (embedded *VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded) Conv
 	}
 	result := &VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -4973,7 +4973,7 @@ func (embedded *VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil

--- a/v2/api/network/v1api20201101/network_security_group_types_gen.go
+++ b/v2/api/network/v1api20201101/network_security_group_types_gen.go
@@ -337,18 +337,18 @@ func (group *NetworkSecurityGroup_Spec) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &NetworkSecurityGroup_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if group.Location != nil {
 		location := *group.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// no assignment for property ‘Properties’
+	// no assignment for property "Properties"
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if group.Tags != nil {
 		result.Tags = make(map[string]string, len(group.Tags))
 		for key, value := range group.Tags {
@@ -370,19 +370,19 @@ func (group *NetworkSecurityGroup_Spec) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroup_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	group.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		group.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	group.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		group.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -631,9 +631,9 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DefaultSecurityRules’:
+	// Set property "DefaultSecurityRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DefaultSecurityRules {
@@ -646,13 +646,13 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘FlowLogs’:
+	// Set property "FlowLogs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.FlowLogs {
@@ -665,25 +665,25 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		embedded.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NetworkInterfaces {
@@ -696,7 +696,7 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -705,7 +705,7 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -714,7 +714,7 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Subnets’:
+	// Set property "Subnets":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Subnets {
@@ -727,7 +727,7 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		embedded.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -735,7 +735,7 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
@@ -996,7 +996,7 @@ func (flowLog *FlowLog_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlowLog_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		flowLog.Id = &id
@@ -1055,7 +1055,7 @@ func (embedded *NetworkInterface_STATUS_NetworkSecurityGroup_SubResourceEmbedded
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterface_STATUS_NetworkSecurityGroup_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -1114,7 +1114,7 @@ func (rule *SecurityRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SecurityRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
@@ -1173,7 +1173,7 @@ func (embedded *Subnet_STATUS_NetworkSecurityGroup_SubResourceEmbedded) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_STATUS_NetworkSecurityGroup_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id

--- a/v2/api/network/v1api20201101/network_security_groups_security_rule_types_gen.go
+++ b/v2/api/network/v1api20201101/network_security_groups_security_rule_types_gen.go
@@ -385,10 +385,10 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) ConvertToARM(resolved genru
 	}
 	result := &NetworkSecurityGroups_SecurityRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.Access != nil ||
 		rule.Description != nil ||
 		rule.DestinationAddressPrefix != nil ||
@@ -483,7 +483,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroups_SecurityRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Access’:
+	// Set property "Access":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Access != nil {
@@ -492,10 +492,10 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -504,7 +504,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘DestinationAddressPrefix’:
+	// Set property "DestinationAddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DestinationAddressPrefix != nil {
@@ -513,7 +513,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘DestinationAddressPrefixes’:
+	// Set property "DestinationAddressPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DestinationAddressPrefixes {
@@ -521,7 +521,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘DestinationApplicationSecurityGroups’:
+	// Set property "DestinationApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DestinationApplicationSecurityGroups {
@@ -534,7 +534,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘DestinationPortRange’:
+	// Set property "DestinationPortRange":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DestinationPortRange != nil {
@@ -543,7 +543,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘DestinationPortRanges’:
+	// Set property "DestinationPortRanges":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DestinationPortRanges {
@@ -551,7 +551,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Direction’:
+	// Set property "Direction":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Direction != nil {
@@ -560,10 +560,10 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -572,7 +572,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -581,7 +581,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘SourceAddressPrefix’:
+	// Set property "SourceAddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceAddressPrefix != nil {
@@ -590,7 +590,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘SourceAddressPrefixes’:
+	// Set property "SourceAddressPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SourceAddressPrefixes {
@@ -598,7 +598,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘SourceApplicationSecurityGroups’:
+	// Set property "SourceApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SourceApplicationSecurityGroups {
@@ -611,7 +611,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘SourcePortRange’:
+	// Set property "SourcePortRange":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourcePortRange != nil {
@@ -620,7 +620,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘SourcePortRanges’:
+	// Set property "SourcePortRanges":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SourcePortRanges {
@@ -1152,7 +1152,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroups_SecurityRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Access’:
+	// Set property "Access":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Access != nil {
@@ -1161,9 +1161,9 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -1172,7 +1172,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘DestinationAddressPrefix’:
+	// Set property "DestinationAddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DestinationAddressPrefix != nil {
@@ -1181,7 +1181,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘DestinationAddressPrefixes’:
+	// Set property "DestinationAddressPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DestinationAddressPrefixes {
@@ -1189,7 +1189,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘DestinationApplicationSecurityGroups’:
+	// Set property "DestinationApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DestinationApplicationSecurityGroups {
@@ -1202,7 +1202,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘DestinationPortRange’:
+	// Set property "DestinationPortRange":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DestinationPortRange != nil {
@@ -1211,7 +1211,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘DestinationPortRanges’:
+	// Set property "DestinationPortRanges":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DestinationPortRanges {
@@ -1219,7 +1219,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Direction’:
+	// Set property "Direction":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Direction != nil {
@@ -1228,25 +1228,25 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		rule.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -1255,7 +1255,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -1264,7 +1264,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1273,7 +1273,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘SourceAddressPrefix’:
+	// Set property "SourceAddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceAddressPrefix != nil {
@@ -1282,7 +1282,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘SourceAddressPrefixes’:
+	// Set property "SourceAddressPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SourceAddressPrefixes {
@@ -1290,7 +1290,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘SourceApplicationSecurityGroups’:
+	// Set property "SourceApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SourceApplicationSecurityGroups {
@@ -1303,7 +1303,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘SourcePortRange’:
+	// Set property "SourcePortRange":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourcePortRange != nil {
@@ -1312,7 +1312,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘SourcePortRanges’:
+	// Set property "SourcePortRanges":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SourcePortRanges {
@@ -1320,7 +1320,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -1599,7 +1599,7 @@ func (embedded *ApplicationSecurityGroup_STATUS_NetworkSecurityGroups_SecurityRu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationSecurityGroup_STATUS_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -1653,7 +1653,7 @@ func (embedded *ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_
 	}
 	result := &ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -1677,7 +1677,7 @@ func (embedded *ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil

--- a/v2/api/network/v1api20201101/public_ip_address_types_gen.go
+++ b/v2/api/network/v1api20201101/public_ip_address_types_gen.go
@@ -379,7 +379,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &PublicIPAddress_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if address.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*address.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -389,16 +389,16 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if address.Location != nil {
 		location := *address.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if address.DdosSettings != nil ||
 		address.DnsSettings != nil ||
 		address.IdleTimeoutInMinutes != nil ||
@@ -484,7 +484,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.ServicePublicIPAddress = &servicePublicIPAddress
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if address.Sku != nil {
 		sku_ARM, err := (*address.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -494,7 +494,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if address.Tags != nil {
 		result.Tags = make(map[string]string, len(address.Tags))
 		for key, value := range address.Tags {
@@ -502,7 +502,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range address.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -521,10 +521,10 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddress_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	address.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DdosSettings’:
+	// Set property "DdosSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DdosSettings != nil {
@@ -538,7 +538,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -552,7 +552,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -563,7 +563,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		address.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -572,7 +572,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpAddress != nil {
@@ -581,7 +581,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -594,7 +594,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘LinkedPublicIPAddress’:
+	// Set property "LinkedPublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinkedPublicIPAddress != nil {
@@ -608,13 +608,13 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		address.Location = &location
 	}
 
-	// Set property ‘NatGateway’:
+	// Set property "NatGateway":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NatGateway != nil {
@@ -628,10 +628,10 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	address.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -640,7 +640,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PublicIPAllocationMethod’:
+	// Set property "PublicIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAllocationMethod != nil {
@@ -649,7 +649,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -663,7 +663,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ServicePublicIPAddress’:
+	// Set property "ServicePublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServicePublicIPAddress != nil {
@@ -677,7 +677,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPAddressSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -688,7 +688,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		address.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		address.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -696,7 +696,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		address.Zones = append(address.Zones, item)
 	}
@@ -1365,9 +1365,9 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DdosSettings’:
+	// Set property "DdosSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DdosSettings != nil {
@@ -1381,7 +1381,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -1395,13 +1395,13 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1412,13 +1412,13 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		embedded.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -1427,7 +1427,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpAddress != nil {
@@ -1436,7 +1436,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘IpConfiguration’:
+	// Set property "IpConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpConfiguration != nil {
@@ -1450,7 +1450,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -1463,13 +1463,13 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		embedded.Location = &location
 	}
 
-	// Set property ‘MigrationPhase’:
+	// Set property "MigrationPhase":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MigrationPhase != nil {
@@ -1478,13 +1478,13 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘NatGateway’:
+	// Set property "NatGateway":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NatGateway != nil {
@@ -1498,7 +1498,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1507,7 +1507,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -1516,7 +1516,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘PublicIPAllocationMethod’:
+	// Set property "PublicIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAllocationMethod != nil {
@@ -1525,7 +1525,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -1539,7 +1539,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -1548,7 +1548,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPAddressSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1559,7 +1559,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		embedded.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		embedded.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1567,13 +1567,13 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		embedded.Zones = append(embedded.Zones, item)
 	}
@@ -1961,7 +1961,7 @@ func (settings *DdosSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &DdosSettings_ARM{}
 
-	// Set property ‘DdosCustomPolicy’:
+	// Set property "DdosCustomPolicy":
 	if settings.DdosCustomPolicy != nil {
 		ddosCustomPolicy_ARM, err := (*settings.DdosCustomPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -1971,13 +1971,13 @@ func (settings *DdosSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.DdosCustomPolicy = &ddosCustomPolicy
 	}
 
-	// Set property ‘ProtectedIP’:
+	// Set property "ProtectedIP":
 	if settings.ProtectedIP != nil {
 		protectedIP := *settings.ProtectedIP
 		result.ProtectedIP = &protectedIP
 	}
 
-	// Set property ‘ProtectionCoverage’:
+	// Set property "ProtectionCoverage":
 	if settings.ProtectionCoverage != nil {
 		protectionCoverage := *settings.ProtectionCoverage
 		result.ProtectionCoverage = &protectionCoverage
@@ -1997,7 +1997,7 @@ func (settings *DdosSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DdosSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DdosCustomPolicy’:
+	// Set property "DdosCustomPolicy":
 	if typedInput.DdosCustomPolicy != nil {
 		var ddosCustomPolicy1 SubResource
 		err := ddosCustomPolicy1.PopulateFromARM(owner, *typedInput.DdosCustomPolicy)
@@ -2008,13 +2008,13 @@ func (settings *DdosSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		settings.DdosCustomPolicy = &ddosCustomPolicy
 	}
 
-	// Set property ‘ProtectedIP’:
+	// Set property "ProtectedIP":
 	if typedInput.ProtectedIP != nil {
 		protectedIP := *typedInput.ProtectedIP
 		settings.ProtectedIP = &protectedIP
 	}
 
-	// Set property ‘ProtectionCoverage’:
+	// Set property "ProtectionCoverage":
 	if typedInput.ProtectionCoverage != nil {
 		protectionCoverage := *typedInput.ProtectionCoverage
 		settings.ProtectionCoverage = &protectionCoverage
@@ -2165,7 +2165,7 @@ func (settings *DdosSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DdosSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DdosCustomPolicy’:
+	// Set property "DdosCustomPolicy":
 	if typedInput.DdosCustomPolicy != nil {
 		var ddosCustomPolicy1 SubResource_STATUS
 		err := ddosCustomPolicy1.PopulateFromARM(owner, *typedInput.DdosCustomPolicy)
@@ -2176,13 +2176,13 @@ func (settings *DdosSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		settings.DdosCustomPolicy = &ddosCustomPolicy
 	}
 
-	// Set property ‘ProtectedIP’:
+	// Set property "ProtectedIP":
 	if typedInput.ProtectedIP != nil {
 		protectedIP := *typedInput.ProtectedIP
 		settings.ProtectedIP = &protectedIP
 	}
 
-	// Set property ‘ProtectionCoverage’:
+	// Set property "ProtectionCoverage":
 	if typedInput.ProtectionCoverage != nil {
 		protectionCoverage := *typedInput.ProtectionCoverage
 		settings.ProtectionCoverage = &protectionCoverage
@@ -2308,7 +2308,7 @@ func (embedded *IPConfiguration_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPConfiguration_STATUS_PublicIPAddress_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2365,13 +2365,13 @@ func (ipTag *IpTag) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &IpTag_ARM{}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if ipTag.IpTagType != nil {
 		ipTagType := *ipTag.IpTagType
 		result.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if ipTag.Tag != nil {
 		tag := *ipTag.Tag
 		result.Tag = &tag
@@ -2391,13 +2391,13 @@ func (ipTag *IpTag) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpTag_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -2478,13 +2478,13 @@ func (ipTag *IpTag_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpTag_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -2566,7 +2566,7 @@ func (embedded *NatGateway_STATUS_PublicIPAddress_SubResourceEmbedded) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NatGateway_STATUS_PublicIPAddress_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2620,7 +2620,7 @@ func (embedded *NatGatewaySpec_PublicIPAddress_SubResourceEmbedded) ConvertToARM
 	}
 	result := &NatGatewaySpec_PublicIPAddress_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -2644,7 +2644,7 @@ func (embedded *NatGatewaySpec_PublicIPAddress_SubResourceEmbedded) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NatGatewaySpec_PublicIPAddress_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2730,19 +2730,19 @@ func (settings *PublicIPAddressDnsSettings) ConvertToARM(resolved genruntime.Con
 	}
 	result := &PublicIPAddressDnsSettings_ARM{}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if settings.DomainNameLabel != nil {
 		domainNameLabel := *settings.DomainNameLabel
 		result.DomainNameLabel = &domainNameLabel
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	if settings.Fqdn != nil {
 		fqdn := *settings.Fqdn
 		result.Fqdn = &fqdn
 	}
 
-	// Set property ‘ReverseFqdn’:
+	// Set property "ReverseFqdn":
 	if settings.ReverseFqdn != nil {
 		reverseFqdn := *settings.ReverseFqdn
 		result.ReverseFqdn = &reverseFqdn
@@ -2762,19 +2762,19 @@ func (settings *PublicIPAddressDnsSettings) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressDnsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		settings.DomainNameLabel = &domainNameLabel
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	if typedInput.Fqdn != nil {
 		fqdn := *typedInput.Fqdn
 		settings.Fqdn = &fqdn
 	}
 
-	// Set property ‘ReverseFqdn’:
+	// Set property "ReverseFqdn":
 	if typedInput.ReverseFqdn != nil {
 		reverseFqdn := *typedInput.ReverseFqdn
 		settings.ReverseFqdn = &reverseFqdn
@@ -2872,19 +2872,19 @@ func (settings *PublicIPAddressDnsSettings_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressDnsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		settings.DomainNameLabel = &domainNameLabel
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	if typedInput.Fqdn != nil {
 		fqdn := *typedInput.Fqdn
 		settings.Fqdn = &fqdn
 	}
 
-	// Set property ‘ReverseFqdn’:
+	// Set property "ReverseFqdn":
 	if typedInput.ReverseFqdn != nil {
 		reverseFqdn := *typedInput.ReverseFqdn
 		settings.ReverseFqdn = &reverseFqdn
@@ -2963,13 +2963,13 @@ func (addressSku *PublicIPAddressSku) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &PublicIPAddressSku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if addressSku.Name != nil {
 		name := *addressSku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if addressSku.Tier != nil {
 		tier := *addressSku.Tier
 		result.Tier = &tier
@@ -2989,13 +2989,13 @@ func (addressSku *PublicIPAddressSku) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		addressSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		addressSku.Tier = &tier
@@ -3106,13 +3106,13 @@ func (addressSku *PublicIPAddressSku_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		addressSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		addressSku.Tier = &tier
@@ -3192,7 +3192,7 @@ func (embedded *PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded) Convert
 	}
 	result := &PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -3216,7 +3216,7 @@ func (embedded *PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil

--- a/v2/api/network/v1api20201101/route_table_types_gen.go
+++ b/v2/api/network/v1api20201101/route_table_types_gen.go
@@ -340,16 +340,16 @@ func (table *RouteTable_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &RouteTable_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if table.Location != nil {
 		location := *table.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if table.DisableBgpRoutePropagation != nil {
 		result.Properties = &RouteTablePropertiesFormat_ARM{}
 	}
@@ -358,7 +358,7 @@ func (table *RouteTable_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Properties.DisableBgpRoutePropagation = &disableBgpRoutePropagation
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if table.Tags != nil {
 		result.Tags = make(map[string]string, len(table.Tags))
 		for key, value := range table.Tags {
@@ -380,10 +380,10 @@ func (table *RouteTable_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteTable_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	table.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DisableBgpRoutePropagation’:
+	// Set property "DisableBgpRoutePropagation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableBgpRoutePropagation != nil {
@@ -392,16 +392,16 @@ func (table *RouteTable_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		table.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	table.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		table.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -665,9 +665,9 @@ func (table *RouteTable_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteTable_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DisableBgpRoutePropagation’:
+	// Set property "DisableBgpRoutePropagation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableBgpRoutePropagation != nil {
@@ -676,31 +676,31 @@ func (table *RouteTable_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		table.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		table.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		table.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		table.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -709,7 +709,7 @@ func (table *RouteTable_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -718,7 +718,7 @@ func (table *RouteTable_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		table.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -726,7 +726,7 @@ func (table *RouteTable_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		table.Type = &typeVar

--- a/v2/api/network/v1api20201101/route_tables_route_types_gen.go
+++ b/v2/api/network/v1api20201101/route_tables_route_types_gen.go
@@ -345,10 +345,10 @@ func (route *RouteTables_Route_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &RouteTables_Route_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if route.AddressPrefix != nil ||
 		route.HasBgpOverride != nil ||
 		route.NextHopIpAddress != nil ||
@@ -386,7 +386,7 @@ func (route *RouteTables_Route_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteTables_Route_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressPrefix’:
+	// Set property "AddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddressPrefix != nil {
@@ -395,10 +395,10 @@ func (route *RouteTables_Route_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	route.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘HasBgpOverride’:
+	// Set property "HasBgpOverride":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HasBgpOverride != nil {
@@ -407,7 +407,7 @@ func (route *RouteTables_Route_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NextHopIpAddress’:
+	// Set property "NextHopIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NextHopIpAddress != nil {
@@ -416,7 +416,7 @@ func (route *RouteTables_Route_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NextHopType’:
+	// Set property "NextHopType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NextHopType != nil {
@@ -425,7 +425,7 @@ func (route *RouteTables_Route_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	route.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -708,7 +708,7 @@ func (route *RouteTables_Route_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteTables_Route_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressPrefix’:
+	// Set property "AddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddressPrefix != nil {
@@ -717,15 +717,15 @@ func (route *RouteTables_Route_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		route.Etag = &etag
 	}
 
-	// Set property ‘HasBgpOverride’:
+	// Set property "HasBgpOverride":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HasBgpOverride != nil {
@@ -734,19 +734,19 @@ func (route *RouteTables_Route_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		route.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		route.Name = &name
 	}
 
-	// Set property ‘NextHopIpAddress’:
+	// Set property "NextHopIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NextHopIpAddress != nil {
@@ -755,7 +755,7 @@ func (route *RouteTables_Route_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘NextHopType’:
+	// Set property "NextHopType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NextHopType != nil {
@@ -764,7 +764,7 @@ func (route *RouteTables_Route_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -773,7 +773,7 @@ func (route *RouteTables_Route_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		route.Type = &typeVar

--- a/v2/api/network/v1api20201101/virtual_network_gateway_types_gen.go
+++ b/v2/api/network/v1api20201101/virtual_network_gateway_types_gen.go
@@ -387,7 +387,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &VirtualNetworkGateway_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if gateway.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*gateway.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -397,16 +397,16 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if gateway.Location != nil {
 		location := *gateway.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if gateway.ActiveActive != nil ||
 		gateway.BgpSettings != nil ||
 		gateway.CustomRoutes != nil ||
@@ -507,7 +507,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.VpnType = &vpnType
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if gateway.Tags != nil {
 		result.Tags = make(map[string]string, len(gateway.Tags))
 		for key, value := range gateway.Tags {
@@ -529,7 +529,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkGateway_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActiveActive’:
+	// Set property "ActiveActive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ActiveActive != nil {
@@ -538,10 +538,10 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	gateway.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BgpSettings’:
+	// Set property "BgpSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BgpSettings != nil {
@@ -555,7 +555,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘CustomRoutes’:
+	// Set property "CustomRoutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomRoutes != nil {
@@ -569,7 +569,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘EnableBgp’:
+	// Set property "EnableBgp":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBgp != nil {
@@ -578,7 +578,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘EnableDnsForwarding’:
+	// Set property "EnableDnsForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableDnsForwarding != nil {
@@ -587,7 +587,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘EnablePrivateIpAddress’:
+	// Set property "EnablePrivateIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePrivateIpAddress != nil {
@@ -596,7 +596,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -607,7 +607,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		gateway.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘GatewayDefaultSite’:
+	// Set property "GatewayDefaultSite":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GatewayDefaultSite != nil {
@@ -621,7 +621,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘GatewayType’:
+	// Set property "GatewayType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GatewayType != nil {
@@ -630,7 +630,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -643,16 +643,16 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		gateway.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	gateway.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -666,7 +666,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		gateway.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -674,9 +674,9 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// no assignment for property ‘VNetExtendedLocationResourceReference’
+	// no assignment for property "VNetExtendedLocationResourceReference"
 
-	// Set property ‘VpnClientConfiguration’:
+	// Set property "VpnClientConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VpnClientConfiguration != nil {
@@ -690,7 +690,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘VpnGatewayGeneration’:
+	// Set property "VpnGatewayGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VpnGatewayGeneration != nil {
@@ -699,7 +699,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘VpnType’:
+	// Set property "VpnType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VpnType != nil {
@@ -1454,7 +1454,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkGateway_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActiveActive’:
+	// Set property "ActiveActive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ActiveActive != nil {
@@ -1463,7 +1463,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘BgpSettings’:
+	// Set property "BgpSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BgpSettings != nil {
@@ -1477,9 +1477,9 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CustomRoutes’:
+	// Set property "CustomRoutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomRoutes != nil {
@@ -1493,7 +1493,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘EnableBgp’:
+	// Set property "EnableBgp":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBgp != nil {
@@ -1502,7 +1502,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘EnableDnsForwarding’:
+	// Set property "EnableDnsForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableDnsForwarding != nil {
@@ -1511,7 +1511,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘EnablePrivateIpAddress’:
+	// Set property "EnablePrivateIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePrivateIpAddress != nil {
@@ -1520,13 +1520,13 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		gateway.Etag = &etag
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1537,7 +1537,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		gateway.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘GatewayDefaultSite’:
+	// Set property "GatewayDefaultSite":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GatewayDefaultSite != nil {
@@ -1551,7 +1551,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘GatewayType’:
+	// Set property "GatewayType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GatewayType != nil {
@@ -1560,13 +1560,13 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		gateway.Id = &id
 	}
 
-	// Set property ‘InboundDnsForwardingEndpoint’:
+	// Set property "InboundDnsForwardingEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InboundDnsForwardingEndpoint != nil {
@@ -1575,7 +1575,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -1588,19 +1588,19 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		gateway.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		gateway.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1609,7 +1609,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -1618,7 +1618,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -1632,7 +1632,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		gateway.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1640,13 +1640,13 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		gateway.Type = &typeVar
 	}
 
-	// Set property ‘VNetExtendedLocationResourceId’:
+	// Set property "VNetExtendedLocationResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VNetExtendedLocationResourceId != nil {
@@ -1655,7 +1655,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘VpnClientConfiguration’:
+	// Set property "VpnClientConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VpnClientConfiguration != nil {
@@ -1669,7 +1669,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘VpnGatewayGeneration’:
+	// Set property "VpnGatewayGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VpnGatewayGeneration != nil {
@@ -1678,7 +1678,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘VpnType’:
+	// Set property "VpnType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VpnType != nil {
@@ -2106,19 +2106,19 @@ func (settings *BgpSettings) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &BgpSettings_ARM{}
 
-	// Set property ‘Asn’:
+	// Set property "Asn":
 	if settings.Asn != nil {
 		asn := *settings.Asn
 		result.Asn = &asn
 	}
 
-	// Set property ‘BgpPeeringAddress’:
+	// Set property "BgpPeeringAddress":
 	if settings.BgpPeeringAddress != nil {
 		bgpPeeringAddress := *settings.BgpPeeringAddress
 		result.BgpPeeringAddress = &bgpPeeringAddress
 	}
 
-	// Set property ‘BgpPeeringAddresses’:
+	// Set property "BgpPeeringAddresses":
 	for _, item := range settings.BgpPeeringAddresses {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2127,7 +2127,7 @@ func (settings *BgpSettings) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.BgpPeeringAddresses = append(result.BgpPeeringAddresses, *item_ARM.(*IPConfigurationBgpPeeringAddress_ARM))
 	}
 
-	// Set property ‘PeerWeight’:
+	// Set property "PeerWeight":
 	if settings.PeerWeight != nil {
 		peerWeight := *settings.PeerWeight
 		result.PeerWeight = &peerWeight
@@ -2147,19 +2147,19 @@ func (settings *BgpSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BgpSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Asn’:
+	// Set property "Asn":
 	if typedInput.Asn != nil {
 		asn := *typedInput.Asn
 		settings.Asn = &asn
 	}
 
-	// Set property ‘BgpPeeringAddress’:
+	// Set property "BgpPeeringAddress":
 	if typedInput.BgpPeeringAddress != nil {
 		bgpPeeringAddress := *typedInput.BgpPeeringAddress
 		settings.BgpPeeringAddress = &bgpPeeringAddress
 	}
 
-	// Set property ‘BgpPeeringAddresses’:
+	// Set property "BgpPeeringAddresses":
 	for _, item := range typedInput.BgpPeeringAddresses {
 		var item1 IPConfigurationBgpPeeringAddress
 		err := item1.PopulateFromARM(owner, item)
@@ -2169,7 +2169,7 @@ func (settings *BgpSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		settings.BgpPeeringAddresses = append(settings.BgpPeeringAddresses, item1)
 	}
 
-	// Set property ‘PeerWeight’:
+	// Set property "PeerWeight":
 	if typedInput.PeerWeight != nil {
 		peerWeight := *typedInput.PeerWeight
 		settings.PeerWeight = &peerWeight
@@ -2334,19 +2334,19 @@ func (settings *BgpSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BgpSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Asn’:
+	// Set property "Asn":
 	if typedInput.Asn != nil {
 		asn := *typedInput.Asn
 		settings.Asn = &asn
 	}
 
-	// Set property ‘BgpPeeringAddress’:
+	// Set property "BgpPeeringAddress":
 	if typedInput.BgpPeeringAddress != nil {
 		bgpPeeringAddress := *typedInput.BgpPeeringAddress
 		settings.BgpPeeringAddress = &bgpPeeringAddress
 	}
 
-	// Set property ‘BgpPeeringAddresses’:
+	// Set property "BgpPeeringAddresses":
 	for _, item := range typedInput.BgpPeeringAddresses {
 		var item1 IPConfigurationBgpPeeringAddress_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2356,7 +2356,7 @@ func (settings *BgpSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		settings.BgpPeeringAddresses = append(settings.BgpPeeringAddresses, item1)
 	}
 
-	// Set property ‘PeerWeight’:
+	// Set property "PeerWeight":
 	if typedInput.PeerWeight != nil {
 		peerWeight := *typedInput.PeerWeight
 		settings.PeerWeight = &peerWeight
@@ -2477,13 +2477,13 @@ func (configuration *VirtualNetworkGatewayIPConfiguration) ConvertToARM(resolved
 	}
 	result := &VirtualNetworkGatewayIPConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.PrivateIPAllocationMethod != nil ||
 		configuration.PublicIPAddress != nil ||
 		configuration.Subnet != nil {
@@ -2524,13 +2524,13 @@ func (configuration *VirtualNetworkGatewayIPConfiguration) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkGatewayIPConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -2539,7 +2539,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘PublicIPAddress’:
+	// Set property "PublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddress != nil {
@@ -2553,7 +2553,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -2747,25 +2747,25 @@ func (configuration *VirtualNetworkGatewayIPConfiguration_STATUS) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkGatewayIPConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		configuration.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -2774,7 +2774,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration_STATUS) PopulateFromAR
 		}
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -2783,7 +2783,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration_STATUS) PopulateFromAR
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2792,7 +2792,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration_STATUS) PopulateFromAR
 		}
 	}
 
-	// Set property ‘PublicIPAddress’:
+	// Set property "PublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddress != nil {
@@ -2806,7 +2806,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration_STATUS) PopulateFromAR
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -3018,13 +3018,13 @@ func (gatewaySku *VirtualNetworkGatewaySku) ConvertToARM(resolved genruntime.Con
 	}
 	result := &VirtualNetworkGatewaySku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if gatewaySku.Name != nil {
 		name := *gatewaySku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if gatewaySku.Tier != nil {
 		tier := *gatewaySku.Tier
 		result.Tier = &tier
@@ -3044,13 +3044,13 @@ func (gatewaySku *VirtualNetworkGatewaySku) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkGatewaySku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		gatewaySku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		gatewaySku.Tier = &tier
@@ -3164,19 +3164,19 @@ func (gatewaySku *VirtualNetworkGatewaySku_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkGatewaySku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		gatewaySku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		gatewaySku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		gatewaySku.Tier = &tier
@@ -3298,37 +3298,37 @@ func (configuration *VpnClientConfiguration) ConvertToARM(resolved genruntime.Co
 	}
 	result := &VpnClientConfiguration_ARM{}
 
-	// Set property ‘AadAudience’:
+	// Set property "AadAudience":
 	if configuration.AadAudience != nil {
 		aadAudience := *configuration.AadAudience
 		result.AadAudience = &aadAudience
 	}
 
-	// Set property ‘AadIssuer’:
+	// Set property "AadIssuer":
 	if configuration.AadIssuer != nil {
 		aadIssuer := *configuration.AadIssuer
 		result.AadIssuer = &aadIssuer
 	}
 
-	// Set property ‘AadTenant’:
+	// Set property "AadTenant":
 	if configuration.AadTenant != nil {
 		aadTenant := *configuration.AadTenant
 		result.AadTenant = &aadTenant
 	}
 
-	// Set property ‘RadiusServerAddress’:
+	// Set property "RadiusServerAddress":
 	if configuration.RadiusServerAddress != nil {
 		radiusServerAddress := *configuration.RadiusServerAddress
 		result.RadiusServerAddress = &radiusServerAddress
 	}
 
-	// Set property ‘RadiusServerSecret’:
+	// Set property "RadiusServerSecret":
 	if configuration.RadiusServerSecret != nil {
 		radiusServerSecret := *configuration.RadiusServerSecret
 		result.RadiusServerSecret = &radiusServerSecret
 	}
 
-	// Set property ‘RadiusServers’:
+	// Set property "RadiusServers":
 	for _, item := range configuration.RadiusServers {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3337,12 +3337,12 @@ func (configuration *VpnClientConfiguration) ConvertToARM(resolved genruntime.Co
 		result.RadiusServers = append(result.RadiusServers, *item_ARM.(*RadiusServer_ARM))
 	}
 
-	// Set property ‘VpnAuthenticationTypes’:
+	// Set property "VpnAuthenticationTypes":
 	for _, item := range configuration.VpnAuthenticationTypes {
 		result.VpnAuthenticationTypes = append(result.VpnAuthenticationTypes, item)
 	}
 
-	// Set property ‘VpnClientAddressPool’:
+	// Set property "VpnClientAddressPool":
 	if configuration.VpnClientAddressPool != nil {
 		vpnClientAddressPool_ARM, err := (*configuration.VpnClientAddressPool).ConvertToARM(resolved)
 		if err != nil {
@@ -3352,7 +3352,7 @@ func (configuration *VpnClientConfiguration) ConvertToARM(resolved genruntime.Co
 		result.VpnClientAddressPool = &vpnClientAddressPool
 	}
 
-	// Set property ‘VpnClientIpsecPolicies’:
+	// Set property "VpnClientIpsecPolicies":
 	for _, item := range configuration.VpnClientIpsecPolicies {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3361,12 +3361,12 @@ func (configuration *VpnClientConfiguration) ConvertToARM(resolved genruntime.Co
 		result.VpnClientIpsecPolicies = append(result.VpnClientIpsecPolicies, *item_ARM.(*IpsecPolicy_ARM))
 	}
 
-	// Set property ‘VpnClientProtocols’:
+	// Set property "VpnClientProtocols":
 	for _, item := range configuration.VpnClientProtocols {
 		result.VpnClientProtocols = append(result.VpnClientProtocols, item)
 	}
 
-	// Set property ‘VpnClientRevokedCertificates’:
+	// Set property "VpnClientRevokedCertificates":
 	for _, item := range configuration.VpnClientRevokedCertificates {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3375,7 +3375,7 @@ func (configuration *VpnClientConfiguration) ConvertToARM(resolved genruntime.Co
 		result.VpnClientRevokedCertificates = append(result.VpnClientRevokedCertificates, *item_ARM.(*VpnClientRevokedCertificate_ARM))
 	}
 
-	// Set property ‘VpnClientRootCertificates’:
+	// Set property "VpnClientRootCertificates":
 	for _, item := range configuration.VpnClientRootCertificates {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3398,37 +3398,37 @@ func (configuration *VpnClientConfiguration) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VpnClientConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadAudience’:
+	// Set property "AadAudience":
 	if typedInput.AadAudience != nil {
 		aadAudience := *typedInput.AadAudience
 		configuration.AadAudience = &aadAudience
 	}
 
-	// Set property ‘AadIssuer’:
+	// Set property "AadIssuer":
 	if typedInput.AadIssuer != nil {
 		aadIssuer := *typedInput.AadIssuer
 		configuration.AadIssuer = &aadIssuer
 	}
 
-	// Set property ‘AadTenant’:
+	// Set property "AadTenant":
 	if typedInput.AadTenant != nil {
 		aadTenant := *typedInput.AadTenant
 		configuration.AadTenant = &aadTenant
 	}
 
-	// Set property ‘RadiusServerAddress’:
+	// Set property "RadiusServerAddress":
 	if typedInput.RadiusServerAddress != nil {
 		radiusServerAddress := *typedInput.RadiusServerAddress
 		configuration.RadiusServerAddress = &radiusServerAddress
 	}
 
-	// Set property ‘RadiusServerSecret’:
+	// Set property "RadiusServerSecret":
 	if typedInput.RadiusServerSecret != nil {
 		radiusServerSecret := *typedInput.RadiusServerSecret
 		configuration.RadiusServerSecret = &radiusServerSecret
 	}
 
-	// Set property ‘RadiusServers’:
+	// Set property "RadiusServers":
 	for _, item := range typedInput.RadiusServers {
 		var item1 RadiusServer
 		err := item1.PopulateFromARM(owner, item)
@@ -3438,12 +3438,12 @@ func (configuration *VpnClientConfiguration) PopulateFromARM(owner genruntime.Ar
 		configuration.RadiusServers = append(configuration.RadiusServers, item1)
 	}
 
-	// Set property ‘VpnAuthenticationTypes’:
+	// Set property "VpnAuthenticationTypes":
 	for _, item := range typedInput.VpnAuthenticationTypes {
 		configuration.VpnAuthenticationTypes = append(configuration.VpnAuthenticationTypes, item)
 	}
 
-	// Set property ‘VpnClientAddressPool’:
+	// Set property "VpnClientAddressPool":
 	if typedInput.VpnClientAddressPool != nil {
 		var vpnClientAddressPool1 AddressSpace
 		err := vpnClientAddressPool1.PopulateFromARM(owner, *typedInput.VpnClientAddressPool)
@@ -3454,7 +3454,7 @@ func (configuration *VpnClientConfiguration) PopulateFromARM(owner genruntime.Ar
 		configuration.VpnClientAddressPool = &vpnClientAddressPool
 	}
 
-	// Set property ‘VpnClientIpsecPolicies’:
+	// Set property "VpnClientIpsecPolicies":
 	for _, item := range typedInput.VpnClientIpsecPolicies {
 		var item1 IpsecPolicy
 		err := item1.PopulateFromARM(owner, item)
@@ -3464,12 +3464,12 @@ func (configuration *VpnClientConfiguration) PopulateFromARM(owner genruntime.Ar
 		configuration.VpnClientIpsecPolicies = append(configuration.VpnClientIpsecPolicies, item1)
 	}
 
-	// Set property ‘VpnClientProtocols’:
+	// Set property "VpnClientProtocols":
 	for _, item := range typedInput.VpnClientProtocols {
 		configuration.VpnClientProtocols = append(configuration.VpnClientProtocols, item)
 	}
 
-	// Set property ‘VpnClientRevokedCertificates’:
+	// Set property "VpnClientRevokedCertificates":
 	for _, item := range typedInput.VpnClientRevokedCertificates {
 		var item1 VpnClientRevokedCertificate
 		err := item1.PopulateFromARM(owner, item)
@@ -3479,7 +3479,7 @@ func (configuration *VpnClientConfiguration) PopulateFromARM(owner genruntime.Ar
 		configuration.VpnClientRevokedCertificates = append(configuration.VpnClientRevokedCertificates, item1)
 	}
 
-	// Set property ‘VpnClientRootCertificates’:
+	// Set property "VpnClientRootCertificates":
 	for _, item := range typedInput.VpnClientRootCertificates {
 		var item1 VpnClientRootCertificate
 		err := item1.PopulateFromARM(owner, item)
@@ -3956,37 +3956,37 @@ func (configuration *VpnClientConfiguration_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VpnClientConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadAudience’:
+	// Set property "AadAudience":
 	if typedInput.AadAudience != nil {
 		aadAudience := *typedInput.AadAudience
 		configuration.AadAudience = &aadAudience
 	}
 
-	// Set property ‘AadIssuer’:
+	// Set property "AadIssuer":
 	if typedInput.AadIssuer != nil {
 		aadIssuer := *typedInput.AadIssuer
 		configuration.AadIssuer = &aadIssuer
 	}
 
-	// Set property ‘AadTenant’:
+	// Set property "AadTenant":
 	if typedInput.AadTenant != nil {
 		aadTenant := *typedInput.AadTenant
 		configuration.AadTenant = &aadTenant
 	}
 
-	// Set property ‘RadiusServerAddress’:
+	// Set property "RadiusServerAddress":
 	if typedInput.RadiusServerAddress != nil {
 		radiusServerAddress := *typedInput.RadiusServerAddress
 		configuration.RadiusServerAddress = &radiusServerAddress
 	}
 
-	// Set property ‘RadiusServerSecret’:
+	// Set property "RadiusServerSecret":
 	if typedInput.RadiusServerSecret != nil {
 		radiusServerSecret := *typedInput.RadiusServerSecret
 		configuration.RadiusServerSecret = &radiusServerSecret
 	}
 
-	// Set property ‘RadiusServers’:
+	// Set property "RadiusServers":
 	for _, item := range typedInput.RadiusServers {
 		var item1 RadiusServer_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3996,12 +3996,12 @@ func (configuration *VpnClientConfiguration_STATUS) PopulateFromARM(owner genrun
 		configuration.RadiusServers = append(configuration.RadiusServers, item1)
 	}
 
-	// Set property ‘VpnAuthenticationTypes’:
+	// Set property "VpnAuthenticationTypes":
 	for _, item := range typedInput.VpnAuthenticationTypes {
 		configuration.VpnAuthenticationTypes = append(configuration.VpnAuthenticationTypes, item)
 	}
 
-	// Set property ‘VpnClientAddressPool’:
+	// Set property "VpnClientAddressPool":
 	if typedInput.VpnClientAddressPool != nil {
 		var vpnClientAddressPool1 AddressSpace_STATUS
 		err := vpnClientAddressPool1.PopulateFromARM(owner, *typedInput.VpnClientAddressPool)
@@ -4012,7 +4012,7 @@ func (configuration *VpnClientConfiguration_STATUS) PopulateFromARM(owner genrun
 		configuration.VpnClientAddressPool = &vpnClientAddressPool
 	}
 
-	// Set property ‘VpnClientIpsecPolicies’:
+	// Set property "VpnClientIpsecPolicies":
 	for _, item := range typedInput.VpnClientIpsecPolicies {
 		var item1 IpsecPolicy_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4022,12 +4022,12 @@ func (configuration *VpnClientConfiguration_STATUS) PopulateFromARM(owner genrun
 		configuration.VpnClientIpsecPolicies = append(configuration.VpnClientIpsecPolicies, item1)
 	}
 
-	// Set property ‘VpnClientProtocols’:
+	// Set property "VpnClientProtocols":
 	for _, item := range typedInput.VpnClientProtocols {
 		configuration.VpnClientProtocols = append(configuration.VpnClientProtocols, item)
 	}
 
-	// Set property ‘VpnClientRevokedCertificates’:
+	// Set property "VpnClientRevokedCertificates":
 	for _, item := range typedInput.VpnClientRevokedCertificates {
 		var item1 VpnClientRevokedCertificate_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4037,7 +4037,7 @@ func (configuration *VpnClientConfiguration_STATUS) PopulateFromARM(owner genrun
 		configuration.VpnClientRevokedCertificates = append(configuration.VpnClientRevokedCertificates, item1)
 	}
 
-	// Set property ‘VpnClientRootCertificates’:
+	// Set property "VpnClientRootCertificates":
 	for _, item := range typedInput.VpnClientRootCertificates {
 		var item1 VpnClientRootCertificate_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4342,12 +4342,12 @@ func (address *IPConfigurationBgpPeeringAddress) ConvertToARM(resolved genruntim
 	}
 	result := &IPConfigurationBgpPeeringAddress_ARM{}
 
-	// Set property ‘CustomBgpIpAddresses’:
+	// Set property "CustomBgpIpAddresses":
 	for _, item := range address.CustomBgpIpAddresses {
 		result.CustomBgpIpAddresses = append(result.CustomBgpIpAddresses, item)
 	}
 
-	// Set property ‘IpconfigurationId’:
+	// Set property "IpconfigurationId":
 	if address.IpconfigurationId != nil {
 		ipconfigurationId := *address.IpconfigurationId
 		result.IpconfigurationId = &ipconfigurationId
@@ -4367,12 +4367,12 @@ func (address *IPConfigurationBgpPeeringAddress) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPConfigurationBgpPeeringAddress_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomBgpIpAddresses’:
+	// Set property "CustomBgpIpAddresses":
 	for _, item := range typedInput.CustomBgpIpAddresses {
 		address.CustomBgpIpAddresses = append(address.CustomBgpIpAddresses, item)
 	}
 
-	// Set property ‘IpconfigurationId’:
+	// Set property "IpconfigurationId":
 	if typedInput.IpconfigurationId != nil {
 		ipconfigurationId := *typedInput.IpconfigurationId
 		address.IpconfigurationId = &ipconfigurationId
@@ -4459,23 +4459,23 @@ func (address *IPConfigurationBgpPeeringAddress_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPConfigurationBgpPeeringAddress_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomBgpIpAddresses’:
+	// Set property "CustomBgpIpAddresses":
 	for _, item := range typedInput.CustomBgpIpAddresses {
 		address.CustomBgpIpAddresses = append(address.CustomBgpIpAddresses, item)
 	}
 
-	// Set property ‘DefaultBgpIpAddresses’:
+	// Set property "DefaultBgpIpAddresses":
 	for _, item := range typedInput.DefaultBgpIpAddresses {
 		address.DefaultBgpIpAddresses = append(address.DefaultBgpIpAddresses, item)
 	}
 
-	// Set property ‘IpconfigurationId’:
+	// Set property "IpconfigurationId":
 	if typedInput.IpconfigurationId != nil {
 		ipconfigurationId := *typedInput.IpconfigurationId
 		address.IpconfigurationId = &ipconfigurationId
 	}
 
-	// Set property ‘TunnelIpAddresses’:
+	// Set property "TunnelIpAddresses":
 	for _, item := range typedInput.TunnelIpAddresses {
 		address.TunnelIpAddresses = append(address.TunnelIpAddresses, item)
 	}
@@ -4577,49 +4577,49 @@ func (policy *IpsecPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &IpsecPolicy_ARM{}
 
-	// Set property ‘DhGroup’:
+	// Set property "DhGroup":
 	if policy.DhGroup != nil {
 		dhGroup := *policy.DhGroup
 		result.DhGroup = &dhGroup
 	}
 
-	// Set property ‘IkeEncryption’:
+	// Set property "IkeEncryption":
 	if policy.IkeEncryption != nil {
 		ikeEncryption := *policy.IkeEncryption
 		result.IkeEncryption = &ikeEncryption
 	}
 
-	// Set property ‘IkeIntegrity’:
+	// Set property "IkeIntegrity":
 	if policy.IkeIntegrity != nil {
 		ikeIntegrity := *policy.IkeIntegrity
 		result.IkeIntegrity = &ikeIntegrity
 	}
 
-	// Set property ‘IpsecEncryption’:
+	// Set property "IpsecEncryption":
 	if policy.IpsecEncryption != nil {
 		ipsecEncryption := *policy.IpsecEncryption
 		result.IpsecEncryption = &ipsecEncryption
 	}
 
-	// Set property ‘IpsecIntegrity’:
+	// Set property "IpsecIntegrity":
 	if policy.IpsecIntegrity != nil {
 		ipsecIntegrity := *policy.IpsecIntegrity
 		result.IpsecIntegrity = &ipsecIntegrity
 	}
 
-	// Set property ‘PfsGroup’:
+	// Set property "PfsGroup":
 	if policy.PfsGroup != nil {
 		pfsGroup := *policy.PfsGroup
 		result.PfsGroup = &pfsGroup
 	}
 
-	// Set property ‘SaDataSizeKilobytes’:
+	// Set property "SaDataSizeKilobytes":
 	if policy.SaDataSizeKilobytes != nil {
 		saDataSizeKilobytes := *policy.SaDataSizeKilobytes
 		result.SaDataSizeKilobytes = &saDataSizeKilobytes
 	}
 
-	// Set property ‘SaLifeTimeSeconds’:
+	// Set property "SaLifeTimeSeconds":
 	if policy.SaLifeTimeSeconds != nil {
 		saLifeTimeSeconds := *policy.SaLifeTimeSeconds
 		result.SaLifeTimeSeconds = &saLifeTimeSeconds
@@ -4639,49 +4639,49 @@ func (policy *IpsecPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpsecPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DhGroup’:
+	// Set property "DhGroup":
 	if typedInput.DhGroup != nil {
 		dhGroup := *typedInput.DhGroup
 		policy.DhGroup = &dhGroup
 	}
 
-	// Set property ‘IkeEncryption’:
+	// Set property "IkeEncryption":
 	if typedInput.IkeEncryption != nil {
 		ikeEncryption := *typedInput.IkeEncryption
 		policy.IkeEncryption = &ikeEncryption
 	}
 
-	// Set property ‘IkeIntegrity’:
+	// Set property "IkeIntegrity":
 	if typedInput.IkeIntegrity != nil {
 		ikeIntegrity := *typedInput.IkeIntegrity
 		policy.IkeIntegrity = &ikeIntegrity
 	}
 
-	// Set property ‘IpsecEncryption’:
+	// Set property "IpsecEncryption":
 	if typedInput.IpsecEncryption != nil {
 		ipsecEncryption := *typedInput.IpsecEncryption
 		policy.IpsecEncryption = &ipsecEncryption
 	}
 
-	// Set property ‘IpsecIntegrity’:
+	// Set property "IpsecIntegrity":
 	if typedInput.IpsecIntegrity != nil {
 		ipsecIntegrity := *typedInput.IpsecIntegrity
 		policy.IpsecIntegrity = &ipsecIntegrity
 	}
 
-	// Set property ‘PfsGroup’:
+	// Set property "PfsGroup":
 	if typedInput.PfsGroup != nil {
 		pfsGroup := *typedInput.PfsGroup
 		policy.PfsGroup = &pfsGroup
 	}
 
-	// Set property ‘SaDataSizeKilobytes’:
+	// Set property "SaDataSizeKilobytes":
 	if typedInput.SaDataSizeKilobytes != nil {
 		saDataSizeKilobytes := *typedInput.SaDataSizeKilobytes
 		policy.SaDataSizeKilobytes = &saDataSizeKilobytes
 	}
 
-	// Set property ‘SaLifeTimeSeconds’:
+	// Set property "SaLifeTimeSeconds":
 	if typedInput.SaLifeTimeSeconds != nil {
 		saLifeTimeSeconds := *typedInput.SaLifeTimeSeconds
 		policy.SaLifeTimeSeconds = &saLifeTimeSeconds
@@ -4926,49 +4926,49 @@ func (policy *IpsecPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpsecPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DhGroup’:
+	// Set property "DhGroup":
 	if typedInput.DhGroup != nil {
 		dhGroup := *typedInput.DhGroup
 		policy.DhGroup = &dhGroup
 	}
 
-	// Set property ‘IkeEncryption’:
+	// Set property "IkeEncryption":
 	if typedInput.IkeEncryption != nil {
 		ikeEncryption := *typedInput.IkeEncryption
 		policy.IkeEncryption = &ikeEncryption
 	}
 
-	// Set property ‘IkeIntegrity’:
+	// Set property "IkeIntegrity":
 	if typedInput.IkeIntegrity != nil {
 		ikeIntegrity := *typedInput.IkeIntegrity
 		policy.IkeIntegrity = &ikeIntegrity
 	}
 
-	// Set property ‘IpsecEncryption’:
+	// Set property "IpsecEncryption":
 	if typedInput.IpsecEncryption != nil {
 		ipsecEncryption := *typedInput.IpsecEncryption
 		policy.IpsecEncryption = &ipsecEncryption
 	}
 
-	// Set property ‘IpsecIntegrity’:
+	// Set property "IpsecIntegrity":
 	if typedInput.IpsecIntegrity != nil {
 		ipsecIntegrity := *typedInput.IpsecIntegrity
 		policy.IpsecIntegrity = &ipsecIntegrity
 	}
 
-	// Set property ‘PfsGroup’:
+	// Set property "PfsGroup":
 	if typedInput.PfsGroup != nil {
 		pfsGroup := *typedInput.PfsGroup
 		policy.PfsGroup = &pfsGroup
 	}
 
-	// Set property ‘SaDataSizeKilobytes’:
+	// Set property "SaDataSizeKilobytes":
 	if typedInput.SaDataSizeKilobytes != nil {
 		saDataSizeKilobytes := *typedInput.SaDataSizeKilobytes
 		policy.SaDataSizeKilobytes = &saDataSizeKilobytes
 	}
 
-	// Set property ‘SaLifeTimeSeconds’:
+	// Set property "SaLifeTimeSeconds":
 	if typedInput.SaLifeTimeSeconds != nil {
 		saLifeTimeSeconds := *typedInput.SaLifeTimeSeconds
 		policy.SaLifeTimeSeconds = &saLifeTimeSeconds
@@ -5131,19 +5131,19 @@ func (server *RadiusServer) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &RadiusServer_ARM{}
 
-	// Set property ‘RadiusServerAddress’:
+	// Set property "RadiusServerAddress":
 	if server.RadiusServerAddress != nil {
 		radiusServerAddress := *server.RadiusServerAddress
 		result.RadiusServerAddress = &radiusServerAddress
 	}
 
-	// Set property ‘RadiusServerScore’:
+	// Set property "RadiusServerScore":
 	if server.RadiusServerScore != nil {
 		radiusServerScore := *server.RadiusServerScore
 		result.RadiusServerScore = &radiusServerScore
 	}
 
-	// Set property ‘RadiusServerSecret’:
+	// Set property "RadiusServerSecret":
 	if server.RadiusServerSecret != nil {
 		radiusServerSecret := *server.RadiusServerSecret
 		result.RadiusServerSecret = &radiusServerSecret
@@ -5163,19 +5163,19 @@ func (server *RadiusServer) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RadiusServer_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RadiusServerAddress’:
+	// Set property "RadiusServerAddress":
 	if typedInput.RadiusServerAddress != nil {
 		radiusServerAddress := *typedInput.RadiusServerAddress
 		server.RadiusServerAddress = &radiusServerAddress
 	}
 
-	// Set property ‘RadiusServerScore’:
+	// Set property "RadiusServerScore":
 	if typedInput.RadiusServerScore != nil {
 		radiusServerScore := *typedInput.RadiusServerScore
 		server.RadiusServerScore = &radiusServerScore
 	}
 
-	// Set property ‘RadiusServerSecret’:
+	// Set property "RadiusServerSecret":
 	if typedInput.RadiusServerSecret != nil {
 		radiusServerSecret := *typedInput.RadiusServerSecret
 		server.RadiusServerSecret = &radiusServerSecret
@@ -5268,19 +5268,19 @@ func (server *RadiusServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RadiusServer_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RadiusServerAddress’:
+	// Set property "RadiusServerAddress":
 	if typedInput.RadiusServerAddress != nil {
 		radiusServerAddress := *typedInput.RadiusServerAddress
 		server.RadiusServerAddress = &radiusServerAddress
 	}
 
-	// Set property ‘RadiusServerScore’:
+	// Set property "RadiusServerScore":
 	if typedInput.RadiusServerScore != nil {
 		radiusServerScore := *typedInput.RadiusServerScore
 		server.RadiusServerScore = &radiusServerScore
 	}
 
-	// Set property ‘RadiusServerSecret’:
+	// Set property "RadiusServerSecret":
 	if typedInput.RadiusServerSecret != nil {
 		radiusServerSecret := *typedInput.RadiusServerSecret
 		server.RadiusServerSecret = &radiusServerSecret
@@ -5473,13 +5473,13 @@ func (certificate *VpnClientRevokedCertificate) ConvertToARM(resolved genruntime
 	}
 	result := &VpnClientRevokedCertificate_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if certificate.Name != nil {
 		name := *certificate.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if certificate.Thumbprint != nil {
 		result.Properties = &VpnClientRevokedCertificatePropertiesFormat_ARM{}
 	}
@@ -5502,13 +5502,13 @@ func (certificate *VpnClientRevokedCertificate) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VpnClientRevokedCertificate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		certificate.Name = &name
 	}
 
-	// Set property ‘Thumbprint’:
+	// Set property "Thumbprint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Thumbprint != nil {
@@ -5601,25 +5601,25 @@ func (certificate *VpnClientRevokedCertificate_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VpnClientRevokedCertificate_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		certificate.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		certificate.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		certificate.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -5628,7 +5628,7 @@ func (certificate *VpnClientRevokedCertificate_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Thumbprint’:
+	// Set property "Thumbprint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Thumbprint != nil {
@@ -5723,13 +5723,13 @@ func (certificate *VpnClientRootCertificate) ConvertToARM(resolved genruntime.Co
 	}
 	result := &VpnClientRootCertificate_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if certificate.Name != nil {
 		name := *certificate.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if certificate.PublicCertData != nil {
 		result.Properties = &VpnClientRootCertificatePropertiesFormat_ARM{}
 	}
@@ -5752,13 +5752,13 @@ func (certificate *VpnClientRootCertificate) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VpnClientRootCertificate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		certificate.Name = &name
 	}
 
-	// Set property ‘PublicCertData’:
+	// Set property "PublicCertData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicCertData != nil {
@@ -5851,25 +5851,25 @@ func (certificate *VpnClientRootCertificate_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VpnClientRootCertificate_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		certificate.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		certificate.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		certificate.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -5878,7 +5878,7 @@ func (certificate *VpnClientRootCertificate_STATUS) PopulateFromARM(owner genrun
 		}
 	}
 
-	// Set property ‘PublicCertData’:
+	// Set property "PublicCertData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicCertData != nil {

--- a/v2/api/network/v1api20201101/virtual_network_types_gen.go
+++ b/v2/api/network/v1api20201101/virtual_network_types_gen.go
@@ -362,7 +362,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &VirtualNetwork_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if network.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*network.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -372,16 +372,16 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if network.Location != nil {
 		location := *network.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if network.AddressSpace != nil ||
 		network.BgpCommunities != nil ||
 		network.DdosProtectionPlan != nil ||
@@ -439,7 +439,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.IpAllocations = append(result.Properties.IpAllocations, *item_ARM.(*SubResource_ARM))
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if network.Tags != nil {
 		result.Tags = make(map[string]string, len(network.Tags))
 		for key, value := range network.Tags {
@@ -461,7 +461,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetwork_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressSpace’:
+	// Set property "AddressSpace":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddressSpace != nil {
@@ -475,10 +475,10 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	network.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BgpCommunities’:
+	// Set property "BgpCommunities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BgpCommunities != nil {
@@ -492,7 +492,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DdosProtectionPlan’:
+	// Set property "DdosProtectionPlan":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DdosProtectionPlan != nil {
@@ -506,7 +506,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DhcpOptions’:
+	// Set property "DhcpOptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DhcpOptions != nil {
@@ -520,7 +520,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableDdosProtection’:
+	// Set property "EnableDdosProtection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableDdosProtection != nil {
@@ -529,7 +529,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableVmProtection’:
+	// Set property "EnableVmProtection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableVmProtection != nil {
@@ -538,7 +538,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -549,7 +549,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		network.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘IpAllocations’:
+	// Set property "IpAllocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpAllocations {
@@ -562,16 +562,16 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		network.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	network.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		network.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1115,7 +1115,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetwork_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressSpace’:
+	// Set property "AddressSpace":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddressSpace != nil {
@@ -1129,7 +1129,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘BgpCommunities’:
+	// Set property "BgpCommunities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BgpCommunities != nil {
@@ -1143,9 +1143,9 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DdosProtectionPlan’:
+	// Set property "DdosProtectionPlan":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DdosProtectionPlan != nil {
@@ -1159,7 +1159,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DhcpOptions’:
+	// Set property "DhcpOptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DhcpOptions != nil {
@@ -1173,7 +1173,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableDdosProtection’:
+	// Set property "EnableDdosProtection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableDdosProtection != nil {
@@ -1182,7 +1182,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableVmProtection’:
+	// Set property "EnableVmProtection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableVmProtection != nil {
@@ -1191,13 +1191,13 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		network.Etag = &etag
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1208,13 +1208,13 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		network.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		network.Id = &id
 	}
 
-	// Set property ‘IpAllocations’:
+	// Set property "IpAllocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpAllocations {
@@ -1227,19 +1227,19 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		network.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		network.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1248,7 +1248,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -1257,7 +1257,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		network.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1265,7 +1265,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		network.Type = &typeVar
@@ -1565,7 +1565,7 @@ func (space *AddressSpace) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &AddressSpace_ARM{}
 
-	// Set property ‘AddressPrefixes’:
+	// Set property "AddressPrefixes":
 	for _, item := range space.AddressPrefixes {
 		result.AddressPrefixes = append(result.AddressPrefixes, item)
 	}
@@ -1584,7 +1584,7 @@ func (space *AddressSpace) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AddressSpace_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressPrefixes’:
+	// Set property "AddressPrefixes":
 	for _, item := range typedInput.AddressPrefixes {
 		space.AddressPrefixes = append(space.AddressPrefixes, item)
 	}
@@ -1652,7 +1652,7 @@ func (space *AddressSpace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AddressSpace_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressPrefixes’:
+	// Set property "AddressPrefixes":
 	for _, item := range typedInput.AddressPrefixes {
 		space.AddressPrefixes = append(space.AddressPrefixes, item)
 	}
@@ -1706,7 +1706,7 @@ func (options *DhcpOptions) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &DhcpOptions_ARM{}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range options.DnsServers {
 		result.DnsServers = append(result.DnsServers, item)
 	}
@@ -1725,7 +1725,7 @@ func (options *DhcpOptions) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DhcpOptions_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		options.DnsServers = append(options.DnsServers, item)
 	}
@@ -1794,7 +1794,7 @@ func (options *DhcpOptions_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DhcpOptions_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		options.DnsServers = append(options.DnsServers, item)
 	}
@@ -1848,7 +1848,7 @@ func (communities *VirtualNetworkBgpCommunities) ConvertToARM(resolved genruntim
 	}
 	result := &VirtualNetworkBgpCommunities_ARM{}
 
-	// Set property ‘VirtualNetworkCommunity’:
+	// Set property "VirtualNetworkCommunity":
 	if communities.VirtualNetworkCommunity != nil {
 		virtualNetworkCommunity := *communities.VirtualNetworkCommunity
 		result.VirtualNetworkCommunity = &virtualNetworkCommunity
@@ -1868,7 +1868,7 @@ func (communities *VirtualNetworkBgpCommunities) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkBgpCommunities_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VirtualNetworkCommunity’:
+	// Set property "VirtualNetworkCommunity":
 	if typedInput.VirtualNetworkCommunity != nil {
 		virtualNetworkCommunity := *typedInput.VirtualNetworkCommunity
 		communities.VirtualNetworkCommunity = &virtualNetworkCommunity
@@ -1940,13 +1940,13 @@ func (communities *VirtualNetworkBgpCommunities_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkBgpCommunities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RegionalCommunity’:
+	// Set property "RegionalCommunity":
 	if typedInput.RegionalCommunity != nil {
 		regionalCommunity := *typedInput.RegionalCommunity
 		communities.RegionalCommunity = &regionalCommunity
 	}
 
-	// Set property ‘VirtualNetworkCommunity’:
+	// Set property "VirtualNetworkCommunity":
 	if typedInput.VirtualNetworkCommunity != nil {
 		virtualNetworkCommunity := *typedInput.VirtualNetworkCommunity
 		communities.VirtualNetworkCommunity = &virtualNetworkCommunity

--- a/v2/api/network/v1api20201101/virtual_networks_subnet_types_gen.go
+++ b/v2/api/network/v1api20201101/virtual_networks_subnet_types_gen.go
@@ -367,10 +367,10 @@ func (subnet *VirtualNetworks_Subnet_Spec) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &VirtualNetworks_Subnet_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if subnet.AddressPrefix != nil ||
 		subnet.AddressPrefixes != nil ||
 		subnet.ApplicationGatewayIpConfigurations != nil ||
@@ -474,7 +474,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworks_Subnet_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressPrefix’:
+	// Set property "AddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddressPrefix != nil {
@@ -483,7 +483,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘AddressPrefixes’:
+	// Set property "AddressPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AddressPrefixes {
@@ -491,7 +491,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘ApplicationGatewayIpConfigurations’:
+	// Set property "ApplicationGatewayIpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayIpConfigurations {
@@ -504,10 +504,10 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	subnet.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Delegations’:
+	// Set property "Delegations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Delegations {
@@ -520,7 +520,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘IpAllocations’:
+	// Set property "IpAllocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpAllocations {
@@ -533,7 +533,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘NatGateway’:
+	// Set property "NatGateway":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NatGateway != nil {
@@ -547,7 +547,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -561,10 +561,10 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	subnet.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PrivateEndpointNetworkPolicies’:
+	// Set property "PrivateEndpointNetworkPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateEndpointNetworkPolicies != nil {
@@ -573,7 +573,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘PrivateLinkServiceNetworkPolicies’:
+	// Set property "PrivateLinkServiceNetworkPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkServiceNetworkPolicies != nil {
@@ -582,7 +582,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘RouteTable’:
+	// Set property "RouteTable":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RouteTable != nil {
@@ -596,7 +596,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘ServiceEndpointPolicies’:
+	// Set property "ServiceEndpointPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ServiceEndpointPolicies {
@@ -609,7 +609,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘ServiceEndpoints’:
+	// Set property "ServiceEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ServiceEndpoints {
@@ -1324,7 +1324,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworks_Subnet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressPrefix’:
+	// Set property "AddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddressPrefix != nil {
@@ -1333,7 +1333,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘AddressPrefixes’:
+	// Set property "AddressPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AddressPrefixes {
@@ -1341,7 +1341,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ApplicationGatewayIpConfigurations’:
+	// Set property "ApplicationGatewayIpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayIpConfigurations {
@@ -1354,9 +1354,9 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Delegations’:
+	// Set property "Delegations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Delegations {
@@ -1369,19 +1369,19 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		subnet.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		subnet.Id = &id
 	}
 
-	// Set property ‘IpAllocations’:
+	// Set property "IpAllocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpAllocations {
@@ -1394,7 +1394,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘IpConfigurationProfiles’:
+	// Set property "IpConfigurationProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurationProfiles {
@@ -1407,7 +1407,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -1420,13 +1420,13 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		subnet.Name = &name
 	}
 
-	// Set property ‘NatGateway’:
+	// Set property "NatGateway":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NatGateway != nil {
@@ -1440,7 +1440,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -1454,7 +1454,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘PrivateEndpointNetworkPolicies’:
+	// Set property "PrivateEndpointNetworkPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateEndpointNetworkPolicies != nil {
@@ -1463,7 +1463,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘PrivateEndpoints’:
+	// Set property "PrivateEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpoints {
@@ -1476,7 +1476,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘PrivateLinkServiceNetworkPolicies’:
+	// Set property "PrivateLinkServiceNetworkPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkServiceNetworkPolicies != nil {
@@ -1485,7 +1485,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1494,7 +1494,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Purpose’:
+	// Set property "Purpose":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Purpose != nil {
@@ -1503,7 +1503,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ResourceNavigationLinks’:
+	// Set property "ResourceNavigationLinks":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ResourceNavigationLinks {
@@ -1516,7 +1516,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘RouteTable’:
+	// Set property "RouteTable":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RouteTable != nil {
@@ -1530,7 +1530,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ServiceAssociationLinks’:
+	// Set property "ServiceAssociationLinks":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ServiceAssociationLinks {
@@ -1543,7 +1543,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ServiceEndpointPolicies’:
+	// Set property "ServiceEndpointPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ServiceEndpointPolicies {
@@ -1556,7 +1556,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ServiceEndpoints’:
+	// Set property "ServiceEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ServiceEndpoints {
@@ -1569,7 +1569,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		subnet.Type = &typeVar
@@ -2150,7 +2150,7 @@ func (embedded *ApplicationGatewayIPConfiguration_STATUS_VirtualNetworks_Subnet_
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationGatewayIPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2204,7 +2204,7 @@ func (embedded *ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubReso
 	}
 	result := &ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -2228,7 +2228,7 @@ func (embedded *ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubReso
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2306,13 +2306,13 @@ func (delegation *Delegation) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Delegation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if delegation.Name != nil {
 		name := *delegation.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if delegation.ServiceName != nil {
 		result.Properties = &ServiceDelegationPropertiesFormat_ARM{}
 	}
@@ -2335,13 +2335,13 @@ func (delegation *Delegation) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Delegation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		delegation.Name = &name
 	}
 
-	// Set property ‘ServiceName’:
+	// Set property "ServiceName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceName != nil {
@@ -2440,7 +2440,7 @@ func (delegation *Delegation_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Delegation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Actions {
@@ -2448,25 +2448,25 @@ func (delegation *Delegation_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		delegation.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		delegation.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		delegation.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2475,7 +2475,7 @@ func (delegation *Delegation_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ServiceName’:
+	// Set property "ServiceName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceName != nil {
@@ -2484,7 +2484,7 @@ func (delegation *Delegation_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		delegation.Type = &typeVar
@@ -2589,7 +2589,7 @@ func (embedded *IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedde
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2648,7 +2648,7 @@ func (profile *IPConfigurationProfile_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPConfigurationProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		profile.Id = &id
@@ -2707,7 +2707,7 @@ func (embedded *NetworkSecurityGroup_STATUS_VirtualNetworks_Subnet_SubResourceEm
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroup_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2761,7 +2761,7 @@ func (embedded *NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbed
 	}
 	result := &NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -2785,7 +2785,7 @@ func (embedded *NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbed
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2865,7 +2865,7 @@ func (embedded *PrivateEndpoint_STATUS_VirtualNetworks_Subnet_SubResourceEmbedde
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpoint_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2924,7 +2924,7 @@ func (link *ResourceNavigationLink_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceNavigationLink_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		link.Id = &id
@@ -2983,7 +2983,7 @@ func (embedded *RouteTable_STATUS_SubResourceEmbedded) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteTable_STATUS_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3037,7 +3037,7 @@ func (embedded *RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded) Conve
 	}
 	result := &RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -3061,7 +3061,7 @@ func (embedded *RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded) Popul
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3141,7 +3141,7 @@ func (link *ServiceAssociationLink_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceAssociationLink_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		link.Id = &id
@@ -3200,7 +3200,7 @@ func (embedded *ServiceEndpointPolicy_STATUS_VirtualNetworks_Subnet_SubResourceE
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceEndpointPolicy_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3254,7 +3254,7 @@ func (embedded *ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbe
 	}
 	result := &ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -3278,7 +3278,7 @@ func (embedded *ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3356,12 +3356,12 @@ func (format *ServiceEndpointPropertiesFormat) ConvertToARM(resolved genruntime.
 	}
 	result := &ServiceEndpointPropertiesFormat_ARM{}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	for _, item := range format.Locations {
 		result.Locations = append(result.Locations, item)
 	}
 
-	// Set property ‘Service’:
+	// Set property "Service":
 	if format.Service != nil {
 		service := *format.Service
 		result.Service = &service
@@ -3381,12 +3381,12 @@ func (format *ServiceEndpointPropertiesFormat) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceEndpointPropertiesFormat_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	for _, item := range typedInput.Locations {
 		format.Locations = append(format.Locations, item)
 	}
 
-	// Set property ‘Service’:
+	// Set property "Service":
 	if typedInput.Service != nil {
 		service := *typedInput.Service
 		format.Service = &service
@@ -3470,18 +3470,18 @@ func (format *ServiceEndpointPropertiesFormat_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceEndpointPropertiesFormat_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	for _, item := range typedInput.Locations {
 		format.Locations = append(format.Locations, item)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		format.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘Service’:
+	// Set property "Service":
 	if typedInput.Service != nil {
 		service := *typedInput.Service
 		format.Service = &service

--- a/v2/api/network/v1api20201101/virtual_networks_virtual_network_peering_types_gen.go
+++ b/v2/api/network/v1api20201101/virtual_networks_virtual_network_peering_types_gen.go
@@ -365,10 +365,10 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) ConvertToARM(resolved
 	}
 	result := &VirtualNetworks_VirtualNetworkPeering_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if peering.AllowForwardedTraffic != nil ||
 		peering.AllowGatewayTransit != nil ||
 		peering.AllowVirtualNetworkAccess != nil ||
@@ -443,7 +443,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworks_VirtualNetworkPeering_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowForwardedTraffic’:
+	// Set property "AllowForwardedTraffic":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowForwardedTraffic != nil {
@@ -452,7 +452,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘AllowGatewayTransit’:
+	// Set property "AllowGatewayTransit":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowGatewayTransit != nil {
@@ -461,7 +461,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘AllowVirtualNetworkAccess’:
+	// Set property "AllowVirtualNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowVirtualNetworkAccess != nil {
@@ -470,10 +470,10 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	peering.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DoNotVerifyRemoteGateways’:
+	// Set property "DoNotVerifyRemoteGateways":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DoNotVerifyRemoteGateways != nil {
@@ -482,10 +482,10 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	peering.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PeeringState’:
+	// Set property "PeeringState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PeeringState != nil {
@@ -494,7 +494,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘RemoteAddressSpace’:
+	// Set property "RemoteAddressSpace":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemoteAddressSpace != nil {
@@ -508,7 +508,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘RemoteBgpCommunities’:
+	// Set property "RemoteBgpCommunities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemoteBgpCommunities != nil {
@@ -522,7 +522,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘RemoteVirtualNetwork’:
+	// Set property "RemoteVirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemoteVirtualNetwork != nil {
@@ -536,7 +536,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘UseRemoteGateways’:
+	// Set property "UseRemoteGateways":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UseRemoteGateways != nil {
@@ -1037,7 +1037,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworks_VirtualNetworkPeering_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowForwardedTraffic’:
+	// Set property "AllowForwardedTraffic":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowForwardedTraffic != nil {
@@ -1046,7 +1046,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘AllowGatewayTransit’:
+	// Set property "AllowGatewayTransit":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowGatewayTransit != nil {
@@ -1055,7 +1055,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘AllowVirtualNetworkAccess’:
+	// Set property "AllowVirtualNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowVirtualNetworkAccess != nil {
@@ -1064,9 +1064,9 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DoNotVerifyRemoteGateways’:
+	// Set property "DoNotVerifyRemoteGateways":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DoNotVerifyRemoteGateways != nil {
@@ -1075,25 +1075,25 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		peering.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		peering.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		peering.Name = &name
 	}
 
-	// Set property ‘PeeringState’:
+	// Set property "PeeringState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PeeringState != nil {
@@ -1102,7 +1102,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1111,7 +1111,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘RemoteAddressSpace’:
+	// Set property "RemoteAddressSpace":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemoteAddressSpace != nil {
@@ -1125,7 +1125,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘RemoteBgpCommunities’:
+	// Set property "RemoteBgpCommunities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemoteBgpCommunities != nil {
@@ -1139,7 +1139,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘RemoteVirtualNetwork’:
+	// Set property "RemoteVirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemoteVirtualNetwork != nil {
@@ -1153,7 +1153,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -1162,13 +1162,13 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		peering.Type = &typeVar
 	}
 
-	// Set property ‘UseRemoteGateways’:
+	// Set property "UseRemoteGateways":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UseRemoteGateways != nil {

--- a/v2/api/network/v1api20220701/bastion_host_types_gen.go
+++ b/v2/api/network/v1api20220701/bastion_host_types_gen.go
@@ -371,16 +371,16 @@ func (host *BastionHost_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &BastionHost_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if host.Location != nil {
 		location := *host.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if host.DisableCopyPaste != nil ||
 		host.DnsName != nil ||
 		host.EnableFileCopy != nil ||
@@ -427,7 +427,7 @@ func (host *BastionHost_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Properties.ScaleUnits = &scaleUnits
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if host.Sku != nil {
 		sku_ARM, err := (*host.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -437,7 +437,7 @@ func (host *BastionHost_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if host.Tags != nil {
 		result.Tags = make(map[string]string, len(host.Tags))
 		for key, value := range host.Tags {
@@ -459,10 +459,10 @@ func (host *BastionHost_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BastionHost_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	host.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DisableCopyPaste’:
+	// Set property "DisableCopyPaste":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableCopyPaste != nil {
@@ -471,7 +471,7 @@ func (host *BastionHost_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘DnsName’:
+	// Set property "DnsName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsName != nil {
@@ -480,7 +480,7 @@ func (host *BastionHost_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘EnableFileCopy’:
+	// Set property "EnableFileCopy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFileCopy != nil {
@@ -489,7 +489,7 @@ func (host *BastionHost_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘EnableIpConnect’:
+	// Set property "EnableIpConnect":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIpConnect != nil {
@@ -498,7 +498,7 @@ func (host *BastionHost_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘EnableShareableLink’:
+	// Set property "EnableShareableLink":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableShareableLink != nil {
@@ -507,7 +507,7 @@ func (host *BastionHost_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘EnableTunneling’:
+	// Set property "EnableTunneling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTunneling != nil {
@@ -516,7 +516,7 @@ func (host *BastionHost_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -529,16 +529,16 @@ func (host *BastionHost_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		host.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	host.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ScaleUnits’:
+	// Set property "ScaleUnits":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleUnits != nil {
@@ -547,7 +547,7 @@ func (host *BastionHost_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -558,7 +558,7 @@ func (host *BastionHost_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		host.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		host.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1062,9 +1062,9 @@ func (host *BastionHost_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BastionHost_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DisableCopyPaste’:
+	// Set property "DisableCopyPaste":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableCopyPaste != nil {
@@ -1073,7 +1073,7 @@ func (host *BastionHost_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘DnsName’:
+	// Set property "DnsName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsName != nil {
@@ -1082,7 +1082,7 @@ func (host *BastionHost_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘EnableFileCopy’:
+	// Set property "EnableFileCopy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFileCopy != nil {
@@ -1091,7 +1091,7 @@ func (host *BastionHost_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘EnableIpConnect’:
+	// Set property "EnableIpConnect":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIpConnect != nil {
@@ -1100,7 +1100,7 @@ func (host *BastionHost_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘EnableShareableLink’:
+	// Set property "EnableShareableLink":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableShareableLink != nil {
@@ -1109,7 +1109,7 @@ func (host *BastionHost_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘EnableTunneling’:
+	// Set property "EnableTunneling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTunneling != nil {
@@ -1118,19 +1118,19 @@ func (host *BastionHost_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		host.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		host.Id = &id
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -1143,19 +1143,19 @@ func (host *BastionHost_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		host.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		host.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1164,7 +1164,7 @@ func (host *BastionHost_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘ScaleUnits’:
+	// Set property "ScaleUnits":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScaleUnits != nil {
@@ -1173,7 +1173,7 @@ func (host *BastionHost_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1184,7 +1184,7 @@ func (host *BastionHost_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		host.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		host.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1192,7 +1192,7 @@ func (host *BastionHost_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		host.Type = &typeVar
@@ -1461,13 +1461,13 @@ func (configuration *BastionHostIPConfiguration) ConvertToARM(resolved genruntim
 	}
 	result := &BastionHostIPConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.PrivateIPAllocationMethod != nil ||
 		configuration.PublicIPAddress != nil ||
 		configuration.Subnet != nil {
@@ -1508,13 +1508,13 @@ func (configuration *BastionHostIPConfiguration) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BastionHostIPConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -1523,7 +1523,7 @@ func (configuration *BastionHostIPConfiguration) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘PublicIPAddress’:
+	// Set property "PublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddress != nil {
@@ -1537,7 +1537,7 @@ func (configuration *BastionHostIPConfiguration) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -1675,7 +1675,7 @@ func (configuration *BastionHostIPConfiguration_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BastionHostIPConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
@@ -1739,7 +1739,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -1759,7 +1759,7 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -1843,7 +1843,7 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -1907,7 +1907,7 @@ func (resource *BastionHostSubResource) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &BastionHostSubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -1931,7 +1931,7 @@ func (resource *BastionHostSubResource) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BastionHostSubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil

--- a/v2/api/network/v1api20220701/dns_forwarding_rule_sets_forwarding_rule_types_gen.go
+++ b/v2/api/network/v1api20220701/dns_forwarding_rule_sets_forwarding_rule_types_gen.go
@@ -358,10 +358,10 @@ func (rule *DnsForwardingRulesets_ForwardingRule_Spec) ConvertToARM(resolved gen
 	}
 	result := &DnsForwardingRulesets_ForwardingRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.DomainName != nil ||
 		rule.ForwardingRuleState != nil ||
 		rule.Metadata != nil ||
@@ -404,10 +404,10 @@ func (rule *DnsForwardingRulesets_ForwardingRule_Spec) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsForwardingRulesets_ForwardingRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DomainName’:
+	// Set property "DomainName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DomainName != nil {
@@ -416,7 +416,7 @@ func (rule *DnsForwardingRulesets_ForwardingRule_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘ForwardingRuleState’:
+	// Set property "ForwardingRuleState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardingRuleState != nil {
@@ -425,7 +425,7 @@ func (rule *DnsForwardingRulesets_ForwardingRule_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -436,10 +436,10 @@ func (rule *DnsForwardingRulesets_ForwardingRule_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘TargetDnsServers’:
+	// Set property "TargetDnsServers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TargetDnsServers {
@@ -768,9 +768,9 @@ func (rule *DnsForwardingRulesets_ForwardingRule_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsForwardingRulesets_ForwardingRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DomainName’:
+	// Set property "DomainName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DomainName != nil {
@@ -779,13 +779,13 @@ func (rule *DnsForwardingRulesets_ForwardingRule_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		rule.Etag = &etag
 	}
 
-	// Set property ‘ForwardingRuleState’:
+	// Set property "ForwardingRuleState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardingRuleState != nil {
@@ -794,13 +794,13 @@ func (rule *DnsForwardingRulesets_ForwardingRule_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -811,13 +811,13 @@ func (rule *DnsForwardingRulesets_ForwardingRule_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -826,7 +826,7 @@ func (rule *DnsForwardingRulesets_ForwardingRule_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -837,7 +837,7 @@ func (rule *DnsForwardingRulesets_ForwardingRule_STATUS) PopulateFromARM(owner g
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘TargetDnsServers’:
+	// Set property "TargetDnsServers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TargetDnsServers {
@@ -850,7 +850,7 @@ func (rule *DnsForwardingRulesets_ForwardingRule_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -1079,37 +1079,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -1219,7 +1219,7 @@ func (server *TargetDnsServer) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &TargetDnsServer_ARM{}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	if server.IpAddress != nil {
 		ipAddress := *server.IpAddress
 		result.IpAddress = &ipAddress
@@ -1233,7 +1233,7 @@ func (server *TargetDnsServer) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.IpAddress = &ipAddress
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if server.Port != nil {
 		port := *server.Port
 		result.Port = &port
@@ -1253,15 +1253,15 @@ func (server *TargetDnsServer) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TargetDnsServer_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	if typedInput.IpAddress != nil {
 		ipAddress := *typedInput.IpAddress
 		server.IpAddress = &ipAddress
 	}
 
-	// no assignment for property ‘IpAddressFromConfig’
+	// no assignment for property "IpAddressFromConfig"
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port := *typedInput.Port
 		server.Port = &port
@@ -1358,13 +1358,13 @@ func (server *TargetDnsServer_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TargetDnsServer_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	if typedInput.IpAddress != nil {
 		ipAddress := *typedInput.IpAddress
 		server.IpAddress = &ipAddress
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	if typedInput.Port != nil {
 		port := *typedInput.Port
 		server.Port = &port

--- a/v2/api/network/v1api20220701/dns_forwarding_ruleset_types_gen.go
+++ b/v2/api/network/v1api20220701/dns_forwarding_ruleset_types_gen.go
@@ -343,16 +343,16 @@ func (ruleset *DnsForwardingRuleset_Spec) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &DnsForwardingRuleset_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if ruleset.Location != nil {
 		location := *ruleset.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if ruleset.DnsResolverOutboundEndpoints != nil {
 		result.Properties = &DnsForwardingRulesetProperties_ARM{}
 	}
@@ -364,7 +364,7 @@ func (ruleset *DnsForwardingRuleset_Spec) ConvertToARM(resolved genruntime.Conve
 		result.Properties.DnsResolverOutboundEndpoints = append(result.Properties.DnsResolverOutboundEndpoints, *item_ARM.(*DnsresolverSubResource_ARM))
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if ruleset.Tags != nil {
 		result.Tags = make(map[string]string, len(ruleset.Tags))
 		for key, value := range ruleset.Tags {
@@ -386,10 +386,10 @@ func (ruleset *DnsForwardingRuleset_Spec) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsForwardingRuleset_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	ruleset.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DnsResolverOutboundEndpoints’:
+	// Set property "DnsResolverOutboundEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DnsResolverOutboundEndpoints {
@@ -402,16 +402,16 @@ func (ruleset *DnsForwardingRuleset_Spec) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		ruleset.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	ruleset.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		ruleset.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -713,9 +713,9 @@ func (ruleset *DnsForwardingRuleset_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsForwardingRuleset_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DnsResolverOutboundEndpoints’:
+	// Set property "DnsResolverOutboundEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DnsResolverOutboundEndpoints {
@@ -728,31 +728,31 @@ func (ruleset *DnsForwardingRuleset_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		ruleset.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		ruleset.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		ruleset.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		ruleset.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -761,7 +761,7 @@ func (ruleset *DnsForwardingRuleset_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -770,7 +770,7 @@ func (ruleset *DnsForwardingRuleset_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -781,7 +781,7 @@ func (ruleset *DnsForwardingRuleset_STATUS) PopulateFromARM(owner genruntime.Arb
 		ruleset.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		ruleset.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -789,7 +789,7 @@ func (ruleset *DnsForwardingRuleset_STATUS) PopulateFromARM(owner genruntime.Arb
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		ruleset.Type = &typeVar
@@ -962,7 +962,7 @@ func (resource *DnsresolverSubResource) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &DnsresolverSubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -986,7 +986,7 @@ func (resource *DnsresolverSubResource) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsresolverSubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1066,7 +1066,7 @@ func (resource *DnsresolverSubResource_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsresolverSubResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id

--- a/v2/api/network/v1api20220701/dns_resolver_types_gen.go
+++ b/v2/api/network/v1api20220701/dns_resolver_types_gen.go
@@ -342,16 +342,16 @@ func (resolver *DnsResolver_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &DnsResolver_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if resolver.Location != nil {
 		location := *resolver.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if resolver.VirtualNetwork != nil {
 		result.Properties = &DnsResolverProperties_ARM{}
 	}
@@ -364,7 +364,7 @@ func (resolver *DnsResolver_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Properties.VirtualNetwork = &virtualNetwork
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if resolver.Tags != nil {
 		result.Tags = make(map[string]string, len(resolver.Tags))
 		for key, value := range resolver.Tags {
@@ -386,19 +386,19 @@ func (resolver *DnsResolver_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsResolver_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	resolver.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		resolver.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	resolver.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		resolver.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -406,7 +406,7 @@ func (resolver *DnsResolver_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘VirtualNetwork’:
+	// Set property "VirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetwork != nil {
@@ -697,9 +697,9 @@ func (resolver *DnsResolver_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsResolver_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DnsResolverState’:
+	// Set property "DnsResolverState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsResolverState != nil {
@@ -708,31 +708,31 @@ func (resolver *DnsResolver_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		resolver.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resolver.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		resolver.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resolver.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -741,7 +741,7 @@ func (resolver *DnsResolver_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -750,7 +750,7 @@ func (resolver *DnsResolver_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -761,7 +761,7 @@ func (resolver *DnsResolver_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		resolver.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		resolver.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -769,13 +769,13 @@ func (resolver *DnsResolver_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		resolver.Type = &typeVar
 	}
 
-	// Set property ‘VirtualNetwork’:
+	// Set property "VirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetwork != nil {

--- a/v2/api/network/v1api20220701/dns_resolvers_inbound_endpoint_types_gen.go
+++ b/v2/api/network/v1api20220701/dns_resolvers_inbound_endpoint_types_gen.go
@@ -342,16 +342,16 @@ func (endpoint *DnsResolvers_InboundEndpoint_Spec) ConvertToARM(resolved genrunt
 	}
 	result := &DnsResolvers_InboundEndpoint_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if endpoint.Location != nil {
 		location := *endpoint.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if endpoint.IpConfigurations != nil {
 		result.Properties = &InboundEndpointProperties_ARM{}
 	}
@@ -363,7 +363,7 @@ func (endpoint *DnsResolvers_InboundEndpoint_Spec) ConvertToARM(resolved genrunt
 		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *item_ARM.(*IpConfiguration_ARM))
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if endpoint.Tags != nil {
 		result.Tags = make(map[string]string, len(endpoint.Tags))
 		for key, value := range endpoint.Tags {
@@ -385,10 +385,10 @@ func (endpoint *DnsResolvers_InboundEndpoint_Spec) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsResolvers_InboundEndpoint_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	endpoint.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -401,16 +401,16 @@ func (endpoint *DnsResolvers_InboundEndpoint_Spec) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		endpoint.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	endpoint.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		endpoint.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -710,21 +710,21 @@ func (endpoint *DnsResolvers_InboundEndpoint_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsResolvers_InboundEndpoint_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		endpoint.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		endpoint.Id = &id
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -737,19 +737,19 @@ func (endpoint *DnsResolvers_InboundEndpoint_STATUS) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		endpoint.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		endpoint.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -758,7 +758,7 @@ func (endpoint *DnsResolvers_InboundEndpoint_STATUS) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -767,7 +767,7 @@ func (endpoint *DnsResolvers_InboundEndpoint_STATUS) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -778,7 +778,7 @@ func (endpoint *DnsResolvers_InboundEndpoint_STATUS) PopulateFromARM(owner genru
 		endpoint.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		endpoint.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -786,7 +786,7 @@ func (endpoint *DnsResolvers_InboundEndpoint_STATUS) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		endpoint.Type = &typeVar
@@ -965,19 +965,19 @@ func (configuration *IpConfiguration) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &IpConfiguration_ARM{}
 
-	// Set property ‘PrivateIpAddress’:
+	// Set property "PrivateIpAddress":
 	if configuration.PrivateIpAddress != nil {
 		privateIpAddress := *configuration.PrivateIpAddress
 		result.PrivateIpAddress = &privateIpAddress
 	}
 
-	// Set property ‘PrivateIpAllocationMethod’:
+	// Set property "PrivateIpAllocationMethod":
 	if configuration.PrivateIpAllocationMethod != nil {
 		privateIpAllocationMethod := *configuration.PrivateIpAllocationMethod
 		result.PrivateIpAllocationMethod = &privateIpAllocationMethod
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if configuration.Subnet != nil {
 		subnet_ARM, err := (*configuration.Subnet).ConvertToARM(resolved)
 		if err != nil {
@@ -1001,19 +1001,19 @@ func (configuration *IpConfiguration) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrivateIpAddress’:
+	// Set property "PrivateIpAddress":
 	if typedInput.PrivateIpAddress != nil {
 		privateIpAddress := *typedInput.PrivateIpAddress
 		configuration.PrivateIpAddress = &privateIpAddress
 	}
 
-	// Set property ‘PrivateIpAllocationMethod’:
+	// Set property "PrivateIpAllocationMethod":
 	if typedInput.PrivateIpAllocationMethod != nil {
 		privateIpAllocationMethod := *typedInput.PrivateIpAllocationMethod
 		configuration.PrivateIpAllocationMethod = &privateIpAllocationMethod
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if typedInput.Subnet != nil {
 		var subnet1 DnsresolverSubResource
 		err := subnet1.PopulateFromARM(owner, *typedInput.Subnet)
@@ -1153,19 +1153,19 @@ func (configuration *IpConfiguration_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrivateIpAddress’:
+	// Set property "PrivateIpAddress":
 	if typedInput.PrivateIpAddress != nil {
 		privateIpAddress := *typedInput.PrivateIpAddress
 		configuration.PrivateIpAddress = &privateIpAddress
 	}
 
-	// Set property ‘PrivateIpAllocationMethod’:
+	// Set property "PrivateIpAllocationMethod":
 	if typedInput.PrivateIpAllocationMethod != nil {
 		privateIpAllocationMethod := *typedInput.PrivateIpAllocationMethod
 		configuration.PrivateIpAllocationMethod = &privateIpAllocationMethod
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	if typedInput.Subnet != nil {
 		var subnet1 DnsresolverSubResource_STATUS
 		err := subnet1.PopulateFromARM(owner, *typedInput.Subnet)

--- a/v2/api/network/v1api20220701/dns_resolvers_outbound_endpoint_types_gen.go
+++ b/v2/api/network/v1api20220701/dns_resolvers_outbound_endpoint_types_gen.go
@@ -342,16 +342,16 @@ func (endpoint *DnsResolvers_OutboundEndpoint_Spec) ConvertToARM(resolved genrun
 	}
 	result := &DnsResolvers_OutboundEndpoint_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if endpoint.Location != nil {
 		location := *endpoint.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if endpoint.Subnet != nil {
 		result.Properties = &OutboundEndpointProperties_ARM{}
 	}
@@ -364,7 +364,7 @@ func (endpoint *DnsResolvers_OutboundEndpoint_Spec) ConvertToARM(resolved genrun
 		result.Properties.Subnet = &subnet
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if endpoint.Tags != nil {
 		result.Tags = make(map[string]string, len(endpoint.Tags))
 		for key, value := range endpoint.Tags {
@@ -386,19 +386,19 @@ func (endpoint *DnsResolvers_OutboundEndpoint_Spec) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsResolvers_OutboundEndpoint_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	endpoint.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		endpoint.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	endpoint.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -412,7 +412,7 @@ func (endpoint *DnsResolvers_OutboundEndpoint_Spec) PopulateFromARM(owner genrun
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		endpoint.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -694,33 +694,33 @@ func (endpoint *DnsResolvers_OutboundEndpoint_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DnsResolvers_OutboundEndpoint_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		endpoint.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		endpoint.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		endpoint.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		endpoint.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -729,7 +729,7 @@ func (endpoint *DnsResolvers_OutboundEndpoint_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -738,7 +738,7 @@ func (endpoint *DnsResolvers_OutboundEndpoint_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -752,7 +752,7 @@ func (endpoint *DnsResolvers_OutboundEndpoint_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -763,7 +763,7 @@ func (endpoint *DnsResolvers_OutboundEndpoint_STATUS) PopulateFromARM(owner genr
 		endpoint.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		endpoint.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -771,7 +771,7 @@ func (endpoint *DnsResolvers_OutboundEndpoint_STATUS) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		endpoint.Type = &typeVar

--- a/v2/api/network/v1api20220701/nat_gateway_types_gen.go
+++ b/v2/api/network/v1api20220701/nat_gateway_types_gen.go
@@ -352,16 +352,16 @@ func (gateway *NatGateway_Spec) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &NatGateway_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if gateway.Location != nil {
 		location := *gateway.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if gateway.IdleTimeoutInMinutes != nil ||
 		gateway.PublicIpAddresses != nil ||
 		gateway.PublicIpPrefixes != nil {
@@ -386,7 +386,7 @@ func (gateway *NatGateway_Spec) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.Properties.PublicIpPrefixes = append(result.Properties.PublicIpPrefixes, *item_ARM.(*ApplicationGatewaySubResource_ARM))
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if gateway.Sku != nil {
 		sku_ARM, err := (*gateway.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -396,7 +396,7 @@ func (gateway *NatGateway_Spec) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if gateway.Tags != nil {
 		result.Tags = make(map[string]string, len(gateway.Tags))
 		for key, value := range gateway.Tags {
@@ -404,7 +404,7 @@ func (gateway *NatGateway_Spec) ConvertToARM(resolved genruntime.ConvertToARMRes
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range gateway.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -423,10 +423,10 @@ func (gateway *NatGateway_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NatGateway_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	gateway.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -435,16 +435,16 @@ func (gateway *NatGateway_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		gateway.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	gateway.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicIpAddresses’:
+	// Set property "PublicIpAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PublicIpAddresses {
@@ -457,7 +457,7 @@ func (gateway *NatGateway_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘PublicIpPrefixes’:
+	// Set property "PublicIpPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PublicIpPrefixes {
@@ -470,7 +470,7 @@ func (gateway *NatGateway_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 NatGatewaySku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -481,7 +481,7 @@ func (gateway *NatGateway_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		gateway.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		gateway.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -489,7 +489,7 @@ func (gateway *NatGateway_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		gateway.Zones = append(gateway.Zones, item)
 	}
@@ -903,21 +903,21 @@ func (gateway *NatGateway_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NatGateway_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		gateway.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		gateway.Id = &id
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -926,19 +926,19 @@ func (gateway *NatGateway_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		gateway.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		gateway.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -947,7 +947,7 @@ func (gateway *NatGateway_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘PublicIpAddresses’:
+	// Set property "PublicIpAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PublicIpAddresses {
@@ -960,7 +960,7 @@ func (gateway *NatGateway_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘PublicIpPrefixes’:
+	// Set property "PublicIpPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PublicIpPrefixes {
@@ -973,7 +973,7 @@ func (gateway *NatGateway_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -982,7 +982,7 @@ func (gateway *NatGateway_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 NatGatewaySku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -993,7 +993,7 @@ func (gateway *NatGateway_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		gateway.Sku = &sku
 	}
 
-	// Set property ‘Subnets’:
+	// Set property "Subnets":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Subnets {
@@ -1006,7 +1006,7 @@ func (gateway *NatGateway_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		gateway.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1014,13 +1014,13 @@ func (gateway *NatGateway_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		gateway.Type = &typeVar
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		gateway.Zones = append(gateway.Zones, item)
 	}
@@ -1285,7 +1285,7 @@ func (resource *ApplicationGatewaySubResource) ConvertToARM(resolved genruntime.
 	}
 	result := &ApplicationGatewaySubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -1309,7 +1309,7 @@ func (resource *ApplicationGatewaySubResource) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationGatewaySubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1389,7 +1389,7 @@ func (resource *ApplicationGatewaySubResource_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationGatewaySubResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
@@ -1443,7 +1443,7 @@ func (gatewaySku *NatGatewaySku) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &NatGatewaySku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if gatewaySku.Name != nil {
 		name := *gatewaySku.Name
 		result.Name = &name
@@ -1463,7 +1463,7 @@ func (gatewaySku *NatGatewaySku) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NatGatewaySku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		gatewaySku.Name = &name
@@ -1547,7 +1547,7 @@ func (gatewaySku *NatGatewaySku_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NatGatewaySku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		gatewaySku.Name = &name

--- a/v2/api/network/v1api20220701/private_endpoint_types_gen.go
+++ b/v2/api/network/v1api20220701/private_endpoint_types_gen.go
@@ -360,7 +360,7 @@ func (endpoint *PrivateEndpoint_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &PrivateEndpoint_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if endpoint.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*endpoint.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -370,16 +370,16 @@ func (endpoint *PrivateEndpoint_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if endpoint.Location != nil {
 		location := *endpoint.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if endpoint.ApplicationSecurityGroups != nil ||
 		endpoint.CustomNetworkInterfaceName != nil ||
 		endpoint.IpConfigurations != nil ||
@@ -429,7 +429,7 @@ func (endpoint *PrivateEndpoint_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.Subnet = &subnet
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if endpoint.Tags != nil {
 		result.Tags = make(map[string]string, len(endpoint.Tags))
 		for key, value := range endpoint.Tags {
@@ -451,7 +451,7 @@ func (endpoint *PrivateEndpoint_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpoint_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -464,10 +464,10 @@ func (endpoint *PrivateEndpoint_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	endpoint.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CustomNetworkInterfaceName’:
+	// Set property "CustomNetworkInterfaceName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomNetworkInterfaceName != nil {
@@ -476,7 +476,7 @@ func (endpoint *PrivateEndpoint_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -487,7 +487,7 @@ func (endpoint *PrivateEndpoint_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		endpoint.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -500,13 +500,13 @@ func (endpoint *PrivateEndpoint_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		endpoint.Location = &location
 	}
 
-	// Set property ‘ManualPrivateLinkServiceConnections’:
+	// Set property "ManualPrivateLinkServiceConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ManualPrivateLinkServiceConnections {
@@ -519,10 +519,10 @@ func (endpoint *PrivateEndpoint_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	endpoint.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PrivateLinkServiceConnections’:
+	// Set property "PrivateLinkServiceConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkServiceConnections {
@@ -535,7 +535,7 @@ func (endpoint *PrivateEndpoint_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -549,7 +549,7 @@ func (endpoint *PrivateEndpoint_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		endpoint.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1109,7 +1109,7 @@ func (embedded *PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -1122,9 +1122,9 @@ func (embedded *PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded) Popu
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CustomDnsConfigs’:
+	// Set property "CustomDnsConfigs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CustomDnsConfigs {
@@ -1137,7 +1137,7 @@ func (embedded *PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘CustomNetworkInterfaceName’:
+	// Set property "CustomNetworkInterfaceName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomNetworkInterfaceName != nil {
@@ -1146,13 +1146,13 @@ func (embedded *PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1163,13 +1163,13 @@ func (embedded *PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded) Popu
 		embedded.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -1182,13 +1182,13 @@ func (embedded *PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		embedded.Location = &location
 	}
 
-	// Set property ‘ManualPrivateLinkServiceConnections’:
+	// Set property "ManualPrivateLinkServiceConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ManualPrivateLinkServiceConnections {
@@ -1201,13 +1201,13 @@ func (embedded *PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NetworkInterfaces {
@@ -1220,7 +1220,7 @@ func (embedded *PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘PrivateLinkServiceConnections’:
+	// Set property "PrivateLinkServiceConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkServiceConnections {
@@ -1233,7 +1233,7 @@ func (embedded *PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1242,7 +1242,7 @@ func (embedded *PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -1256,7 +1256,7 @@ func (embedded *PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		embedded.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1264,7 +1264,7 @@ func (embedded *PrivateEndpoint_STATUS_PrivateEndpoint_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
@@ -1645,7 +1645,7 @@ func (embedded *ApplicationSecurityGroup_STATUS_PrivateEndpoint_SubResourceEmbed
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationSecurityGroup_STATUS_PrivateEndpoint_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -1699,7 +1699,7 @@ func (embedded *ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded
 	}
 	result := &ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -1723,7 +1723,7 @@ func (embedded *ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1806,13 +1806,13 @@ func (format *CustomDnsConfigPropertiesFormat_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CustomDnsConfigPropertiesFormat_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	if typedInput.Fqdn != nil {
 		fqdn := *typedInput.Fqdn
 		format.Fqdn = &fqdn
 	}
 
-	// Set property ‘IpAddresses’:
+	// Set property "IpAddresses":
 	for _, item := range typedInput.IpAddresses {
 		format.IpAddresses = append(format.IpAddresses, item)
 	}
@@ -1874,13 +1874,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -1900,13 +1900,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -2002,13 +2002,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -2083,7 +2083,7 @@ func (embedded *NetworkInterface_STATUS_PrivateEndpoint_SubResourceEmbedded) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterface_STATUS_PrivateEndpoint_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2146,13 +2146,13 @@ func (configuration *PrivateEndpointIPConfiguration) ConvertToARM(resolved genru
 	}
 	result := &PrivateEndpointIPConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.GroupId != nil ||
 		configuration.MemberName != nil ||
 		configuration.PrivateIPAddress != nil {
@@ -2185,7 +2185,7 @@ func (configuration *PrivateEndpointIPConfiguration) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointIPConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GroupId != nil {
@@ -2194,7 +2194,7 @@ func (configuration *PrivateEndpointIPConfiguration) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘MemberName’:
+	// Set property "MemberName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MemberName != nil {
@@ -2203,13 +2203,13 @@ func (configuration *PrivateEndpointIPConfiguration) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -2323,13 +2323,13 @@ func (configuration *PrivateEndpointIPConfiguration_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointIPConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		configuration.Etag = &etag
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GroupId != nil {
@@ -2338,7 +2338,7 @@ func (configuration *PrivateEndpointIPConfiguration_STATUS) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘MemberName’:
+	// Set property "MemberName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MemberName != nil {
@@ -2347,13 +2347,13 @@ func (configuration *PrivateEndpointIPConfiguration_STATUS) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -2362,7 +2362,7 @@ func (configuration *PrivateEndpointIPConfiguration_STATUS) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		configuration.Type = &typeVar
@@ -2460,13 +2460,13 @@ func (connection *PrivateLinkServiceConnection) ConvertToARM(resolved genruntime
 	}
 	result := &PrivateLinkServiceConnection_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if connection.Name != nil {
 		name := *connection.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if connection.GroupIds != nil ||
 		connection.PrivateLinkServiceConnectionState != nil ||
 		connection.PrivateLinkServiceReference != nil ||
@@ -2511,7 +2511,7 @@ func (connection *PrivateLinkServiceConnection) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkServiceConnection_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupIds’:
+	// Set property "GroupIds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.GroupIds {
@@ -2519,13 +2519,13 @@ func (connection *PrivateLinkServiceConnection) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		connection.Name = &name
 	}
 
-	// Set property ‘PrivateLinkServiceConnectionState’:
+	// Set property "PrivateLinkServiceConnectionState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkServiceConnectionState != nil {
@@ -2539,9 +2539,9 @@ func (connection *PrivateLinkServiceConnection) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// no assignment for property ‘PrivateLinkServiceReference’
+	// no assignment for property "PrivateLinkServiceReference"
 
-	// Set property ‘RequestMessage’:
+	// Set property "RequestMessage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequestMessage != nil {
@@ -2717,13 +2717,13 @@ func (connection *PrivateLinkServiceConnection_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkServiceConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		connection.Etag = &etag
 	}
 
-	// Set property ‘GroupIds’:
+	// Set property "GroupIds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.GroupIds {
@@ -2731,19 +2731,19 @@ func (connection *PrivateLinkServiceConnection_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		connection.Name = &name
 	}
 
-	// Set property ‘PrivateLinkServiceConnectionState’:
+	// Set property "PrivateLinkServiceConnectionState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkServiceConnectionState != nil {
@@ -2757,7 +2757,7 @@ func (connection *PrivateLinkServiceConnection_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘PrivateLinkServiceId’:
+	// Set property "PrivateLinkServiceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkServiceId != nil {
@@ -2766,7 +2766,7 @@ func (connection *PrivateLinkServiceConnection_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2775,7 +2775,7 @@ func (connection *PrivateLinkServiceConnection_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘RequestMessage’:
+	// Set property "RequestMessage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequestMessage != nil {
@@ -2784,7 +2784,7 @@ func (connection *PrivateLinkServiceConnection_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		connection.Type = &typeVar
@@ -2914,7 +2914,7 @@ func (embedded *Subnet_PrivateEndpoint_SubResourceEmbedded) ConvertToARM(resolve
 	}
 	result := &Subnet_PrivateEndpoint_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -2938,7 +2938,7 @@ func (embedded *Subnet_PrivateEndpoint_SubResourceEmbedded) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_PrivateEndpoint_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3018,7 +3018,7 @@ func (embedded *Subnet_STATUS_PrivateEndpoint_SubResourceEmbedded) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_STATUS_PrivateEndpoint_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3078,19 +3078,19 @@ func (state *PrivateLinkServiceConnectionState) ConvertToARM(resolved genruntime
 	}
 	result := &PrivateLinkServiceConnectionState_ARM{}
 
-	// Set property ‘ActionsRequired’:
+	// Set property "ActionsRequired":
 	if state.ActionsRequired != nil {
 		actionsRequired := *state.ActionsRequired
 		result.ActionsRequired = &actionsRequired
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if state.Description != nil {
 		description := *state.Description
 		result.Description = &description
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if state.Status != nil {
 		status := *state.Status
 		result.Status = &status
@@ -3110,19 +3110,19 @@ func (state *PrivateLinkServiceConnectionState) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkServiceConnectionState_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionsRequired’:
+	// Set property "ActionsRequired":
 	if typedInput.ActionsRequired != nil {
 		actionsRequired := *typedInput.ActionsRequired
 		state.ActionsRequired = &actionsRequired
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		state.Description = &description
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		state.Status = &status
@@ -3215,19 +3215,19 @@ func (state *PrivateLinkServiceConnectionState_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkServiceConnectionState_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionsRequired’:
+	// Set property "ActionsRequired":
 	if typedInput.ActionsRequired != nil {
 		actionsRequired := *typedInput.ActionsRequired
 		state.ActionsRequired = &actionsRequired
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		state.Description = &description
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		state.Status = &status

--- a/v2/api/network/v1api20220701/private_endpoints_private_dns_zone_group_types_gen.go
+++ b/v2/api/network/v1api20220701/private_endpoints_private_dns_zone_group_types_gen.go
@@ -334,10 +334,10 @@ func (group *PrivateEndpoints_PrivateDnsZoneGroup_Spec) ConvertToARM(resolved ge
 	}
 	result := &PrivateEndpoints_PrivateDnsZoneGroup_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if group.PrivateDnsZoneConfigs != nil {
 		result.Properties = &PrivateDnsZoneGroupPropertiesFormat_ARM{}
 	}
@@ -363,13 +363,13 @@ func (group *PrivateEndpoints_PrivateDnsZoneGroup_Spec) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpoints_PrivateDnsZoneGroup_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	group.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	group.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PrivateDnsZoneConfigs’:
+	// Set property "PrivateDnsZoneConfigs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateDnsZoneConfigs {
@@ -639,27 +639,27 @@ func (group *PrivateEndpoints_PrivateDnsZoneGroup_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpoints_PrivateDnsZoneGroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		group.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		group.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		group.Name = &name
 	}
 
-	// Set property ‘PrivateDnsZoneConfigs’:
+	// Set property "PrivateDnsZoneConfigs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateDnsZoneConfigs {
@@ -672,7 +672,7 @@ func (group *PrivateEndpoints_PrivateDnsZoneGroup_STATUS) PopulateFromARM(owner 
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -802,13 +802,13 @@ func (config *PrivateDnsZoneConfig) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &PrivateDnsZoneConfig_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if config.Name != nil {
 		name := *config.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if config.PrivateDnsZoneReference != nil {
 		result.Properties = &PrivateDnsZonePropertiesFormat_ARM{}
 	}
@@ -835,13 +835,13 @@ func (config *PrivateDnsZoneConfig) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZoneConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		config.Name = &name
 	}
 
-	// no assignment for property ‘PrivateDnsZoneReference’
+	// no assignment for property "PrivateDnsZoneReference"
 
 	// No error
 	return nil
@@ -936,13 +936,13 @@ func (config *PrivateDnsZoneConfig_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZoneConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		config.Name = &name
 	}
 
-	// Set property ‘PrivateDnsZoneId’:
+	// Set property "PrivateDnsZoneId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateDnsZoneId != nil {
@@ -951,7 +951,7 @@ func (config *PrivateDnsZoneConfig_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘RecordSets’:
+	// Set property "RecordSets":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.RecordSets {
@@ -1084,36 +1084,36 @@ func (recordSet *RecordSet_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RecordSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	if typedInput.Fqdn != nil {
 		fqdn := *typedInput.Fqdn
 		recordSet.Fqdn = &fqdn
 	}
 
-	// Set property ‘IpAddresses’:
+	// Set property "IpAddresses":
 	for _, item := range typedInput.IpAddresses {
 		recordSet.IpAddresses = append(recordSet.IpAddresses, item)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		recordSet.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘RecordSetName’:
+	// Set property "RecordSetName":
 	if typedInput.RecordSetName != nil {
 		recordSetName := *typedInput.RecordSetName
 		recordSet.RecordSetName = &recordSetName
 	}
 
-	// Set property ‘RecordType’:
+	// Set property "RecordType":
 	if typedInput.RecordType != nil {
 		recordType := *typedInput.RecordType
 		recordSet.RecordType = &recordType
 	}
 
-	// Set property ‘Ttl’:
+	// Set property "Ttl":
 	if typedInput.Ttl != nil {
 		ttl := *typedInput.Ttl
 		recordSet.Ttl = &ttl

--- a/v2/api/network/v1api20220701/private_link_service_types_gen.go
+++ b/v2/api/network/v1api20220701/private_link_service_types_gen.go
@@ -402,7 +402,7 @@ func (service *PrivateLinkService_Spec) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &PrivateLinkService_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if service.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*service.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -412,16 +412,16 @@ func (service *PrivateLinkService_Spec) ConvertToARM(resolved genruntime.Convert
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if service.Location != nil {
 		location := *service.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if service.AutoApproval != nil ||
 		service.EnableProxyProtocol != nil ||
 		service.Fqdns != nil ||
@@ -468,7 +468,7 @@ func (service *PrivateLinkService_Spec) ConvertToARM(resolved genruntime.Convert
 		result.Properties.Visibility = &visibility
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if service.Tags != nil {
 		result.Tags = make(map[string]string, len(service.Tags))
 		for key, value := range service.Tags {
@@ -490,7 +490,7 @@ func (service *PrivateLinkService_Spec) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkService_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoApproval’:
+	// Set property "AutoApproval":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoApproval != nil {
@@ -504,10 +504,10 @@ func (service *PrivateLinkService_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	service.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EnableProxyProtocol’:
+	// Set property "EnableProxyProtocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableProxyProtocol != nil {
@@ -516,7 +516,7 @@ func (service *PrivateLinkService_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -527,7 +527,7 @@ func (service *PrivateLinkService_Spec) PopulateFromARM(owner genruntime.Arbitra
 		service.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Fqdns’:
+	// Set property "Fqdns":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Fqdns {
@@ -535,7 +535,7 @@ func (service *PrivateLinkService_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -548,7 +548,7 @@ func (service *PrivateLinkService_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘LoadBalancerFrontendIpConfigurations’:
+	// Set property "LoadBalancerFrontendIpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerFrontendIpConfigurations {
@@ -561,18 +561,18 @@ func (service *PrivateLinkService_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		service.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		service.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -580,7 +580,7 @@ func (service *PrivateLinkService_Spec) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Visibility’:
+	// Set property "Visibility":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Visibility != nil {
@@ -1123,7 +1123,7 @@ func (embedded *PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Alias’:
+	// Set property "Alias":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Alias != nil {
@@ -1132,7 +1132,7 @@ func (embedded *PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
 		}
 	}
 
-	// Set property ‘AutoApproval’:
+	// Set property "AutoApproval":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoApproval != nil {
@@ -1146,9 +1146,9 @@ func (embedded *PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EnableProxyProtocol’:
+	// Set property "EnableProxyProtocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableProxyProtocol != nil {
@@ -1157,13 +1157,13 @@ func (embedded *PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1174,7 +1174,7 @@ func (embedded *PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
 		embedded.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Fqdns’:
+	// Set property "Fqdns":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Fqdns {
@@ -1182,13 +1182,13 @@ func (embedded *PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -1201,7 +1201,7 @@ func (embedded *PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
 		}
 	}
 
-	// Set property ‘LoadBalancerFrontendIpConfigurations’:
+	// Set property "LoadBalancerFrontendIpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerFrontendIpConfigurations {
@@ -1214,19 +1214,19 @@ func (embedded *PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		embedded.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NetworkInterfaces {
@@ -1239,7 +1239,7 @@ func (embedded *PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1252,7 +1252,7 @@ func (embedded *PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1261,7 +1261,7 @@ func (embedded *PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		embedded.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1269,13 +1269,13 @@ func (embedded *PrivateLinkService_STATUS_PrivateLinkService_SubResourceEmbedded
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
 	}
 
-	// Set property ‘Visibility’:
+	// Set property "Visibility":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Visibility != nil {
@@ -1633,7 +1633,7 @@ func (embedded *FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded) 
 	}
 	result := &FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -1657,7 +1657,7 @@ func (embedded *FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FrontendIPConfiguration_PrivateLinkService_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1737,7 +1737,7 @@ func (embedded *FrontendIPConfiguration_STATUS_PrivateLinkService_SubResourceEmb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FrontendIPConfiguration_STATUS_PrivateLinkService_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -1796,7 +1796,7 @@ func (embedded *NetworkInterface_STATUS_PrivateLinkService_SubResourceEmbedded) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterface_STATUS_PrivateLinkService_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -1855,7 +1855,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -1924,13 +1924,13 @@ func (configuration *PrivateLinkServiceIpConfiguration) ConvertToARM(resolved ge
 	}
 	result := &PrivateLinkServiceIpConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.Primary != nil ||
 		configuration.PrivateIPAddress != nil ||
 		configuration.PrivateIPAddressVersion != nil ||
@@ -1977,13 +1977,13 @@ func (configuration *PrivateLinkServiceIpConfiguration) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkServiceIpConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -1992,7 +1992,7 @@ func (configuration *PrivateLinkServiceIpConfiguration) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -2001,7 +2001,7 @@ func (configuration *PrivateLinkServiceIpConfiguration) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -2010,7 +2010,7 @@ func (configuration *PrivateLinkServiceIpConfiguration) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -2019,7 +2019,7 @@ func (configuration *PrivateLinkServiceIpConfiguration) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -2240,25 +2240,25 @@ func (configuration *PrivateLinkServiceIpConfiguration_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkServiceIpConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		configuration.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -2267,7 +2267,7 @@ func (configuration *PrivateLinkServiceIpConfiguration_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -2276,7 +2276,7 @@ func (configuration *PrivateLinkServiceIpConfiguration_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -2285,7 +2285,7 @@ func (configuration *PrivateLinkServiceIpConfiguration_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -2294,7 +2294,7 @@ func (configuration *PrivateLinkServiceIpConfiguration_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2303,7 +2303,7 @@ func (configuration *PrivateLinkServiceIpConfiguration_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -2317,7 +2317,7 @@ func (configuration *PrivateLinkServiceIpConfiguration_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		configuration.Type = &typeVar
@@ -2536,7 +2536,7 @@ func (resourceSet *ResourceSet) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &ResourceSet_ARM{}
 
-	// Set property ‘Subscriptions’:
+	// Set property "Subscriptions":
 	for _, item := range resourceSet.Subscriptions {
 		result.Subscriptions = append(result.Subscriptions, item)
 	}
@@ -2555,7 +2555,7 @@ func (resourceSet *ResourceSet) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceSet_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Subscriptions’:
+	// Set property "Subscriptions":
 	for _, item := range typedInput.Subscriptions {
 		resourceSet.Subscriptions = append(resourceSet.Subscriptions, item)
 	}
@@ -2623,7 +2623,7 @@ func (resourceSet *ResourceSet_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Subscriptions’:
+	// Set property "Subscriptions":
 	for _, item := range typedInput.Subscriptions {
 		resourceSet.Subscriptions = append(resourceSet.Subscriptions, item)
 	}
@@ -2728,7 +2728,7 @@ func (embedded *Subnet_PrivateLinkService_SubResourceEmbedded) ConvertToARM(reso
 	}
 	result := &Subnet_PrivateLinkService_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -2752,7 +2752,7 @@ func (embedded *Subnet_PrivateLinkService_SubResourceEmbedded) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_PrivateLinkService_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2832,7 +2832,7 @@ func (embedded *Subnet_STATUS_PrivateLinkService_SubResourceEmbedded) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_STATUS_PrivateLinkService_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id

--- a/v2/api/network/v1api20220701/public_ip_prefix_types_gen.go
+++ b/v2/api/network/v1api20220701/public_ip_prefix_types_gen.go
@@ -361,7 +361,7 @@ func (prefix *PublicIPPrefix_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &PublicIPPrefix_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if prefix.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*prefix.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -371,16 +371,16 @@ func (prefix *PublicIPPrefix_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if prefix.Location != nil {
 		location := *prefix.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if prefix.CustomIPPrefix != nil ||
 		prefix.IpTags != nil ||
 		prefix.NatGateway != nil ||
@@ -420,7 +420,7 @@ func (prefix *PublicIPPrefix_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.PublicIPAddressVersion = &publicIPAddressVersion
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if prefix.Sku != nil {
 		sku_ARM, err := (*prefix.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -430,7 +430,7 @@ func (prefix *PublicIPPrefix_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if prefix.Tags != nil {
 		result.Tags = make(map[string]string, len(prefix.Tags))
 		for key, value := range prefix.Tags {
@@ -438,7 +438,7 @@ func (prefix *PublicIPPrefix_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range prefix.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -457,10 +457,10 @@ func (prefix *PublicIPPrefix_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPPrefix_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	prefix.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CustomIPPrefix’:
+	// Set property "CustomIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomIPPrefix != nil {
@@ -474,7 +474,7 @@ func (prefix *PublicIPPrefix_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -485,7 +485,7 @@ func (prefix *PublicIPPrefix_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		prefix.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -498,13 +498,13 @@ func (prefix *PublicIPPrefix_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		prefix.Location = &location
 	}
 
-	// Set property ‘NatGateway’:
+	// Set property "NatGateway":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NatGateway != nil {
@@ -518,10 +518,10 @@ func (prefix *PublicIPPrefix_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	prefix.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PrefixLength’:
+	// Set property "PrefixLength":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrefixLength != nil {
@@ -530,7 +530,7 @@ func (prefix *PublicIPPrefix_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -539,7 +539,7 @@ func (prefix *PublicIPPrefix_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPPrefixSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -550,7 +550,7 @@ func (prefix *PublicIPPrefix_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		prefix.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		prefix.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -558,7 +558,7 @@ func (prefix *PublicIPPrefix_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		prefix.Zones = append(prefix.Zones, item)
 	}
@@ -1066,9 +1066,9 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPPrefix_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CustomIPPrefix’:
+	// Set property "CustomIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomIPPrefix != nil {
@@ -1082,13 +1082,13 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		prefix.Etag = &etag
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1099,13 +1099,13 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		prefix.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		prefix.Id = &id
 	}
 
-	// Set property ‘IpPrefix’:
+	// Set property "IpPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpPrefix != nil {
@@ -1114,7 +1114,7 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -1127,7 +1127,7 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘LoadBalancerFrontendIpConfiguration’:
+	// Set property "LoadBalancerFrontendIpConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LoadBalancerFrontendIpConfiguration != nil {
@@ -1141,19 +1141,19 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		prefix.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		prefix.Name = &name
 	}
 
-	// Set property ‘NatGateway’:
+	// Set property "NatGateway":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NatGateway != nil {
@@ -1167,7 +1167,7 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PrefixLength’:
+	// Set property "PrefixLength":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrefixLength != nil {
@@ -1176,7 +1176,7 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1185,7 +1185,7 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -1194,7 +1194,7 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PublicIPAddresses’:
+	// Set property "PublicIPAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PublicIPAddresses {
@@ -1207,7 +1207,7 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -1216,7 +1216,7 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPPrefixSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1227,7 +1227,7 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		prefix.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		prefix.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1235,13 +1235,13 @@ func (prefix *PublicIPPrefix_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		prefix.Type = &typeVar
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		prefix.Zones = append(prefix.Zones, item)
 	}
@@ -1581,13 +1581,13 @@ func (ipTag *IpTag) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &IpTag_ARM{}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if ipTag.IpTagType != nil {
 		ipTagType := *ipTag.IpTagType
 		result.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if ipTag.Tag != nil {
 		tag := *ipTag.Tag
 		result.Tag = &tag
@@ -1607,13 +1607,13 @@ func (ipTag *IpTag) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpTag_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -1694,13 +1694,13 @@ func (ipTag *IpTag_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpTag_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -1782,7 +1782,7 @@ func (embedded *NatGateway_STATUS_PublicIPPrefix_SubResourceEmbedded) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NatGateway_STATUS_PublicIPPrefix_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -1836,7 +1836,7 @@ func (embedded *NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded) ConvertToARM(
 	}
 	result := &NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -1860,7 +1860,7 @@ func (embedded *NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NatGatewaySpec_PublicIPPrefix_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1948,13 +1948,13 @@ func (prefixSku *PublicIPPrefixSku) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &PublicIPPrefixSku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if prefixSku.Name != nil {
 		name := *prefixSku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if prefixSku.Tier != nil {
 		tier := *prefixSku.Tier
 		result.Tier = &tier
@@ -1974,13 +1974,13 @@ func (prefixSku *PublicIPPrefixSku) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPPrefixSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		prefixSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		prefixSku.Tier = &tier
@@ -2091,13 +2091,13 @@ func (prefixSku *PublicIPPrefixSku_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPPrefixSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		prefixSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		prefixSku.Tier = &tier
@@ -2177,7 +2177,7 @@ func (resource *PublicIpPrefixSubResource) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &PublicIpPrefixSubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -2201,7 +2201,7 @@ func (resource *PublicIpPrefixSubResource) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIpPrefixSubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2281,7 +2281,7 @@ func (resource *PublicIpPrefixSubResource_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIpPrefixSubResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
@@ -2340,7 +2340,7 @@ func (address *ReferencedPublicIpAddress_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ReferencedPublicIpAddress_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		address.Id = &id

--- a/v2/api/network/v1beta20180901/private_dns_zone_types_gen.go
+++ b/v2/api/network/v1beta20180901/private_dns_zone_types_gen.go
@@ -339,22 +339,22 @@ func (zone *PrivateDnsZone_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &PrivateDnsZone_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if zone.Etag != nil {
 		etag := *zone.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if zone.Location != nil {
 		location := *zone.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if zone.Tags != nil {
 		result.Tags = make(map[string]string, len(zone.Tags))
 		for key, value := range zone.Tags {
@@ -376,25 +376,25 @@ func (zone *PrivateDnsZone_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZone_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	zone.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zone.Etag = &etag
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		zone.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	zone.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		zone.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -613,27 +613,27 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateDnsZone_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		zone.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		zone.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		zone.Location = &location
 	}
 
-	// Set property ‘MaxNumberOfRecordSets’:
+	// Set property "MaxNumberOfRecordSets":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxNumberOfRecordSets != nil {
@@ -642,7 +642,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MaxNumberOfVirtualNetworkLinks’:
+	// Set property "MaxNumberOfVirtualNetworkLinks":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxNumberOfVirtualNetworkLinks != nil {
@@ -651,7 +651,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MaxNumberOfVirtualNetworkLinksWithRegistration’:
+	// Set property "MaxNumberOfVirtualNetworkLinksWithRegistration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxNumberOfVirtualNetworkLinksWithRegistration != nil {
@@ -660,13 +660,13 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		zone.Name = &name
 	}
 
-	// Set property ‘NumberOfRecordSets’:
+	// Set property "NumberOfRecordSets":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfRecordSets != nil {
@@ -675,7 +675,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘NumberOfVirtualNetworkLinks’:
+	// Set property "NumberOfVirtualNetworkLinks":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfVirtualNetworkLinks != nil {
@@ -684,7 +684,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘NumberOfVirtualNetworkLinksWithRegistration’:
+	// Set property "NumberOfVirtualNetworkLinksWithRegistration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfVirtualNetworkLinksWithRegistration != nil {
@@ -693,7 +693,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -702,7 +702,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		zone.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -710,7 +710,7 @@ func (zone *PrivateDnsZone_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		zone.Type = &typeVar

--- a/v2/api/network/v1beta20201101/load_balancer_types_gen.go
+++ b/v2/api/network/v1beta20201101/load_balancer_types_gen.go
@@ -347,7 +347,7 @@ func (balancer *LoadBalancer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &LoadBalancer_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if balancer.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*balancer.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -357,16 +357,16 @@ func (balancer *LoadBalancer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if balancer.Location != nil {
 		location := *balancer.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if balancer.BackendAddressPools != nil ||
 		balancer.FrontendIPConfigurations != nil ||
 		balancer.InboundNatPools != nil ||
@@ -426,7 +426,7 @@ func (balancer *LoadBalancer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.Probes = append(result.Properties.Probes, *item_ARM.(*Probe_ARM))
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if balancer.Sku != nil {
 		sku_ARM, err := (*balancer.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -436,7 +436,7 @@ func (balancer *LoadBalancer_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if balancer.Tags != nil {
 		result.Tags = make(map[string]string, len(balancer.Tags))
 		for key, value := range balancer.Tags {
@@ -458,10 +458,10 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancer_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	balancer.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BackendAddressPools’:
+	// Set property "BackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.BackendAddressPools {
@@ -474,7 +474,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -485,7 +485,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		balancer.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FrontendIPConfigurations’:
+	// Set property "FrontendIPConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.FrontendIPConfigurations {
@@ -498,7 +498,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘InboundNatPools’:
+	// Set property "InboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundNatPools {
@@ -511,7 +511,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘InboundNatRules’:
+	// Set property "InboundNatRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundNatRules {
@@ -524,7 +524,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘LoadBalancingRules’:
+	// Set property "LoadBalancingRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancingRules {
@@ -537,13 +537,13 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		balancer.Location = &location
 	}
 
-	// Set property ‘OutboundRules’:
+	// Set property "OutboundRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.OutboundRules {
@@ -556,10 +556,10 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	balancer.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Probes’:
+	// Set property "Probes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Probes {
@@ -572,7 +572,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 LoadBalancerSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -583,7 +583,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		balancer.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		balancer.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1101,7 +1101,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancer_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendAddressPools’:
+	// Set property "BackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.BackendAddressPools {
@@ -1114,15 +1114,15 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		balancer.Etag = &etag
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1133,7 +1133,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		balancer.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FrontendIPConfigurations’:
+	// Set property "FrontendIPConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.FrontendIPConfigurations {
@@ -1146,13 +1146,13 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		balancer.Id = &id
 	}
 
-	// Set property ‘InboundNatPools’:
+	// Set property "InboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundNatPools {
@@ -1165,7 +1165,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘InboundNatRules’:
+	// Set property "InboundNatRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundNatRules {
@@ -1178,7 +1178,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘LoadBalancingRules’:
+	// Set property "LoadBalancingRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancingRules {
@@ -1191,19 +1191,19 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		balancer.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		balancer.Name = &name
 	}
 
-	// Set property ‘OutboundRules’:
+	// Set property "OutboundRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.OutboundRules {
@@ -1216,7 +1216,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Probes’:
+	// Set property "Probes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Probes {
@@ -1229,7 +1229,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1238,7 +1238,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -1247,7 +1247,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 LoadBalancerSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1258,7 +1258,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		balancer.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		balancer.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1266,7 +1266,7 @@ func (balancer *LoadBalancer_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		balancer.Type = &typeVar
@@ -1678,13 +1678,13 @@ func (embedded *BackendAddressPool_LoadBalancer_SubResourceEmbedded) ConvertToAR
 	}
 	result := &BackendAddressPool_LoadBalancer_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if embedded.Name != nil {
 		name := *embedded.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if embedded.LoadBalancerBackendAddresses != nil {
 		result.Properties = &BackendAddressPoolPropertiesFormat_ARM{}
 	}
@@ -1710,7 +1710,7 @@ func (embedded *BackendAddressPool_LoadBalancer_SubResourceEmbedded) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackendAddressPool_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘LoadBalancerBackendAddresses’:
+	// Set property "LoadBalancerBackendAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddresses {
@@ -1723,7 +1723,7 @@ func (embedded *BackendAddressPool_LoadBalancer_SubResourceEmbedded) PopulateFro
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
@@ -1826,7 +1826,7 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendIPConfigurations’:
+	// Set property "BackendIPConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.BackendIPConfigurations {
@@ -1839,19 +1839,19 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘LoadBalancerBackendAddresses’:
+	// Set property "LoadBalancerBackendAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddresses {
@@ -1864,7 +1864,7 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘LoadBalancingRules’:
+	// Set property "LoadBalancingRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancingRules {
@@ -1877,13 +1877,13 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘OutboundRule’:
+	// Set property "OutboundRule":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OutboundRule != nil {
@@ -1897,7 +1897,7 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘OutboundRules’:
+	// Set property "OutboundRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.OutboundRules {
@@ -1910,7 +1910,7 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1919,7 +1919,7 @@ func (embedded *BackendAddressPool_STATUS_LoadBalancer_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
@@ -2178,13 +2178,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -2204,13 +2204,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -2285,13 +2285,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -2367,13 +2367,13 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Conver
 	}
 	result := &FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if embedded.Name != nil {
 		name := *embedded.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if embedded.PrivateIPAddress != nil ||
 		embedded.PrivateIPAddressVersion != nil ||
 		embedded.PrivateIPAllocationMethod != nil ||
@@ -2419,7 +2419,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Conver
 		result.Properties.Subnet = &subnet
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range embedded.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -2438,13 +2438,13 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -2453,7 +2453,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -2462,7 +2462,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		}
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -2471,7 +2471,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		}
 	}
 
-	// Set property ‘PublicIPAddress’:
+	// Set property "PublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddress != nil {
@@ -2485,7 +2485,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -2499,7 +2499,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -2513,7 +2513,7 @@ func (embedded *FrontendIPConfiguration_LoadBalancer_SubResourceEmbedded) Popula
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		embedded.Zones = append(embedded.Zones, item)
 	}
@@ -2701,19 +2701,19 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘InboundNatPools’:
+	// Set property "InboundNatPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundNatPools {
@@ -2726,7 +2726,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘InboundNatRules’:
+	// Set property "InboundNatRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.InboundNatRules {
@@ -2739,7 +2739,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘LoadBalancingRules’:
+	// Set property "LoadBalancingRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancingRules {
@@ -2752,13 +2752,13 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘OutboundRules’:
+	// Set property "OutboundRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.OutboundRules {
@@ -2771,7 +2771,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -2780,7 +2780,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -2789,7 +2789,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -2798,7 +2798,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2807,7 +2807,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘PublicIPAddress’:
+	// Set property "PublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddress != nil {
@@ -2821,7 +2821,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -2835,7 +2835,7 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -2849,13 +2849,13 @@ func (embedded *FrontendIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded)
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		embedded.Zones = append(embedded.Zones, item)
 	}
@@ -3216,13 +3216,13 @@ func (pool *InboundNatPool) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &InboundNatPool_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if pool.Name != nil {
 		name := *pool.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if pool.BackendPort != nil ||
 		pool.EnableFloatingIP != nil ||
 		pool.EnableTcpReset != nil ||
@@ -3284,7 +3284,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundNatPool_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -3293,7 +3293,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -3302,7 +3302,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -3311,7 +3311,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -3325,7 +3325,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘FrontendPortRangeEnd’:
+	// Set property "FrontendPortRangeEnd":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPortRangeEnd != nil {
@@ -3334,7 +3334,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘FrontendPortRangeStart’:
+	// Set property "FrontendPortRangeStart":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPortRangeStart != nil {
@@ -3343,7 +3343,7 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -3352,13 +3352,13 @@ func (pool *InboundNatPool) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pool.Name = &name
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -3527,7 +3527,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundNatPool_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -3536,7 +3536,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -3545,7 +3545,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -3554,13 +3554,13 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		pool.Etag = &etag
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -3574,7 +3574,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘FrontendPortRangeEnd’:
+	// Set property "FrontendPortRangeEnd":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPortRangeEnd != nil {
@@ -3583,7 +3583,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘FrontendPortRangeStart’:
+	// Set property "FrontendPortRangeStart":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPortRangeStart != nil {
@@ -3592,13 +3592,13 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		pool.Id = &id
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -3607,13 +3607,13 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pool.Name = &name
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -3622,7 +3622,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -3631,7 +3631,7 @@ func (pool *InboundNatPool_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		pool.Type = &typeVar
@@ -3821,13 +3821,13 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) ConvertToARM(re
 	}
 	result := &InboundNatRule_LoadBalancer_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if embedded.Name != nil {
 		name := *embedded.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if embedded.BackendPort != nil ||
 		embedded.EnableFloatingIP != nil ||
 		embedded.EnableTcpReset != nil ||
@@ -3884,7 +3884,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundNatRule_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -3893,7 +3893,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -3902,7 +3902,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -3911,7 +3911,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		}
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -3925,7 +3925,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		}
 	}
 
-	// Set property ‘FrontendPort’:
+	// Set property "FrontendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPort != nil {
@@ -3934,7 +3934,7 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -3943,13 +3943,13 @@ func (embedded *InboundNatRule_LoadBalancer_SubResourceEmbedded) PopulateFromARM
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -4112,7 +4112,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendIPConfiguration’:
+	// Set property "BackendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendIPConfiguration != nil {
@@ -4126,7 +4126,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -4135,7 +4135,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -4144,7 +4144,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -4153,13 +4153,13 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -4173,7 +4173,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘FrontendPort’:
+	// Set property "FrontendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPort != nil {
@@ -4182,13 +4182,13 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -4197,13 +4197,13 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -4212,7 +4212,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -4221,7 +4221,7 @@ func (embedded *InboundNatRule_STATUS_LoadBalancer_SubResourceEmbedded) Populate
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
@@ -4423,13 +4423,13 @@ func (balancerSku *LoadBalancerSku) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &LoadBalancerSku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if balancerSku.Name != nil {
 		name := *balancerSku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if balancerSku.Tier != nil {
 		tier := *balancerSku.Tier
 		result.Tier = &tier
@@ -4449,13 +4449,13 @@ func (balancerSku *LoadBalancerSku) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancerSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		balancerSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		balancerSku.Tier = &tier
@@ -4540,13 +4540,13 @@ func (balancerSku *LoadBalancerSku_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancerSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		balancerSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		balancerSku.Tier = &tier
@@ -4640,13 +4640,13 @@ func (rule *LoadBalancingRule) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &LoadBalancingRule_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if rule.Name != nil {
 		name := *rule.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.BackendAddressPool != nil ||
 		rule.BackendPort != nil ||
 		rule.DisableOutboundSnat != nil ||
@@ -4731,7 +4731,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancingRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendAddressPool’:
+	// Set property "BackendAddressPool":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendAddressPool != nil {
@@ -4745,7 +4745,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -4754,7 +4754,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘DisableOutboundSnat’:
+	// Set property "DisableOutboundSnat":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableOutboundSnat != nil {
@@ -4763,7 +4763,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -4772,7 +4772,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -4781,7 +4781,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -4795,7 +4795,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘FrontendPort’:
+	// Set property "FrontendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPort != nil {
@@ -4804,7 +4804,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -4813,7 +4813,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘LoadDistribution’:
+	// Set property "LoadDistribution":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LoadDistribution != nil {
@@ -4822,13 +4822,13 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Probe’:
+	// Set property "Probe":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Probe != nil {
@@ -4842,7 +4842,7 @@ func (rule *LoadBalancingRule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -5088,7 +5088,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancingRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BackendAddressPool’:
+	// Set property "BackendAddressPool":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendAddressPool != nil {
@@ -5102,7 +5102,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘BackendPort’:
+	// Set property "BackendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendPort != nil {
@@ -5111,7 +5111,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DisableOutboundSnat’:
+	// Set property "DisableOutboundSnat":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableOutboundSnat != nil {
@@ -5120,7 +5120,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableFloatingIP’:
+	// Set property "EnableFloatingIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableFloatingIP != nil {
@@ -5129,7 +5129,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -5138,13 +5138,13 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		rule.Etag = &etag
 	}
 
-	// Set property ‘FrontendIPConfiguration’:
+	// Set property "FrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendIPConfiguration != nil {
@@ -5158,7 +5158,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘FrontendPort’:
+	// Set property "FrontendPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FrontendPort != nil {
@@ -5167,13 +5167,13 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -5182,7 +5182,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LoadDistribution’:
+	// Set property "LoadDistribution":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LoadDistribution != nil {
@@ -5191,13 +5191,13 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Probe’:
+	// Set property "Probe":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Probe != nil {
@@ -5211,7 +5211,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -5220,7 +5220,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -5229,7 +5229,7 @@ func (rule *LoadBalancingRule_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -5498,13 +5498,13 @@ func (rule *OutboundRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &OutboundRule_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if rule.Name != nil {
 		name := *rule.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.AllocatedOutboundPorts != nil ||
 		rule.BackendAddressPool != nil ||
 		rule.EnableTcpReset != nil ||
@@ -5559,7 +5559,7 @@ func (rule *OutboundRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OutboundRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllocatedOutboundPorts != nil {
@@ -5568,7 +5568,7 @@ func (rule *OutboundRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘BackendAddressPool’:
+	// Set property "BackendAddressPool":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendAddressPool != nil {
@@ -5582,7 +5582,7 @@ func (rule *OutboundRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -5591,7 +5591,7 @@ func (rule *OutboundRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘FrontendIPConfigurations’:
+	// Set property "FrontendIPConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.FrontendIPConfigurations {
@@ -5604,7 +5604,7 @@ func (rule *OutboundRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -5613,13 +5613,13 @@ func (rule *OutboundRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -5794,7 +5794,7 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected OutboundRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllocatedOutboundPorts’:
+	// Set property "AllocatedOutboundPorts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllocatedOutboundPorts != nil {
@@ -5803,7 +5803,7 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘BackendAddressPool’:
+	// Set property "BackendAddressPool":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BackendAddressPool != nil {
@@ -5817,7 +5817,7 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘EnableTcpReset’:
+	// Set property "EnableTcpReset":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableTcpReset != nil {
@@ -5826,13 +5826,13 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		rule.Etag = &etag
 	}
 
-	// Set property ‘FrontendIPConfigurations’:
+	// Set property "FrontendIPConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.FrontendIPConfigurations {
@@ -5845,13 +5845,13 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -5860,13 +5860,13 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -5875,7 +5875,7 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -5884,7 +5884,7 @@ func (rule *OutboundRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -6084,13 +6084,13 @@ func (probe *Probe) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &Probe_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if probe.Name != nil {
 		name := *probe.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if probe.IntervalInSeconds != nil ||
 		probe.NumberOfProbes != nil ||
 		probe.Port != nil ||
@@ -6133,7 +6133,7 @@ func (probe *Probe) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Probe_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IntervalInSeconds’:
+	// Set property "IntervalInSeconds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IntervalInSeconds != nil {
@@ -6142,13 +6142,13 @@ func (probe *Probe) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		probe.Name = &name
 	}
 
-	// Set property ‘NumberOfProbes’:
+	// Set property "NumberOfProbes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfProbes != nil {
@@ -6157,7 +6157,7 @@ func (probe *Probe) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		}
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Port != nil {
@@ -6166,7 +6166,7 @@ func (probe *Probe) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		}
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -6175,7 +6175,7 @@ func (probe *Probe) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		}
 	}
 
-	// Set property ‘RequestPath’:
+	// Set property "RequestPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequestPath != nil {
@@ -6286,19 +6286,19 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Probe_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		probe.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		probe.Id = &id
 	}
 
-	// Set property ‘IntervalInSeconds’:
+	// Set property "IntervalInSeconds":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IntervalInSeconds != nil {
@@ -6307,7 +6307,7 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘LoadBalancingRules’:
+	// Set property "LoadBalancingRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancingRules {
@@ -6320,13 +6320,13 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		probe.Name = &name
 	}
 
-	// Set property ‘NumberOfProbes’:
+	// Set property "NumberOfProbes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfProbes != nil {
@@ -6335,7 +6335,7 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Port’:
+	// Set property "Port":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Port != nil {
@@ -6344,7 +6344,7 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -6353,7 +6353,7 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -6362,7 +6362,7 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘RequestPath’:
+	// Set property "RequestPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequestPath != nil {
@@ -6371,7 +6371,7 @@ func (probe *Probe_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		probe.Type = &typeVar
@@ -6548,13 +6548,13 @@ func (address *LoadBalancerBackendAddress) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &LoadBalancerBackendAddress_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if address.Name != nil {
 		name := *address.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if address.IpAddress != nil ||
 		address.LoadBalancerFrontendIPConfiguration != nil ||
 		address.Subnet != nil ||
@@ -6604,7 +6604,7 @@ func (address *LoadBalancerBackendAddress) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancerBackendAddress_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpAddress != nil {
@@ -6613,7 +6613,7 @@ func (address *LoadBalancerBackendAddress) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘LoadBalancerFrontendIPConfiguration’:
+	// Set property "LoadBalancerFrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LoadBalancerFrontendIPConfiguration != nil {
@@ -6627,13 +6627,13 @@ func (address *LoadBalancerBackendAddress) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		address.Name = &name
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -6647,7 +6647,7 @@ func (address *LoadBalancerBackendAddress) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘VirtualNetwork’:
+	// Set property "VirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetwork != nil {
@@ -6796,7 +6796,7 @@ func (address *LoadBalancerBackendAddress_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LoadBalancerBackendAddress_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpAddress != nil {
@@ -6805,7 +6805,7 @@ func (address *LoadBalancerBackendAddress_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘LoadBalancerFrontendIPConfiguration’:
+	// Set property "LoadBalancerFrontendIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LoadBalancerFrontendIPConfiguration != nil {
@@ -6819,13 +6819,13 @@ func (address *LoadBalancerBackendAddress_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		address.Name = &name
 	}
 
-	// Set property ‘NetworkInterfaceIPConfiguration’:
+	// Set property "NetworkInterfaceIPConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkInterfaceIPConfiguration != nil {
@@ -6839,7 +6839,7 @@ func (address *LoadBalancerBackendAddress_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -6853,7 +6853,7 @@ func (address *LoadBalancerBackendAddress_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘VirtualNetwork’:
+	// Set property "VirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetwork != nil {
@@ -7042,7 +7042,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_LoadBalancer_SubResourceE
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceIPConfiguration_STATUS_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -7141,7 +7141,7 @@ func (embedded *PublicIPAddress_STATUS_LoadBalancer_SubResourceEmbedded) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddress_STATUS_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -7194,7 +7194,7 @@ func (embedded *PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded) ConvertToA
 	}
 	result := &PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -7218,7 +7218,7 @@ func (embedded *PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSpec_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -7277,7 +7277,7 @@ func (embedded *Subnet_LoadBalancer_SubResourceEmbedded) ConvertToARM(resolved g
 	}
 	result := &Subnet_LoadBalancer_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -7301,7 +7301,7 @@ func (embedded *Subnet_LoadBalancer_SubResourceEmbedded) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -7365,7 +7365,7 @@ func (embedded *Subnet_STATUS_LoadBalancer_SubResourceEmbedded) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_STATUS_LoadBalancer_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id

--- a/v2/api/network/v1beta20201101/network_interface_types_gen.go
+++ b/v2/api/network/v1beta20201101/network_interface_types_gen.go
@@ -340,7 +340,7 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &NetworkInterface_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if networkInterface.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*networkInterface.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -350,16 +350,16 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if networkInterface.Location != nil {
 		location := *networkInterface.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if networkInterface.DnsSettings != nil ||
 		networkInterface.EnableAcceleratedNetworking != nil ||
 		networkInterface.EnableIPForwarding != nil ||
@@ -413,7 +413,7 @@ func (networkInterface *NetworkInterface_Spec) ConvertToARM(resolved genruntime.
 		result.Properties.PrivateLinkService = &privateLinkService
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if networkInterface.Tags != nil {
 		result.Tags = make(map[string]string, len(networkInterface.Tags))
 		for key, value := range networkInterface.Tags {
@@ -435,10 +435,10 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterface_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	networkInterface.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -452,7 +452,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -461,7 +461,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -470,7 +470,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -481,7 +481,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		networkInterface.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -494,13 +494,13 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		networkInterface.Location = &location
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -514,7 +514,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘NicType’:
+	// Set property "NicType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NicType != nil {
@@ -523,10 +523,10 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	networkInterface.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PrivateLinkService’:
+	// Set property "PrivateLinkService":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkService != nil {
@@ -540,7 +540,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		networkInterface.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -946,9 +946,9 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -962,7 +962,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘DscpConfiguration’:
+	// Set property "DscpConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DscpConfiguration != nil {
@@ -976,7 +976,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘EnableAcceleratedNetworking’:
+	// Set property "EnableAcceleratedNetworking":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableAcceleratedNetworking != nil {
@@ -985,7 +985,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘EnableIPForwarding’:
+	// Set property "EnableIPForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableIPForwarding != nil {
@@ -994,13 +994,13 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1011,7 +1011,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		embedded.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostedWorkloads’:
+	// Set property "HostedWorkloads":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.HostedWorkloads {
@@ -1019,13 +1019,13 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -1038,13 +1038,13 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		embedded.Location = &location
 	}
 
-	// Set property ‘MacAddress’:
+	// Set property "MacAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MacAddress != nil {
@@ -1053,7 +1053,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘MigrationPhase’:
+	// Set property "MigrationPhase":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MigrationPhase != nil {
@@ -1062,13 +1062,13 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -1082,7 +1082,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘NicType’:
+	// Set property "NicType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NicType != nil {
@@ -1091,7 +1091,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -1100,7 +1100,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘PrivateEndpoint’:
+	// Set property "PrivateEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateEndpoint != nil {
@@ -1114,7 +1114,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘PrivateLinkService’:
+	// Set property "PrivateLinkService":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkService != nil {
@@ -1128,7 +1128,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1137,7 +1137,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -1146,7 +1146,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		embedded.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1154,7 +1154,7 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘TapConfigurations’:
+	// Set property "TapConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TapConfigurations {
@@ -1167,13 +1167,13 @@ func (embedded *NetworkInterface_STATUS_NetworkInterface_SubResourceEmbedded) Po
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
 	}
 
-	// Set property ‘VirtualMachine’:
+	// Set property "VirtualMachine":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualMachine != nil {
@@ -1625,12 +1625,12 @@ func (settings *NetworkInterfaceDnsSettings) ConvertToARM(resolved genruntime.Co
 	}
 	result := &NetworkInterfaceDnsSettings_ARM{}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range settings.DnsServers {
 		result.DnsServers = append(result.DnsServers, item)
 	}
 
-	// Set property ‘InternalDnsNameLabel’:
+	// Set property "InternalDnsNameLabel":
 	if settings.InternalDnsNameLabel != nil {
 		internalDnsNameLabel := *settings.InternalDnsNameLabel
 		result.InternalDnsNameLabel = &internalDnsNameLabel
@@ -1650,12 +1650,12 @@ func (settings *NetworkInterfaceDnsSettings) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceDnsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		settings.DnsServers = append(settings.DnsServers, item)
 	}
 
-	// Set property ‘InternalDnsNameLabel’:
+	// Set property "InternalDnsNameLabel":
 	if typedInput.InternalDnsNameLabel != nil {
 		internalDnsNameLabel := *typedInput.InternalDnsNameLabel
 		settings.InternalDnsNameLabel = &internalDnsNameLabel
@@ -1723,29 +1723,29 @@ func (settings *NetworkInterfaceDnsSettings_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceDnsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AppliedDnsServers’:
+	// Set property "AppliedDnsServers":
 	for _, item := range typedInput.AppliedDnsServers {
 		settings.AppliedDnsServers = append(settings.AppliedDnsServers, item)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		settings.DnsServers = append(settings.DnsServers, item)
 	}
 
-	// Set property ‘InternalDnsNameLabel’:
+	// Set property "InternalDnsNameLabel":
 	if typedInput.InternalDnsNameLabel != nil {
 		internalDnsNameLabel := *typedInput.InternalDnsNameLabel
 		settings.InternalDnsNameLabel = &internalDnsNameLabel
 	}
 
-	// Set property ‘InternalDomainNameSuffix’:
+	// Set property "InternalDomainNameSuffix":
 	if typedInput.InternalDomainNameSuffix != nil {
 		internalDomainNameSuffix := *typedInput.InternalDomainNameSuffix
 		settings.InternalDomainNameSuffix = &internalDomainNameSuffix
 	}
 
-	// Set property ‘InternalFqdn’:
+	// Set property "InternalFqdn":
 	if typedInput.InternalFqdn != nil {
 		internalFqdn := *typedInput.InternalFqdn
 		settings.InternalFqdn = &internalFqdn
@@ -1833,13 +1833,13 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 	}
 	result := &NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if embedded.Name != nil {
 		name := *embedded.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if embedded.ApplicationGatewayBackendAddressPools != nil ||
 		embedded.ApplicationSecurityGroups != nil ||
 		embedded.LoadBalancerBackendAddressPools != nil ||
@@ -1935,7 +1935,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -1948,7 +1948,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -1961,7 +1961,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -1974,7 +1974,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘LoadBalancerInboundNatRules’:
+	// Set property "LoadBalancerInboundNatRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerInboundNatRules {
@@ -1987,13 +1987,13 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -2002,7 +2002,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -2011,7 +2011,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -2020,7 +2020,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -2029,7 +2029,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘PublicIPAddress’:
+	// Set property "PublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddress != nil {
@@ -2043,7 +2043,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -2057,7 +2057,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘VirtualNetworkTaps’:
+	// Set property "VirtualNetworkTaps":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VirtualNetworkTaps {
@@ -2420,7 +2420,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApplicationGatewayBackendAddressPools’:
+	// Set property "ApplicationGatewayBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayBackendAddressPools {
@@ -2433,7 +2433,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘ApplicationSecurityGroups’:
+	// Set property "ApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationSecurityGroups {
@@ -2446,19 +2446,19 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘LoadBalancerBackendAddressPools’:
+	// Set property "LoadBalancerBackendAddressPools":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerBackendAddressPools {
@@ -2471,7 +2471,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘LoadBalancerInboundNatRules’:
+	// Set property "LoadBalancerInboundNatRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.LoadBalancerInboundNatRules {
@@ -2484,13 +2484,13 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘Primary’:
+	// Set property "Primary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Primary != nil {
@@ -2499,7 +2499,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -2508,7 +2508,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘PrivateIPAddressVersion’:
+	// Set property "PrivateIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddressVersion != nil {
@@ -2517,7 +2517,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -2526,7 +2526,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘PrivateLinkConnectionProperties’:
+	// Set property "PrivateLinkConnectionProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkConnectionProperties != nil {
@@ -2540,7 +2540,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2549,7 +2549,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘PublicIPAddress’:
+	// Set property "PublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddress != nil {
@@ -2563,7 +2563,7 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -2577,13 +2577,13 @@ func (embedded *NetworkInterfaceIPConfiguration_STATUS_NetworkInterface_SubResou
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
 	}
 
-	// Set property ‘VirtualNetworkTaps’:
+	// Set property "VirtualNetworkTaps":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.VirtualNetworkTaps {
@@ -3019,7 +3019,7 @@ func (embedded *NetworkInterfaceTapConfiguration_STATUS_NetworkInterface_SubReso
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceTapConfiguration_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3077,7 +3077,7 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3130,7 +3130,7 @@ func (embedded *NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded) C
 	}
 	result := &NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -3154,7 +3154,7 @@ func (embedded *NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded) P
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroupSpec_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3218,7 +3218,7 @@ func (embedded *PrivateEndpoint_STATUS_NetworkInterface_SubResourceEmbedded) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpoint_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3276,7 +3276,7 @@ func (embedded *PrivateLinkService_STATUS_NetworkInterface_SubResourceEmbedded) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkService_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3329,7 +3329,7 @@ func (service *PrivateLinkServiceSpec) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &PrivateLinkServiceSpec_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if service.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*service.Reference)
 		if err != nil {
@@ -3353,7 +3353,7 @@ func (service *PrivateLinkServiceSpec) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkServiceSpec_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3417,7 +3417,7 @@ func (resource *SubResource_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
@@ -3470,7 +3470,7 @@ func (embedded *ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourc
 	}
 	result := &ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -3494,7 +3494,7 @@ func (embedded *ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationGatewayBackendAddressPool_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3558,7 +3558,7 @@ func (embedded *ApplicationGatewayBackendAddressPool_STATUS_NetworkInterface_Sub
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationGatewayBackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3616,7 +3616,7 @@ func (embedded *ApplicationSecurityGroup_STATUS_NetworkInterface_SubResourceEmbe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationSecurityGroup_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3669,7 +3669,7 @@ func (embedded *ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedde
 	}
 	result := &ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -3693,7 +3693,7 @@ func (embedded *ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedde
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationSecurityGroupSpec_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3752,7 +3752,7 @@ func (embedded *BackendAddressPool_NetworkInterface_SubResourceEmbedded) Convert
 	}
 	result := &BackendAddressPool_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -3776,7 +3776,7 @@ func (embedded *BackendAddressPool_NetworkInterface_SubResourceEmbedded) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackendAddressPool_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3840,7 +3840,7 @@ func (embedded *BackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded) 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BackendAddressPool_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3893,7 +3893,7 @@ func (embedded *InboundNatRule_NetworkInterface_SubResourceEmbedded) ConvertToAR
 	}
 	result := &InboundNatRule_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -3917,7 +3917,7 @@ func (embedded *InboundNatRule_NetworkInterface_SubResourceEmbedded) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundNatRule_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3981,7 +3981,7 @@ func (embedded *InboundNatRule_STATUS_NetworkInterface_SubResourceEmbedded) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected InboundNatRule_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -4041,18 +4041,18 @@ func (properties *NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Fqdns’:
+	// Set property "Fqdns":
 	for _, item := range typedInput.Fqdns {
 		properties.Fqdns = append(properties.Fqdns, item)
 	}
 
-	// Set property ‘GroupId’:
+	// Set property "GroupId":
 	if typedInput.GroupId != nil {
 		groupId := *typedInput.GroupId
 		properties.GroupId = &groupId
 	}
 
-	// Set property ‘RequiredMemberName’:
+	// Set property "RequiredMemberName":
 	if typedInput.RequiredMemberName != nil {
 		requiredMemberName := *typedInput.RequiredMemberName
 		properties.RequiredMemberName = &requiredMemberName
@@ -4122,7 +4122,7 @@ func (embedded *PublicIPAddress_STATUS_NetworkInterface_SubResourceEmbedded) Pop
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddress_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -4175,7 +4175,7 @@ func (embedded *PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded) Conver
 	}
 	result := &PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -4199,7 +4199,7 @@ func (embedded *PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded) Popula
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSpec_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -4258,7 +4258,7 @@ func (embedded *Subnet_NetworkInterface_SubResourceEmbedded) ConvertToARM(resolv
 	}
 	result := &Subnet_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -4282,7 +4282,7 @@ func (embedded *Subnet_NetworkInterface_SubResourceEmbedded) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -4346,7 +4346,7 @@ func (embedded *Subnet_STATUS_NetworkInterface_SubResourceEmbedded) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -4404,7 +4404,7 @@ func (embedded *VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded) P
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkTap_STATUS_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -4457,7 +4457,7 @@ func (embedded *VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded) Conv
 	}
 	result := &VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -4481,7 +4481,7 @@ func (embedded *VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkTapSpec_NetworkInterface_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil

--- a/v2/api/network/v1beta20201101/network_security_group_types_gen.go
+++ b/v2/api/network/v1beta20201101/network_security_group_types_gen.go
@@ -332,18 +332,18 @@ func (group *NetworkSecurityGroup_Spec) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &NetworkSecurityGroup_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if group.Location != nil {
 		location := *group.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// no assignment for property ‘Properties’
+	// no assignment for property "Properties"
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if group.Tags != nil {
 		result.Tags = make(map[string]string, len(group.Tags))
 		for key, value := range group.Tags {
@@ -365,19 +365,19 @@ func (group *NetworkSecurityGroup_Spec) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroup_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	group.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		group.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	group.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		group.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -589,9 +589,9 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DefaultSecurityRules’:
+	// Set property "DefaultSecurityRules":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DefaultSecurityRules {
@@ -604,13 +604,13 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘FlowLogs’:
+	// Set property "FlowLogs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.FlowLogs {
@@ -623,25 +623,25 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		embedded.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘NetworkInterfaces’:
+	// Set property "NetworkInterfaces":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.NetworkInterfaces {
@@ -654,7 +654,7 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -663,7 +663,7 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -672,7 +672,7 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Subnets’:
+	// Set property "Subnets":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Subnets {
@@ -685,7 +685,7 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		embedded.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -693,7 +693,7 @@ func (embedded *NetworkSecurityGroup_STATUS_NetworkSecurityGroup_SubResourceEmbe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
@@ -953,7 +953,7 @@ func (flowLog *FlowLog_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FlowLog_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		flowLog.Id = &id
@@ -1011,7 +1011,7 @@ func (embedded *NetworkInterface_STATUS_NetworkSecurityGroup_SubResourceEmbedded
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkInterface_STATUS_NetworkSecurityGroup_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -1069,7 +1069,7 @@ func (rule *SecurityRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SecurityRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
@@ -1127,7 +1127,7 @@ func (embedded *Subnet_STATUS_NetworkSecurityGroup_SubResourceEmbedded) Populate
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Subnet_STATUS_NetworkSecurityGroup_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id

--- a/v2/api/network/v1beta20201101/network_security_groups_security_rule_types_gen.go
+++ b/v2/api/network/v1beta20201101/network_security_groups_security_rule_types_gen.go
@@ -351,10 +351,10 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) ConvertToARM(resolved genru
 	}
 	result := &NetworkSecurityGroups_SecurityRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.Access != nil ||
 		rule.Description != nil ||
 		rule.DestinationAddressPrefix != nil ||
@@ -449,7 +449,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroups_SecurityRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Access’:
+	// Set property "Access":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Access != nil {
@@ -458,10 +458,10 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -470,7 +470,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘DestinationAddressPrefix’:
+	// Set property "DestinationAddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DestinationAddressPrefix != nil {
@@ -479,7 +479,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘DestinationAddressPrefixes’:
+	// Set property "DestinationAddressPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DestinationAddressPrefixes {
@@ -487,7 +487,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘DestinationApplicationSecurityGroups’:
+	// Set property "DestinationApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DestinationApplicationSecurityGroups {
@@ -500,7 +500,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘DestinationPortRange’:
+	// Set property "DestinationPortRange":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DestinationPortRange != nil {
@@ -509,7 +509,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘DestinationPortRanges’:
+	// Set property "DestinationPortRanges":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DestinationPortRanges {
@@ -517,7 +517,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Direction’:
+	// Set property "Direction":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Direction != nil {
@@ -526,10 +526,10 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -538,7 +538,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -547,7 +547,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘SourceAddressPrefix’:
+	// Set property "SourceAddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceAddressPrefix != nil {
@@ -556,7 +556,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘SourceAddressPrefixes’:
+	// Set property "SourceAddressPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SourceAddressPrefixes {
@@ -564,7 +564,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘SourceApplicationSecurityGroups’:
+	// Set property "SourceApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SourceApplicationSecurityGroups {
@@ -577,7 +577,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘SourcePortRange’:
+	// Set property "SourcePortRange":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourcePortRange != nil {
@@ -586,7 +586,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 		}
 	}
 
-	// Set property ‘SourcePortRanges’:
+	// Set property "SourcePortRanges":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SourcePortRanges {
@@ -977,7 +977,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroups_SecurityRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Access’:
+	// Set property "Access":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Access != nil {
@@ -986,9 +986,9 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Description != nil {
@@ -997,7 +997,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘DestinationAddressPrefix’:
+	// Set property "DestinationAddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DestinationAddressPrefix != nil {
@@ -1006,7 +1006,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘DestinationAddressPrefixes’:
+	// Set property "DestinationAddressPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DestinationAddressPrefixes {
@@ -1014,7 +1014,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘DestinationApplicationSecurityGroups’:
+	// Set property "DestinationApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DestinationApplicationSecurityGroups {
@@ -1027,7 +1027,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘DestinationPortRange’:
+	// Set property "DestinationPortRange":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DestinationPortRange != nil {
@@ -1036,7 +1036,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘DestinationPortRanges’:
+	// Set property "DestinationPortRanges":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DestinationPortRanges {
@@ -1044,7 +1044,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Direction’:
+	// Set property "Direction":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Direction != nil {
@@ -1053,25 +1053,25 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		rule.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Priority != nil {
@@ -1080,7 +1080,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Protocol’:
+	// Set property "Protocol":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Protocol != nil {
@@ -1089,7 +1089,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1098,7 +1098,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘SourceAddressPrefix’:
+	// Set property "SourceAddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceAddressPrefix != nil {
@@ -1107,7 +1107,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘SourceAddressPrefixes’:
+	// Set property "SourceAddressPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SourceAddressPrefixes {
@@ -1115,7 +1115,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘SourceApplicationSecurityGroups’:
+	// Set property "SourceApplicationSecurityGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SourceApplicationSecurityGroups {
@@ -1128,7 +1128,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘SourcePortRange’:
+	// Set property "SourcePortRange":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourcePortRange != nil {
@@ -1137,7 +1137,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘SourcePortRanges’:
+	// Set property "SourcePortRanges":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SourcePortRanges {
@@ -1145,7 +1145,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -1423,7 +1423,7 @@ func (embedded *ApplicationSecurityGroup_STATUS_NetworkSecurityGroups_SecurityRu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationSecurityGroup_STATUS_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -1476,7 +1476,7 @@ func (embedded *ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_
 	}
 	result := &ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -1500,7 +1500,7 @@ func (embedded *ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationSecurityGroupSpec_NetworkSecurityGroups_SecurityRule_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil

--- a/v2/api/network/v1beta20201101/public_ip_address_types_gen.go
+++ b/v2/api/network/v1beta20201101/public_ip_address_types_gen.go
@@ -346,7 +346,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &PublicIPAddress_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if address.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*address.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -356,16 +356,16 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if address.Location != nil {
 		location := *address.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if address.DdosSettings != nil ||
 		address.DnsSettings != nil ||
 		address.IdleTimeoutInMinutes != nil ||
@@ -451,7 +451,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Properties.ServicePublicIPAddress = &servicePublicIPAddress
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if address.Sku != nil {
 		sku_ARM, err := (*address.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -461,7 +461,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if address.Tags != nil {
 		result.Tags = make(map[string]string, len(address.Tags))
 		for key, value := range address.Tags {
@@ -469,7 +469,7 @@ func (address *PublicIPAddress_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range address.Zones {
 		result.Zones = append(result.Zones, item)
 	}
@@ -488,10 +488,10 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddress_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	address.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DdosSettings’:
+	// Set property "DdosSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DdosSettings != nil {
@@ -505,7 +505,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -519,7 +519,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -530,7 +530,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		address.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -539,7 +539,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpAddress != nil {
@@ -548,7 +548,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -561,7 +561,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘LinkedPublicIPAddress’:
+	// Set property "LinkedPublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LinkedPublicIPAddress != nil {
@@ -575,13 +575,13 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		address.Location = &location
 	}
 
-	// Set property ‘NatGateway’:
+	// Set property "NatGateway":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NatGateway != nil {
@@ -595,10 +595,10 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	address.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -607,7 +607,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PublicIPAllocationMethod’:
+	// Set property "PublicIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAllocationMethod != nil {
@@ -616,7 +616,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -630,7 +630,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ServicePublicIPAddress’:
+	// Set property "ServicePublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServicePublicIPAddress != nil {
@@ -644,7 +644,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPAddressSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -655,7 +655,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		address.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		address.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -663,7 +663,7 @@ func (address *PublicIPAddress_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		address.Zones = append(address.Zones, item)
 	}
@@ -1160,9 +1160,9 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DdosSettings’:
+	// Set property "DdosSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DdosSettings != nil {
@@ -1176,7 +1176,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘DnsSettings’:
+	// Set property "DnsSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsSettings != nil {
@@ -1190,13 +1190,13 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		embedded.Etag = &etag
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1207,13 +1207,13 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		embedded.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
 	}
 
-	// Set property ‘IdleTimeoutInMinutes’:
+	// Set property "IdleTimeoutInMinutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IdleTimeoutInMinutes != nil {
@@ -1222,7 +1222,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpAddress != nil {
@@ -1231,7 +1231,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘IpConfiguration’:
+	// Set property "IpConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IpConfiguration != nil {
@@ -1245,7 +1245,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘IpTags’:
+	// Set property "IpTags":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpTags {
@@ -1258,13 +1258,13 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		embedded.Location = &location
 	}
 
-	// Set property ‘MigrationPhase’:
+	// Set property "MigrationPhase":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MigrationPhase != nil {
@@ -1273,13 +1273,13 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		embedded.Name = &name
 	}
 
-	// Set property ‘NatGateway’:
+	// Set property "NatGateway":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NatGateway != nil {
@@ -1293,7 +1293,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1302,7 +1302,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘PublicIPAddressVersion’:
+	// Set property "PublicIPAddressVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddressVersion != nil {
@@ -1311,7 +1311,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘PublicIPAllocationMethod’:
+	// Set property "PublicIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAllocationMethod != nil {
@@ -1320,7 +1320,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘PublicIPPrefix’:
+	// Set property "PublicIPPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPPrefix != nil {
@@ -1334,7 +1334,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -1343,7 +1343,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 PublicIPAddressSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1354,7 +1354,7 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		embedded.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		embedded.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1362,13 +1362,13 @@ func (embedded *PublicIPAddress_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		embedded.Type = &typeVar
 	}
 
-	// Set property ‘Zones’:
+	// Set property "Zones":
 	for _, item := range typedInput.Zones {
 		embedded.Zones = append(embedded.Zones, item)
 	}
@@ -1750,7 +1750,7 @@ func (settings *DdosSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &DdosSettings_ARM{}
 
-	// Set property ‘DdosCustomPolicy’:
+	// Set property "DdosCustomPolicy":
 	if settings.DdosCustomPolicy != nil {
 		ddosCustomPolicy_ARM, err := (*settings.DdosCustomPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -1760,13 +1760,13 @@ func (settings *DdosSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.DdosCustomPolicy = &ddosCustomPolicy
 	}
 
-	// Set property ‘ProtectedIP’:
+	// Set property "ProtectedIP":
 	if settings.ProtectedIP != nil {
 		protectedIP := *settings.ProtectedIP
 		result.ProtectedIP = &protectedIP
 	}
 
-	// Set property ‘ProtectionCoverage’:
+	// Set property "ProtectionCoverage":
 	if settings.ProtectionCoverage != nil {
 		protectionCoverage := *settings.ProtectionCoverage
 		result.ProtectionCoverage = &protectionCoverage
@@ -1786,7 +1786,7 @@ func (settings *DdosSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DdosSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DdosCustomPolicy’:
+	// Set property "DdosCustomPolicy":
 	if typedInput.DdosCustomPolicy != nil {
 		var ddosCustomPolicy1 SubResource
 		err := ddosCustomPolicy1.PopulateFromARM(owner, *typedInput.DdosCustomPolicy)
@@ -1797,13 +1797,13 @@ func (settings *DdosSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		settings.DdosCustomPolicy = &ddosCustomPolicy
 	}
 
-	// Set property ‘ProtectedIP’:
+	// Set property "ProtectedIP":
 	if typedInput.ProtectedIP != nil {
 		protectedIP := *typedInput.ProtectedIP
 		settings.ProtectedIP = &protectedIP
 	}
 
-	// Set property ‘ProtectionCoverage’:
+	// Set property "ProtectionCoverage":
 	if typedInput.ProtectionCoverage != nil {
 		protectionCoverage := *typedInput.ProtectionCoverage
 		settings.ProtectionCoverage = &protectionCoverage
@@ -1913,7 +1913,7 @@ func (settings *DdosSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DdosSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DdosCustomPolicy’:
+	// Set property "DdosCustomPolicy":
 	if typedInput.DdosCustomPolicy != nil {
 		var ddosCustomPolicy1 SubResource_STATUS
 		err := ddosCustomPolicy1.PopulateFromARM(owner, *typedInput.DdosCustomPolicy)
@@ -1924,13 +1924,13 @@ func (settings *DdosSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		settings.DdosCustomPolicy = &ddosCustomPolicy
 	}
 
-	// Set property ‘ProtectedIP’:
+	// Set property "ProtectedIP":
 	if typedInput.ProtectedIP != nil {
 		protectedIP := *typedInput.ProtectedIP
 		settings.ProtectedIP = &protectedIP
 	}
 
-	// Set property ‘ProtectionCoverage’:
+	// Set property "ProtectionCoverage":
 	if typedInput.ProtectionCoverage != nil {
 		protectionCoverage := *typedInput.ProtectionCoverage
 		settings.ProtectionCoverage = &protectionCoverage
@@ -2055,7 +2055,7 @@ func (embedded *IPConfiguration_STATUS_PublicIPAddress_SubResourceEmbedded) Popu
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPConfiguration_STATUS_PublicIPAddress_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2109,13 +2109,13 @@ func (ipTag *IpTag) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &IpTag_ARM{}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if ipTag.IpTagType != nil {
 		ipTagType := *ipTag.IpTagType
 		result.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if ipTag.Tag != nil {
 		tag := *ipTag.Tag
 		result.Tag = &tag
@@ -2135,13 +2135,13 @@ func (ipTag *IpTag) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpTag_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -2206,13 +2206,13 @@ func (ipTag *IpTag_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpTag_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpTagType’:
+	// Set property "IpTagType":
 	if typedInput.IpTagType != nil {
 		ipTagType := *typedInput.IpTagType
 		ipTag.IpTagType = &ipTagType
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		ipTag.Tag = &tag
@@ -2293,7 +2293,7 @@ func (embedded *NatGateway_STATUS_PublicIPAddress_SubResourceEmbedded) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NatGateway_STATUS_PublicIPAddress_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2346,7 +2346,7 @@ func (embedded *NatGatewaySpec_PublicIPAddress_SubResourceEmbedded) ConvertToARM
 	}
 	result := &NatGatewaySpec_PublicIPAddress_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -2370,7 +2370,7 @@ func (embedded *NatGatewaySpec_PublicIPAddress_SubResourceEmbedded) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NatGatewaySpec_PublicIPAddress_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2431,19 +2431,19 @@ func (settings *PublicIPAddressDnsSettings) ConvertToARM(resolved genruntime.Con
 	}
 	result := &PublicIPAddressDnsSettings_ARM{}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if settings.DomainNameLabel != nil {
 		domainNameLabel := *settings.DomainNameLabel
 		result.DomainNameLabel = &domainNameLabel
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	if settings.Fqdn != nil {
 		fqdn := *settings.Fqdn
 		result.Fqdn = &fqdn
 	}
 
-	// Set property ‘ReverseFqdn’:
+	// Set property "ReverseFqdn":
 	if settings.ReverseFqdn != nil {
 		reverseFqdn := *settings.ReverseFqdn
 		result.ReverseFqdn = &reverseFqdn
@@ -2463,19 +2463,19 @@ func (settings *PublicIPAddressDnsSettings) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressDnsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		settings.DomainNameLabel = &domainNameLabel
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	if typedInput.Fqdn != nil {
 		fqdn := *typedInput.Fqdn
 		settings.Fqdn = &fqdn
 	}
 
-	// Set property ‘ReverseFqdn’:
+	// Set property "ReverseFqdn":
 	if typedInput.ReverseFqdn != nil {
 		reverseFqdn := *typedInput.ReverseFqdn
 		settings.ReverseFqdn = &reverseFqdn
@@ -2547,19 +2547,19 @@ func (settings *PublicIPAddressDnsSettings_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressDnsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DomainNameLabel’:
+	// Set property "DomainNameLabel":
 	if typedInput.DomainNameLabel != nil {
 		domainNameLabel := *typedInput.DomainNameLabel
 		settings.DomainNameLabel = &domainNameLabel
 	}
 
-	// Set property ‘Fqdn’:
+	// Set property "Fqdn":
 	if typedInput.Fqdn != nil {
 		fqdn := *typedInput.Fqdn
 		settings.Fqdn = &fqdn
 	}
 
-	// Set property ‘ReverseFqdn’:
+	// Set property "ReverseFqdn":
 	if typedInput.ReverseFqdn != nil {
 		reverseFqdn := *typedInput.ReverseFqdn
 		settings.ReverseFqdn = &reverseFqdn
@@ -2637,13 +2637,13 @@ func (addressSku *PublicIPAddressSku) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &PublicIPAddressSku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if addressSku.Name != nil {
 		name := *addressSku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if addressSku.Tier != nil {
 		tier := *addressSku.Tier
 		result.Tier = &tier
@@ -2663,13 +2663,13 @@ func (addressSku *PublicIPAddressSku) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		addressSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		addressSku.Tier = &tier
@@ -2754,13 +2754,13 @@ func (addressSku *PublicIPAddressSku_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		addressSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		addressSku.Tier = &tier
@@ -2839,7 +2839,7 @@ func (embedded *PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded) Convert
 	}
 	result := &PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -2863,7 +2863,7 @@ func (embedded *PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PublicIPAddressSpec_PublicIPAddress_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2922,7 +2922,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SubResource_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if resource.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*resource.Reference)
 		if err != nil {
@@ -2946,7 +2946,7 @@ func (resource *SubResource) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubResource_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil

--- a/v2/api/network/v1beta20201101/route_table_types_gen.go
+++ b/v2/api/network/v1beta20201101/route_table_types_gen.go
@@ -333,16 +333,16 @@ func (table *RouteTable_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &RouteTable_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if table.Location != nil {
 		location := *table.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if table.DisableBgpRoutePropagation != nil {
 		result.Properties = &RouteTablePropertiesFormat_ARM{}
 	}
@@ -351,7 +351,7 @@ func (table *RouteTable_Spec) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Properties.DisableBgpRoutePropagation = &disableBgpRoutePropagation
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if table.Tags != nil {
 		result.Tags = make(map[string]string, len(table.Tags))
 		for key, value := range table.Tags {
@@ -373,10 +373,10 @@ func (table *RouteTable_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteTable_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	table.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DisableBgpRoutePropagation’:
+	// Set property "DisableBgpRoutePropagation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableBgpRoutePropagation != nil {
@@ -385,16 +385,16 @@ func (table *RouteTable_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		table.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	table.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		table.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -619,9 +619,9 @@ func (table *RouteTable_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteTable_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DisableBgpRoutePropagation’:
+	// Set property "DisableBgpRoutePropagation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableBgpRoutePropagation != nil {
@@ -630,31 +630,31 @@ func (table *RouteTable_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		table.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		table.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		table.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		table.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -663,7 +663,7 @@ func (table *RouteTable_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -672,7 +672,7 @@ func (table *RouteTable_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		table.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -680,7 +680,7 @@ func (table *RouteTable_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		table.Type = &typeVar

--- a/v2/api/network/v1beta20201101/route_tables_route_types_gen.go
+++ b/v2/api/network/v1beta20201101/route_tables_route_types_gen.go
@@ -337,10 +337,10 @@ func (route *RouteTables_Route_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &RouteTables_Route_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if route.AddressPrefix != nil ||
 		route.HasBgpOverride != nil ||
 		route.NextHopIpAddress != nil ||
@@ -378,7 +378,7 @@ func (route *RouteTables_Route_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteTables_Route_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressPrefix’:
+	// Set property "AddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddressPrefix != nil {
@@ -387,10 +387,10 @@ func (route *RouteTables_Route_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	route.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘HasBgpOverride’:
+	// Set property "HasBgpOverride":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HasBgpOverride != nil {
@@ -399,7 +399,7 @@ func (route *RouteTables_Route_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NextHopIpAddress’:
+	// Set property "NextHopIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NextHopIpAddress != nil {
@@ -408,7 +408,7 @@ func (route *RouteTables_Route_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NextHopType’:
+	// Set property "NextHopType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NextHopType != nil {
@@ -417,7 +417,7 @@ func (route *RouteTables_Route_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	route.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -654,7 +654,7 @@ func (route *RouteTables_Route_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteTables_Route_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressPrefix’:
+	// Set property "AddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddressPrefix != nil {
@@ -663,15 +663,15 @@ func (route *RouteTables_Route_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		route.Etag = &etag
 	}
 
-	// Set property ‘HasBgpOverride’:
+	// Set property "HasBgpOverride":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HasBgpOverride != nil {
@@ -680,19 +680,19 @@ func (route *RouteTables_Route_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		route.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		route.Name = &name
 	}
 
-	// Set property ‘NextHopIpAddress’:
+	// Set property "NextHopIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NextHopIpAddress != nil {
@@ -701,7 +701,7 @@ func (route *RouteTables_Route_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘NextHopType’:
+	// Set property "NextHopType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NextHopType != nil {
@@ -710,7 +710,7 @@ func (route *RouteTables_Route_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -719,7 +719,7 @@ func (route *RouteTables_Route_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		route.Type = &typeVar

--- a/v2/api/network/v1beta20201101/virtual_network_gateway_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_network_gateway_types_gen.go
@@ -348,7 +348,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &VirtualNetworkGateway_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if gateway.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*gateway.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -358,16 +358,16 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if gateway.Location != nil {
 		location := *gateway.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if gateway.ActiveActive != nil ||
 		gateway.BgpSettings != nil ||
 		gateway.CustomRoutes != nil ||
@@ -468,7 +468,7 @@ func (gateway *VirtualNetworkGateway_Spec) ConvertToARM(resolved genruntime.Conv
 		result.Properties.VpnType = &vpnType
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if gateway.Tags != nil {
 		result.Tags = make(map[string]string, len(gateway.Tags))
 		for key, value := range gateway.Tags {
@@ -490,7 +490,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkGateway_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActiveActive’:
+	// Set property "ActiveActive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ActiveActive != nil {
@@ -499,10 +499,10 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	gateway.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BgpSettings’:
+	// Set property "BgpSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BgpSettings != nil {
@@ -516,7 +516,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘CustomRoutes’:
+	// Set property "CustomRoutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomRoutes != nil {
@@ -530,7 +530,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘EnableBgp’:
+	// Set property "EnableBgp":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBgp != nil {
@@ -539,7 +539,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘EnableDnsForwarding’:
+	// Set property "EnableDnsForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableDnsForwarding != nil {
@@ -548,7 +548,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘EnablePrivateIpAddress’:
+	// Set property "EnablePrivateIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePrivateIpAddress != nil {
@@ -557,7 +557,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -568,7 +568,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		gateway.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘GatewayDefaultSite’:
+	// Set property "GatewayDefaultSite":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GatewayDefaultSite != nil {
@@ -582,7 +582,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘GatewayType’:
+	// Set property "GatewayType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GatewayType != nil {
@@ -591,7 +591,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -604,16 +604,16 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		gateway.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	gateway.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -627,7 +627,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		gateway.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -635,9 +635,9 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// no assignment for property ‘VNetExtendedLocationResourceReference’
+	// no assignment for property "VNetExtendedLocationResourceReference"
 
-	// Set property ‘VpnClientConfiguration’:
+	// Set property "VpnClientConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VpnClientConfiguration != nil {
@@ -651,7 +651,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘VpnGatewayGeneration’:
+	// Set property "VpnGatewayGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VpnGatewayGeneration != nil {
@@ -660,7 +660,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘VpnType’:
+	// Set property "VpnType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VpnType != nil {
@@ -1196,7 +1196,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkGateway_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActiveActive’:
+	// Set property "ActiveActive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ActiveActive != nil {
@@ -1205,7 +1205,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘BgpSettings’:
+	// Set property "BgpSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BgpSettings != nil {
@@ -1219,9 +1219,9 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CustomRoutes’:
+	// Set property "CustomRoutes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomRoutes != nil {
@@ -1235,7 +1235,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘EnableBgp’:
+	// Set property "EnableBgp":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBgp != nil {
@@ -1244,7 +1244,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘EnableDnsForwarding’:
+	// Set property "EnableDnsForwarding":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableDnsForwarding != nil {
@@ -1253,7 +1253,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘EnablePrivateIpAddress’:
+	// Set property "EnablePrivateIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePrivateIpAddress != nil {
@@ -1262,13 +1262,13 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		gateway.Etag = &etag
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1279,7 +1279,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		gateway.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘GatewayDefaultSite’:
+	// Set property "GatewayDefaultSite":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GatewayDefaultSite != nil {
@@ -1293,7 +1293,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘GatewayType’:
+	// Set property "GatewayType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GatewayType != nil {
@@ -1302,13 +1302,13 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		gateway.Id = &id
 	}
 
-	// Set property ‘InboundDnsForwardingEndpoint’:
+	// Set property "InboundDnsForwardingEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InboundDnsForwardingEndpoint != nil {
@@ -1317,7 +1317,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -1330,19 +1330,19 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		gateway.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		gateway.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1351,7 +1351,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -1360,7 +1360,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -1374,7 +1374,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		gateway.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1382,13 +1382,13 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		gateway.Type = &typeVar
 	}
 
-	// Set property ‘VNetExtendedLocationResourceId’:
+	// Set property "VNetExtendedLocationResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VNetExtendedLocationResourceId != nil {
@@ -1397,7 +1397,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘VpnClientConfiguration’:
+	// Set property "VpnClientConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VpnClientConfiguration != nil {
@@ -1411,7 +1411,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘VpnGatewayGeneration’:
+	// Set property "VpnGatewayGeneration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VpnGatewayGeneration != nil {
@@ -1420,7 +1420,7 @@ func (gateway *VirtualNetworkGateway_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘VpnType’:
+	// Set property "VpnType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VpnType != nil {
@@ -1841,19 +1841,19 @@ func (settings *BgpSettings) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &BgpSettings_ARM{}
 
-	// Set property ‘Asn’:
+	// Set property "Asn":
 	if settings.Asn != nil {
 		asn := *settings.Asn
 		result.Asn = &asn
 	}
 
-	// Set property ‘BgpPeeringAddress’:
+	// Set property "BgpPeeringAddress":
 	if settings.BgpPeeringAddress != nil {
 		bgpPeeringAddress := *settings.BgpPeeringAddress
 		result.BgpPeeringAddress = &bgpPeeringAddress
 	}
 
-	// Set property ‘BgpPeeringAddresses’:
+	// Set property "BgpPeeringAddresses":
 	for _, item := range settings.BgpPeeringAddresses {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1862,7 +1862,7 @@ func (settings *BgpSettings) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.BgpPeeringAddresses = append(result.BgpPeeringAddresses, *item_ARM.(*IPConfigurationBgpPeeringAddress_ARM))
 	}
 
-	// Set property ‘PeerWeight’:
+	// Set property "PeerWeight":
 	if settings.PeerWeight != nil {
 		peerWeight := *settings.PeerWeight
 		result.PeerWeight = &peerWeight
@@ -1882,19 +1882,19 @@ func (settings *BgpSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BgpSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Asn’:
+	// Set property "Asn":
 	if typedInput.Asn != nil {
 		asn := *typedInput.Asn
 		settings.Asn = &asn
 	}
 
-	// Set property ‘BgpPeeringAddress’:
+	// Set property "BgpPeeringAddress":
 	if typedInput.BgpPeeringAddress != nil {
 		bgpPeeringAddress := *typedInput.BgpPeeringAddress
 		settings.BgpPeeringAddress = &bgpPeeringAddress
 	}
 
-	// Set property ‘BgpPeeringAddresses’:
+	// Set property "BgpPeeringAddresses":
 	for _, item := range typedInput.BgpPeeringAddresses {
 		var item1 IPConfigurationBgpPeeringAddress
 		err := item1.PopulateFromARM(owner, item)
@@ -1904,7 +1904,7 @@ func (settings *BgpSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		settings.BgpPeeringAddresses = append(settings.BgpPeeringAddresses, item1)
 	}
 
-	// Set property ‘PeerWeight’:
+	// Set property "PeerWeight":
 	if typedInput.PeerWeight != nil {
 		peerWeight := *typedInput.PeerWeight
 		settings.PeerWeight = &peerWeight
@@ -2023,19 +2023,19 @@ func (settings *BgpSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BgpSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Asn’:
+	// Set property "Asn":
 	if typedInput.Asn != nil {
 		asn := *typedInput.Asn
 		settings.Asn = &asn
 	}
 
-	// Set property ‘BgpPeeringAddress’:
+	// Set property "BgpPeeringAddress":
 	if typedInput.BgpPeeringAddress != nil {
 		bgpPeeringAddress := *typedInput.BgpPeeringAddress
 		settings.BgpPeeringAddress = &bgpPeeringAddress
 	}
 
-	// Set property ‘BgpPeeringAddresses’:
+	// Set property "BgpPeeringAddresses":
 	for _, item := range typedInput.BgpPeeringAddresses {
 		var item1 IPConfigurationBgpPeeringAddress_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2045,7 +2045,7 @@ func (settings *BgpSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		settings.BgpPeeringAddresses = append(settings.BgpPeeringAddresses, item1)
 	}
 
-	// Set property ‘PeerWeight’:
+	// Set property "PeerWeight":
 	if typedInput.PeerWeight != nil {
 		peerWeight := *typedInput.PeerWeight
 		settings.PeerWeight = &peerWeight
@@ -2159,13 +2159,13 @@ func (configuration *VirtualNetworkGatewayIPConfiguration) ConvertToARM(resolved
 	}
 	result := &VirtualNetworkGatewayIPConfiguration_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if configuration.Name != nil {
 		name := *configuration.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if configuration.PrivateIPAllocationMethod != nil ||
 		configuration.PublicIPAddress != nil ||
 		configuration.Subnet != nil {
@@ -2206,13 +2206,13 @@ func (configuration *VirtualNetworkGatewayIPConfiguration) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkGatewayIPConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -2221,7 +2221,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘PublicIPAddress’:
+	// Set property "PublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddress != nil {
@@ -2235,7 +2235,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -2372,25 +2372,25 @@ func (configuration *VirtualNetworkGatewayIPConfiguration_STATUS) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkGatewayIPConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		configuration.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		configuration.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		configuration.Name = &name
 	}
 
-	// Set property ‘PrivateIPAddress’:
+	// Set property "PrivateIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAddress != nil {
@@ -2399,7 +2399,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration_STATUS) PopulateFromAR
 		}
 	}
 
-	// Set property ‘PrivateIPAllocationMethod’:
+	// Set property "PrivateIPAllocationMethod":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateIPAllocationMethod != nil {
@@ -2408,7 +2408,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration_STATUS) PopulateFromAR
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2417,7 +2417,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration_STATUS) PopulateFromAR
 		}
 	}
 
-	// Set property ‘PublicIPAddress’:
+	// Set property "PublicIPAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicIPAddress != nil {
@@ -2431,7 +2431,7 @@ func (configuration *VirtualNetworkGatewayIPConfiguration_STATUS) PopulateFromAR
 		}
 	}
 
-	// Set property ‘Subnet’:
+	// Set property "Subnet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subnet != nil {
@@ -2652,13 +2652,13 @@ func (gatewaySku *VirtualNetworkGatewaySku) ConvertToARM(resolved genruntime.Con
 	}
 	result := &VirtualNetworkGatewaySku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if gatewaySku.Name != nil {
 		name := *gatewaySku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if gatewaySku.Tier != nil {
 		tier := *gatewaySku.Tier
 		result.Tier = &tier
@@ -2678,13 +2678,13 @@ func (gatewaySku *VirtualNetworkGatewaySku) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkGatewaySku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		gatewaySku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		gatewaySku.Tier = &tier
@@ -2770,19 +2770,19 @@ func (gatewaySku *VirtualNetworkGatewaySku_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkGatewaySku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		gatewaySku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		gatewaySku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		gatewaySku.Tier = &tier
@@ -2878,37 +2878,37 @@ func (configuration *VpnClientConfiguration) ConvertToARM(resolved genruntime.Co
 	}
 	result := &VpnClientConfiguration_ARM{}
 
-	// Set property ‘AadAudience’:
+	// Set property "AadAudience":
 	if configuration.AadAudience != nil {
 		aadAudience := *configuration.AadAudience
 		result.AadAudience = &aadAudience
 	}
 
-	// Set property ‘AadIssuer’:
+	// Set property "AadIssuer":
 	if configuration.AadIssuer != nil {
 		aadIssuer := *configuration.AadIssuer
 		result.AadIssuer = &aadIssuer
 	}
 
-	// Set property ‘AadTenant’:
+	// Set property "AadTenant":
 	if configuration.AadTenant != nil {
 		aadTenant := *configuration.AadTenant
 		result.AadTenant = &aadTenant
 	}
 
-	// Set property ‘RadiusServerAddress’:
+	// Set property "RadiusServerAddress":
 	if configuration.RadiusServerAddress != nil {
 		radiusServerAddress := *configuration.RadiusServerAddress
 		result.RadiusServerAddress = &radiusServerAddress
 	}
 
-	// Set property ‘RadiusServerSecret’:
+	// Set property "RadiusServerSecret":
 	if configuration.RadiusServerSecret != nil {
 		radiusServerSecret := *configuration.RadiusServerSecret
 		result.RadiusServerSecret = &radiusServerSecret
 	}
 
-	// Set property ‘RadiusServers’:
+	// Set property "RadiusServers":
 	for _, item := range configuration.RadiusServers {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2917,12 +2917,12 @@ func (configuration *VpnClientConfiguration) ConvertToARM(resolved genruntime.Co
 		result.RadiusServers = append(result.RadiusServers, *item_ARM.(*RadiusServer_ARM))
 	}
 
-	// Set property ‘VpnAuthenticationTypes’:
+	// Set property "VpnAuthenticationTypes":
 	for _, item := range configuration.VpnAuthenticationTypes {
 		result.VpnAuthenticationTypes = append(result.VpnAuthenticationTypes, item)
 	}
 
-	// Set property ‘VpnClientAddressPool’:
+	// Set property "VpnClientAddressPool":
 	if configuration.VpnClientAddressPool != nil {
 		vpnClientAddressPool_ARM, err := (*configuration.VpnClientAddressPool).ConvertToARM(resolved)
 		if err != nil {
@@ -2932,7 +2932,7 @@ func (configuration *VpnClientConfiguration) ConvertToARM(resolved genruntime.Co
 		result.VpnClientAddressPool = &vpnClientAddressPool
 	}
 
-	// Set property ‘VpnClientIpsecPolicies’:
+	// Set property "VpnClientIpsecPolicies":
 	for _, item := range configuration.VpnClientIpsecPolicies {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2941,12 +2941,12 @@ func (configuration *VpnClientConfiguration) ConvertToARM(resolved genruntime.Co
 		result.VpnClientIpsecPolicies = append(result.VpnClientIpsecPolicies, *item_ARM.(*IpsecPolicy_ARM))
 	}
 
-	// Set property ‘VpnClientProtocols’:
+	// Set property "VpnClientProtocols":
 	for _, item := range configuration.VpnClientProtocols {
 		result.VpnClientProtocols = append(result.VpnClientProtocols, item)
 	}
 
-	// Set property ‘VpnClientRevokedCertificates’:
+	// Set property "VpnClientRevokedCertificates":
 	for _, item := range configuration.VpnClientRevokedCertificates {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2955,7 +2955,7 @@ func (configuration *VpnClientConfiguration) ConvertToARM(resolved genruntime.Co
 		result.VpnClientRevokedCertificates = append(result.VpnClientRevokedCertificates, *item_ARM.(*VpnClientRevokedCertificate_ARM))
 	}
 
-	// Set property ‘VpnClientRootCertificates’:
+	// Set property "VpnClientRootCertificates":
 	for _, item := range configuration.VpnClientRootCertificates {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2978,37 +2978,37 @@ func (configuration *VpnClientConfiguration) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VpnClientConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadAudience’:
+	// Set property "AadAudience":
 	if typedInput.AadAudience != nil {
 		aadAudience := *typedInput.AadAudience
 		configuration.AadAudience = &aadAudience
 	}
 
-	// Set property ‘AadIssuer’:
+	// Set property "AadIssuer":
 	if typedInput.AadIssuer != nil {
 		aadIssuer := *typedInput.AadIssuer
 		configuration.AadIssuer = &aadIssuer
 	}
 
-	// Set property ‘AadTenant’:
+	// Set property "AadTenant":
 	if typedInput.AadTenant != nil {
 		aadTenant := *typedInput.AadTenant
 		configuration.AadTenant = &aadTenant
 	}
 
-	// Set property ‘RadiusServerAddress’:
+	// Set property "RadiusServerAddress":
 	if typedInput.RadiusServerAddress != nil {
 		radiusServerAddress := *typedInput.RadiusServerAddress
 		configuration.RadiusServerAddress = &radiusServerAddress
 	}
 
-	// Set property ‘RadiusServerSecret’:
+	// Set property "RadiusServerSecret":
 	if typedInput.RadiusServerSecret != nil {
 		radiusServerSecret := *typedInput.RadiusServerSecret
 		configuration.RadiusServerSecret = &radiusServerSecret
 	}
 
-	// Set property ‘RadiusServers’:
+	// Set property "RadiusServers":
 	for _, item := range typedInput.RadiusServers {
 		var item1 RadiusServer
 		err := item1.PopulateFromARM(owner, item)
@@ -3018,12 +3018,12 @@ func (configuration *VpnClientConfiguration) PopulateFromARM(owner genruntime.Ar
 		configuration.RadiusServers = append(configuration.RadiusServers, item1)
 	}
 
-	// Set property ‘VpnAuthenticationTypes’:
+	// Set property "VpnAuthenticationTypes":
 	for _, item := range typedInput.VpnAuthenticationTypes {
 		configuration.VpnAuthenticationTypes = append(configuration.VpnAuthenticationTypes, item)
 	}
 
-	// Set property ‘VpnClientAddressPool’:
+	// Set property "VpnClientAddressPool":
 	if typedInput.VpnClientAddressPool != nil {
 		var vpnClientAddressPool1 AddressSpace
 		err := vpnClientAddressPool1.PopulateFromARM(owner, *typedInput.VpnClientAddressPool)
@@ -3034,7 +3034,7 @@ func (configuration *VpnClientConfiguration) PopulateFromARM(owner genruntime.Ar
 		configuration.VpnClientAddressPool = &vpnClientAddressPool
 	}
 
-	// Set property ‘VpnClientIpsecPolicies’:
+	// Set property "VpnClientIpsecPolicies":
 	for _, item := range typedInput.VpnClientIpsecPolicies {
 		var item1 IpsecPolicy
 		err := item1.PopulateFromARM(owner, item)
@@ -3044,12 +3044,12 @@ func (configuration *VpnClientConfiguration) PopulateFromARM(owner genruntime.Ar
 		configuration.VpnClientIpsecPolicies = append(configuration.VpnClientIpsecPolicies, item1)
 	}
 
-	// Set property ‘VpnClientProtocols’:
+	// Set property "VpnClientProtocols":
 	for _, item := range typedInput.VpnClientProtocols {
 		configuration.VpnClientProtocols = append(configuration.VpnClientProtocols, item)
 	}
 
-	// Set property ‘VpnClientRevokedCertificates’:
+	// Set property "VpnClientRevokedCertificates":
 	for _, item := range typedInput.VpnClientRevokedCertificates {
 		var item1 VpnClientRevokedCertificate
 		err := item1.PopulateFromARM(owner, item)
@@ -3059,7 +3059,7 @@ func (configuration *VpnClientConfiguration) PopulateFromARM(owner genruntime.Ar
 		configuration.VpnClientRevokedCertificates = append(configuration.VpnClientRevokedCertificates, item1)
 	}
 
-	// Set property ‘VpnClientRootCertificates’:
+	// Set property "VpnClientRootCertificates":
 	for _, item := range typedInput.VpnClientRootCertificates {
 		var item1 VpnClientRootCertificate
 		err := item1.PopulateFromARM(owner, item)
@@ -3376,37 +3376,37 @@ func (configuration *VpnClientConfiguration_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VpnClientConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadAudience’:
+	// Set property "AadAudience":
 	if typedInput.AadAudience != nil {
 		aadAudience := *typedInput.AadAudience
 		configuration.AadAudience = &aadAudience
 	}
 
-	// Set property ‘AadIssuer’:
+	// Set property "AadIssuer":
 	if typedInput.AadIssuer != nil {
 		aadIssuer := *typedInput.AadIssuer
 		configuration.AadIssuer = &aadIssuer
 	}
 
-	// Set property ‘AadTenant’:
+	// Set property "AadTenant":
 	if typedInput.AadTenant != nil {
 		aadTenant := *typedInput.AadTenant
 		configuration.AadTenant = &aadTenant
 	}
 
-	// Set property ‘RadiusServerAddress’:
+	// Set property "RadiusServerAddress":
 	if typedInput.RadiusServerAddress != nil {
 		radiusServerAddress := *typedInput.RadiusServerAddress
 		configuration.RadiusServerAddress = &radiusServerAddress
 	}
 
-	// Set property ‘RadiusServerSecret’:
+	// Set property "RadiusServerSecret":
 	if typedInput.RadiusServerSecret != nil {
 		radiusServerSecret := *typedInput.RadiusServerSecret
 		configuration.RadiusServerSecret = &radiusServerSecret
 	}
 
-	// Set property ‘RadiusServers’:
+	// Set property "RadiusServers":
 	for _, item := range typedInput.RadiusServers {
 		var item1 RadiusServer_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3416,12 +3416,12 @@ func (configuration *VpnClientConfiguration_STATUS) PopulateFromARM(owner genrun
 		configuration.RadiusServers = append(configuration.RadiusServers, item1)
 	}
 
-	// Set property ‘VpnAuthenticationTypes’:
+	// Set property "VpnAuthenticationTypes":
 	for _, item := range typedInput.VpnAuthenticationTypes {
 		configuration.VpnAuthenticationTypes = append(configuration.VpnAuthenticationTypes, item)
 	}
 
-	// Set property ‘VpnClientAddressPool’:
+	// Set property "VpnClientAddressPool":
 	if typedInput.VpnClientAddressPool != nil {
 		var vpnClientAddressPool1 AddressSpace_STATUS
 		err := vpnClientAddressPool1.PopulateFromARM(owner, *typedInput.VpnClientAddressPool)
@@ -3432,7 +3432,7 @@ func (configuration *VpnClientConfiguration_STATUS) PopulateFromARM(owner genrun
 		configuration.VpnClientAddressPool = &vpnClientAddressPool
 	}
 
-	// Set property ‘VpnClientIpsecPolicies’:
+	// Set property "VpnClientIpsecPolicies":
 	for _, item := range typedInput.VpnClientIpsecPolicies {
 		var item1 IpsecPolicy_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3442,12 +3442,12 @@ func (configuration *VpnClientConfiguration_STATUS) PopulateFromARM(owner genrun
 		configuration.VpnClientIpsecPolicies = append(configuration.VpnClientIpsecPolicies, item1)
 	}
 
-	// Set property ‘VpnClientProtocols’:
+	// Set property "VpnClientProtocols":
 	for _, item := range typedInput.VpnClientProtocols {
 		configuration.VpnClientProtocols = append(configuration.VpnClientProtocols, item)
 	}
 
-	// Set property ‘VpnClientRevokedCertificates’:
+	// Set property "VpnClientRevokedCertificates":
 	for _, item := range typedInput.VpnClientRevokedCertificates {
 		var item1 VpnClientRevokedCertificate_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3457,7 +3457,7 @@ func (configuration *VpnClientConfiguration_STATUS) PopulateFromARM(owner genrun
 		configuration.VpnClientRevokedCertificates = append(configuration.VpnClientRevokedCertificates, item1)
 	}
 
-	// Set property ‘VpnClientRootCertificates’:
+	// Set property "VpnClientRootCertificates":
 	for _, item := range typedInput.VpnClientRootCertificates {
 		var item1 VpnClientRootCertificate_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3759,12 +3759,12 @@ func (address *IPConfigurationBgpPeeringAddress) ConvertToARM(resolved genruntim
 	}
 	result := &IPConfigurationBgpPeeringAddress_ARM{}
 
-	// Set property ‘CustomBgpIpAddresses’:
+	// Set property "CustomBgpIpAddresses":
 	for _, item := range address.CustomBgpIpAddresses {
 		result.CustomBgpIpAddresses = append(result.CustomBgpIpAddresses, item)
 	}
 
-	// Set property ‘IpconfigurationId’:
+	// Set property "IpconfigurationId":
 	if address.IpconfigurationId != nil {
 		ipconfigurationId := *address.IpconfigurationId
 		result.IpconfigurationId = &ipconfigurationId
@@ -3784,12 +3784,12 @@ func (address *IPConfigurationBgpPeeringAddress) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPConfigurationBgpPeeringAddress_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomBgpIpAddresses’:
+	// Set property "CustomBgpIpAddresses":
 	for _, item := range typedInput.CustomBgpIpAddresses {
 		address.CustomBgpIpAddresses = append(address.CustomBgpIpAddresses, item)
 	}
 
-	// Set property ‘IpconfigurationId’:
+	// Set property "IpconfigurationId":
 	if typedInput.IpconfigurationId != nil {
 		ipconfigurationId := *typedInput.IpconfigurationId
 		address.IpconfigurationId = &ipconfigurationId
@@ -3856,23 +3856,23 @@ func (address *IPConfigurationBgpPeeringAddress_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPConfigurationBgpPeeringAddress_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CustomBgpIpAddresses’:
+	// Set property "CustomBgpIpAddresses":
 	for _, item := range typedInput.CustomBgpIpAddresses {
 		address.CustomBgpIpAddresses = append(address.CustomBgpIpAddresses, item)
 	}
 
-	// Set property ‘DefaultBgpIpAddresses’:
+	// Set property "DefaultBgpIpAddresses":
 	for _, item := range typedInput.DefaultBgpIpAddresses {
 		address.DefaultBgpIpAddresses = append(address.DefaultBgpIpAddresses, item)
 	}
 
-	// Set property ‘IpconfigurationId’:
+	// Set property "IpconfigurationId":
 	if typedInput.IpconfigurationId != nil {
 		ipconfigurationId := *typedInput.IpconfigurationId
 		address.IpconfigurationId = &ipconfigurationId
 	}
 
-	// Set property ‘TunnelIpAddresses’:
+	// Set property "TunnelIpAddresses":
 	for _, item := range typedInput.TunnelIpAddresses {
 		address.TunnelIpAddresses = append(address.TunnelIpAddresses, item)
 	}
@@ -3964,49 +3964,49 @@ func (policy *IpsecPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &IpsecPolicy_ARM{}
 
-	// Set property ‘DhGroup’:
+	// Set property "DhGroup":
 	if policy.DhGroup != nil {
 		dhGroup := *policy.DhGroup
 		result.DhGroup = &dhGroup
 	}
 
-	// Set property ‘IkeEncryption’:
+	// Set property "IkeEncryption":
 	if policy.IkeEncryption != nil {
 		ikeEncryption := *policy.IkeEncryption
 		result.IkeEncryption = &ikeEncryption
 	}
 
-	// Set property ‘IkeIntegrity’:
+	// Set property "IkeIntegrity":
 	if policy.IkeIntegrity != nil {
 		ikeIntegrity := *policy.IkeIntegrity
 		result.IkeIntegrity = &ikeIntegrity
 	}
 
-	// Set property ‘IpsecEncryption’:
+	// Set property "IpsecEncryption":
 	if policy.IpsecEncryption != nil {
 		ipsecEncryption := *policy.IpsecEncryption
 		result.IpsecEncryption = &ipsecEncryption
 	}
 
-	// Set property ‘IpsecIntegrity’:
+	// Set property "IpsecIntegrity":
 	if policy.IpsecIntegrity != nil {
 		ipsecIntegrity := *policy.IpsecIntegrity
 		result.IpsecIntegrity = &ipsecIntegrity
 	}
 
-	// Set property ‘PfsGroup’:
+	// Set property "PfsGroup":
 	if policy.PfsGroup != nil {
 		pfsGroup := *policy.PfsGroup
 		result.PfsGroup = &pfsGroup
 	}
 
-	// Set property ‘SaDataSizeKilobytes’:
+	// Set property "SaDataSizeKilobytes":
 	if policy.SaDataSizeKilobytes != nil {
 		saDataSizeKilobytes := *policy.SaDataSizeKilobytes
 		result.SaDataSizeKilobytes = &saDataSizeKilobytes
 	}
 
-	// Set property ‘SaLifeTimeSeconds’:
+	// Set property "SaLifeTimeSeconds":
 	if policy.SaLifeTimeSeconds != nil {
 		saLifeTimeSeconds := *policy.SaLifeTimeSeconds
 		result.SaLifeTimeSeconds = &saLifeTimeSeconds
@@ -4026,49 +4026,49 @@ func (policy *IpsecPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpsecPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DhGroup’:
+	// Set property "DhGroup":
 	if typedInput.DhGroup != nil {
 		dhGroup := *typedInput.DhGroup
 		policy.DhGroup = &dhGroup
 	}
 
-	// Set property ‘IkeEncryption’:
+	// Set property "IkeEncryption":
 	if typedInput.IkeEncryption != nil {
 		ikeEncryption := *typedInput.IkeEncryption
 		policy.IkeEncryption = &ikeEncryption
 	}
 
-	// Set property ‘IkeIntegrity’:
+	// Set property "IkeIntegrity":
 	if typedInput.IkeIntegrity != nil {
 		ikeIntegrity := *typedInput.IkeIntegrity
 		policy.IkeIntegrity = &ikeIntegrity
 	}
 
-	// Set property ‘IpsecEncryption’:
+	// Set property "IpsecEncryption":
 	if typedInput.IpsecEncryption != nil {
 		ipsecEncryption := *typedInput.IpsecEncryption
 		policy.IpsecEncryption = &ipsecEncryption
 	}
 
-	// Set property ‘IpsecIntegrity’:
+	// Set property "IpsecIntegrity":
 	if typedInput.IpsecIntegrity != nil {
 		ipsecIntegrity := *typedInput.IpsecIntegrity
 		policy.IpsecIntegrity = &ipsecIntegrity
 	}
 
-	// Set property ‘PfsGroup’:
+	// Set property "PfsGroup":
 	if typedInput.PfsGroup != nil {
 		pfsGroup := *typedInput.PfsGroup
 		policy.PfsGroup = &pfsGroup
 	}
 
-	// Set property ‘SaDataSizeKilobytes’:
+	// Set property "SaDataSizeKilobytes":
 	if typedInput.SaDataSizeKilobytes != nil {
 		saDataSizeKilobytes := *typedInput.SaDataSizeKilobytes
 		policy.SaDataSizeKilobytes = &saDataSizeKilobytes
 	}
 
-	// Set property ‘SaLifeTimeSeconds’:
+	// Set property "SaLifeTimeSeconds":
 	if typedInput.SaLifeTimeSeconds != nil {
 		saLifeTimeSeconds := *typedInput.SaLifeTimeSeconds
 		policy.SaLifeTimeSeconds = &saLifeTimeSeconds
@@ -4235,49 +4235,49 @@ func (policy *IpsecPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpsecPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DhGroup’:
+	// Set property "DhGroup":
 	if typedInput.DhGroup != nil {
 		dhGroup := *typedInput.DhGroup
 		policy.DhGroup = &dhGroup
 	}
 
-	// Set property ‘IkeEncryption’:
+	// Set property "IkeEncryption":
 	if typedInput.IkeEncryption != nil {
 		ikeEncryption := *typedInput.IkeEncryption
 		policy.IkeEncryption = &ikeEncryption
 	}
 
-	// Set property ‘IkeIntegrity’:
+	// Set property "IkeIntegrity":
 	if typedInput.IkeIntegrity != nil {
 		ikeIntegrity := *typedInput.IkeIntegrity
 		policy.IkeIntegrity = &ikeIntegrity
 	}
 
-	// Set property ‘IpsecEncryption’:
+	// Set property "IpsecEncryption":
 	if typedInput.IpsecEncryption != nil {
 		ipsecEncryption := *typedInput.IpsecEncryption
 		policy.IpsecEncryption = &ipsecEncryption
 	}
 
-	// Set property ‘IpsecIntegrity’:
+	// Set property "IpsecIntegrity":
 	if typedInput.IpsecIntegrity != nil {
 		ipsecIntegrity := *typedInput.IpsecIntegrity
 		policy.IpsecIntegrity = &ipsecIntegrity
 	}
 
-	// Set property ‘PfsGroup’:
+	// Set property "PfsGroup":
 	if typedInput.PfsGroup != nil {
 		pfsGroup := *typedInput.PfsGroup
 		policy.PfsGroup = &pfsGroup
 	}
 
-	// Set property ‘SaDataSizeKilobytes’:
+	// Set property "SaDataSizeKilobytes":
 	if typedInput.SaDataSizeKilobytes != nil {
 		saDataSizeKilobytes := *typedInput.SaDataSizeKilobytes
 		policy.SaDataSizeKilobytes = &saDataSizeKilobytes
 	}
 
-	// Set property ‘SaLifeTimeSeconds’:
+	// Set property "SaLifeTimeSeconds":
 	if typedInput.SaLifeTimeSeconds != nil {
 		saLifeTimeSeconds := *typedInput.SaLifeTimeSeconds
 		policy.SaLifeTimeSeconds = &saLifeTimeSeconds
@@ -4435,19 +4435,19 @@ func (server *RadiusServer) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &RadiusServer_ARM{}
 
-	// Set property ‘RadiusServerAddress’:
+	// Set property "RadiusServerAddress":
 	if server.RadiusServerAddress != nil {
 		radiusServerAddress := *server.RadiusServerAddress
 		result.RadiusServerAddress = &radiusServerAddress
 	}
 
-	// Set property ‘RadiusServerScore’:
+	// Set property "RadiusServerScore":
 	if server.RadiusServerScore != nil {
 		radiusServerScore := *server.RadiusServerScore
 		result.RadiusServerScore = &radiusServerScore
 	}
 
-	// Set property ‘RadiusServerSecret’:
+	// Set property "RadiusServerSecret":
 	if server.RadiusServerSecret != nil {
 		radiusServerSecret := *server.RadiusServerSecret
 		result.RadiusServerSecret = &radiusServerSecret
@@ -4467,19 +4467,19 @@ func (server *RadiusServer) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RadiusServer_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RadiusServerAddress’:
+	// Set property "RadiusServerAddress":
 	if typedInput.RadiusServerAddress != nil {
 		radiusServerAddress := *typedInput.RadiusServerAddress
 		server.RadiusServerAddress = &radiusServerAddress
 	}
 
-	// Set property ‘RadiusServerScore’:
+	// Set property "RadiusServerScore":
 	if typedInput.RadiusServerScore != nil {
 		radiusServerScore := *typedInput.RadiusServerScore
 		server.RadiusServerScore = &radiusServerScore
 	}
 
-	// Set property ‘RadiusServerSecret’:
+	// Set property "RadiusServerSecret":
 	if typedInput.RadiusServerSecret != nil {
 		radiusServerSecret := *typedInput.RadiusServerSecret
 		server.RadiusServerSecret = &radiusServerSecret
@@ -4551,19 +4551,19 @@ func (server *RadiusServer_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RadiusServer_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RadiusServerAddress’:
+	// Set property "RadiusServerAddress":
 	if typedInput.RadiusServerAddress != nil {
 		radiusServerAddress := *typedInput.RadiusServerAddress
 		server.RadiusServerAddress = &radiusServerAddress
 	}
 
-	// Set property ‘RadiusServerScore’:
+	// Set property "RadiusServerScore":
 	if typedInput.RadiusServerScore != nil {
 		radiusServerScore := *typedInput.RadiusServerScore
 		server.RadiusServerScore = &radiusServerScore
 	}
 
-	// Set property ‘RadiusServerSecret’:
+	// Set property "RadiusServerSecret":
 	if typedInput.RadiusServerSecret != nil {
 		radiusServerSecret := *typedInput.RadiusServerSecret
 		server.RadiusServerSecret = &radiusServerSecret
@@ -4767,13 +4767,13 @@ func (certificate *VpnClientRevokedCertificate) ConvertToARM(resolved genruntime
 	}
 	result := &VpnClientRevokedCertificate_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if certificate.Name != nil {
 		name := *certificate.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if certificate.Thumbprint != nil {
 		result.Properties = &VpnClientRevokedCertificatePropertiesFormat_ARM{}
 	}
@@ -4796,13 +4796,13 @@ func (certificate *VpnClientRevokedCertificate) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VpnClientRevokedCertificate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		certificate.Name = &name
 	}
 
-	// Set property ‘Thumbprint’:
+	// Set property "Thumbprint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Thumbprint != nil {
@@ -4873,25 +4873,25 @@ func (certificate *VpnClientRevokedCertificate_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VpnClientRevokedCertificate_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		certificate.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		certificate.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		certificate.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -4900,7 +4900,7 @@ func (certificate *VpnClientRevokedCertificate_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Thumbprint’:
+	// Set property "Thumbprint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Thumbprint != nil {
@@ -4993,13 +4993,13 @@ func (certificate *VpnClientRootCertificate) ConvertToARM(resolved genruntime.Co
 	}
 	result := &VpnClientRootCertificate_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if certificate.Name != nil {
 		name := *certificate.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if certificate.PublicCertData != nil {
 		result.Properties = &VpnClientRootCertificatePropertiesFormat_ARM{}
 	}
@@ -5022,13 +5022,13 @@ func (certificate *VpnClientRootCertificate) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VpnClientRootCertificate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		certificate.Name = &name
 	}
 
-	// Set property ‘PublicCertData’:
+	// Set property "PublicCertData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicCertData != nil {
@@ -5099,25 +5099,25 @@ func (certificate *VpnClientRootCertificate_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VpnClientRootCertificate_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		certificate.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		certificate.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		certificate.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -5126,7 +5126,7 @@ func (certificate *VpnClientRootCertificate_STATUS) PopulateFromARM(owner genrun
 		}
 	}
 
-	// Set property ‘PublicCertData’:
+	// Set property "PublicCertData":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicCertData != nil {

--- a/v2/api/network/v1beta20201101/virtual_network_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_network_types_gen.go
@@ -341,7 +341,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &VirtualNetwork_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if network.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*network.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -351,16 +351,16 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if network.Location != nil {
 		location := *network.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if network.AddressSpace != nil ||
 		network.BgpCommunities != nil ||
 		network.DdosProtectionPlan != nil ||
@@ -418,7 +418,7 @@ func (network *VirtualNetwork_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.IpAllocations = append(result.Properties.IpAllocations, *item_ARM.(*SubResource_ARM))
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if network.Tags != nil {
 		result.Tags = make(map[string]string, len(network.Tags))
 		for key, value := range network.Tags {
@@ -440,7 +440,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetwork_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressSpace’:
+	// Set property "AddressSpace":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddressSpace != nil {
@@ -454,10 +454,10 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	network.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘BgpCommunities’:
+	// Set property "BgpCommunities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BgpCommunities != nil {
@@ -471,7 +471,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DdosProtectionPlan’:
+	// Set property "DdosProtectionPlan":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DdosProtectionPlan != nil {
@@ -485,7 +485,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DhcpOptions’:
+	// Set property "DhcpOptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DhcpOptions != nil {
@@ -499,7 +499,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableDdosProtection’:
+	// Set property "EnableDdosProtection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableDdosProtection != nil {
@@ -508,7 +508,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableVmProtection’:
+	// Set property "EnableVmProtection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableVmProtection != nil {
@@ -517,7 +517,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -528,7 +528,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		network.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘IpAllocations’:
+	// Set property "IpAllocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpAllocations {
@@ -541,16 +541,16 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		network.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	network.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		network.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -955,7 +955,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetwork_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressSpace’:
+	// Set property "AddressSpace":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddressSpace != nil {
@@ -969,7 +969,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘BgpCommunities’:
+	// Set property "BgpCommunities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BgpCommunities != nil {
@@ -983,9 +983,9 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DdosProtectionPlan’:
+	// Set property "DdosProtectionPlan":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DdosProtectionPlan != nil {
@@ -999,7 +999,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DhcpOptions’:
+	// Set property "DhcpOptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DhcpOptions != nil {
@@ -1013,7 +1013,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableDdosProtection’:
+	// Set property "EnableDdosProtection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableDdosProtection != nil {
@@ -1022,7 +1022,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableVmProtection’:
+	// Set property "EnableVmProtection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableVmProtection != nil {
@@ -1031,13 +1031,13 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		network.Etag = &etag
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1048,13 +1048,13 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		network.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		network.Id = &id
 	}
 
-	// Set property ‘IpAllocations’:
+	// Set property "IpAllocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpAllocations {
@@ -1067,19 +1067,19 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		network.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		network.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1088,7 +1088,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -1097,7 +1097,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		network.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1105,7 +1105,7 @@ func (network *VirtualNetwork_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		network.Type = &typeVar
@@ -1404,7 +1404,7 @@ func (space *AddressSpace) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &AddressSpace_ARM{}
 
-	// Set property ‘AddressPrefixes’:
+	// Set property "AddressPrefixes":
 	for _, item := range space.AddressPrefixes {
 		result.AddressPrefixes = append(result.AddressPrefixes, item)
 	}
@@ -1423,7 +1423,7 @@ func (space *AddressSpace) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AddressSpace_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressPrefixes’:
+	// Set property "AddressPrefixes":
 	for _, item := range typedInput.AddressPrefixes {
 		space.AddressPrefixes = append(space.AddressPrefixes, item)
 	}
@@ -1480,7 +1480,7 @@ func (space *AddressSpace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AddressSpace_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressPrefixes’:
+	// Set property "AddressPrefixes":
 	for _, item := range typedInput.AddressPrefixes {
 		space.AddressPrefixes = append(space.AddressPrefixes, item)
 	}
@@ -1532,7 +1532,7 @@ func (options *DhcpOptions) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &DhcpOptions_ARM{}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range options.DnsServers {
 		result.DnsServers = append(result.DnsServers, item)
 	}
@@ -1551,7 +1551,7 @@ func (options *DhcpOptions) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DhcpOptions_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		options.DnsServers = append(options.DnsServers, item)
 	}
@@ -1608,7 +1608,7 @@ func (options *DhcpOptions_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DhcpOptions_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DnsServers’:
+	// Set property "DnsServers":
 	for _, item := range typedInput.DnsServers {
 		options.DnsServers = append(options.DnsServers, item)
 	}
@@ -1661,7 +1661,7 @@ func (communities *VirtualNetworkBgpCommunities) ConvertToARM(resolved genruntim
 	}
 	result := &VirtualNetworkBgpCommunities_ARM{}
 
-	// Set property ‘VirtualNetworkCommunity’:
+	// Set property "VirtualNetworkCommunity":
 	if communities.VirtualNetworkCommunity != nil {
 		virtualNetworkCommunity := *communities.VirtualNetworkCommunity
 		result.VirtualNetworkCommunity = &virtualNetworkCommunity
@@ -1681,7 +1681,7 @@ func (communities *VirtualNetworkBgpCommunities) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkBgpCommunities_ARM, got %T", armInput)
 	}
 
-	// Set property ‘VirtualNetworkCommunity’:
+	// Set property "VirtualNetworkCommunity":
 	if typedInput.VirtualNetworkCommunity != nil {
 		virtualNetworkCommunity := *typedInput.VirtualNetworkCommunity
 		communities.VirtualNetworkCommunity = &virtualNetworkCommunity
@@ -1740,13 +1740,13 @@ func (communities *VirtualNetworkBgpCommunities_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkBgpCommunities_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RegionalCommunity’:
+	// Set property "RegionalCommunity":
 	if typedInput.RegionalCommunity != nil {
 		regionalCommunity := *typedInput.RegionalCommunity
 		communities.RegionalCommunity = &regionalCommunity
 	}
 
-	// Set property ‘VirtualNetworkCommunity’:
+	// Set property "VirtualNetworkCommunity":
 	if typedInput.VirtualNetworkCommunity != nil {
 		virtualNetworkCommunity := *typedInput.VirtualNetworkCommunity
 		communities.VirtualNetworkCommunity = &virtualNetworkCommunity

--- a/v2/api/network/v1beta20201101/virtual_networks_subnet_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_networks_subnet_types_gen.go
@@ -343,10 +343,10 @@ func (subnet *VirtualNetworks_Subnet_Spec) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &VirtualNetworks_Subnet_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if subnet.AddressPrefix != nil ||
 		subnet.AddressPrefixes != nil ||
 		subnet.ApplicationGatewayIpConfigurations != nil ||
@@ -450,7 +450,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworks_Subnet_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressPrefix’:
+	// Set property "AddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddressPrefix != nil {
@@ -459,7 +459,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘AddressPrefixes’:
+	// Set property "AddressPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AddressPrefixes {
@@ -467,7 +467,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘ApplicationGatewayIpConfigurations’:
+	// Set property "ApplicationGatewayIpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayIpConfigurations {
@@ -480,10 +480,10 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	subnet.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Delegations’:
+	// Set property "Delegations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Delegations {
@@ -496,7 +496,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘IpAllocations’:
+	// Set property "IpAllocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpAllocations {
@@ -509,7 +509,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘NatGateway’:
+	// Set property "NatGateway":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NatGateway != nil {
@@ -523,7 +523,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -537,10 +537,10 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	subnet.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PrivateEndpointNetworkPolicies’:
+	// Set property "PrivateEndpointNetworkPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateEndpointNetworkPolicies != nil {
@@ -549,7 +549,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘PrivateLinkServiceNetworkPolicies’:
+	// Set property "PrivateLinkServiceNetworkPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkServiceNetworkPolicies != nil {
@@ -558,7 +558,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘RouteTable’:
+	// Set property "RouteTable":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RouteTable != nil {
@@ -572,7 +572,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘ServiceEndpointPolicies’:
+	// Set property "ServiceEndpointPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ServiceEndpointPolicies {
@@ -585,7 +585,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘ServiceEndpoints’:
+	// Set property "ServiceEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ServiceEndpoints {
@@ -1100,7 +1100,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworks_Subnet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AddressPrefix’:
+	// Set property "AddressPrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AddressPrefix != nil {
@@ -1109,7 +1109,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘AddressPrefixes’:
+	// Set property "AddressPrefixes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AddressPrefixes {
@@ -1117,7 +1117,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ApplicationGatewayIpConfigurations’:
+	// Set property "ApplicationGatewayIpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ApplicationGatewayIpConfigurations {
@@ -1130,9 +1130,9 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Delegations’:
+	// Set property "Delegations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Delegations {
@@ -1145,19 +1145,19 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		subnet.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		subnet.Id = &id
 	}
 
-	// Set property ‘IpAllocations’:
+	// Set property "IpAllocations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpAllocations {
@@ -1170,7 +1170,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘IpConfigurationProfiles’:
+	// Set property "IpConfigurationProfiles":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurationProfiles {
@@ -1183,7 +1183,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘IpConfigurations’:
+	// Set property "IpConfigurations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.IpConfigurations {
@@ -1196,13 +1196,13 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		subnet.Name = &name
 	}
 
-	// Set property ‘NatGateway’:
+	// Set property "NatGateway":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NatGateway != nil {
@@ -1216,7 +1216,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘NetworkSecurityGroup’:
+	// Set property "NetworkSecurityGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkSecurityGroup != nil {
@@ -1230,7 +1230,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘PrivateEndpointNetworkPolicies’:
+	// Set property "PrivateEndpointNetworkPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateEndpointNetworkPolicies != nil {
@@ -1239,7 +1239,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘PrivateEndpoints’:
+	// Set property "PrivateEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpoints {
@@ -1252,7 +1252,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘PrivateLinkServiceNetworkPolicies’:
+	// Set property "PrivateLinkServiceNetworkPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrivateLinkServiceNetworkPolicies != nil {
@@ -1261,7 +1261,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1270,7 +1270,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Purpose’:
+	// Set property "Purpose":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Purpose != nil {
@@ -1279,7 +1279,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ResourceNavigationLinks’:
+	// Set property "ResourceNavigationLinks":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ResourceNavigationLinks {
@@ -1292,7 +1292,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘RouteTable’:
+	// Set property "RouteTable":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RouteTable != nil {
@@ -1306,7 +1306,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ServiceAssociationLinks’:
+	// Set property "ServiceAssociationLinks":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ServiceAssociationLinks {
@@ -1319,7 +1319,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ServiceEndpointPolicies’:
+	// Set property "ServiceEndpointPolicies":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ServiceEndpointPolicies {
@@ -1332,7 +1332,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘ServiceEndpoints’:
+	// Set property "ServiceEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.ServiceEndpoints {
@@ -1345,7 +1345,7 @@ func (subnet *VirtualNetworks_Subnet_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		subnet.Type = &typeVar
@@ -1925,7 +1925,7 @@ func (embedded *ApplicationGatewayIPConfiguration_STATUS_VirtualNetworks_Subnet_
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationGatewayIPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -1978,7 +1978,7 @@ func (embedded *ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubReso
 	}
 	result := &ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -2002,7 +2002,7 @@ func (embedded *ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubReso
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApplicationGatewayIPConfiguration_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2062,13 +2062,13 @@ func (delegation *Delegation) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Delegation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if delegation.Name != nil {
 		name := *delegation.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if delegation.ServiceName != nil {
 		result.Properties = &ServiceDelegationPropertiesFormat_ARM{}
 	}
@@ -2091,13 +2091,13 @@ func (delegation *Delegation) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Delegation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		delegation.Name = &name
 	}
 
-	// Set property ‘ServiceName’:
+	// Set property "ServiceName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceName != nil {
@@ -2170,7 +2170,7 @@ func (delegation *Delegation_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Delegation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Actions {
@@ -2178,25 +2178,25 @@ func (delegation *Delegation_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		delegation.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		delegation.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		delegation.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2205,7 +2205,7 @@ func (delegation *Delegation_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ServiceName’:
+	// Set property "ServiceName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceName != nil {
@@ -2214,7 +2214,7 @@ func (delegation *Delegation_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		delegation.Type = &typeVar
@@ -2318,7 +2318,7 @@ func (embedded *IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedde
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2376,7 +2376,7 @@ func (profile *IPConfigurationProfile_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPConfigurationProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		profile.Id = &id
@@ -2434,7 +2434,7 @@ func (embedded *NetworkSecurityGroup_STATUS_VirtualNetworks_Subnet_SubResourceEm
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroup_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2487,7 +2487,7 @@ func (embedded *NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbed
 	}
 	result := &NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -2511,7 +2511,7 @@ func (embedded *NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbed
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkSecurityGroupSpec_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2575,7 +2575,7 @@ func (embedded *PrivateEndpoint_STATUS_VirtualNetworks_Subnet_SubResourceEmbedde
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpoint_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2633,7 +2633,7 @@ func (link *ResourceNavigationLink_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceNavigationLink_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		link.Id = &id
@@ -2691,7 +2691,7 @@ func (embedded *RouteTable_STATUS_SubResourceEmbedded) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteTable_STATUS_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2744,7 +2744,7 @@ func (embedded *RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded) Conve
 	}
 	result := &RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -2768,7 +2768,7 @@ func (embedded *RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded) Popul
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RouteTableSpec_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2832,7 +2832,7 @@ func (link *ServiceAssociationLink_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceAssociationLink_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		link.Id = &id
@@ -2890,7 +2890,7 @@ func (embedded *ServiceEndpointPolicy_STATUS_VirtualNetworks_Subnet_SubResourceE
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceEndpointPolicy_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2943,7 +2943,7 @@ func (embedded *ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbe
 	}
 	result := &ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if embedded.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*embedded.Reference)
 		if err != nil {
@@ -2967,7 +2967,7 @@ func (embedded *ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceEndpointPolicySpec_VirtualNetworks_Subnet_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -3027,12 +3027,12 @@ func (format *ServiceEndpointPropertiesFormat) ConvertToARM(resolved genruntime.
 	}
 	result := &ServiceEndpointPropertiesFormat_ARM{}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	for _, item := range format.Locations {
 		result.Locations = append(result.Locations, item)
 	}
 
-	// Set property ‘Service’:
+	// Set property "Service":
 	if format.Service != nil {
 		service := *format.Service
 		result.Service = &service
@@ -3052,12 +3052,12 @@ func (format *ServiceEndpointPropertiesFormat) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceEndpointPropertiesFormat_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	for _, item := range typedInput.Locations {
 		format.Locations = append(format.Locations, item)
 	}
 
-	// Set property ‘Service’:
+	// Set property "Service":
 	if typedInput.Service != nil {
 		service := *typedInput.Service
 		format.Service = &service
@@ -3123,18 +3123,18 @@ func (format *ServiceEndpointPropertiesFormat_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServiceEndpointPropertiesFormat_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	for _, item := range typedInput.Locations {
 		format.Locations = append(format.Locations, item)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		format.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘Service’:
+	// Set property "Service":
 	if typedInput.Service != nil {
 		service := *typedInput.Service
 		format.Service = &service

--- a/v2/api/network/v1beta20201101/virtual_networks_virtual_network_peering_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_networks_virtual_network_peering_types_gen.go
@@ -340,10 +340,10 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) ConvertToARM(resolved
 	}
 	result := &VirtualNetworks_VirtualNetworkPeering_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if peering.AllowForwardedTraffic != nil ||
 		peering.AllowGatewayTransit != nil ||
 		peering.AllowVirtualNetworkAccess != nil ||
@@ -418,7 +418,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworks_VirtualNetworkPeering_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowForwardedTraffic’:
+	// Set property "AllowForwardedTraffic":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowForwardedTraffic != nil {
@@ -427,7 +427,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘AllowGatewayTransit’:
+	// Set property "AllowGatewayTransit":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowGatewayTransit != nil {
@@ -436,7 +436,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘AllowVirtualNetworkAccess’:
+	// Set property "AllowVirtualNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowVirtualNetworkAccess != nil {
@@ -445,10 +445,10 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	peering.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DoNotVerifyRemoteGateways’:
+	// Set property "DoNotVerifyRemoteGateways":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DoNotVerifyRemoteGateways != nil {
@@ -457,10 +457,10 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	peering.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PeeringState’:
+	// Set property "PeeringState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PeeringState != nil {
@@ -469,7 +469,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘RemoteAddressSpace’:
+	// Set property "RemoteAddressSpace":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemoteAddressSpace != nil {
@@ -483,7 +483,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘RemoteBgpCommunities’:
+	// Set property "RemoteBgpCommunities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemoteBgpCommunities != nil {
@@ -497,7 +497,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘RemoteVirtualNetwork’:
+	// Set property "RemoteVirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemoteVirtualNetwork != nil {
@@ -511,7 +511,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘UseRemoteGateways’:
+	// Set property "UseRemoteGateways":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UseRemoteGateways != nil {
@@ -886,7 +886,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworks_VirtualNetworkPeering_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowForwardedTraffic’:
+	// Set property "AllowForwardedTraffic":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowForwardedTraffic != nil {
@@ -895,7 +895,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘AllowGatewayTransit’:
+	// Set property "AllowGatewayTransit":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowGatewayTransit != nil {
@@ -904,7 +904,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘AllowVirtualNetworkAccess’:
+	// Set property "AllowVirtualNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowVirtualNetworkAccess != nil {
@@ -913,9 +913,9 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DoNotVerifyRemoteGateways’:
+	// Set property "DoNotVerifyRemoteGateways":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DoNotVerifyRemoteGateways != nil {
@@ -924,25 +924,25 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		peering.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		peering.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		peering.Name = &name
 	}
 
-	// Set property ‘PeeringState’:
+	// Set property "PeeringState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PeeringState != nil {
@@ -951,7 +951,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -960,7 +960,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘RemoteAddressSpace’:
+	// Set property "RemoteAddressSpace":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemoteAddressSpace != nil {
@@ -974,7 +974,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘RemoteBgpCommunities’:
+	// Set property "RemoteBgpCommunities":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemoteBgpCommunities != nil {
@@ -988,7 +988,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘RemoteVirtualNetwork’:
+	// Set property "RemoteVirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemoteVirtualNetwork != nil {
@@ -1002,7 +1002,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘ResourceGuid’:
+	// Set property "ResourceGuid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGuid != nil {
@@ -1011,13 +1011,13 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_STATUS) PopulateFromARM(own
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		peering.Type = &typeVar
 	}
 
-	// Set property ‘UseRemoteGateways’:
+	// Set property "UseRemoteGateways":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UseRemoteGateways != nil {

--- a/v2/api/operationalinsights/v1api20210601/workspace_types_gen.go
+++ b/v2/api/operationalinsights/v1api20210601/workspace_types_gen.go
@@ -374,22 +374,22 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &Workspace_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if workspace.Etag != nil {
 		etag := *workspace.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if workspace.Location != nil {
 		location := *workspace.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if workspace.Features != nil ||
 		workspace.ForceCmkForQuery != nil ||
 		workspace.ProvisioningState != nil ||
@@ -445,7 +445,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.WorkspaceCapping = &workspaceCapping
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if workspace.Tags != nil {
 		result.Tags = make(map[string]string, len(workspace.Tags))
 		for key, value := range workspace.Tags {
@@ -467,16 +467,16 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspace_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	workspace.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		workspace.Etag = &etag
 	}
 
-	// Set property ‘Features’:
+	// Set property "Features":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Features != nil {
@@ -490,7 +490,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ForceCmkForQuery’:
+	// Set property "ForceCmkForQuery":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceCmkForQuery != nil {
@@ -499,16 +499,16 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		workspace.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	workspace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -517,7 +517,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForIngestion’:
+	// Set property "PublicNetworkAccessForIngestion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForIngestion != nil {
@@ -526,7 +526,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForQuery’:
+	// Set property "PublicNetworkAccessForQuery":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForQuery != nil {
@@ -535,7 +535,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionInDays != nil {
@@ -544,7 +544,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -558,7 +558,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		workspace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -566,7 +566,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘WorkspaceCapping’:
+	// Set property "WorkspaceCapping":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkspaceCapping != nil {
@@ -1063,9 +1063,9 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspace_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreatedDate’:
+	// Set property "CreatedDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedDate != nil {
@@ -1074,7 +1074,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CustomerId’:
+	// Set property "CustomerId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomerId != nil {
@@ -1083,13 +1083,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		workspace.Etag = &etag
 	}
 
-	// Set property ‘Features’:
+	// Set property "Features":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Features != nil {
@@ -1103,7 +1103,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ForceCmkForQuery’:
+	// Set property "ForceCmkForQuery":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceCmkForQuery != nil {
@@ -1112,19 +1112,19 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		workspace.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		workspace.Location = &location
 	}
 
-	// Set property ‘ModifiedDate’:
+	// Set property "ModifiedDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ModifiedDate != nil {
@@ -1133,13 +1133,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		workspace.Name = &name
 	}
 
-	// Set property ‘PrivateLinkScopedResources’:
+	// Set property "PrivateLinkScopedResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkScopedResources {
@@ -1152,7 +1152,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1161,7 +1161,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForIngestion’:
+	// Set property "PublicNetworkAccessForIngestion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForIngestion != nil {
@@ -1170,7 +1170,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForQuery’:
+	// Set property "PublicNetworkAccessForQuery":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForQuery != nil {
@@ -1179,7 +1179,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionInDays != nil {
@@ -1188,7 +1188,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -1202,7 +1202,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		workspace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1210,13 +1210,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		workspace.Type = &typeVar
 	}
 
-	// Set property ‘WorkspaceCapping’:
+	// Set property "WorkspaceCapping":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkspaceCapping != nil {
@@ -1518,13 +1518,13 @@ func (resource *PrivateLinkScopedResource_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkScopedResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		resource.ResourceId = &resourceId
 	}
 
-	// Set property ‘ScopeId’:
+	// Set property "ScopeId":
 	if typedInput.ScopeId != nil {
 		scopeId := *typedInput.ScopeId
 		resource.ScopeId = &scopeId
@@ -1601,7 +1601,7 @@ func (capping *WorkspaceCapping) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &WorkspaceCapping_ARM{}
 
-	// Set property ‘DailyQuotaGb’:
+	// Set property "DailyQuotaGb":
 	if capping.DailyQuotaGb != nil {
 		dailyQuotaGb := *capping.DailyQuotaGb
 		result.DailyQuotaGb = &dailyQuotaGb
@@ -1621,7 +1621,7 @@ func (capping *WorkspaceCapping) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceCapping_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DailyQuotaGb’:
+	// Set property "DailyQuotaGb":
 	if typedInput.DailyQuotaGb != nil {
 		dailyQuotaGb := *typedInput.DailyQuotaGb
 		capping.DailyQuotaGb = &dailyQuotaGb
@@ -1711,19 +1711,19 @@ func (capping *WorkspaceCapping_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceCapping_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DailyQuotaGb’:
+	// Set property "DailyQuotaGb":
 	if typedInput.DailyQuotaGb != nil {
 		dailyQuotaGb := *typedInput.DailyQuotaGb
 		capping.DailyQuotaGb = &dailyQuotaGb
 	}
 
-	// Set property ‘DataIngestionStatus’:
+	// Set property "DataIngestionStatus":
 	if typedInput.DataIngestionStatus != nil {
 		dataIngestionStatus := *typedInput.DataIngestionStatus
 		capping.DataIngestionStatus = &dataIngestionStatus
 	}
 
-	// Set property ‘QuotaNextResetTime’:
+	// Set property "QuotaNextResetTime":
 	if typedInput.QuotaNextResetTime != nil {
 		quotaNextResetTime := *typedInput.QuotaNextResetTime
 		capping.QuotaNextResetTime = &quotaNextResetTime
@@ -1821,7 +1821,7 @@ func (features *WorkspaceFeatures) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &WorkspaceFeatures_ARM{}
 
-	// Set property ‘ClusterResourceId’:
+	// Set property "ClusterResourceId":
 	if features.ClusterResourceReference != nil {
 		clusterResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*features.ClusterResourceReference)
 		if err != nil {
@@ -1831,25 +1831,25 @@ func (features *WorkspaceFeatures) ConvertToARM(resolved genruntime.ConvertToARM
 		result.ClusterResourceId = &clusterResourceReference
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if features.DisableLocalAuth != nil {
 		disableLocalAuth := *features.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘EnableDataExport’:
+	// Set property "EnableDataExport":
 	if features.EnableDataExport != nil {
 		enableDataExport := *features.EnableDataExport
 		result.EnableDataExport = &enableDataExport
 	}
 
-	// Set property ‘EnableLogAccessUsingOnlyResourcePermissions’:
+	// Set property "EnableLogAccessUsingOnlyResourcePermissions":
 	if features.EnableLogAccessUsingOnlyResourcePermissions != nil {
 		enableLogAccessUsingOnlyResourcePermissions := *features.EnableLogAccessUsingOnlyResourcePermissions
 		result.EnableLogAccessUsingOnlyResourcePermissions = &enableLogAccessUsingOnlyResourcePermissions
 	}
 
-	// Set property ‘ImmediatePurgeDataOn30Days’:
+	// Set property "ImmediatePurgeDataOn30Days":
 	if features.ImmediatePurgeDataOn30Days != nil {
 		immediatePurgeDataOn30Days := *features.ImmediatePurgeDataOn30Days
 		result.ImmediatePurgeDataOn30Days = &immediatePurgeDataOn30Days
@@ -1869,27 +1869,27 @@ func (features *WorkspaceFeatures) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceFeatures_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘ClusterResourceReference’
+	// no assignment for property "ClusterResourceReference"
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		features.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘EnableDataExport’:
+	// Set property "EnableDataExport":
 	if typedInput.EnableDataExport != nil {
 		enableDataExport := *typedInput.EnableDataExport
 		features.EnableDataExport = &enableDataExport
 	}
 
-	// Set property ‘EnableLogAccessUsingOnlyResourcePermissions’:
+	// Set property "EnableLogAccessUsingOnlyResourcePermissions":
 	if typedInput.EnableLogAccessUsingOnlyResourcePermissions != nil {
 		enableLogAccessUsingOnlyResourcePermissions := *typedInput.EnableLogAccessUsingOnlyResourcePermissions
 		features.EnableLogAccessUsingOnlyResourcePermissions = &enableLogAccessUsingOnlyResourcePermissions
 	}
 
-	// Set property ‘ImmediatePurgeDataOn30Days’:
+	// Set property "ImmediatePurgeDataOn30Days":
 	if typedInput.ImmediatePurgeDataOn30Days != nil {
 		immediatePurgeDataOn30Days := *typedInput.ImmediatePurgeDataOn30Days
 		features.ImmediatePurgeDataOn30Days = &immediatePurgeDataOn30Days
@@ -2081,31 +2081,31 @@ func (features *WorkspaceFeatures_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceFeatures_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClusterResourceId’:
+	// Set property "ClusterResourceId":
 	if typedInput.ClusterResourceId != nil {
 		clusterResourceId := *typedInput.ClusterResourceId
 		features.ClusterResourceId = &clusterResourceId
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		features.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘EnableDataExport’:
+	// Set property "EnableDataExport":
 	if typedInput.EnableDataExport != nil {
 		enableDataExport := *typedInput.EnableDataExport
 		features.EnableDataExport = &enableDataExport
 	}
 
-	// Set property ‘EnableLogAccessUsingOnlyResourcePermissions’:
+	// Set property "EnableLogAccessUsingOnlyResourcePermissions":
 	if typedInput.EnableLogAccessUsingOnlyResourcePermissions != nil {
 		enableLogAccessUsingOnlyResourcePermissions := *typedInput.EnableLogAccessUsingOnlyResourcePermissions
 		features.EnableLogAccessUsingOnlyResourcePermissions = &enableLogAccessUsingOnlyResourcePermissions
 	}
 
-	// Set property ‘ImmediatePurgeDataOn30Days’:
+	// Set property "ImmediatePurgeDataOn30Days":
 	if typedInput.ImmediatePurgeDataOn30Days != nil {
 		immediatePurgeDataOn30Days := *typedInput.ImmediatePurgeDataOn30Days
 		features.ImmediatePurgeDataOn30Days = &immediatePurgeDataOn30Days
@@ -2253,13 +2253,13 @@ func (workspaceSku *WorkspaceSku) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &WorkspaceSku_ARM{}
 
-	// Set property ‘CapacityReservationLevel’:
+	// Set property "CapacityReservationLevel":
 	if workspaceSku.CapacityReservationLevel != nil {
 		capacityReservationLevel := *workspaceSku.CapacityReservationLevel
 		result.CapacityReservationLevel = &capacityReservationLevel
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if workspaceSku.Name != nil {
 		name := *workspaceSku.Name
 		result.Name = &name
@@ -2279,13 +2279,13 @@ func (workspaceSku *WorkspaceSku) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CapacityReservationLevel’:
+	// Set property "CapacityReservationLevel":
 	if typedInput.CapacityReservationLevel != nil {
 		capacityReservationLevel := *typedInput.CapacityReservationLevel
 		workspaceSku.CapacityReservationLevel = &capacityReservationLevel
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		workspaceSku.Name = &name
@@ -2400,19 +2400,19 @@ func (workspaceSku *WorkspaceSku_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CapacityReservationLevel’:
+	// Set property "CapacityReservationLevel":
 	if typedInput.CapacityReservationLevel != nil {
 		capacityReservationLevel := *typedInput.CapacityReservationLevel
 		workspaceSku.CapacityReservationLevel = &capacityReservationLevel
 	}
 
-	// Set property ‘LastSkuUpdate’:
+	// Set property "LastSkuUpdate":
 	if typedInput.LastSkuUpdate != nil {
 		lastSkuUpdate := *typedInput.LastSkuUpdate
 		workspaceSku.LastSkuUpdate = &lastSkuUpdate
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		workspaceSku.Name = &name

--- a/v2/api/operationalinsights/v1beta20210601/workspace_types_gen.go
+++ b/v2/api/operationalinsights/v1beta20210601/workspace_types_gen.go
@@ -352,22 +352,22 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &Workspace_Spec_ARM{}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if workspace.Etag != nil {
 		etag := *workspace.Etag
 		result.Etag = &etag
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if workspace.Location != nil {
 		location := *workspace.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if workspace.Features != nil ||
 		workspace.ForceCmkForQuery != nil ||
 		workspace.ProvisioningState != nil ||
@@ -423,7 +423,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.WorkspaceCapping = &workspaceCapping
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if workspace.Tags != nil {
 		result.Tags = make(map[string]string, len(workspace.Tags))
 		for key, value := range workspace.Tags {
@@ -445,16 +445,16 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspace_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	workspace.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		workspace.Etag = &etag
 	}
 
-	// Set property ‘Features’:
+	// Set property "Features":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Features != nil {
@@ -468,7 +468,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ForceCmkForQuery’:
+	// Set property "ForceCmkForQuery":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceCmkForQuery != nil {
@@ -477,16 +477,16 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		workspace.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	workspace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -495,7 +495,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForIngestion’:
+	// Set property "PublicNetworkAccessForIngestion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForIngestion != nil {
@@ -504,7 +504,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForQuery’:
+	// Set property "PublicNetworkAccessForQuery":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForQuery != nil {
@@ -513,7 +513,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionInDays != nil {
@@ -522,7 +522,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -536,7 +536,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		workspace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -544,7 +544,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘WorkspaceCapping’:
+	// Set property "WorkspaceCapping":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkspaceCapping != nil {
@@ -916,9 +916,9 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspace_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreatedDate’:
+	// Set property "CreatedDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedDate != nil {
@@ -927,7 +927,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CustomerId’:
+	// Set property "CustomerId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomerId != nil {
@@ -936,13 +936,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		workspace.Etag = &etag
 	}
 
-	// Set property ‘Features’:
+	// Set property "Features":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Features != nil {
@@ -956,7 +956,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ForceCmkForQuery’:
+	// Set property "ForceCmkForQuery":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForceCmkForQuery != nil {
@@ -965,19 +965,19 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		workspace.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		workspace.Location = &location
 	}
 
-	// Set property ‘ModifiedDate’:
+	// Set property "ModifiedDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ModifiedDate != nil {
@@ -986,13 +986,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		workspace.Name = &name
 	}
 
-	// Set property ‘PrivateLinkScopedResources’:
+	// Set property "PrivateLinkScopedResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateLinkScopedResources {
@@ -1005,7 +1005,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1014,7 +1014,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForIngestion’:
+	// Set property "PublicNetworkAccessForIngestion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForIngestion != nil {
@@ -1023,7 +1023,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PublicNetworkAccessForQuery’:
+	// Set property "PublicNetworkAccessForQuery":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccessForQuery != nil {
@@ -1032,7 +1032,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionInDays != nil {
@@ -1041,7 +1041,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sku != nil {
@@ -1055,7 +1055,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		workspace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1063,13 +1063,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		workspace.Type = &typeVar
 	}
 
-	// Set property ‘WorkspaceCapping’:
+	// Set property "WorkspaceCapping":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkspaceCapping != nil {
@@ -1368,13 +1368,13 @@ func (resource *PrivateLinkScopedResource_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkScopedResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		resource.ResourceId = &resourceId
 	}
 
-	// Set property ‘ScopeId’:
+	// Set property "ScopeId":
 	if typedInput.ScopeId != nil {
 		scopeId := *typedInput.ScopeId
 		resource.ScopeId = &scopeId
@@ -1450,7 +1450,7 @@ func (capping *WorkspaceCapping) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &WorkspaceCapping_ARM{}
 
-	// Set property ‘DailyQuotaGb’:
+	// Set property "DailyQuotaGb":
 	if capping.DailyQuotaGb != nil {
 		dailyQuotaGb := *capping.DailyQuotaGb
 		result.DailyQuotaGb = &dailyQuotaGb
@@ -1470,7 +1470,7 @@ func (capping *WorkspaceCapping) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceCapping_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DailyQuotaGb’:
+	// Set property "DailyQuotaGb":
 	if typedInput.DailyQuotaGb != nil {
 		dailyQuotaGb := *typedInput.DailyQuotaGb
 		capping.DailyQuotaGb = &dailyQuotaGb
@@ -1540,19 +1540,19 @@ func (capping *WorkspaceCapping_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceCapping_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DailyQuotaGb’:
+	// Set property "DailyQuotaGb":
 	if typedInput.DailyQuotaGb != nil {
 		dailyQuotaGb := *typedInput.DailyQuotaGb
 		capping.DailyQuotaGb = &dailyQuotaGb
 	}
 
-	// Set property ‘DataIngestionStatus’:
+	// Set property "DataIngestionStatus":
 	if typedInput.DataIngestionStatus != nil {
 		dataIngestionStatus := *typedInput.DataIngestionStatus
 		capping.DataIngestionStatus = &dataIngestionStatus
 	}
 
-	// Set property ‘QuotaNextResetTime’:
+	// Set property "QuotaNextResetTime":
 	if typedInput.QuotaNextResetTime != nil {
 		quotaNextResetTime := *typedInput.QuotaNextResetTime
 		capping.QuotaNextResetTime = &quotaNextResetTime
@@ -1641,7 +1641,7 @@ func (features *WorkspaceFeatures) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &WorkspaceFeatures_ARM{}
 
-	// Set property ‘ClusterResourceId’:
+	// Set property "ClusterResourceId":
 	if features.ClusterResourceReference != nil {
 		clusterResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*features.ClusterResourceReference)
 		if err != nil {
@@ -1651,25 +1651,25 @@ func (features *WorkspaceFeatures) ConvertToARM(resolved genruntime.ConvertToARM
 		result.ClusterResourceId = &clusterResourceReference
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if features.DisableLocalAuth != nil {
 		disableLocalAuth := *features.DisableLocalAuth
 		result.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘EnableDataExport’:
+	// Set property "EnableDataExport":
 	if features.EnableDataExport != nil {
 		enableDataExport := *features.EnableDataExport
 		result.EnableDataExport = &enableDataExport
 	}
 
-	// Set property ‘EnableLogAccessUsingOnlyResourcePermissions’:
+	// Set property "EnableLogAccessUsingOnlyResourcePermissions":
 	if features.EnableLogAccessUsingOnlyResourcePermissions != nil {
 		enableLogAccessUsingOnlyResourcePermissions := *features.EnableLogAccessUsingOnlyResourcePermissions
 		result.EnableLogAccessUsingOnlyResourcePermissions = &enableLogAccessUsingOnlyResourcePermissions
 	}
 
-	// Set property ‘ImmediatePurgeDataOn30Days’:
+	// Set property "ImmediatePurgeDataOn30Days":
 	if features.ImmediatePurgeDataOn30Days != nil {
 		immediatePurgeDataOn30Days := *features.ImmediatePurgeDataOn30Days
 		result.ImmediatePurgeDataOn30Days = &immediatePurgeDataOn30Days
@@ -1689,27 +1689,27 @@ func (features *WorkspaceFeatures) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceFeatures_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘ClusterResourceReference’
+	// no assignment for property "ClusterResourceReference"
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		features.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘EnableDataExport’:
+	// Set property "EnableDataExport":
 	if typedInput.EnableDataExport != nil {
 		enableDataExport := *typedInput.EnableDataExport
 		features.EnableDataExport = &enableDataExport
 	}
 
-	// Set property ‘EnableLogAccessUsingOnlyResourcePermissions’:
+	// Set property "EnableLogAccessUsingOnlyResourcePermissions":
 	if typedInput.EnableLogAccessUsingOnlyResourcePermissions != nil {
 		enableLogAccessUsingOnlyResourcePermissions := *typedInput.EnableLogAccessUsingOnlyResourcePermissions
 		features.EnableLogAccessUsingOnlyResourcePermissions = &enableLogAccessUsingOnlyResourcePermissions
 	}
 
-	// Set property ‘ImmediatePurgeDataOn30Days’:
+	// Set property "ImmediatePurgeDataOn30Days":
 	if typedInput.ImmediatePurgeDataOn30Days != nil {
 		immediatePurgeDataOn30Days := *typedInput.ImmediatePurgeDataOn30Days
 		features.ImmediatePurgeDataOn30Days = &immediatePurgeDataOn30Days
@@ -1845,31 +1845,31 @@ func (features *WorkspaceFeatures_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceFeatures_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClusterResourceId’:
+	// Set property "ClusterResourceId":
 	if typedInput.ClusterResourceId != nil {
 		clusterResourceId := *typedInput.ClusterResourceId
 		features.ClusterResourceId = &clusterResourceId
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	if typedInput.DisableLocalAuth != nil {
 		disableLocalAuth := *typedInput.DisableLocalAuth
 		features.DisableLocalAuth = &disableLocalAuth
 	}
 
-	// Set property ‘EnableDataExport’:
+	// Set property "EnableDataExport":
 	if typedInput.EnableDataExport != nil {
 		enableDataExport := *typedInput.EnableDataExport
 		features.EnableDataExport = &enableDataExport
 	}
 
-	// Set property ‘EnableLogAccessUsingOnlyResourcePermissions’:
+	// Set property "EnableLogAccessUsingOnlyResourcePermissions":
 	if typedInput.EnableLogAccessUsingOnlyResourcePermissions != nil {
 		enableLogAccessUsingOnlyResourcePermissions := *typedInput.EnableLogAccessUsingOnlyResourcePermissions
 		features.EnableLogAccessUsingOnlyResourcePermissions = &enableLogAccessUsingOnlyResourcePermissions
 	}
 
-	// Set property ‘ImmediatePurgeDataOn30Days’:
+	// Set property "ImmediatePurgeDataOn30Days":
 	if typedInput.ImmediatePurgeDataOn30Days != nil {
 		immediatePurgeDataOn30Days := *typedInput.ImmediatePurgeDataOn30Days
 		features.ImmediatePurgeDataOn30Days = &immediatePurgeDataOn30Days
@@ -2018,13 +2018,13 @@ func (workspaceSku *WorkspaceSku) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &WorkspaceSku_ARM{}
 
-	// Set property ‘CapacityReservationLevel’:
+	// Set property "CapacityReservationLevel":
 	if workspaceSku.CapacityReservationLevel != nil {
 		capacityReservationLevel := *workspaceSku.CapacityReservationLevel
 		result.CapacityReservationLevel = &capacityReservationLevel
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if workspaceSku.Name != nil {
 		name := *workspaceSku.Name
 		result.Name = &name
@@ -2044,13 +2044,13 @@ func (workspaceSku *WorkspaceSku) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CapacityReservationLevel’:
+	// Set property "CapacityReservationLevel":
 	if typedInput.CapacityReservationLevel != nil {
 		capacityReservationLevel := *typedInput.CapacityReservationLevel
 		workspaceSku.CapacityReservationLevel = &capacityReservationLevel
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		workspaceSku.Name = &name
@@ -2136,19 +2136,19 @@ func (workspaceSku *WorkspaceSku_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CapacityReservationLevel’:
+	// Set property "CapacityReservationLevel":
 	if typedInput.CapacityReservationLevel != nil {
 		capacityReservationLevel := *typedInput.CapacityReservationLevel
 		workspaceSku.CapacityReservationLevel = &capacityReservationLevel
 	}
 
-	// Set property ‘LastSkuUpdate’:
+	// Set property "LastSkuUpdate":
 	if typedInput.LastSkuUpdate != nil {
 		lastSkuUpdate := *typedInput.LastSkuUpdate
 		workspaceSku.LastSkuUpdate = &lastSkuUpdate
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		workspaceSku.Name = &name

--- a/v2/api/resources/v1api20200601/resource_group_types_gen.go
+++ b/v2/api/resources/v1api20200601/resource_group_types_gen.go
@@ -348,22 +348,22 @@ func (group *ResourceGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ResourceGroup_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if group.Location != nil {
 		location := *group.Location
 		result.Location = &location
 	}
 
-	// Set property ‘ManagedBy’:
+	// Set property "ManagedBy":
 	if group.ManagedBy != nil {
 		managedBy := *group.ManagedBy
 		result.ManagedBy = &managedBy
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if group.Tags != nil {
 		result.Tags = make(map[string]string, len(group.Tags))
 		for key, value := range group.Tags {
@@ -385,22 +385,22 @@ func (group *ResourceGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceGroup_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	group.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		group.Location = &location
 	}
 
-	// Set property ‘ManagedBy’:
+	// Set property "ManagedBy":
 	if typedInput.ManagedBy != nil {
 		managedBy := *typedInput.ManagedBy
 		group.ManagedBy = &managedBy
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		group.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -628,33 +628,33 @@ func (group *ResourceGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceGroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		group.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		group.Location = &location
 	}
 
-	// Set property ‘ManagedBy’:
+	// Set property "ManagedBy":
 	if typedInput.ManagedBy != nil {
 		managedBy := *typedInput.ManagedBy
 		group.ManagedBy = &managedBy
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		group.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 ResourceGroupProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -665,7 +665,7 @@ func (group *ResourceGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		group.Properties = &properties
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		group.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -673,7 +673,7 @@ func (group *ResourceGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		group.Type = &typeVar
@@ -792,7 +792,7 @@ func (properties *ResourceGroupProperties_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceGroupProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		properties.ProvisioningState = &provisioningState

--- a/v2/api/resources/v1beta20200601/resource_group_types_gen.go
+++ b/v2/api/resources/v1beta20200601/resource_group_types_gen.go
@@ -342,22 +342,22 @@ func (group *ResourceGroup_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ResourceGroup_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if group.Location != nil {
 		location := *group.Location
 		result.Location = &location
 	}
 
-	// Set property ‘ManagedBy’:
+	// Set property "ManagedBy":
 	if group.ManagedBy != nil {
 		managedBy := *group.ManagedBy
 		result.ManagedBy = &managedBy
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if group.Tags != nil {
 		result.Tags = make(map[string]string, len(group.Tags))
 		for key, value := range group.Tags {
@@ -379,22 +379,22 @@ func (group *ResourceGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceGroup_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	group.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		group.Location = &location
 	}
 
-	// Set property ‘ManagedBy’:
+	// Set property "ManagedBy":
 	if typedInput.ManagedBy != nil {
 		managedBy := *typedInput.ManagedBy
 		group.ManagedBy = &managedBy
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		group.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -591,33 +591,33 @@ func (group *ResourceGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceGroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		group.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		group.Location = &location
 	}
 
-	// Set property ‘ManagedBy’:
+	// Set property "ManagedBy":
 	if typedInput.ManagedBy != nil {
 		managedBy := *typedInput.ManagedBy
 		group.ManagedBy = &managedBy
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		group.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 ResourceGroupProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -628,7 +628,7 @@ func (group *ResourceGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		group.Properties = &properties
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		group.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -636,7 +636,7 @@ func (group *ResourceGroup_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		group.Type = &typeVar
@@ -754,7 +754,7 @@ func (properties *ResourceGroupProperties_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceGroupProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		properties.ProvisioningState = &provisioningState

--- a/v2/api/search/v1api20220901/search_service_types_gen.go
+++ b/v2/api/search/v1api20220901/search_service_types_gen.go
@@ -413,7 +413,7 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &SearchService_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if service.Identity != nil {
 		identity_ARM, err := (*service.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -423,16 +423,16 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if service.Location != nil {
 		location := *service.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if service.AuthOptions != nil ||
 		service.DisableLocalAuth != nil ||
 		service.EncryptionWithCmk != nil ||
@@ -488,7 +488,7 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.ReplicaCount = &replicaCount
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if service.Sku != nil {
 		sku_ARM, err := (*service.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -498,7 +498,7 @@ func (service *SearchService_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if service.Tags != nil {
 		result.Tags = make(map[string]string, len(service.Tags))
 		for key, value := range service.Tags {
@@ -520,7 +520,7 @@ func (service *SearchService_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SearchService_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthOptions’:
+	// Set property "AuthOptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AuthOptions != nil {
@@ -534,10 +534,10 @@ func (service *SearchService_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	service.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -546,7 +546,7 @@ func (service *SearchService_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘EncryptionWithCmk’:
+	// Set property "EncryptionWithCmk":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionWithCmk != nil {
@@ -560,7 +560,7 @@ func (service *SearchService_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HostingMode’:
+	// Set property "HostingMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostingMode != nil {
@@ -569,7 +569,7 @@ func (service *SearchService_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -580,13 +580,13 @@ func (service *SearchService_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		service.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		service.Location = &location
 	}
 
-	// Set property ‘NetworkRuleSet’:
+	// Set property "NetworkRuleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkRuleSet != nil {
@@ -600,12 +600,12 @@ func (service *SearchService_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PartitionCount’:
+	// Set property "PartitionCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PartitionCount != nil {
@@ -614,7 +614,7 @@ func (service *SearchService_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -623,7 +623,7 @@ func (service *SearchService_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ReplicaCount’:
+	// Set property "ReplicaCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicaCount != nil {
@@ -632,7 +632,7 @@ func (service *SearchService_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -643,7 +643,7 @@ func (service *SearchService_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		service.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		service.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1264,7 +1264,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SearchService_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthOptions’:
+	// Set property "AuthOptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AuthOptions != nil {
@@ -1278,9 +1278,9 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -1289,7 +1289,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘EncryptionWithCmk’:
+	// Set property "EncryptionWithCmk":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EncryptionWithCmk != nil {
@@ -1303,7 +1303,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘HostingMode’:
+	// Set property "HostingMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostingMode != nil {
@@ -1312,13 +1312,13 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		service.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1329,19 +1329,19 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		service.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		service.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		service.Name = &name
 	}
 
-	// Set property ‘NetworkRuleSet’:
+	// Set property "NetworkRuleSet":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkRuleSet != nil {
@@ -1355,7 +1355,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PartitionCount’:
+	// Set property "PartitionCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PartitionCount != nil {
@@ -1364,7 +1364,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1377,7 +1377,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1386,7 +1386,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1395,7 +1395,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ReplicaCount’:
+	// Set property "ReplicaCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicaCount != nil {
@@ -1404,7 +1404,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘SharedPrivateLinkResources’:
+	// Set property "SharedPrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SharedPrivateLinkResources {
@@ -1417,7 +1417,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1428,7 +1428,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		service.Sku = &sku
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -1437,7 +1437,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘StatusDetails’:
+	// Set property "StatusDetails":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StatusDetails != nil {
@@ -1446,7 +1446,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		service.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1454,7 +1454,7 @@ func (service *SearchService_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		service.Type = &typeVar
@@ -1830,7 +1830,7 @@ func (options *DataPlaneAuthOptions) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &DataPlaneAuthOptions_ARM{}
 
-	// Set property ‘AadOrApiKey’:
+	// Set property "AadOrApiKey":
 	if options.AadOrApiKey != nil {
 		aadOrApiKey_ARM, err := (*options.AadOrApiKey).ConvertToARM(resolved)
 		if err != nil {
@@ -1854,7 +1854,7 @@ func (options *DataPlaneAuthOptions) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataPlaneAuthOptions_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadOrApiKey’:
+	// Set property "AadOrApiKey":
 	if typedInput.AadOrApiKey != nil {
 		var aadOrApiKey1 DataPlaneAadOrApiKeyAuthOption
 		err := aadOrApiKey1.PopulateFromARM(owner, *typedInput.AadOrApiKey)
@@ -1960,7 +1960,7 @@ func (options *DataPlaneAuthOptions_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataPlaneAuthOptions_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadOrApiKey’:
+	// Set property "AadOrApiKey":
 	if typedInput.AadOrApiKey != nil {
 		var aadOrApiKey1 DataPlaneAadOrApiKeyAuthOption_STATUS
 		err := aadOrApiKey1.PopulateFromARM(owner, *typedInput.AadOrApiKey)
@@ -1971,7 +1971,7 @@ func (options *DataPlaneAuthOptions_STATUS) PopulateFromARM(owner genruntime.Arb
 		options.AadOrApiKey = &aadOrApiKey
 	}
 
-	// Set property ‘ApiKeyOnly’:
+	// Set property "ApiKeyOnly":
 	if typedInput.ApiKeyOnly != nil {
 		options.ApiKeyOnly = make(map[string]v1.JSON, len(typedInput.ApiKeyOnly))
 		for key, value := range typedInput.ApiKeyOnly {
@@ -2072,7 +2072,7 @@ func (withCmk *EncryptionWithCmk) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &EncryptionWithCmk_ARM{}
 
-	// Set property ‘Enforcement’:
+	// Set property "Enforcement":
 	if withCmk.Enforcement != nil {
 		enforcement := *withCmk.Enforcement
 		result.Enforcement = &enforcement
@@ -2092,7 +2092,7 @@ func (withCmk *EncryptionWithCmk) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionWithCmk_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enforcement’:
+	// Set property "Enforcement":
 	if typedInput.Enforcement != nil {
 		enforcement := *typedInput.Enforcement
 		withCmk.Enforcement = &enforcement
@@ -2182,13 +2182,13 @@ func (withCmk *EncryptionWithCmk_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionWithCmk_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EncryptionComplianceStatus’:
+	// Set property "EncryptionComplianceStatus":
 	if typedInput.EncryptionComplianceStatus != nil {
 		encryptionComplianceStatus := *typedInput.EncryptionComplianceStatus
 		withCmk.EncryptionComplianceStatus = &encryptionComplianceStatus
 	}
 
-	// Set property ‘Enforcement’:
+	// Set property "Enforcement":
 	if typedInput.Enforcement != nil {
 		enforcement := *typedInput.Enforcement
 		withCmk.Enforcement = &enforcement
@@ -2269,7 +2269,7 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Identity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
@@ -2289,7 +2289,7 @@ func (identity *Identity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
@@ -2379,19 +2379,19 @@ func (identity *Identity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
@@ -2470,7 +2470,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &NetworkRuleSet_ARM{}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range ruleSet.IpRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2493,7 +2493,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IpRule
 		err := item1.PopulateFromARM(owner, item)
@@ -2614,7 +2614,7 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IpRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2708,7 +2708,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -2870,7 +2870,7 @@ func (resource *SharedPrivateLinkResource_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SharedPrivateLinkResource_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		resource.Id = &id
@@ -2929,7 +2929,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
@@ -2949,7 +2949,7 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -3038,7 +3038,7 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
@@ -3103,7 +3103,7 @@ func (option *DataPlaneAadOrApiKeyAuthOption) ConvertToARM(resolved genruntime.C
 	}
 	result := &DataPlaneAadOrApiKeyAuthOption_ARM{}
 
-	// Set property ‘AadAuthFailureMode’:
+	// Set property "AadAuthFailureMode":
 	if option.AadAuthFailureMode != nil {
 		aadAuthFailureMode := *option.AadAuthFailureMode
 		result.AadAuthFailureMode = &aadAuthFailureMode
@@ -3123,7 +3123,7 @@ func (option *DataPlaneAadOrApiKeyAuthOption) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataPlaneAadOrApiKeyAuthOption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadAuthFailureMode’:
+	// Set property "AadAuthFailureMode":
 	if typedInput.AadAuthFailureMode != nil {
 		aadAuthFailureMode := *typedInput.AadAuthFailureMode
 		option.AadAuthFailureMode = &aadAuthFailureMode
@@ -3208,7 +3208,7 @@ func (option *DataPlaneAadOrApiKeyAuthOption_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataPlaneAadOrApiKeyAuthOption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AadAuthFailureMode’:
+	// Set property "AadAuthFailureMode":
 	if typedInput.AadAuthFailureMode != nil {
 		aadAuthFailureMode := *typedInput.AadAuthFailureMode
 		option.AadAuthFailureMode = &aadAuthFailureMode
@@ -3297,7 +3297,7 @@ func (rule *IpRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &IpRule_ARM{}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if rule.Value != nil {
 		value := *rule.Value
 		result.Value = &value
@@ -3317,7 +3317,7 @@ func (rule *IpRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -3387,7 +3387,7 @@ func (rule *IpRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value

--- a/v2/api/servicebus/v1api20210101preview/namespace_types_gen.go
+++ b/v2/api/servicebus/v1api20210101preview/namespace_types_gen.go
@@ -381,7 +381,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &Namespace_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if namespace.Identity != nil {
 		identity_ARM, err := (*namespace.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -391,16 +391,16 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if namespace.Location != nil {
 		location := *namespace.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if namespace.Encryption != nil || namespace.ZoneRedundant != nil {
 		result.Properties = &SBNamespaceProperties_ARM{}
 	}
@@ -417,7 +417,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.ZoneRedundant = &zoneRedundant
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if namespace.Sku != nil {
 		sku_ARM, err := (*namespace.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -427,7 +427,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if namespace.Tags != nil {
 		result.Tags = make(map[string]string, len(namespace.Tags))
 		for key, value := range namespace.Tags {
@@ -449,10 +449,10 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespace_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	namespace.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -466,7 +466,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -477,18 +477,18 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		namespace.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		namespace.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	namespace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 SBSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -499,7 +499,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		namespace.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		namespace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -507,7 +507,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -927,9 +927,9 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespace_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -938,7 +938,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -952,13 +952,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		namespace.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -969,13 +969,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		namespace.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		namespace.Location = &location
 	}
 
-	// Set property ‘MetricId’:
+	// Set property "MetricId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MetricId != nil {
@@ -984,13 +984,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		namespace.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1003,7 +1003,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1012,7 +1012,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ServiceBusEndpoint’:
+	// Set property "ServiceBusEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceBusEndpoint != nil {
@@ -1021,7 +1021,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 SBSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1032,7 +1032,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		namespace.Sku = &sku
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -1041,7 +1041,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1052,7 +1052,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		namespace.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		namespace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1060,13 +1060,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		namespace.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {
@@ -1075,7 +1075,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -1352,13 +1352,13 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Encryption_ARM{}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if encryption.KeySource != nil {
 		keySource := *encryption.KeySource
 		result.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	for _, item := range encryption.KeyVaultProperties {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1367,7 +1367,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.KeyVaultProperties = append(result.KeyVaultProperties, *item_ARM.(*KeyVaultProperties_ARM))
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if encryption.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *encryption.RequireInfrastructureEncryption
 		result.RequireInfrastructureEncryption = &requireInfrastructureEncryption
@@ -1387,13 +1387,13 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	for _, item := range typedInput.KeyVaultProperties {
 		var item1 KeyVaultProperties
 		err := item1.PopulateFromARM(owner, item)
@@ -1403,7 +1403,7 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		encryption.KeyVaultProperties = append(encryption.KeyVaultProperties, item1)
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
@@ -1571,13 +1571,13 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	for _, item := range typedInput.KeyVaultProperties {
 		var item1 KeyVaultProperties_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1587,7 +1587,7 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		encryption.KeyVaultProperties = append(encryption.KeyVaultProperties, item1)
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
@@ -1706,13 +1706,13 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Identity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -1737,13 +1737,13 @@ func (identity *Identity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -1880,25 +1880,25 @@ func (identity *Identity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]DictionaryValue_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2075,7 +2075,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -2136,19 +2136,19 @@ func (sbSku *SBSku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &SBSku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sbSku.Capacity != nil {
 		capacity := *sbSku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sbSku.Name != nil {
 		name := *sbSku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sbSku.Tier != nil {
 		tier := *sbSku.Tier
 		result.Tier = &tier
@@ -2168,19 +2168,19 @@ func (sbSku *SBSku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SBSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sbSku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sbSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sbSku.Tier = &tier
@@ -2303,19 +2303,19 @@ func (sbSku *SBSku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SBSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sbSku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sbSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sbSku.Tier = &tier
@@ -2421,37 +2421,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -2563,13 +2563,13 @@ func (value *DictionaryValue_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DictionaryValue_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		value.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		value.PrincipalId = &principalId
@@ -2646,7 +2646,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if properties.Identity != nil {
 		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -2656,19 +2656,19 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 		result.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if properties.KeyName != nil {
 		keyName := *properties.KeyName
 		result.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVaultUri’:
+	// Set property "KeyVaultUri":
 	if properties.KeyVaultUri != nil {
 		keyVaultUri := *properties.KeyVaultUri
 		result.KeyVaultUri = &keyVaultUri
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if properties.KeyVersion != nil {
 		keyVersion := *properties.KeyVersion
 		result.KeyVersion = &keyVersion
@@ -2688,7 +2688,7 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 UserAssignedIdentityProperties
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2699,19 +2699,19 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		properties.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		properties.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVaultUri’:
+	// Set property "KeyVaultUri":
 	if typedInput.KeyVaultUri != nil {
 		keyVaultUri := *typedInput.KeyVaultUri
 		properties.KeyVaultUri = &keyVaultUri
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		properties.KeyVersion = &keyVersion
@@ -2842,7 +2842,7 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 UserAssignedIdentityProperties_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2853,19 +2853,19 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		properties.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		properties.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVaultUri’:
+	// Set property "KeyVaultUri":
 	if typedInput.KeyVaultUri != nil {
 		keyVaultUri := *typedInput.KeyVaultUri
 		properties.KeyVaultUri = &keyVaultUri
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		properties.KeyVersion = &keyVersion
@@ -3112,7 +3112,7 @@ func (properties *UserAssignedIdentityProperties) ConvertToARM(resolved genrunti
 	}
 	result := &UserAssignedIdentityProperties_ARM{}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if properties.UserAssignedIdentityReference != nil {
 		userAssignedIdentityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.UserAssignedIdentityReference)
 		if err != nil {
@@ -3136,7 +3136,7 @@ func (properties *UserAssignedIdentityProperties) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentityProperties_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘UserAssignedIdentityReference’
+	// no assignment for property "UserAssignedIdentityReference"
 
 	// No error
 	return nil
@@ -3207,7 +3207,7 @@ func (properties *UserAssignedIdentityProperties_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentityProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		properties.UserAssignedIdentity = &userAssignedIdentity

--- a/v2/api/servicebus/v1api20210101preview/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/servicebus/v1api20210101preview/namespaces_authorization_rule_types_gen.go
@@ -362,10 +362,10 @@ func (rule *Namespaces_AuthorizationRule_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &Namespaces_AuthorizationRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.Rights != nil {
 		result.Properties = &Namespaces_AuthorizationRule_Properties_Spec_ARM{}
 	}
@@ -387,15 +387,15 @@ func (rule *Namespaces_AuthorizationRule_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_AuthorizationRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Rights’:
+	// Set property "Rights":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Rights {
@@ -670,21 +670,21 @@ func (rule *Namespaces_AuthorizationRule_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_AuthorizationRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Rights’:
+	// Set property "Rights":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Rights {
@@ -692,7 +692,7 @@ func (rule *Namespaces_AuthorizationRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -703,7 +703,7 @@ func (rule *Namespaces_AuthorizationRule_STATUS) PopulateFromARM(owner genruntim
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/servicebus/v1api20210101preview/namespaces_queue_types_gen.go
+++ b/v2/api/servicebus/v1api20210101preview/namespaces_queue_types_gen.go
@@ -383,10 +383,10 @@ func (queue *Namespaces_Queue_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &Namespaces_Queue_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if queue.AutoDeleteOnIdle != nil ||
 		queue.DeadLetteringOnMessageExpiration != nil ||
 		queue.DefaultMessageTimeToLive != nil ||
@@ -474,7 +474,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Queue_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoDeleteOnIdle’:
+	// Set property "AutoDeleteOnIdle":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoDeleteOnIdle != nil {
@@ -483,10 +483,10 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	queue.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DeadLetteringOnMessageExpiration’:
+	// Set property "DeadLetteringOnMessageExpiration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetteringOnMessageExpiration != nil {
@@ -495,7 +495,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DefaultMessageTimeToLive’:
+	// Set property "DefaultMessageTimeToLive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultMessageTimeToLive != nil {
@@ -504,7 +504,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DuplicateDetectionHistoryTimeWindow’:
+	// Set property "DuplicateDetectionHistoryTimeWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DuplicateDetectionHistoryTimeWindow != nil {
@@ -513,7 +513,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableBatchedOperations’:
+	// Set property "EnableBatchedOperations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBatchedOperations != nil {
@@ -522,7 +522,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableExpress’:
+	// Set property "EnableExpress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableExpress != nil {
@@ -531,7 +531,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnablePartitioning’:
+	// Set property "EnablePartitioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePartitioning != nil {
@@ -540,7 +540,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ForwardDeadLetteredMessagesTo’:
+	// Set property "ForwardDeadLetteredMessagesTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardDeadLetteredMessagesTo != nil {
@@ -549,7 +549,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ForwardTo’:
+	// Set property "ForwardTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardTo != nil {
@@ -558,7 +558,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘LockDuration’:
+	// Set property "LockDuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LockDuration != nil {
@@ -567,7 +567,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxDeliveryCount != nil {
@@ -576,7 +576,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘MaxSizeInMegabytes’:
+	// Set property "MaxSizeInMegabytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxSizeInMegabytes != nil {
@@ -585,10 +585,10 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	queue.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RequiresDuplicateDetection’:
+	// Set property "RequiresDuplicateDetection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresDuplicateDetection != nil {
@@ -597,7 +597,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘RequiresSession’:
+	// Set property "RequiresSession":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresSession != nil {
@@ -1092,7 +1092,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Queue_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessedAt’:
+	// Set property "AccessedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessedAt != nil {
@@ -1101,7 +1101,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AutoDeleteOnIdle’:
+	// Set property "AutoDeleteOnIdle":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoDeleteOnIdle != nil {
@@ -1110,9 +1110,9 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CountDetails’:
+	// Set property "CountDetails":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CountDetails != nil {
@@ -1126,7 +1126,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -1135,7 +1135,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DeadLetteringOnMessageExpiration’:
+	// Set property "DeadLetteringOnMessageExpiration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetteringOnMessageExpiration != nil {
@@ -1144,7 +1144,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DefaultMessageTimeToLive’:
+	// Set property "DefaultMessageTimeToLive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultMessageTimeToLive != nil {
@@ -1153,7 +1153,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DuplicateDetectionHistoryTimeWindow’:
+	// Set property "DuplicateDetectionHistoryTimeWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DuplicateDetectionHistoryTimeWindow != nil {
@@ -1162,7 +1162,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableBatchedOperations’:
+	// Set property "EnableBatchedOperations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBatchedOperations != nil {
@@ -1171,7 +1171,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableExpress’:
+	// Set property "EnableExpress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableExpress != nil {
@@ -1180,7 +1180,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnablePartitioning’:
+	// Set property "EnablePartitioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePartitioning != nil {
@@ -1189,7 +1189,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ForwardDeadLetteredMessagesTo’:
+	// Set property "ForwardDeadLetteredMessagesTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardDeadLetteredMessagesTo != nil {
@@ -1198,7 +1198,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ForwardTo’:
+	// Set property "ForwardTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardTo != nil {
@@ -1207,13 +1207,13 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		queue.Id = &id
 	}
 
-	// Set property ‘LockDuration’:
+	// Set property "LockDuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LockDuration != nil {
@@ -1222,7 +1222,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxDeliveryCount != nil {
@@ -1231,7 +1231,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘MaxSizeInMegabytes’:
+	// Set property "MaxSizeInMegabytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxSizeInMegabytes != nil {
@@ -1240,7 +1240,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘MessageCount’:
+	// Set property "MessageCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MessageCount != nil {
@@ -1249,13 +1249,13 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		queue.Name = &name
 	}
 
-	// Set property ‘RequiresDuplicateDetection’:
+	// Set property "RequiresDuplicateDetection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresDuplicateDetection != nil {
@@ -1264,7 +1264,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘RequiresSession’:
+	// Set property "RequiresSession":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresSession != nil {
@@ -1273,7 +1273,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SizeInBytes’:
+	// Set property "SizeInBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SizeInBytes != nil {
@@ -1282,7 +1282,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -1291,7 +1291,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1302,13 +1302,13 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		queue.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		queue.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {
@@ -1653,31 +1653,31 @@ func (details *MessageCountDetails_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MessageCountDetails_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActiveMessageCount’:
+	// Set property "ActiveMessageCount":
 	if typedInput.ActiveMessageCount != nil {
 		activeMessageCount := *typedInput.ActiveMessageCount
 		details.ActiveMessageCount = &activeMessageCount
 	}
 
-	// Set property ‘DeadLetterMessageCount’:
+	// Set property "DeadLetterMessageCount":
 	if typedInput.DeadLetterMessageCount != nil {
 		deadLetterMessageCount := *typedInput.DeadLetterMessageCount
 		details.DeadLetterMessageCount = &deadLetterMessageCount
 	}
 
-	// Set property ‘ScheduledMessageCount’:
+	// Set property "ScheduledMessageCount":
 	if typedInput.ScheduledMessageCount != nil {
 		scheduledMessageCount := *typedInput.ScheduledMessageCount
 		details.ScheduledMessageCount = &scheduledMessageCount
 	}
 
-	// Set property ‘TransferDeadLetterMessageCount’:
+	// Set property "TransferDeadLetterMessageCount":
 	if typedInput.TransferDeadLetterMessageCount != nil {
 		transferDeadLetterMessageCount := *typedInput.TransferDeadLetterMessageCount
 		details.TransferDeadLetterMessageCount = &transferDeadLetterMessageCount
 	}
 
-	// Set property ‘TransferMessageCount’:
+	// Set property "TransferMessageCount":
 	if typedInput.TransferMessageCount != nil {
 		transferMessageCount := *typedInput.TransferMessageCount
 		details.TransferMessageCount = &transferMessageCount

--- a/v2/api/servicebus/v1api20210101preview/namespaces_topic_types_gen.go
+++ b/v2/api/servicebus/v1api20210101preview/namespaces_topic_types_gen.go
@@ -365,10 +365,10 @@ func (topic *Namespaces_Topic_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &Namespaces_Topic_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if topic.AutoDeleteOnIdle != nil ||
 		topic.DefaultMessageTimeToLive != nil ||
 		topic.DuplicateDetectionHistoryTimeWindow != nil ||
@@ -431,7 +431,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Topic_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoDeleteOnIdle’:
+	// Set property "AutoDeleteOnIdle":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoDeleteOnIdle != nil {
@@ -440,10 +440,10 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	topic.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DefaultMessageTimeToLive’:
+	// Set property "DefaultMessageTimeToLive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultMessageTimeToLive != nil {
@@ -452,7 +452,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DuplicateDetectionHistoryTimeWindow’:
+	// Set property "DuplicateDetectionHistoryTimeWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DuplicateDetectionHistoryTimeWindow != nil {
@@ -461,7 +461,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableBatchedOperations’:
+	// Set property "EnableBatchedOperations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBatchedOperations != nil {
@@ -470,7 +470,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableExpress’:
+	// Set property "EnableExpress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableExpress != nil {
@@ -479,7 +479,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnablePartitioning’:
+	// Set property "EnablePartitioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePartitioning != nil {
@@ -488,7 +488,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘MaxSizeInMegabytes’:
+	// Set property "MaxSizeInMegabytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxSizeInMegabytes != nil {
@@ -497,10 +497,10 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	topic.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RequiresDuplicateDetection’:
+	// Set property "RequiresDuplicateDetection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresDuplicateDetection != nil {
@@ -509,7 +509,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SupportOrdering’:
+	// Set property "SupportOrdering":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SupportOrdering != nil {
@@ -926,7 +926,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Topic_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessedAt’:
+	// Set property "AccessedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessedAt != nil {
@@ -935,7 +935,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AutoDeleteOnIdle’:
+	// Set property "AutoDeleteOnIdle":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoDeleteOnIdle != nil {
@@ -944,9 +944,9 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CountDetails’:
+	// Set property "CountDetails":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CountDetails != nil {
@@ -960,7 +960,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -969,7 +969,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DefaultMessageTimeToLive’:
+	// Set property "DefaultMessageTimeToLive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultMessageTimeToLive != nil {
@@ -978,7 +978,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DuplicateDetectionHistoryTimeWindow’:
+	// Set property "DuplicateDetectionHistoryTimeWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DuplicateDetectionHistoryTimeWindow != nil {
@@ -987,7 +987,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableBatchedOperations’:
+	// Set property "EnableBatchedOperations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBatchedOperations != nil {
@@ -996,7 +996,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableExpress’:
+	// Set property "EnableExpress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableExpress != nil {
@@ -1005,7 +1005,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnablePartitioning’:
+	// Set property "EnablePartitioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePartitioning != nil {
@@ -1014,13 +1014,13 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		topic.Id = &id
 	}
 
-	// Set property ‘MaxSizeInMegabytes’:
+	// Set property "MaxSizeInMegabytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxSizeInMegabytes != nil {
@@ -1029,13 +1029,13 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		topic.Name = &name
 	}
 
-	// Set property ‘RequiresDuplicateDetection’:
+	// Set property "RequiresDuplicateDetection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresDuplicateDetection != nil {
@@ -1044,7 +1044,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SizeInBytes’:
+	// Set property "SizeInBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SizeInBytes != nil {
@@ -1053,7 +1053,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -1062,7 +1062,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SubscriptionCount’:
+	// Set property "SubscriptionCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SubscriptionCount != nil {
@@ -1071,7 +1071,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SupportOrdering’:
+	// Set property "SupportOrdering":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SupportOrdering != nil {
@@ -1080,7 +1080,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1091,13 +1091,13 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		topic.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		topic.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {

--- a/v2/api/servicebus/v1api20210101preview/namespaces_topics_subscription_types_gen.go
+++ b/v2/api/servicebus/v1api20210101preview/namespaces_topics_subscription_types_gen.go
@@ -372,10 +372,10 @@ func (subscription *Namespaces_Topics_Subscription_Spec) ConvertToARM(resolved g
 	}
 	result := &Namespaces_Topics_Subscription_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if subscription.AutoDeleteOnIdle != nil ||
 		subscription.DeadLetteringOnFilterEvaluationExceptions != nil ||
 		subscription.DeadLetteringOnMessageExpiration != nil ||
@@ -448,7 +448,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Topics_Subscription_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoDeleteOnIdle’:
+	// Set property "AutoDeleteOnIdle":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoDeleteOnIdle != nil {
@@ -457,10 +457,10 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	subscription.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DeadLetteringOnFilterEvaluationExceptions’:
+	// Set property "DeadLetteringOnFilterEvaluationExceptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetteringOnFilterEvaluationExceptions != nil {
@@ -469,7 +469,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘DeadLetteringOnMessageExpiration’:
+	// Set property "DeadLetteringOnMessageExpiration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetteringOnMessageExpiration != nil {
@@ -478,7 +478,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘DefaultMessageTimeToLive’:
+	// Set property "DefaultMessageTimeToLive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultMessageTimeToLive != nil {
@@ -487,7 +487,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘DuplicateDetectionHistoryTimeWindow’:
+	// Set property "DuplicateDetectionHistoryTimeWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DuplicateDetectionHistoryTimeWindow != nil {
@@ -496,7 +496,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘EnableBatchedOperations’:
+	// Set property "EnableBatchedOperations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBatchedOperations != nil {
@@ -505,7 +505,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ForwardDeadLetteredMessagesTo’:
+	// Set property "ForwardDeadLetteredMessagesTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardDeadLetteredMessagesTo != nil {
@@ -514,7 +514,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ForwardTo’:
+	// Set property "ForwardTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardTo != nil {
@@ -523,7 +523,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘LockDuration’:
+	// Set property "LockDuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LockDuration != nil {
@@ -532,7 +532,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxDeliveryCount != nil {
@@ -541,10 +541,10 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	subscription.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RequiresSession’:
+	// Set property "RequiresSession":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresSession != nil {
@@ -969,7 +969,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Topics_Subscription_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessedAt’:
+	// Set property "AccessedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessedAt != nil {
@@ -978,7 +978,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘AutoDeleteOnIdle’:
+	// Set property "AutoDeleteOnIdle":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoDeleteOnIdle != nil {
@@ -987,9 +987,9 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CountDetails’:
+	// Set property "CountDetails":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CountDetails != nil {
@@ -1003,7 +1003,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -1012,7 +1012,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DeadLetteringOnFilterEvaluationExceptions’:
+	// Set property "DeadLetteringOnFilterEvaluationExceptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetteringOnFilterEvaluationExceptions != nil {
@@ -1021,7 +1021,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DeadLetteringOnMessageExpiration’:
+	// Set property "DeadLetteringOnMessageExpiration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetteringOnMessageExpiration != nil {
@@ -1030,7 +1030,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DefaultMessageTimeToLive’:
+	// Set property "DefaultMessageTimeToLive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultMessageTimeToLive != nil {
@@ -1039,7 +1039,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DuplicateDetectionHistoryTimeWindow’:
+	// Set property "DuplicateDetectionHistoryTimeWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DuplicateDetectionHistoryTimeWindow != nil {
@@ -1048,7 +1048,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘EnableBatchedOperations’:
+	// Set property "EnableBatchedOperations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBatchedOperations != nil {
@@ -1057,7 +1057,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘ForwardDeadLetteredMessagesTo’:
+	// Set property "ForwardDeadLetteredMessagesTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardDeadLetteredMessagesTo != nil {
@@ -1066,7 +1066,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘ForwardTo’:
+	// Set property "ForwardTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardTo != nil {
@@ -1075,13 +1075,13 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		subscription.Id = &id
 	}
 
-	// Set property ‘LockDuration’:
+	// Set property "LockDuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LockDuration != nil {
@@ -1090,7 +1090,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxDeliveryCount != nil {
@@ -1099,7 +1099,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘MessageCount’:
+	// Set property "MessageCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MessageCount != nil {
@@ -1108,13 +1108,13 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		subscription.Name = &name
 	}
 
-	// Set property ‘RequiresSession’:
+	// Set property "RequiresSession":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresSession != nil {
@@ -1123,7 +1123,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -1132,7 +1132,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1143,13 +1143,13 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		subscription.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		subscription.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {

--- a/v2/api/servicebus/v1api20210101preview/namespaces_topics_subscriptions_rule_types_gen.go
+++ b/v2/api/servicebus/v1api20210101preview/namespaces_topics_subscriptions_rule_types_gen.go
@@ -346,10 +346,10 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_Spec) ConvertToARM(resolved gen
 	}
 	result := &Namespaces_Topics_Subscriptions_Rule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.Action != nil ||
 		rule.CorrelationFilter != nil ||
 		rule.FilterType != nil ||
@@ -399,7 +399,7 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_Spec) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Topics_Subscriptions_Rule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Action != nil {
@@ -413,10 +413,10 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CorrelationFilter’:
+	// Set property "CorrelationFilter":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CorrelationFilter != nil {
@@ -430,7 +430,7 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘FilterType’:
+	// Set property "FilterType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FilterType != nil {
@@ -439,10 +439,10 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘SqlFilter’:
+	// Set property "SqlFilter":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SqlFilter != nil {
@@ -801,7 +801,7 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Topics_Subscriptions_Rule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Action != nil {
@@ -815,9 +815,9 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CorrelationFilter’:
+	// Set property "CorrelationFilter":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CorrelationFilter != nil {
@@ -831,7 +831,7 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘FilterType’:
+	// Set property "FilterType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FilterType != nil {
@@ -840,19 +840,19 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘SqlFilter’:
+	// Set property "SqlFilter":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SqlFilter != nil {
@@ -866,7 +866,7 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -877,7 +877,7 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_STATUS) PopulateFromARM(owner g
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -1069,19 +1069,19 @@ func (action *Action) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &Action_ARM{}
 
-	// Set property ‘CompatibilityLevel’:
+	// Set property "CompatibilityLevel":
 	if action.CompatibilityLevel != nil {
 		compatibilityLevel := *action.CompatibilityLevel
 		result.CompatibilityLevel = &compatibilityLevel
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if action.RequiresPreprocessing != nil {
 		requiresPreprocessing := *action.RequiresPreprocessing
 		result.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SqlExpression’:
+	// Set property "SqlExpression":
 	if action.SqlExpression != nil {
 		sqlExpression := *action.SqlExpression
 		result.SqlExpression = &sqlExpression
@@ -1101,19 +1101,19 @@ func (action *Action) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Action_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CompatibilityLevel’:
+	// Set property "CompatibilityLevel":
 	if typedInput.CompatibilityLevel != nil {
 		compatibilityLevel := *typedInput.CompatibilityLevel
 		action.CompatibilityLevel = &compatibilityLevel
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if typedInput.RequiresPreprocessing != nil {
 		requiresPreprocessing := *typedInput.RequiresPreprocessing
 		action.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SqlExpression’:
+	// Set property "SqlExpression":
 	if typedInput.SqlExpression != nil {
 		sqlExpression := *typedInput.SqlExpression
 		action.SqlExpression = &sqlExpression
@@ -1223,19 +1223,19 @@ func (action *Action_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Action_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CompatibilityLevel’:
+	// Set property "CompatibilityLevel":
 	if typedInput.CompatibilityLevel != nil {
 		compatibilityLevel := *typedInput.CompatibilityLevel
 		action.CompatibilityLevel = &compatibilityLevel
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if typedInput.RequiresPreprocessing != nil {
 		requiresPreprocessing := *typedInput.RequiresPreprocessing
 		action.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SqlExpression’:
+	// Set property "SqlExpression":
 	if typedInput.SqlExpression != nil {
 		sqlExpression := *typedInput.SqlExpression
 		action.SqlExpression = &sqlExpression
@@ -1338,31 +1338,31 @@ func (filter *CorrelationFilter) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &CorrelationFilter_ARM{}
 
-	// Set property ‘ContentType’:
+	// Set property "ContentType":
 	if filter.ContentType != nil {
 		contentType := *filter.ContentType
 		result.ContentType = &contentType
 	}
 
-	// Set property ‘CorrelationId’:
+	// Set property "CorrelationId":
 	if filter.CorrelationId != nil {
 		correlationId := *filter.CorrelationId
 		result.CorrelationId = &correlationId
 	}
 
-	// Set property ‘Label’:
+	// Set property "Label":
 	if filter.Label != nil {
 		label := *filter.Label
 		result.Label = &label
 	}
 
-	// Set property ‘MessageId’:
+	// Set property "MessageId":
 	if filter.MessageId != nil {
 		messageId := *filter.MessageId
 		result.MessageId = &messageId
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if filter.Properties != nil {
 		result.Properties = make(map[string]string, len(filter.Properties))
 		for key, value := range filter.Properties {
@@ -1370,31 +1370,31 @@ func (filter *CorrelationFilter) ConvertToARM(resolved genruntime.ConvertToARMRe
 		}
 	}
 
-	// Set property ‘ReplyTo’:
+	// Set property "ReplyTo":
 	if filter.ReplyTo != nil {
 		replyTo := *filter.ReplyTo
 		result.ReplyTo = &replyTo
 	}
 
-	// Set property ‘ReplyToSessionId’:
+	// Set property "ReplyToSessionId":
 	if filter.ReplyToSessionId != nil {
 		replyToSessionId := *filter.ReplyToSessionId
 		result.ReplyToSessionId = &replyToSessionId
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if filter.RequiresPreprocessing != nil {
 		requiresPreprocessing := *filter.RequiresPreprocessing
 		result.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SessionId’:
+	// Set property "SessionId":
 	if filter.SessionId != nil {
 		sessionId := *filter.SessionId
 		result.SessionId = &sessionId
 	}
 
-	// Set property ‘To’:
+	// Set property "To":
 	if filter.To != nil {
 		to := *filter.To
 		result.To = &to
@@ -1414,31 +1414,31 @@ func (filter *CorrelationFilter) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorrelationFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContentType’:
+	// Set property "ContentType":
 	if typedInput.ContentType != nil {
 		contentType := *typedInput.ContentType
 		filter.ContentType = &contentType
 	}
 
-	// Set property ‘CorrelationId’:
+	// Set property "CorrelationId":
 	if typedInput.CorrelationId != nil {
 		correlationId := *typedInput.CorrelationId
 		filter.CorrelationId = &correlationId
 	}
 
-	// Set property ‘Label’:
+	// Set property "Label":
 	if typedInput.Label != nil {
 		label := *typedInput.Label
 		filter.Label = &label
 	}
 
-	// Set property ‘MessageId’:
+	// Set property "MessageId":
 	if typedInput.MessageId != nil {
 		messageId := *typedInput.MessageId
 		filter.MessageId = &messageId
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		filter.Properties = make(map[string]string, len(typedInput.Properties))
 		for key, value := range typedInput.Properties {
@@ -1446,31 +1446,31 @@ func (filter *CorrelationFilter) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ReplyTo’:
+	// Set property "ReplyTo":
 	if typedInput.ReplyTo != nil {
 		replyTo := *typedInput.ReplyTo
 		filter.ReplyTo = &replyTo
 	}
 
-	// Set property ‘ReplyToSessionId’:
+	// Set property "ReplyToSessionId":
 	if typedInput.ReplyToSessionId != nil {
 		replyToSessionId := *typedInput.ReplyToSessionId
 		filter.ReplyToSessionId = &replyToSessionId
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if typedInput.RequiresPreprocessing != nil {
 		requiresPreprocessing := *typedInput.RequiresPreprocessing
 		filter.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SessionId’:
+	// Set property "SessionId":
 	if typedInput.SessionId != nil {
 		sessionId := *typedInput.SessionId
 		filter.SessionId = &sessionId
 	}
 
-	// Set property ‘To’:
+	// Set property "To":
 	if typedInput.To != nil {
 		to := *typedInput.To
 		filter.To = &to
@@ -1662,31 +1662,31 @@ func (filter *CorrelationFilter_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorrelationFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContentType’:
+	// Set property "ContentType":
 	if typedInput.ContentType != nil {
 		contentType := *typedInput.ContentType
 		filter.ContentType = &contentType
 	}
 
-	// Set property ‘CorrelationId’:
+	// Set property "CorrelationId":
 	if typedInput.CorrelationId != nil {
 		correlationId := *typedInput.CorrelationId
 		filter.CorrelationId = &correlationId
 	}
 
-	// Set property ‘Label’:
+	// Set property "Label":
 	if typedInput.Label != nil {
 		label := *typedInput.Label
 		filter.Label = &label
 	}
 
-	// Set property ‘MessageId’:
+	// Set property "MessageId":
 	if typedInput.MessageId != nil {
 		messageId := *typedInput.MessageId
 		filter.MessageId = &messageId
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		filter.Properties = make(map[string]string, len(typedInput.Properties))
 		for key, value := range typedInput.Properties {
@@ -1694,31 +1694,31 @@ func (filter *CorrelationFilter_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘ReplyTo’:
+	// Set property "ReplyTo":
 	if typedInput.ReplyTo != nil {
 		replyTo := *typedInput.ReplyTo
 		filter.ReplyTo = &replyTo
 	}
 
-	// Set property ‘ReplyToSessionId’:
+	// Set property "ReplyToSessionId":
 	if typedInput.ReplyToSessionId != nil {
 		replyToSessionId := *typedInput.ReplyToSessionId
 		filter.ReplyToSessionId = &replyToSessionId
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if typedInput.RequiresPreprocessing != nil {
 		requiresPreprocessing := *typedInput.RequiresPreprocessing
 		filter.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SessionId’:
+	// Set property "SessionId":
 	if typedInput.SessionId != nil {
 		sessionId := *typedInput.SessionId
 		filter.SessionId = &sessionId
 	}
 
-	// Set property ‘To’:
+	// Set property "To":
 	if typedInput.To != nil {
 		to := *typedInput.To
 		filter.To = &to
@@ -1862,19 +1862,19 @@ func (filter *SqlFilter) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &SqlFilter_ARM{}
 
-	// Set property ‘CompatibilityLevel’:
+	// Set property "CompatibilityLevel":
 	if filter.CompatibilityLevel != nil {
 		compatibilityLevel := *filter.CompatibilityLevel
 		result.CompatibilityLevel = &compatibilityLevel
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if filter.RequiresPreprocessing != nil {
 		requiresPreprocessing := *filter.RequiresPreprocessing
 		result.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SqlExpression’:
+	// Set property "SqlExpression":
 	if filter.SqlExpression != nil {
 		sqlExpression := *filter.SqlExpression
 		result.SqlExpression = &sqlExpression
@@ -1894,19 +1894,19 @@ func (filter *SqlFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CompatibilityLevel’:
+	// Set property "CompatibilityLevel":
 	if typedInput.CompatibilityLevel != nil {
 		compatibilityLevel := *typedInput.CompatibilityLevel
 		filter.CompatibilityLevel = &compatibilityLevel
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if typedInput.RequiresPreprocessing != nil {
 		requiresPreprocessing := *typedInput.RequiresPreprocessing
 		filter.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SqlExpression’:
+	// Set property "SqlExpression":
 	if typedInput.SqlExpression != nil {
 		sqlExpression := *typedInput.SqlExpression
 		filter.SqlExpression = &sqlExpression
@@ -2030,19 +2030,19 @@ func (filter *SqlFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CompatibilityLevel’:
+	// Set property "CompatibilityLevel":
 	if typedInput.CompatibilityLevel != nil {
 		compatibilityLevel := *typedInput.CompatibilityLevel
 		filter.CompatibilityLevel = &compatibilityLevel
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if typedInput.RequiresPreprocessing != nil {
 		requiresPreprocessing := *typedInput.RequiresPreprocessing
 		filter.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SqlExpression’:
+	// Set property "SqlExpression":
 	if typedInput.SqlExpression != nil {
 		sqlExpression := *typedInput.SqlExpression
 		filter.SqlExpression = &sqlExpression

--- a/v2/api/servicebus/v1beta20210101preview/namespace_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespace_types_gen.go
@@ -370,7 +370,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &Namespace_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if namespace.Identity != nil {
 		identity_ARM, err := (*namespace.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -380,16 +380,16 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if namespace.Location != nil {
 		location := *namespace.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if namespace.Encryption != nil || namespace.ZoneRedundant != nil {
 		result.Properties = &SBNamespaceProperties_ARM{}
 	}
@@ -406,7 +406,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.ZoneRedundant = &zoneRedundant
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if namespace.Sku != nil {
 		sku_ARM, err := (*namespace.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -416,7 +416,7 @@ func (namespace *Namespace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if namespace.Tags != nil {
 		result.Tags = make(map[string]string, len(namespace.Tags))
 		for key, value := range namespace.Tags {
@@ -438,10 +438,10 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespace_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	namespace.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -455,7 +455,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -466,18 +466,18 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		namespace.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		namespace.Location = &location
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	namespace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 SBSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -488,7 +488,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		namespace.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		namespace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -496,7 +496,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -826,9 +826,9 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespace_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -837,7 +837,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -851,13 +851,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		namespace.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -868,13 +868,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		namespace.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		namespace.Location = &location
 	}
 
-	// Set property ‘MetricId’:
+	// Set property "MetricId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MetricId != nil {
@@ -883,13 +883,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		namespace.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -902,7 +902,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -911,7 +911,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ServiceBusEndpoint’:
+	// Set property "ServiceBusEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServiceBusEndpoint != nil {
@@ -920,7 +920,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 SBSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -931,7 +931,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		namespace.Sku = &sku
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -940,7 +940,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -951,7 +951,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		namespace.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		namespace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -959,13 +959,13 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		namespace.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {
@@ -974,7 +974,7 @@ func (namespace *Namespace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -1246,13 +1246,13 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Encryption_ARM{}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if encryption.KeySource != nil {
 		keySource := *encryption.KeySource
 		result.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	for _, item := range encryption.KeyVaultProperties {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1261,7 +1261,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.KeyVaultProperties = append(result.KeyVaultProperties, *item_ARM.(*KeyVaultProperties_ARM))
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if encryption.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *encryption.RequireInfrastructureEncryption
 		result.RequireInfrastructureEncryption = &requireInfrastructureEncryption
@@ -1281,13 +1281,13 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	for _, item := range typedInput.KeyVaultProperties {
 		var item1 KeyVaultProperties
 		err := item1.PopulateFromARM(owner, item)
@@ -1297,7 +1297,7 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		encryption.KeyVaultProperties = append(encryption.KeyVaultProperties, item1)
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
@@ -1419,13 +1419,13 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘KeyVaultProperties’:
+	// Set property "KeyVaultProperties":
 	for _, item := range typedInput.KeyVaultProperties {
 		var item1 KeyVaultProperties_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1435,7 +1435,7 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		encryption.KeyVaultProperties = append(encryption.KeyVaultProperties, item1)
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
@@ -1551,13 +1551,13 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Identity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -1582,13 +1582,13 @@ func (identity *Identity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -1691,25 +1691,25 @@ func (identity *Identity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]DictionaryValue_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -1885,7 +1885,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -1942,19 +1942,19 @@ func (sbSku *SBSku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &SBSku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sbSku.Capacity != nil {
 		capacity := *sbSku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sbSku.Name != nil {
 		name := *sbSku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sbSku.Tier != nil {
 		tier := *sbSku.Tier
 		result.Tier = &tier
@@ -1974,19 +1974,19 @@ func (sbSku *SBSku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SBSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sbSku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sbSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sbSku.Tier = &tier
@@ -2078,19 +2078,19 @@ func (sbSku *SBSku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SBSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sbSku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sbSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sbSku.Tier = &tier
@@ -2185,37 +2185,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -2324,13 +2324,13 @@ func (value *DictionaryValue_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DictionaryValue_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		value.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		value.PrincipalId = &principalId
@@ -2403,7 +2403,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if properties.Identity != nil {
 		identity_ARM, err := (*properties.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -2413,19 +2413,19 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 		result.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if properties.KeyName != nil {
 		keyName := *properties.KeyName
 		result.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVaultUri’:
+	// Set property "KeyVaultUri":
 	if properties.KeyVaultUri != nil {
 		keyVaultUri := *properties.KeyVaultUri
 		result.KeyVaultUri = &keyVaultUri
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if properties.KeyVersion != nil {
 		keyVersion := *properties.KeyVersion
 		result.KeyVersion = &keyVersion
@@ -2445,7 +2445,7 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 UserAssignedIdentityProperties
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2456,19 +2456,19 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		properties.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		properties.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVaultUri’:
+	// Set property "KeyVaultUri":
 	if typedInput.KeyVaultUri != nil {
 		keyVaultUri := *typedInput.KeyVaultUri
 		properties.KeyVaultUri = &keyVaultUri
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		properties.KeyVersion = &keyVersion
@@ -2565,7 +2565,7 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 UserAssignedIdentityProperties_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2576,19 +2576,19 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		properties.Identity = &identity
 	}
 
-	// Set property ‘KeyName’:
+	// Set property "KeyName":
 	if typedInput.KeyName != nil {
 		keyName := *typedInput.KeyName
 		properties.KeyName = &keyName
 	}
 
-	// Set property ‘KeyVaultUri’:
+	// Set property "KeyVaultUri":
 	if typedInput.KeyVaultUri != nil {
 		keyVaultUri := *typedInput.KeyVaultUri
 		properties.KeyVaultUri = &keyVaultUri
 	}
 
-	// Set property ‘KeyVersion’:
+	// Set property "KeyVersion":
 	if typedInput.KeyVersion != nil {
 		keyVersion := *typedInput.KeyVersion
 		properties.KeyVersion = &keyVersion
@@ -2835,7 +2835,7 @@ func (properties *UserAssignedIdentityProperties) ConvertToARM(resolved genrunti
 	}
 	result := &UserAssignedIdentityProperties_ARM{}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if properties.UserAssignedIdentityReference != nil {
 		userAssignedIdentityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.UserAssignedIdentityReference)
 		if err != nil {
@@ -2859,7 +2859,7 @@ func (properties *UserAssignedIdentityProperties) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentityProperties_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘UserAssignedIdentityReference’
+	// no assignment for property "UserAssignedIdentityReference"
 
 	// No error
 	return nil
@@ -2923,7 +2923,7 @@ func (properties *UserAssignedIdentityProperties_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentityProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		properties.UserAssignedIdentity = &userAssignedIdentity

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_queue_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_queue_types_gen.go
@@ -346,10 +346,10 @@ func (queue *Namespaces_Queue_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &Namespaces_Queue_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if queue.AutoDeleteOnIdle != nil ||
 		queue.DeadLetteringOnMessageExpiration != nil ||
 		queue.DefaultMessageTimeToLive != nil ||
@@ -437,7 +437,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Queue_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoDeleteOnIdle’:
+	// Set property "AutoDeleteOnIdle":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoDeleteOnIdle != nil {
@@ -446,10 +446,10 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	queue.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DeadLetteringOnMessageExpiration’:
+	// Set property "DeadLetteringOnMessageExpiration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetteringOnMessageExpiration != nil {
@@ -458,7 +458,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DefaultMessageTimeToLive’:
+	// Set property "DefaultMessageTimeToLive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultMessageTimeToLive != nil {
@@ -467,7 +467,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DuplicateDetectionHistoryTimeWindow’:
+	// Set property "DuplicateDetectionHistoryTimeWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DuplicateDetectionHistoryTimeWindow != nil {
@@ -476,7 +476,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableBatchedOperations’:
+	// Set property "EnableBatchedOperations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBatchedOperations != nil {
@@ -485,7 +485,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableExpress’:
+	// Set property "EnableExpress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableExpress != nil {
@@ -494,7 +494,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnablePartitioning’:
+	// Set property "EnablePartitioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePartitioning != nil {
@@ -503,7 +503,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ForwardDeadLetteredMessagesTo’:
+	// Set property "ForwardDeadLetteredMessagesTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardDeadLetteredMessagesTo != nil {
@@ -512,7 +512,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ForwardTo’:
+	// Set property "ForwardTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardTo != nil {
@@ -521,7 +521,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘LockDuration’:
+	// Set property "LockDuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LockDuration != nil {
@@ -530,7 +530,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxDeliveryCount != nil {
@@ -539,7 +539,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘MaxSizeInMegabytes’:
+	// Set property "MaxSizeInMegabytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxSizeInMegabytes != nil {
@@ -548,10 +548,10 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	queue.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RequiresDuplicateDetection’:
+	// Set property "RequiresDuplicateDetection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresDuplicateDetection != nil {
@@ -560,7 +560,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘RequiresSession’:
+	// Set property "RequiresSession":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresSession != nil {
@@ -919,7 +919,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Queue_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessedAt’:
+	// Set property "AccessedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessedAt != nil {
@@ -928,7 +928,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AutoDeleteOnIdle’:
+	// Set property "AutoDeleteOnIdle":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoDeleteOnIdle != nil {
@@ -937,9 +937,9 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CountDetails’:
+	// Set property "CountDetails":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CountDetails != nil {
@@ -953,7 +953,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -962,7 +962,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DeadLetteringOnMessageExpiration’:
+	// Set property "DeadLetteringOnMessageExpiration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetteringOnMessageExpiration != nil {
@@ -971,7 +971,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DefaultMessageTimeToLive’:
+	// Set property "DefaultMessageTimeToLive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultMessageTimeToLive != nil {
@@ -980,7 +980,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DuplicateDetectionHistoryTimeWindow’:
+	// Set property "DuplicateDetectionHistoryTimeWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DuplicateDetectionHistoryTimeWindow != nil {
@@ -989,7 +989,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableBatchedOperations’:
+	// Set property "EnableBatchedOperations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBatchedOperations != nil {
@@ -998,7 +998,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableExpress’:
+	// Set property "EnableExpress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableExpress != nil {
@@ -1007,7 +1007,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnablePartitioning’:
+	// Set property "EnablePartitioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePartitioning != nil {
@@ -1016,7 +1016,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ForwardDeadLetteredMessagesTo’:
+	// Set property "ForwardDeadLetteredMessagesTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardDeadLetteredMessagesTo != nil {
@@ -1025,7 +1025,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ForwardTo’:
+	// Set property "ForwardTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardTo != nil {
@@ -1034,13 +1034,13 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		queue.Id = &id
 	}
 
-	// Set property ‘LockDuration’:
+	// Set property "LockDuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LockDuration != nil {
@@ -1049,7 +1049,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxDeliveryCount != nil {
@@ -1058,7 +1058,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘MaxSizeInMegabytes’:
+	// Set property "MaxSizeInMegabytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxSizeInMegabytes != nil {
@@ -1067,7 +1067,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘MessageCount’:
+	// Set property "MessageCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MessageCount != nil {
@@ -1076,13 +1076,13 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		queue.Name = &name
 	}
 
-	// Set property ‘RequiresDuplicateDetection’:
+	// Set property "RequiresDuplicateDetection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresDuplicateDetection != nil {
@@ -1091,7 +1091,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘RequiresSession’:
+	// Set property "RequiresSession":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresSession != nil {
@@ -1100,7 +1100,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SizeInBytes’:
+	// Set property "SizeInBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SizeInBytes != nil {
@@ -1109,7 +1109,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -1118,7 +1118,7 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1129,13 +1129,13 @@ func (queue *Namespaces_Queue_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		queue.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		queue.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {
@@ -1471,31 +1471,31 @@ func (details *MessageCountDetails_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected MessageCountDetails_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActiveMessageCount’:
+	// Set property "ActiveMessageCount":
 	if typedInput.ActiveMessageCount != nil {
 		activeMessageCount := *typedInput.ActiveMessageCount
 		details.ActiveMessageCount = &activeMessageCount
 	}
 
-	// Set property ‘DeadLetterMessageCount’:
+	// Set property "DeadLetterMessageCount":
 	if typedInput.DeadLetterMessageCount != nil {
 		deadLetterMessageCount := *typedInput.DeadLetterMessageCount
 		details.DeadLetterMessageCount = &deadLetterMessageCount
 	}
 
-	// Set property ‘ScheduledMessageCount’:
+	// Set property "ScheduledMessageCount":
 	if typedInput.ScheduledMessageCount != nil {
 		scheduledMessageCount := *typedInput.ScheduledMessageCount
 		details.ScheduledMessageCount = &scheduledMessageCount
 	}
 
-	// Set property ‘TransferDeadLetterMessageCount’:
+	// Set property "TransferDeadLetterMessageCount":
 	if typedInput.TransferDeadLetterMessageCount != nil {
 		transferDeadLetterMessageCount := *typedInput.TransferDeadLetterMessageCount
 		details.TransferDeadLetterMessageCount = &transferDeadLetterMessageCount
 	}
 
-	// Set property ‘TransferMessageCount’:
+	// Set property "TransferMessageCount":
 	if typedInput.TransferMessageCount != nil {
 		transferMessageCount := *typedInput.TransferMessageCount
 		details.TransferMessageCount = &transferMessageCount

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_topic_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_topic_types_gen.go
@@ -341,10 +341,10 @@ func (topic *Namespaces_Topic_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &Namespaces_Topic_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if topic.AutoDeleteOnIdle != nil ||
 		topic.DefaultMessageTimeToLive != nil ||
 		topic.DuplicateDetectionHistoryTimeWindow != nil ||
@@ -407,7 +407,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Topic_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoDeleteOnIdle’:
+	// Set property "AutoDeleteOnIdle":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoDeleteOnIdle != nil {
@@ -416,10 +416,10 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	topic.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DefaultMessageTimeToLive’:
+	// Set property "DefaultMessageTimeToLive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultMessageTimeToLive != nil {
@@ -428,7 +428,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DuplicateDetectionHistoryTimeWindow’:
+	// Set property "DuplicateDetectionHistoryTimeWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DuplicateDetectionHistoryTimeWindow != nil {
@@ -437,7 +437,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableBatchedOperations’:
+	// Set property "EnableBatchedOperations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBatchedOperations != nil {
@@ -446,7 +446,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnableExpress’:
+	// Set property "EnableExpress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableExpress != nil {
@@ -455,7 +455,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘EnablePartitioning’:
+	// Set property "EnablePartitioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePartitioning != nil {
@@ -464,7 +464,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘MaxSizeInMegabytes’:
+	// Set property "MaxSizeInMegabytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxSizeInMegabytes != nil {
@@ -473,10 +473,10 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	topic.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RequiresDuplicateDetection’:
+	// Set property "RequiresDuplicateDetection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresDuplicateDetection != nil {
@@ -485,7 +485,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SupportOrdering’:
+	// Set property "SupportOrdering":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SupportOrdering != nil {
@@ -799,7 +799,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Topic_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessedAt’:
+	// Set property "AccessedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessedAt != nil {
@@ -808,7 +808,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AutoDeleteOnIdle’:
+	// Set property "AutoDeleteOnIdle":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoDeleteOnIdle != nil {
@@ -817,9 +817,9 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CountDetails’:
+	// Set property "CountDetails":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CountDetails != nil {
@@ -833,7 +833,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -842,7 +842,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DefaultMessageTimeToLive’:
+	// Set property "DefaultMessageTimeToLive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultMessageTimeToLive != nil {
@@ -851,7 +851,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DuplicateDetectionHistoryTimeWindow’:
+	// Set property "DuplicateDetectionHistoryTimeWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DuplicateDetectionHistoryTimeWindow != nil {
@@ -860,7 +860,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableBatchedOperations’:
+	// Set property "EnableBatchedOperations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBatchedOperations != nil {
@@ -869,7 +869,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnableExpress’:
+	// Set property "EnableExpress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableExpress != nil {
@@ -878,7 +878,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘EnablePartitioning’:
+	// Set property "EnablePartitioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnablePartitioning != nil {
@@ -887,13 +887,13 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		topic.Id = &id
 	}
 
-	// Set property ‘MaxSizeInMegabytes’:
+	// Set property "MaxSizeInMegabytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxSizeInMegabytes != nil {
@@ -902,13 +902,13 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		topic.Name = &name
 	}
 
-	// Set property ‘RequiresDuplicateDetection’:
+	// Set property "RequiresDuplicateDetection":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresDuplicateDetection != nil {
@@ -917,7 +917,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SizeInBytes’:
+	// Set property "SizeInBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SizeInBytes != nil {
@@ -926,7 +926,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -935,7 +935,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SubscriptionCount’:
+	// Set property "SubscriptionCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SubscriptionCount != nil {
@@ -944,7 +944,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SupportOrdering’:
+	// Set property "SupportOrdering":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SupportOrdering != nil {
@@ -953,7 +953,7 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -964,13 +964,13 @@ func (topic *Namespaces_Topic_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		topic.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		topic.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_topics_subscription_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_topics_subscription_types_gen.go
@@ -344,10 +344,10 @@ func (subscription *Namespaces_Topics_Subscription_Spec) ConvertToARM(resolved g
 	}
 	result := &Namespaces_Topics_Subscription_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if subscription.AutoDeleteOnIdle != nil ||
 		subscription.DeadLetteringOnFilterEvaluationExceptions != nil ||
 		subscription.DeadLetteringOnMessageExpiration != nil ||
@@ -420,7 +420,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Topics_Subscription_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoDeleteOnIdle’:
+	// Set property "AutoDeleteOnIdle":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoDeleteOnIdle != nil {
@@ -429,10 +429,10 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	subscription.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DeadLetteringOnFilterEvaluationExceptions’:
+	// Set property "DeadLetteringOnFilterEvaluationExceptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetteringOnFilterEvaluationExceptions != nil {
@@ -441,7 +441,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘DeadLetteringOnMessageExpiration’:
+	// Set property "DeadLetteringOnMessageExpiration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetteringOnMessageExpiration != nil {
@@ -450,7 +450,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘DefaultMessageTimeToLive’:
+	// Set property "DefaultMessageTimeToLive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultMessageTimeToLive != nil {
@@ -459,7 +459,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘DuplicateDetectionHistoryTimeWindow’:
+	// Set property "DuplicateDetectionHistoryTimeWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DuplicateDetectionHistoryTimeWindow != nil {
@@ -468,7 +468,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘EnableBatchedOperations’:
+	// Set property "EnableBatchedOperations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBatchedOperations != nil {
@@ -477,7 +477,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ForwardDeadLetteredMessagesTo’:
+	// Set property "ForwardDeadLetteredMessagesTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardDeadLetteredMessagesTo != nil {
@@ -486,7 +486,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘ForwardTo’:
+	// Set property "ForwardTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardTo != nil {
@@ -495,7 +495,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘LockDuration’:
+	// Set property "LockDuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LockDuration != nil {
@@ -504,7 +504,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxDeliveryCount != nil {
@@ -513,10 +513,10 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	subscription.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RequiresSession’:
+	// Set property "RequiresSession":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresSession != nil {
@@ -835,7 +835,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Topics_Subscription_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessedAt’:
+	// Set property "AccessedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessedAt != nil {
@@ -844,7 +844,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘AutoDeleteOnIdle’:
+	// Set property "AutoDeleteOnIdle":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoDeleteOnIdle != nil {
@@ -853,9 +853,9 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CountDetails’:
+	// Set property "CountDetails":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CountDetails != nil {
@@ -869,7 +869,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreatedAt != nil {
@@ -878,7 +878,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DeadLetteringOnFilterEvaluationExceptions’:
+	// Set property "DeadLetteringOnFilterEvaluationExceptions":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetteringOnFilterEvaluationExceptions != nil {
@@ -887,7 +887,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DeadLetteringOnMessageExpiration’:
+	// Set property "DeadLetteringOnMessageExpiration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeadLetteringOnMessageExpiration != nil {
@@ -896,7 +896,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DefaultMessageTimeToLive’:
+	// Set property "DefaultMessageTimeToLive":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultMessageTimeToLive != nil {
@@ -905,7 +905,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘DuplicateDetectionHistoryTimeWindow’:
+	// Set property "DuplicateDetectionHistoryTimeWindow":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DuplicateDetectionHistoryTimeWindow != nil {
@@ -914,7 +914,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘EnableBatchedOperations’:
+	// Set property "EnableBatchedOperations":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableBatchedOperations != nil {
@@ -923,7 +923,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘ForwardDeadLetteredMessagesTo’:
+	// Set property "ForwardDeadLetteredMessagesTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardDeadLetteredMessagesTo != nil {
@@ -932,7 +932,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘ForwardTo’:
+	// Set property "ForwardTo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ForwardTo != nil {
@@ -941,13 +941,13 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		subscription.Id = &id
 	}
 
-	// Set property ‘LockDuration’:
+	// Set property "LockDuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LockDuration != nil {
@@ -956,7 +956,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘MaxDeliveryCount’:
+	// Set property "MaxDeliveryCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxDeliveryCount != nil {
@@ -965,7 +965,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘MessageCount’:
+	// Set property "MessageCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MessageCount != nil {
@@ -974,13 +974,13 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		subscription.Name = &name
 	}
 
-	// Set property ‘RequiresSession’:
+	// Set property "RequiresSession":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequiresSession != nil {
@@ -989,7 +989,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -998,7 +998,7 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1009,13 +1009,13 @@ func (subscription *Namespaces_Topics_Subscription_STATUS) PopulateFromARM(owner
 		subscription.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		subscription.Type = &typeVar
 	}
 
-	// Set property ‘UpdatedAt’:
+	// Set property "UpdatedAt":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UpdatedAt != nil {

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_topics_subscriptions_rule_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_topics_subscriptions_rule_types_gen.go
@@ -337,10 +337,10 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_Spec) ConvertToARM(resolved gen
 	}
 	result := &Namespaces_Topics_Subscriptions_Rule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.Action != nil ||
 		rule.CorrelationFilter != nil ||
 		rule.FilterType != nil ||
@@ -390,7 +390,7 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_Spec) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Topics_Subscriptions_Rule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Action != nil {
@@ -404,10 +404,10 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CorrelationFilter’:
+	// Set property "CorrelationFilter":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CorrelationFilter != nil {
@@ -421,7 +421,7 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘FilterType’:
+	// Set property "FilterType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FilterType != nil {
@@ -430,10 +430,10 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘SqlFilter’:
+	// Set property "SqlFilter":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SqlFilter != nil {
@@ -726,7 +726,7 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Namespaces_Topics_Subscriptions_Rule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Action != nil {
@@ -740,9 +740,9 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CorrelationFilter’:
+	// Set property "CorrelationFilter":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CorrelationFilter != nil {
@@ -756,7 +756,7 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘FilterType’:
+	// Set property "FilterType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FilterType != nil {
@@ -765,19 +765,19 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘SqlFilter’:
+	// Set property "SqlFilter":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SqlFilter != nil {
@@ -791,7 +791,7 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -802,7 +802,7 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_STATUS) PopulateFromARM(owner g
 		rule.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -987,19 +987,19 @@ func (action *Action) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &Action_ARM{}
 
-	// Set property ‘CompatibilityLevel’:
+	// Set property "CompatibilityLevel":
 	if action.CompatibilityLevel != nil {
 		compatibilityLevel := *action.CompatibilityLevel
 		result.CompatibilityLevel = &compatibilityLevel
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if action.RequiresPreprocessing != nil {
 		requiresPreprocessing := *action.RequiresPreprocessing
 		result.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SqlExpression’:
+	// Set property "SqlExpression":
 	if action.SqlExpression != nil {
 		sqlExpression := *action.SqlExpression
 		result.SqlExpression = &sqlExpression
@@ -1019,19 +1019,19 @@ func (action *Action) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Action_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CompatibilityLevel’:
+	// Set property "CompatibilityLevel":
 	if typedInput.CompatibilityLevel != nil {
 		compatibilityLevel := *typedInput.CompatibilityLevel
 		action.CompatibilityLevel = &compatibilityLevel
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if typedInput.RequiresPreprocessing != nil {
 		requiresPreprocessing := *typedInput.RequiresPreprocessing
 		action.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SqlExpression’:
+	// Set property "SqlExpression":
 	if typedInput.SqlExpression != nil {
 		sqlExpression := *typedInput.SqlExpression
 		action.SqlExpression = &sqlExpression
@@ -1113,19 +1113,19 @@ func (action *Action_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Action_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CompatibilityLevel’:
+	// Set property "CompatibilityLevel":
 	if typedInput.CompatibilityLevel != nil {
 		compatibilityLevel := *typedInput.CompatibilityLevel
 		action.CompatibilityLevel = &compatibilityLevel
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if typedInput.RequiresPreprocessing != nil {
 		requiresPreprocessing := *typedInput.RequiresPreprocessing
 		action.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SqlExpression’:
+	// Set property "SqlExpression":
 	if typedInput.SqlExpression != nil {
 		sqlExpression := *typedInput.SqlExpression
 		action.SqlExpression = &sqlExpression
@@ -1209,31 +1209,31 @@ func (filter *CorrelationFilter) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &CorrelationFilter_ARM{}
 
-	// Set property ‘ContentType’:
+	// Set property "ContentType":
 	if filter.ContentType != nil {
 		contentType := *filter.ContentType
 		result.ContentType = &contentType
 	}
 
-	// Set property ‘CorrelationId’:
+	// Set property "CorrelationId":
 	if filter.CorrelationId != nil {
 		correlationId := *filter.CorrelationId
 		result.CorrelationId = &correlationId
 	}
 
-	// Set property ‘Label’:
+	// Set property "Label":
 	if filter.Label != nil {
 		label := *filter.Label
 		result.Label = &label
 	}
 
-	// Set property ‘MessageId’:
+	// Set property "MessageId":
 	if filter.MessageId != nil {
 		messageId := *filter.MessageId
 		result.MessageId = &messageId
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if filter.Properties != nil {
 		result.Properties = make(map[string]string, len(filter.Properties))
 		for key, value := range filter.Properties {
@@ -1241,31 +1241,31 @@ func (filter *CorrelationFilter) ConvertToARM(resolved genruntime.ConvertToARMRe
 		}
 	}
 
-	// Set property ‘ReplyTo’:
+	// Set property "ReplyTo":
 	if filter.ReplyTo != nil {
 		replyTo := *filter.ReplyTo
 		result.ReplyTo = &replyTo
 	}
 
-	// Set property ‘ReplyToSessionId’:
+	// Set property "ReplyToSessionId":
 	if filter.ReplyToSessionId != nil {
 		replyToSessionId := *filter.ReplyToSessionId
 		result.ReplyToSessionId = &replyToSessionId
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if filter.RequiresPreprocessing != nil {
 		requiresPreprocessing := *filter.RequiresPreprocessing
 		result.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SessionId’:
+	// Set property "SessionId":
 	if filter.SessionId != nil {
 		sessionId := *filter.SessionId
 		result.SessionId = &sessionId
 	}
 
-	// Set property ‘To’:
+	// Set property "To":
 	if filter.To != nil {
 		to := *filter.To
 		result.To = &to
@@ -1285,31 +1285,31 @@ func (filter *CorrelationFilter) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorrelationFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContentType’:
+	// Set property "ContentType":
 	if typedInput.ContentType != nil {
 		contentType := *typedInput.ContentType
 		filter.ContentType = &contentType
 	}
 
-	// Set property ‘CorrelationId’:
+	// Set property "CorrelationId":
 	if typedInput.CorrelationId != nil {
 		correlationId := *typedInput.CorrelationId
 		filter.CorrelationId = &correlationId
 	}
 
-	// Set property ‘Label’:
+	// Set property "Label":
 	if typedInput.Label != nil {
 		label := *typedInput.Label
 		filter.Label = &label
 	}
 
-	// Set property ‘MessageId’:
+	// Set property "MessageId":
 	if typedInput.MessageId != nil {
 		messageId := *typedInput.MessageId
 		filter.MessageId = &messageId
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		filter.Properties = make(map[string]string, len(typedInput.Properties))
 		for key, value := range typedInput.Properties {
@@ -1317,31 +1317,31 @@ func (filter *CorrelationFilter) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ReplyTo’:
+	// Set property "ReplyTo":
 	if typedInput.ReplyTo != nil {
 		replyTo := *typedInput.ReplyTo
 		filter.ReplyTo = &replyTo
 	}
 
-	// Set property ‘ReplyToSessionId’:
+	// Set property "ReplyToSessionId":
 	if typedInput.ReplyToSessionId != nil {
 		replyToSessionId := *typedInput.ReplyToSessionId
 		filter.ReplyToSessionId = &replyToSessionId
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if typedInput.RequiresPreprocessing != nil {
 		requiresPreprocessing := *typedInput.RequiresPreprocessing
 		filter.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SessionId’:
+	// Set property "SessionId":
 	if typedInput.SessionId != nil {
 		sessionId := *typedInput.SessionId
 		filter.SessionId = &sessionId
 	}
 
-	// Set property ‘To’:
+	// Set property "To":
 	if typedInput.To != nil {
 		to := *typedInput.To
 		filter.To = &to
@@ -1472,31 +1472,31 @@ func (filter *CorrelationFilter_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorrelationFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContentType’:
+	// Set property "ContentType":
 	if typedInput.ContentType != nil {
 		contentType := *typedInput.ContentType
 		filter.ContentType = &contentType
 	}
 
-	// Set property ‘CorrelationId’:
+	// Set property "CorrelationId":
 	if typedInput.CorrelationId != nil {
 		correlationId := *typedInput.CorrelationId
 		filter.CorrelationId = &correlationId
 	}
 
-	// Set property ‘Label’:
+	// Set property "Label":
 	if typedInput.Label != nil {
 		label := *typedInput.Label
 		filter.Label = &label
 	}
 
-	// Set property ‘MessageId’:
+	// Set property "MessageId":
 	if typedInput.MessageId != nil {
 		messageId := *typedInput.MessageId
 		filter.MessageId = &messageId
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		filter.Properties = make(map[string]string, len(typedInput.Properties))
 		for key, value := range typedInput.Properties {
@@ -1504,31 +1504,31 @@ func (filter *CorrelationFilter_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘ReplyTo’:
+	// Set property "ReplyTo":
 	if typedInput.ReplyTo != nil {
 		replyTo := *typedInput.ReplyTo
 		filter.ReplyTo = &replyTo
 	}
 
-	// Set property ‘ReplyToSessionId’:
+	// Set property "ReplyToSessionId":
 	if typedInput.ReplyToSessionId != nil {
 		replyToSessionId := *typedInput.ReplyToSessionId
 		filter.ReplyToSessionId = &replyToSessionId
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if typedInput.RequiresPreprocessing != nil {
 		requiresPreprocessing := *typedInput.RequiresPreprocessing
 		filter.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SessionId’:
+	// Set property "SessionId":
 	if typedInput.SessionId != nil {
 		sessionId := *typedInput.SessionId
 		filter.SessionId = &sessionId
 	}
 
-	// Set property ‘To’:
+	// Set property "To":
 	if typedInput.To != nil {
 		to := *typedInput.To
 		filter.To = &to
@@ -1666,19 +1666,19 @@ func (filter *SqlFilter) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &SqlFilter_ARM{}
 
-	// Set property ‘CompatibilityLevel’:
+	// Set property "CompatibilityLevel":
 	if filter.CompatibilityLevel != nil {
 		compatibilityLevel := *filter.CompatibilityLevel
 		result.CompatibilityLevel = &compatibilityLevel
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if filter.RequiresPreprocessing != nil {
 		requiresPreprocessing := *filter.RequiresPreprocessing
 		result.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SqlExpression’:
+	// Set property "SqlExpression":
 	if filter.SqlExpression != nil {
 		sqlExpression := *filter.SqlExpression
 		result.SqlExpression = &sqlExpression
@@ -1698,19 +1698,19 @@ func (filter *SqlFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CompatibilityLevel’:
+	// Set property "CompatibilityLevel":
 	if typedInput.CompatibilityLevel != nil {
 		compatibilityLevel := *typedInput.CompatibilityLevel
 		filter.CompatibilityLevel = &compatibilityLevel
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if typedInput.RequiresPreprocessing != nil {
 		requiresPreprocessing := *typedInput.RequiresPreprocessing
 		filter.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SqlExpression’:
+	// Set property "SqlExpression":
 	if typedInput.SqlExpression != nil {
 		sqlExpression := *typedInput.SqlExpression
 		filter.SqlExpression = &sqlExpression
@@ -1802,19 +1802,19 @@ func (filter *SqlFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SqlFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CompatibilityLevel’:
+	// Set property "CompatibilityLevel":
 	if typedInput.CompatibilityLevel != nil {
 		compatibilityLevel := *typedInput.CompatibilityLevel
 		filter.CompatibilityLevel = &compatibilityLevel
 	}
 
-	// Set property ‘RequiresPreprocessing’:
+	// Set property "RequiresPreprocessing":
 	if typedInput.RequiresPreprocessing != nil {
 		requiresPreprocessing := *typedInput.RequiresPreprocessing
 		filter.RequiresPreprocessing = &requiresPreprocessing
 	}
 
-	// Set property ‘SqlExpression’:
+	// Set property "SqlExpression":
 	if typedInput.SqlExpression != nil {
 		sqlExpression := *typedInput.SqlExpression
 		filter.SqlExpression = &sqlExpression

--- a/v2/api/signalrservice/v1api20211001/signal_r_types_gen.go
+++ b/v2/api/signalrservice/v1api20211001/signal_r_types_gen.go
@@ -388,7 +388,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SignalR_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if signalR.Identity != nil {
 		identity_ARM, err := (*signalR.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -398,22 +398,22 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Identity = &identity
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if signalR.Kind != nil {
 		kind := *signalR.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if signalR.Location != nil {
 		location := *signalR.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if signalR.Cors != nil ||
 		signalR.DisableAadAuth != nil ||
 		signalR.DisableLocalAuth != nil ||
@@ -485,7 +485,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Upstream = &upstream
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if signalR.Sku != nil {
 		sku_ARM, err := (*signalR.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -495,7 +495,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if signalR.Tags != nil {
 		result.Tags = make(map[string]string, len(signalR.Tags))
 		for key, value := range signalR.Tags {
@@ -517,10 +517,10 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalR_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	signalR.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -534,7 +534,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘DisableAadAuth’:
+	// Set property "DisableAadAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableAadAuth != nil {
@@ -543,7 +543,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -552,7 +552,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Features’:
+	// Set property "Features":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Features {
@@ -565,7 +565,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -576,19 +576,19 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		signalR.Identity = &identity
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		signalR.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		signalR.Location = &location
 	}
 
-	// Set property ‘NetworkACLs’:
+	// Set property "NetworkACLs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkACLs != nil {
@@ -602,10 +602,10 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	signalR.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -614,7 +614,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘ResourceLogConfiguration’:
+	// Set property "ResourceLogConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceLogConfiguration != nil {
@@ -628,7 +628,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 ResourceSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -639,7 +639,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		signalR.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		signalR.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -647,7 +647,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Tls’:
+	// Set property "Tls":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tls != nil {
@@ -661,7 +661,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Upstream’:
+	// Set property "Upstream":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Upstream != nil {
@@ -1357,9 +1357,9 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalR_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -1373,7 +1373,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘DisableAadAuth’:
+	// Set property "DisableAadAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableAadAuth != nil {
@@ -1382,7 +1382,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -1391,7 +1391,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ExternalIP’:
+	// Set property "ExternalIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExternalIP != nil {
@@ -1400,7 +1400,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Features’:
+	// Set property "Features":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Features {
@@ -1413,7 +1413,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -1422,7 +1422,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘HostNamePrefix’:
+	// Set property "HostNamePrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostNamePrefix != nil {
@@ -1431,13 +1431,13 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		signalR.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1448,25 +1448,25 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		signalR.Identity = &identity
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		signalR.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		signalR.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		signalR.Name = &name
 	}
 
-	// Set property ‘NetworkACLs’:
+	// Set property "NetworkACLs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkACLs != nil {
@@ -1480,7 +1480,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1493,7 +1493,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1502,7 +1502,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1511,7 +1511,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘PublicPort’:
+	// Set property "PublicPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicPort != nil {
@@ -1520,7 +1520,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ResourceLogConfiguration’:
+	// Set property "ResourceLogConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceLogConfiguration != nil {
@@ -1534,7 +1534,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ServerPort’:
+	// Set property "ServerPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServerPort != nil {
@@ -1543,7 +1543,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘SharedPrivateLinkResources’:
+	// Set property "SharedPrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SharedPrivateLinkResources {
@@ -1556,7 +1556,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 ResourceSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1567,7 +1567,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		signalR.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1578,7 +1578,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		signalR.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		signalR.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1586,7 +1586,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Tls’:
+	// Set property "Tls":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tls != nil {
@@ -1600,13 +1600,13 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		signalR.Type = &typeVar
 	}
 
-	// Set property ‘Upstream’:
+	// Set property "Upstream":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Upstream != nil {
@@ -1620,7 +1620,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -2116,13 +2116,13 @@ func (identity *ManagedIdentity) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ManagedIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -2147,13 +2147,13 @@ func (identity *ManagedIdentity) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -2292,25 +2292,25 @@ func (identity *ManagedIdentity_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedIdentityProperty_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2434,7 +2434,7 @@ func (embedded *PrivateEndpointConnection_STATUS_SignalR_SubResourceEmbedded) Po
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_SignalR_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2503,7 +2503,7 @@ func (configuration *ResourceLogConfiguration) ConvertToARM(resolved genruntime.
 	}
 	result := &ResourceLogConfiguration_ARM{}
 
-	// Set property ‘Categories’:
+	// Set property "Categories":
 	for _, item := range configuration.Categories {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2526,7 +2526,7 @@ func (configuration *ResourceLogConfiguration) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceLogConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Categories’:
+	// Set property "Categories":
 	for _, item := range typedInput.Categories {
 		var item1 ResourceLogCategory
 		err := item1.PopulateFromARM(owner, item)
@@ -2644,7 +2644,7 @@ func (configuration *ResourceLogConfiguration_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceLogConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Categories’:
+	// Set property "Categories":
 	for _, item := range typedInput.Categories {
 		var item1 ResourceLogCategory_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2744,19 +2744,19 @@ func (resourceSku *ResourceSku) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &ResourceSku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if resourceSku.Capacity != nil {
 		capacity := *resourceSku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if resourceSku.Name != nil {
 		name := *resourceSku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if resourceSku.Tier != nil {
 		tier := *resourceSku.Tier
 		result.Tier = &tier
@@ -2776,19 +2776,19 @@ func (resourceSku *ResourceSku) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		resourceSku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resourceSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		resourceSku.Tier = &tier
@@ -2907,31 +2907,31 @@ func (resourceSku *ResourceSku_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		resourceSku.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		resourceSku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resourceSku.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if typedInput.Size != nil {
 		size := *typedInput.Size
 		resourceSku.Size = &size
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		resourceSku.Tier = &tier
@@ -3019,7 +3019,7 @@ func (settings *ServerlessUpstreamSettings) ConvertToARM(resolved genruntime.Con
 	}
 	result := &ServerlessUpstreamSettings_ARM{}
 
-	// Set property ‘Templates’:
+	// Set property "Templates":
 	for _, item := range settings.Templates {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3042,7 +3042,7 @@ func (settings *ServerlessUpstreamSettings) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerlessUpstreamSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Templates’:
+	// Set property "Templates":
 	for _, item := range typedInput.Templates {
 		var item1 UpstreamTemplate
 		err := item1.PopulateFromARM(owner, item)
@@ -3160,7 +3160,7 @@ func (settings *ServerlessUpstreamSettings_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerlessUpstreamSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Templates’:
+	// Set property "Templates":
 	for _, item := range typedInput.Templates {
 		var item1 UpstreamTemplate_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3253,7 +3253,7 @@ func (embedded *SharedPrivateLinkResource_STATUS_SignalR_SubResourceEmbedded) Po
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SharedPrivateLinkResource_STATUS_SignalR_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -3308,7 +3308,7 @@ func (settings *SignalRCorsSettings) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &SignalRCorsSettings_ARM{}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range settings.AllowedOrigins {
 		result.AllowedOrigins = append(result.AllowedOrigins, item)
 	}
@@ -3327,7 +3327,7 @@ func (settings *SignalRCorsSettings) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRCorsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		settings.AllowedOrigins = append(settings.AllowedOrigins, item)
 	}
@@ -3396,7 +3396,7 @@ func (settings *SignalRCorsSettings_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRCorsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		settings.AllowedOrigins = append(settings.AllowedOrigins, item)
 	}
@@ -3469,13 +3469,13 @@ func (feature *SignalRFeature) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &SignalRFeature_ARM{}
 
-	// Set property ‘Flag’:
+	// Set property "Flag":
 	if feature.Flag != nil {
 		flag := *feature.Flag
 		result.Flag = &flag
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if feature.Properties != nil {
 		result.Properties = make(map[string]string, len(feature.Properties))
 		for key, value := range feature.Properties {
@@ -3483,7 +3483,7 @@ func (feature *SignalRFeature) ConvertToARM(resolved genruntime.ConvertToARMReso
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if feature.Value != nil {
 		value := *feature.Value
 		result.Value = &value
@@ -3503,13 +3503,13 @@ func (feature *SignalRFeature) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRFeature_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Flag’:
+	// Set property "Flag":
 	if typedInput.Flag != nil {
 		flag := *typedInput.Flag
 		feature.Flag = &flag
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		feature.Properties = make(map[string]string, len(typedInput.Properties))
 		for key, value := range typedInput.Properties {
@@ -3517,7 +3517,7 @@ func (feature *SignalRFeature) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		feature.Value = &value
@@ -3650,13 +3650,13 @@ func (feature *SignalRFeature_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRFeature_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Flag’:
+	// Set property "Flag":
 	if typedInput.Flag != nil {
 		flag := *typedInput.Flag
 		feature.Flag = &flag
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		feature.Properties = make(map[string]string, len(typedInput.Properties))
 		for key, value := range typedInput.Properties {
@@ -3664,7 +3664,7 @@ func (feature *SignalRFeature_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		feature.Value = &value
@@ -3746,13 +3746,13 @@ func (acLs *SignalRNetworkACLs) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &SignalRNetworkACLs_ARM{}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if acLs.DefaultAction != nil {
 		defaultAction := *acLs.DefaultAction
 		result.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘PrivateEndpoints’:
+	// Set property "PrivateEndpoints":
 	for _, item := range acLs.PrivateEndpoints {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3761,7 +3761,7 @@ func (acLs *SignalRNetworkACLs) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.PrivateEndpoints = append(result.PrivateEndpoints, *item_ARM.(*PrivateEndpointACL_ARM))
 	}
 
-	// Set property ‘PublicNetwork’:
+	// Set property "PublicNetwork":
 	if acLs.PublicNetwork != nil {
 		publicNetwork_ARM, err := (*acLs.PublicNetwork).ConvertToARM(resolved)
 		if err != nil {
@@ -3785,13 +3785,13 @@ func (acLs *SignalRNetworkACLs) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRNetworkACLs_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		acLs.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘PrivateEndpoints’:
+	// Set property "PrivateEndpoints":
 	for _, item := range typedInput.PrivateEndpoints {
 		var item1 PrivateEndpointACL
 		err := item1.PopulateFromARM(owner, item)
@@ -3801,7 +3801,7 @@ func (acLs *SignalRNetworkACLs) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		acLs.PrivateEndpoints = append(acLs.PrivateEndpoints, item1)
 	}
 
-	// Set property ‘PublicNetwork’:
+	// Set property "PublicNetwork":
 	if typedInput.PublicNetwork != nil {
 		var publicNetwork1 NetworkACL
 		err := publicNetwork1.PopulateFromARM(owner, *typedInput.PublicNetwork)
@@ -3986,13 +3986,13 @@ func (acLs *SignalRNetworkACLs_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRNetworkACLs_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		acLs.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘PrivateEndpoints’:
+	// Set property "PrivateEndpoints":
 	for _, item := range typedInput.PrivateEndpoints {
 		var item1 PrivateEndpointACL_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -4002,7 +4002,7 @@ func (acLs *SignalRNetworkACLs_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		acLs.PrivateEndpoints = append(acLs.PrivateEndpoints, item1)
 	}
 
-	// Set property ‘PublicNetwork’:
+	// Set property "PublicNetwork":
 	if typedInput.PublicNetwork != nil {
 		var publicNetwork1 NetworkACL_STATUS
 		err := publicNetwork1.PopulateFromARM(owner, *typedInput.PublicNetwork)
@@ -4131,7 +4131,7 @@ func (settings *SignalRTlsSettings) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &SignalRTlsSettings_ARM{}
 
-	// Set property ‘ClientCertEnabled’:
+	// Set property "ClientCertEnabled":
 	if settings.ClientCertEnabled != nil {
 		clientCertEnabled := *settings.ClientCertEnabled
 		result.ClientCertEnabled = &clientCertEnabled
@@ -4151,7 +4151,7 @@ func (settings *SignalRTlsSettings) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRTlsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientCertEnabled’:
+	// Set property "ClientCertEnabled":
 	if typedInput.ClientCertEnabled != nil {
 		clientCertEnabled := *typedInput.ClientCertEnabled
 		settings.ClientCertEnabled = &clientCertEnabled
@@ -4235,7 +4235,7 @@ func (settings *SignalRTlsSettings_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRTlsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientCertEnabled’:
+	// Set property "ClientCertEnabled":
 	if typedInput.ClientCertEnabled != nil {
 		clientCertEnabled := *typedInput.ClientCertEnabled
 		settings.ClientCertEnabled = &clientCertEnabled
@@ -4319,37 +4319,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -4518,12 +4518,12 @@ func (networkACL *NetworkACL) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &NetworkACL_ARM{}
 
-	// Set property ‘Allow’:
+	// Set property "Allow":
 	for _, item := range networkACL.Allow {
 		result.Allow = append(result.Allow, item)
 	}
 
-	// Set property ‘Deny’:
+	// Set property "Deny":
 	for _, item := range networkACL.Deny {
 		result.Deny = append(result.Deny, item)
 	}
@@ -4542,12 +4542,12 @@ func (networkACL *NetworkACL) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkACL_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Allow’:
+	// Set property "Allow":
 	for _, item := range typedInput.Allow {
 		networkACL.Allow = append(networkACL.Allow, item)
 	}
 
-	// Set property ‘Deny’:
+	// Set property "Deny":
 	for _, item := range typedInput.Deny {
 		networkACL.Deny = append(networkACL.Deny, item)
 	}
@@ -4689,12 +4689,12 @@ func (networkACL *NetworkACL_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkACL_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Allow’:
+	// Set property "Allow":
 	for _, item := range typedInput.Allow {
 		networkACL.Allow = append(networkACL.Allow, item)
 	}
 
-	// Set property ‘Deny’:
+	// Set property "Deny":
 	for _, item := range typedInput.Deny {
 		networkACL.Deny = append(networkACL.Deny, item)
 	}
@@ -4800,17 +4800,17 @@ func (endpointACL *PrivateEndpointACL) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &PrivateEndpointACL_ARM{}
 
-	// Set property ‘Allow’:
+	// Set property "Allow":
 	for _, item := range endpointACL.Allow {
 		result.Allow = append(result.Allow, item)
 	}
 
-	// Set property ‘Deny’:
+	// Set property "Deny":
 	for _, item := range endpointACL.Deny {
 		result.Deny = append(result.Deny, item)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if endpointACL.Name != nil {
 		name := *endpointACL.Name
 		result.Name = &name
@@ -4830,17 +4830,17 @@ func (endpointACL *PrivateEndpointACL) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointACL_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Allow’:
+	// Set property "Allow":
 	for _, item := range typedInput.Allow {
 		endpointACL.Allow = append(endpointACL.Allow, item)
 	}
 
-	// Set property ‘Deny’:
+	// Set property "Deny":
 	for _, item := range typedInput.Deny {
 		endpointACL.Deny = append(endpointACL.Deny, item)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		endpointACL.Name = &name
@@ -4995,17 +4995,17 @@ func (endpointACL *PrivateEndpointACL_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointACL_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Allow’:
+	// Set property "Allow":
 	for _, item := range typedInput.Allow {
 		endpointACL.Allow = append(endpointACL.Allow, item)
 	}
 
-	// Set property ‘Deny’:
+	// Set property "Deny":
 	for _, item := range typedInput.Deny {
 		endpointACL.Deny = append(endpointACL.Deny, item)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		endpointACL.Name = &name
@@ -5118,13 +5118,13 @@ func (category *ResourceLogCategory) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &ResourceLogCategory_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if category.Enabled != nil {
 		enabled := *category.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if category.Name != nil {
 		name := *category.Name
 		result.Name = &name
@@ -5144,13 +5144,13 @@ func (category *ResourceLogCategory) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceLogCategory_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		category.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		category.Name = &name
@@ -5235,13 +5235,13 @@ func (category *ResourceLogCategory_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceLogCategory_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		category.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		category.Name = &name
@@ -5332,7 +5332,7 @@ func (template *UpstreamTemplate) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &UpstreamTemplate_ARM{}
 
-	// Set property ‘Auth’:
+	// Set property "Auth":
 	if template.Auth != nil {
 		auth_ARM, err := (*template.Auth).ConvertToARM(resolved)
 		if err != nil {
@@ -5342,25 +5342,25 @@ func (template *UpstreamTemplate) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Auth = &auth
 	}
 
-	// Set property ‘CategoryPattern’:
+	// Set property "CategoryPattern":
 	if template.CategoryPattern != nil {
 		categoryPattern := *template.CategoryPattern
 		result.CategoryPattern = &categoryPattern
 	}
 
-	// Set property ‘EventPattern’:
+	// Set property "EventPattern":
 	if template.EventPattern != nil {
 		eventPattern := *template.EventPattern
 		result.EventPattern = &eventPattern
 	}
 
-	// Set property ‘HubPattern’:
+	// Set property "HubPattern":
 	if template.HubPattern != nil {
 		hubPattern := *template.HubPattern
 		result.HubPattern = &hubPattern
 	}
 
-	// Set property ‘UrlTemplate’:
+	// Set property "UrlTemplate":
 	if template.UrlTemplate != nil {
 		urlTemplate := *template.UrlTemplate
 		result.UrlTemplate = &urlTemplate
@@ -5380,7 +5380,7 @@ func (template *UpstreamTemplate) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpstreamTemplate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Auth’:
+	// Set property "Auth":
 	if typedInput.Auth != nil {
 		var auth1 UpstreamAuthSettings
 		err := auth1.PopulateFromARM(owner, *typedInput.Auth)
@@ -5391,25 +5391,25 @@ func (template *UpstreamTemplate) PopulateFromARM(owner genruntime.ArbitraryOwne
 		template.Auth = &auth
 	}
 
-	// Set property ‘CategoryPattern’:
+	// Set property "CategoryPattern":
 	if typedInput.CategoryPattern != nil {
 		categoryPattern := *typedInput.CategoryPattern
 		template.CategoryPattern = &categoryPattern
 	}
 
-	// Set property ‘EventPattern’:
+	// Set property "EventPattern":
 	if typedInput.EventPattern != nil {
 		eventPattern := *typedInput.EventPattern
 		template.EventPattern = &eventPattern
 	}
 
-	// Set property ‘HubPattern’:
+	// Set property "HubPattern":
 	if typedInput.HubPattern != nil {
 		hubPattern := *typedInput.HubPattern
 		template.HubPattern = &hubPattern
 	}
 
-	// Set property ‘UrlTemplate’:
+	// Set property "UrlTemplate":
 	if typedInput.UrlTemplate != nil {
 		urlTemplate := *typedInput.UrlTemplate
 		template.UrlTemplate = &urlTemplate
@@ -5571,7 +5571,7 @@ func (template *UpstreamTemplate_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpstreamTemplate_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Auth’:
+	// Set property "Auth":
 	if typedInput.Auth != nil {
 		var auth1 UpstreamAuthSettings_STATUS
 		err := auth1.PopulateFromARM(owner, *typedInput.Auth)
@@ -5582,25 +5582,25 @@ func (template *UpstreamTemplate_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		template.Auth = &auth
 	}
 
-	// Set property ‘CategoryPattern’:
+	// Set property "CategoryPattern":
 	if typedInput.CategoryPattern != nil {
 		categoryPattern := *typedInput.CategoryPattern
 		template.CategoryPattern = &categoryPattern
 	}
 
-	// Set property ‘EventPattern’:
+	// Set property "EventPattern":
 	if typedInput.EventPattern != nil {
 		eventPattern := *typedInput.EventPattern
 		template.EventPattern = &eventPattern
 	}
 
-	// Set property ‘HubPattern’:
+	// Set property "HubPattern":
 	if typedInput.HubPattern != nil {
 		hubPattern := *typedInput.HubPattern
 		template.HubPattern = &hubPattern
 	}
 
-	// Set property ‘UrlTemplate’:
+	// Set property "UrlTemplate":
 	if typedInput.UrlTemplate != nil {
 		urlTemplate := *typedInput.UrlTemplate
 		template.UrlTemplate = &urlTemplate
@@ -5738,13 +5738,13 @@ func (property *UserAssignedIdentityProperty_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentityProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		property.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		property.PrincipalId = &principalId
@@ -5828,7 +5828,7 @@ func (settings *UpstreamAuthSettings) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &UpstreamAuthSettings_ARM{}
 
-	// Set property ‘ManagedIdentity’:
+	// Set property "ManagedIdentity":
 	if settings.ManagedIdentity != nil {
 		managedIdentity_ARM, err := (*settings.ManagedIdentity).ConvertToARM(resolved)
 		if err != nil {
@@ -5838,7 +5838,7 @@ func (settings *UpstreamAuthSettings) ConvertToARM(resolved genruntime.ConvertTo
 		result.ManagedIdentity = &managedIdentity
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if settings.Type != nil {
 		typeVar := *settings.Type
 		result.Type = &typeVar
@@ -5858,7 +5858,7 @@ func (settings *UpstreamAuthSettings) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpstreamAuthSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ManagedIdentity’:
+	// Set property "ManagedIdentity":
 	if typedInput.ManagedIdentity != nil {
 		var managedIdentity1 ManagedIdentitySettings
 		err := managedIdentity1.PopulateFromARM(owner, *typedInput.ManagedIdentity)
@@ -5869,7 +5869,7 @@ func (settings *UpstreamAuthSettings) PopulateFromARM(owner genruntime.Arbitrary
 		settings.ManagedIdentity = &managedIdentity
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		settings.Type = &typeVar
@@ -5992,7 +5992,7 @@ func (settings *UpstreamAuthSettings_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpstreamAuthSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ManagedIdentity’:
+	// Set property "ManagedIdentity":
 	if typedInput.ManagedIdentity != nil {
 		var managedIdentity1 ManagedIdentitySettings_STATUS
 		err := managedIdentity1.PopulateFromARM(owner, *typedInput.ManagedIdentity)
@@ -6003,7 +6003,7 @@ func (settings *UpstreamAuthSettings_STATUS) PopulateFromARM(owner genruntime.Ar
 		settings.ManagedIdentity = &managedIdentity
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		settings.Type = &typeVar
@@ -6092,7 +6092,7 @@ func (settings *ManagedIdentitySettings) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &ManagedIdentitySettings_ARM{}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	if settings.Resource != nil {
 		resource := *settings.Resource
 		result.Resource = &resource
@@ -6112,7 +6112,7 @@ func (settings *ManagedIdentitySettings) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedIdentitySettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	if typedInput.Resource != nil {
 		resource := *typedInput.Resource
 		settings.Resource = &resource
@@ -6182,7 +6182,7 @@ func (settings *ManagedIdentitySettings_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedIdentitySettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	if typedInput.Resource != nil {
 		resource := *typedInput.Resource
 		settings.Resource = &resource

--- a/v2/api/signalrservice/v1beta20211001/signal_r_types_gen.go
+++ b/v2/api/signalrservice/v1beta20211001/signal_r_types_gen.go
@@ -350,7 +350,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SignalR_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if signalR.Identity != nil {
 		identity_ARM, err := (*signalR.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -360,22 +360,22 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Identity = &identity
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if signalR.Kind != nil {
 		kind := *signalR.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if signalR.Location != nil {
 		location := *signalR.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if signalR.Cors != nil ||
 		signalR.DisableAadAuth != nil ||
 		signalR.DisableLocalAuth != nil ||
@@ -447,7 +447,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Properties.Upstream = &upstream
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if signalR.Sku != nil {
 		sku_ARM, err := (*signalR.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -457,7 +457,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if signalR.Tags != nil {
 		result.Tags = make(map[string]string, len(signalR.Tags))
 		for key, value := range signalR.Tags {
@@ -479,10 +479,10 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalR_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	signalR.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -496,7 +496,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘DisableAadAuth’:
+	// Set property "DisableAadAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableAadAuth != nil {
@@ -505,7 +505,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -514,7 +514,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Features’:
+	// Set property "Features":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Features {
@@ -527,7 +527,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -538,19 +538,19 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		signalR.Identity = &identity
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		signalR.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		signalR.Location = &location
 	}
 
-	// Set property ‘NetworkACLs’:
+	// Set property "NetworkACLs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkACLs != nil {
@@ -564,10 +564,10 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	signalR.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -576,7 +576,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘ResourceLogConfiguration’:
+	// Set property "ResourceLogConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceLogConfiguration != nil {
@@ -590,7 +590,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 ResourceSku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -601,7 +601,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		signalR.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		signalR.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -609,7 +609,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Tls’:
+	// Set property "Tls":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tls != nil {
@@ -623,7 +623,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Upstream’:
+	// Set property "Upstream":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Upstream != nil {
@@ -1114,9 +1114,9 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalR_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -1130,7 +1130,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘DisableAadAuth’:
+	// Set property "DisableAadAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableAadAuth != nil {
@@ -1139,7 +1139,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘DisableLocalAuth’:
+	// Set property "DisableLocalAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DisableLocalAuth != nil {
@@ -1148,7 +1148,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ExternalIP’:
+	// Set property "ExternalIP":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExternalIP != nil {
@@ -1157,7 +1157,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Features’:
+	// Set property "Features":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Features {
@@ -1170,7 +1170,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostName != nil {
@@ -1179,7 +1179,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘HostNamePrefix’:
+	// Set property "HostNamePrefix":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostNamePrefix != nil {
@@ -1188,13 +1188,13 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		signalR.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1205,25 +1205,25 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		signalR.Identity = &identity
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		signalR.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		signalR.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		signalR.Name = &name
 	}
 
-	// Set property ‘NetworkACLs’:
+	// Set property "NetworkACLs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkACLs != nil {
@@ -1237,7 +1237,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1250,7 +1250,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1259,7 +1259,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1268,7 +1268,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘PublicPort’:
+	// Set property "PublicPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicPort != nil {
@@ -1277,7 +1277,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ResourceLogConfiguration’:
+	// Set property "ResourceLogConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceLogConfiguration != nil {
@@ -1291,7 +1291,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘ServerPort’:
+	// Set property "ServerPort":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServerPort != nil {
@@ -1300,7 +1300,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘SharedPrivateLinkResources’:
+	// Set property "SharedPrivateLinkResources":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SharedPrivateLinkResources {
@@ -1313,7 +1313,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 ResourceSku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1324,7 +1324,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		signalR.Sku = &sku
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -1335,7 +1335,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		signalR.SystemData = &systemData
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		signalR.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1343,7 +1343,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Tls’:
+	// Set property "Tls":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Tls != nil {
@@ -1357,13 +1357,13 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		signalR.Type = &typeVar
 	}
 
-	// Set property ‘Upstream’:
+	// Set property "Upstream":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Upstream != nil {
@@ -1377,7 +1377,7 @@ func (signalR *SignalR_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1870,13 +1870,13 @@ func (identity *ManagedIdentity) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ManagedIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -1901,13 +1901,13 @@ func (identity *ManagedIdentity) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -2010,25 +2010,25 @@ func (identity *ManagedIdentity_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedIdentityProperty_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -2151,7 +2151,7 @@ func (embedded *PrivateEndpointConnection_STATUS_SignalR_SubResourceEmbedded) Po
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_SignalR_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2219,7 +2219,7 @@ func (configuration *ResourceLogConfiguration) ConvertToARM(resolved genruntime.
 	}
 	result := &ResourceLogConfiguration_ARM{}
 
-	// Set property ‘Categories’:
+	// Set property "Categories":
 	for _, item := range configuration.Categories {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2242,7 +2242,7 @@ func (configuration *ResourceLogConfiguration) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceLogConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Categories’:
+	// Set property "Categories":
 	for _, item := range typedInput.Categories {
 		var item1 ResourceLogCategory
 		err := item1.PopulateFromARM(owner, item)
@@ -2334,7 +2334,7 @@ func (configuration *ResourceLogConfiguration_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceLogConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Categories’:
+	// Set property "Categories":
 	for _, item := range typedInput.Categories {
 		var item1 ResourceLogCategory_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2425,19 +2425,19 @@ func (resourceSku *ResourceSku) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &ResourceSku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if resourceSku.Capacity != nil {
 		capacity := *resourceSku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if resourceSku.Name != nil {
 		name := *resourceSku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if resourceSku.Tier != nil {
 		tier := *resourceSku.Tier
 		result.Tier = &tier
@@ -2457,19 +2457,19 @@ func (resourceSku *ResourceSku) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceSku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		resourceSku.Capacity = &capacity
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resourceSku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		resourceSku.Tier = &tier
@@ -2553,31 +2553,31 @@ func (resourceSku *ResourceSku_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceSku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		resourceSku.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		resourceSku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		resourceSku.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if typedInput.Size != nil {
 		size := *typedInput.Size
 		resourceSku.Size = &size
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		resourceSku.Tier = &tier
@@ -2664,7 +2664,7 @@ func (settings *ServerlessUpstreamSettings) ConvertToARM(resolved genruntime.Con
 	}
 	result := &ServerlessUpstreamSettings_ARM{}
 
-	// Set property ‘Templates’:
+	// Set property "Templates":
 	for _, item := range settings.Templates {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2687,7 +2687,7 @@ func (settings *ServerlessUpstreamSettings) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerlessUpstreamSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Templates’:
+	// Set property "Templates":
 	for _, item := range typedInput.Templates {
 		var item1 UpstreamTemplate
 		err := item1.PopulateFromARM(owner, item)
@@ -2779,7 +2779,7 @@ func (settings *ServerlessUpstreamSettings_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerlessUpstreamSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Templates’:
+	// Set property "Templates":
 	for _, item := range typedInput.Templates {
 		var item1 UpstreamTemplate_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2871,7 +2871,7 @@ func (embedded *SharedPrivateLinkResource_STATUS_SignalR_SubResourceEmbedded) Po
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SharedPrivateLinkResource_STATUS_SignalR_SubResourceEmbedded_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		embedded.Id = &id
@@ -2924,7 +2924,7 @@ func (settings *SignalRCorsSettings) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &SignalRCorsSettings_ARM{}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range settings.AllowedOrigins {
 		result.AllowedOrigins = append(result.AllowedOrigins, item)
 	}
@@ -2943,7 +2943,7 @@ func (settings *SignalRCorsSettings) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRCorsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		settings.AllowedOrigins = append(settings.AllowedOrigins, item)
 	}
@@ -3000,7 +3000,7 @@ func (settings *SignalRCorsSettings_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRCorsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		settings.AllowedOrigins = append(settings.AllowedOrigins, item)
 	}
@@ -3059,13 +3059,13 @@ func (feature *SignalRFeature) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &SignalRFeature_ARM{}
 
-	// Set property ‘Flag’:
+	// Set property "Flag":
 	if feature.Flag != nil {
 		flag := *feature.Flag
 		result.Flag = &flag
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if feature.Properties != nil {
 		result.Properties = make(map[string]string, len(feature.Properties))
 		for key, value := range feature.Properties {
@@ -3073,7 +3073,7 @@ func (feature *SignalRFeature) ConvertToARM(resolved genruntime.ConvertToARMReso
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if feature.Value != nil {
 		value := *feature.Value
 		result.Value = &value
@@ -3093,13 +3093,13 @@ func (feature *SignalRFeature) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRFeature_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Flag’:
+	// Set property "Flag":
 	if typedInput.Flag != nil {
 		flag := *typedInput.Flag
 		feature.Flag = &flag
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		feature.Properties = make(map[string]string, len(typedInput.Properties))
 		for key, value := range typedInput.Properties {
@@ -3107,7 +3107,7 @@ func (feature *SignalRFeature) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		feature.Value = &value
@@ -3199,13 +3199,13 @@ func (feature *SignalRFeature_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRFeature_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Flag’:
+	// Set property "Flag":
 	if typedInput.Flag != nil {
 		flag := *typedInput.Flag
 		feature.Flag = &flag
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		feature.Properties = make(map[string]string, len(typedInput.Properties))
 		for key, value := range typedInput.Properties {
@@ -3213,7 +3213,7 @@ func (feature *SignalRFeature_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		feature.Value = &value
@@ -3290,13 +3290,13 @@ func (acLs *SignalRNetworkACLs) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &SignalRNetworkACLs_ARM{}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if acLs.DefaultAction != nil {
 		defaultAction := *acLs.DefaultAction
 		result.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘PrivateEndpoints’:
+	// Set property "PrivateEndpoints":
 	for _, item := range acLs.PrivateEndpoints {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -3305,7 +3305,7 @@ func (acLs *SignalRNetworkACLs) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.PrivateEndpoints = append(result.PrivateEndpoints, *item_ARM.(*PrivateEndpointACL_ARM))
 	}
 
-	// Set property ‘PublicNetwork’:
+	// Set property "PublicNetwork":
 	if acLs.PublicNetwork != nil {
 		publicNetwork_ARM, err := (*acLs.PublicNetwork).ConvertToARM(resolved)
 		if err != nil {
@@ -3329,13 +3329,13 @@ func (acLs *SignalRNetworkACLs) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRNetworkACLs_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		acLs.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘PrivateEndpoints’:
+	// Set property "PrivateEndpoints":
 	for _, item := range typedInput.PrivateEndpoints {
 		var item1 PrivateEndpointACL
 		err := item1.PopulateFromARM(owner, item)
@@ -3345,7 +3345,7 @@ func (acLs *SignalRNetworkACLs) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		acLs.PrivateEndpoints = append(acLs.PrivateEndpoints, item1)
 	}
 
-	// Set property ‘PublicNetwork’:
+	// Set property "PublicNetwork":
 	if typedInput.PublicNetwork != nil {
 		var publicNetwork1 NetworkACL
 		err := publicNetwork1.PopulateFromARM(owner, *typedInput.PublicNetwork)
@@ -3480,13 +3480,13 @@ func (acLs *SignalRNetworkACLs_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRNetworkACLs_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		acLs.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘PrivateEndpoints’:
+	// Set property "PrivateEndpoints":
 	for _, item := range typedInput.PrivateEndpoints {
 		var item1 PrivateEndpointACL_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3496,7 +3496,7 @@ func (acLs *SignalRNetworkACLs_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		acLs.PrivateEndpoints = append(acLs.PrivateEndpoints, item1)
 	}
 
-	// Set property ‘PublicNetwork’:
+	// Set property "PublicNetwork":
 	if typedInput.PublicNetwork != nil {
 		var publicNetwork1 NetworkACL_STATUS
 		err := publicNetwork1.PopulateFromARM(owner, *typedInput.PublicNetwork)
@@ -3624,7 +3624,7 @@ func (settings *SignalRTlsSettings) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &SignalRTlsSettings_ARM{}
 
-	// Set property ‘ClientCertEnabled’:
+	// Set property "ClientCertEnabled":
 	if settings.ClientCertEnabled != nil {
 		clientCertEnabled := *settings.ClientCertEnabled
 		result.ClientCertEnabled = &clientCertEnabled
@@ -3644,7 +3644,7 @@ func (settings *SignalRTlsSettings) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRTlsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientCertEnabled’:
+	// Set property "ClientCertEnabled":
 	if typedInput.ClientCertEnabled != nil {
 		clientCertEnabled := *typedInput.ClientCertEnabled
 		settings.ClientCertEnabled = &clientCertEnabled
@@ -3712,7 +3712,7 @@ func (settings *SignalRTlsSettings_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignalRTlsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientCertEnabled’:
+	// Set property "ClientCertEnabled":
 	if typedInput.ClientCertEnabled != nil {
 		clientCertEnabled := *typedInput.ClientCertEnabled
 		settings.ClientCertEnabled = &clientCertEnabled
@@ -3785,37 +3785,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -3957,12 +3957,12 @@ func (networkACL *NetworkACL) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &NetworkACL_ARM{}
 
-	// Set property ‘Allow’:
+	// Set property "Allow":
 	for _, item := range networkACL.Allow {
 		result.Allow = append(result.Allow, item)
 	}
 
-	// Set property ‘Deny’:
+	// Set property "Deny":
 	for _, item := range networkACL.Deny {
 		result.Deny = append(result.Deny, item)
 	}
@@ -3981,12 +3981,12 @@ func (networkACL *NetworkACL) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkACL_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Allow’:
+	// Set property "Allow":
 	for _, item := range typedInput.Allow {
 		networkACL.Allow = append(networkACL.Allow, item)
 	}
 
-	// Set property ‘Deny’:
+	// Set property "Deny":
 	for _, item := range typedInput.Deny {
 		networkACL.Deny = append(networkACL.Deny, item)
 	}
@@ -4090,12 +4090,12 @@ func (networkACL *NetworkACL_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkACL_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Allow’:
+	// Set property "Allow":
 	for _, item := range typedInput.Allow {
 		networkACL.Allow = append(networkACL.Allow, item)
 	}
 
-	// Set property ‘Deny’:
+	// Set property "Deny":
 	for _, item := range typedInput.Deny {
 		networkACL.Deny = append(networkACL.Deny, item)
 	}
@@ -4197,17 +4197,17 @@ func (endpointACL *PrivateEndpointACL) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &PrivateEndpointACL_ARM{}
 
-	// Set property ‘Allow’:
+	// Set property "Allow":
 	for _, item := range endpointACL.Allow {
 		result.Allow = append(result.Allow, item)
 	}
 
-	// Set property ‘Deny’:
+	// Set property "Deny":
 	for _, item := range endpointACL.Deny {
 		result.Deny = append(result.Deny, item)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if endpointACL.Name != nil {
 		name := *endpointACL.Name
 		result.Name = &name
@@ -4227,17 +4227,17 @@ func (endpointACL *PrivateEndpointACL) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointACL_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Allow’:
+	// Set property "Allow":
 	for _, item := range typedInput.Allow {
 		endpointACL.Allow = append(endpointACL.Allow, item)
 	}
 
-	// Set property ‘Deny’:
+	// Set property "Deny":
 	for _, item := range typedInput.Deny {
 		endpointACL.Deny = append(endpointACL.Deny, item)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		endpointACL.Name = &name
@@ -4349,17 +4349,17 @@ func (endpointACL *PrivateEndpointACL_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointACL_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Allow’:
+	// Set property "Allow":
 	for _, item := range typedInput.Allow {
 		endpointACL.Allow = append(endpointACL.Allow, item)
 	}
 
-	// Set property ‘Deny’:
+	// Set property "Deny":
 	for _, item := range typedInput.Deny {
 		endpointACL.Deny = append(endpointACL.Deny, item)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		endpointACL.Name = &name
@@ -4465,13 +4465,13 @@ func (category *ResourceLogCategory) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &ResourceLogCategory_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if category.Enabled != nil {
 		enabled := *category.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if category.Name != nil {
 		name := *category.Name
 		result.Name = &name
@@ -4491,13 +4491,13 @@ func (category *ResourceLogCategory) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceLogCategory_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		category.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		category.Name = &name
@@ -4562,13 +4562,13 @@ func (category *ResourceLogCategory_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceLogCategory_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		category.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		category.Name = &name
@@ -4633,7 +4633,7 @@ func (template *UpstreamTemplate) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &UpstreamTemplate_ARM{}
 
-	// Set property ‘Auth’:
+	// Set property "Auth":
 	if template.Auth != nil {
 		auth_ARM, err := (*template.Auth).ConvertToARM(resolved)
 		if err != nil {
@@ -4643,25 +4643,25 @@ func (template *UpstreamTemplate) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Auth = &auth
 	}
 
-	// Set property ‘CategoryPattern’:
+	// Set property "CategoryPattern":
 	if template.CategoryPattern != nil {
 		categoryPattern := *template.CategoryPattern
 		result.CategoryPattern = &categoryPattern
 	}
 
-	// Set property ‘EventPattern’:
+	// Set property "EventPattern":
 	if template.EventPattern != nil {
 		eventPattern := *template.EventPattern
 		result.EventPattern = &eventPattern
 	}
 
-	// Set property ‘HubPattern’:
+	// Set property "HubPattern":
 	if template.HubPattern != nil {
 		hubPattern := *template.HubPattern
 		result.HubPattern = &hubPattern
 	}
 
-	// Set property ‘UrlTemplate’:
+	// Set property "UrlTemplate":
 	if template.UrlTemplate != nil {
 		urlTemplate := *template.UrlTemplate
 		result.UrlTemplate = &urlTemplate
@@ -4681,7 +4681,7 @@ func (template *UpstreamTemplate) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpstreamTemplate_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Auth’:
+	// Set property "Auth":
 	if typedInput.Auth != nil {
 		var auth1 UpstreamAuthSettings
 		err := auth1.PopulateFromARM(owner, *typedInput.Auth)
@@ -4692,25 +4692,25 @@ func (template *UpstreamTemplate) PopulateFromARM(owner genruntime.ArbitraryOwne
 		template.Auth = &auth
 	}
 
-	// Set property ‘CategoryPattern’:
+	// Set property "CategoryPattern":
 	if typedInput.CategoryPattern != nil {
 		categoryPattern := *typedInput.CategoryPattern
 		template.CategoryPattern = &categoryPattern
 	}
 
-	// Set property ‘EventPattern’:
+	// Set property "EventPattern":
 	if typedInput.EventPattern != nil {
 		eventPattern := *typedInput.EventPattern
 		template.EventPattern = &eventPattern
 	}
 
-	// Set property ‘HubPattern’:
+	// Set property "HubPattern":
 	if typedInput.HubPattern != nil {
 		hubPattern := *typedInput.HubPattern
 		template.HubPattern = &hubPattern
 	}
 
-	// Set property ‘UrlTemplate’:
+	// Set property "UrlTemplate":
 	if typedInput.UrlTemplate != nil {
 		urlTemplate := *typedInput.UrlTemplate
 		template.UrlTemplate = &urlTemplate
@@ -4814,7 +4814,7 @@ func (template *UpstreamTemplate_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpstreamTemplate_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Auth’:
+	// Set property "Auth":
 	if typedInput.Auth != nil {
 		var auth1 UpstreamAuthSettings_STATUS
 		err := auth1.PopulateFromARM(owner, *typedInput.Auth)
@@ -4825,25 +4825,25 @@ func (template *UpstreamTemplate_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		template.Auth = &auth
 	}
 
-	// Set property ‘CategoryPattern’:
+	// Set property "CategoryPattern":
 	if typedInput.CategoryPattern != nil {
 		categoryPattern := *typedInput.CategoryPattern
 		template.CategoryPattern = &categoryPattern
 	}
 
-	// Set property ‘EventPattern’:
+	// Set property "EventPattern":
 	if typedInput.EventPattern != nil {
 		eventPattern := *typedInput.EventPattern
 		template.EventPattern = &eventPattern
 	}
 
-	// Set property ‘HubPattern’:
+	// Set property "HubPattern":
 	if typedInput.HubPattern != nil {
 		hubPattern := *typedInput.HubPattern
 		template.HubPattern = &hubPattern
 	}
 
-	// Set property ‘UrlTemplate’:
+	// Set property "UrlTemplate":
 	if typedInput.UrlTemplate != nil {
 		urlTemplate := *typedInput.UrlTemplate
 		template.UrlTemplate = &urlTemplate
@@ -4978,13 +4978,13 @@ func (property *UserAssignedIdentityProperty_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentityProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		property.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		property.PrincipalId = &principalId
@@ -5065,7 +5065,7 @@ func (settings *UpstreamAuthSettings) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &UpstreamAuthSettings_ARM{}
 
-	// Set property ‘ManagedIdentity’:
+	// Set property "ManagedIdentity":
 	if settings.ManagedIdentity != nil {
 		managedIdentity_ARM, err := (*settings.ManagedIdentity).ConvertToARM(resolved)
 		if err != nil {
@@ -5075,7 +5075,7 @@ func (settings *UpstreamAuthSettings) ConvertToARM(resolved genruntime.ConvertTo
 		result.ManagedIdentity = &managedIdentity
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if settings.Type != nil {
 		typeVar := *settings.Type
 		result.Type = &typeVar
@@ -5095,7 +5095,7 @@ func (settings *UpstreamAuthSettings) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpstreamAuthSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ManagedIdentity’:
+	// Set property "ManagedIdentity":
 	if typedInput.ManagedIdentity != nil {
 		var managedIdentity1 ManagedIdentitySettings
 		err := managedIdentity1.PopulateFromARM(owner, *typedInput.ManagedIdentity)
@@ -5106,7 +5106,7 @@ func (settings *UpstreamAuthSettings) PopulateFromARM(owner genruntime.Arbitrary
 		settings.ManagedIdentity = &managedIdentity
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		settings.Type = &typeVar
@@ -5199,7 +5199,7 @@ func (settings *UpstreamAuthSettings_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpstreamAuthSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ManagedIdentity’:
+	// Set property "ManagedIdentity":
 	if typedInput.ManagedIdentity != nil {
 		var managedIdentity1 ManagedIdentitySettings_STATUS
 		err := managedIdentity1.PopulateFromARM(owner, *typedInput.ManagedIdentity)
@@ -5210,7 +5210,7 @@ func (settings *UpstreamAuthSettings_STATUS) PopulateFromARM(owner genruntime.Ar
 		settings.ManagedIdentity = &managedIdentity
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		settings.Type = &typeVar
@@ -5297,7 +5297,7 @@ func (settings *ManagedIdentitySettings) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &ManagedIdentitySettings_ARM{}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	if settings.Resource != nil {
 		resource := *settings.Resource
 		result.Resource = &resource
@@ -5317,7 +5317,7 @@ func (settings *ManagedIdentitySettings) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedIdentitySettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	if typedInput.Resource != nil {
 		resource := *typedInput.Resource
 		settings.Resource = &resource
@@ -5375,7 +5375,7 @@ func (settings *ManagedIdentitySettings_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedIdentitySettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Resource’:
+	// Set property "Resource":
 	if typedInput.Resource != nil {
 		resource := *typedInput.Resource
 		settings.Resource = &resource

--- a/v2/api/sql/v1api20211101/server_types_gen.go
+++ b/v2/api/sql/v1api20211101/server_types_gen.go
@@ -423,7 +423,7 @@ func (server *Server_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &Server_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if server.Identity != nil {
 		identity_ARM, err := (*server.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -433,16 +433,16 @@ func (server *Server_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if server.Location != nil {
 		location := *server.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if server.AdministratorLogin != nil ||
 		server.AdministratorLoginPassword != nil ||
 		server.Administrators != nil ||
@@ -508,7 +508,7 @@ func (server *Server_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Properties.Version = &version
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if server.Tags != nil {
 		result.Tags = make(map[string]string, len(server.Tags))
 		for key, value := range server.Tags {
@@ -530,7 +530,7 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Server_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -539,9 +539,9 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// no assignment for property ‘AdministratorLoginPassword’
+	// no assignment for property "AdministratorLoginPassword"
 
-	// Set property ‘Administrators’:
+	// Set property "Administrators":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Administrators != nil {
@@ -555,10 +555,10 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	server.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘FederatedClientId’:
+	// Set property "FederatedClientId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FederatedClientId != nil {
@@ -567,7 +567,7 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ResourceIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -578,7 +578,7 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		server.Identity = &identity
 	}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyId != nil {
@@ -587,13 +587,13 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimalTlsVersion != nil {
@@ -602,14 +602,14 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// no assignment for property ‘PrimaryUserAssignedIdentityReference’
+	// no assignment for property "PrimaryUserAssignedIdentityReference"
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -618,7 +618,7 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘RestrictOutboundNetworkAccess’:
+	// Set property "RestrictOutboundNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestrictOutboundNetworkAccess != nil {
@@ -627,7 +627,7 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -635,7 +635,7 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1155,7 +1155,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Server_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorLogin’:
+	// Set property "AdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorLogin != nil {
@@ -1164,7 +1164,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Administrators’:
+	// Set property "Administrators":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Administrators != nil {
@@ -1178,9 +1178,9 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘FederatedClientId’:
+	// Set property "FederatedClientId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FederatedClientId != nil {
@@ -1189,7 +1189,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘FullyQualifiedDomainName’:
+	// Set property "FullyQualifiedDomainName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FullyQualifiedDomainName != nil {
@@ -1198,13 +1198,13 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		server.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ResourceIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1215,7 +1215,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		server.Identity = &identity
 	}
 
-	// Set property ‘KeyId’:
+	// Set property "KeyId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyId != nil {
@@ -1224,19 +1224,19 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		server.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		server.Location = &location
 	}
 
-	// Set property ‘MinimalTlsVersion’:
+	// Set property "MinimalTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimalTlsVersion != nil {
@@ -1245,13 +1245,13 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		server.Name = &name
 	}
 
-	// Set property ‘PrimaryUserAssignedIdentityId’:
+	// Set property "PrimaryUserAssignedIdentityId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrimaryUserAssignedIdentityId != nil {
@@ -1260,7 +1260,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1273,7 +1273,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1282,7 +1282,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘RestrictOutboundNetworkAccess’:
+	// Set property "RestrictOutboundNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestrictOutboundNetworkAccess != nil {
@@ -1291,7 +1291,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1300,7 +1300,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		server.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1308,13 +1308,13 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		server.Type = &typeVar
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1323,7 +1323,7 @@ func (server *Server_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		}
 	}
 
-	// Set property ‘WorkspaceFeature’:
+	// Set property "WorkspaceFeature":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkspaceFeature != nil {
@@ -1600,13 +1600,13 @@ func (identity *ResourceIdentity) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ResourceIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -1631,13 +1631,13 @@ func (identity *ResourceIdentity) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -1775,25 +1775,25 @@ func (identity *ResourceIdentity_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -1929,37 +1929,37 @@ func (administrator *ServerExternalAdministrator) ConvertToARM(resolved genrunti
 	}
 	result := &ServerExternalAdministrator_ARM{}
 
-	// Set property ‘AdministratorType’:
+	// Set property "AdministratorType":
 	if administrator.AdministratorType != nil {
 		administratorType := *administrator.AdministratorType
 		result.AdministratorType = &administratorType
 	}
 
-	// Set property ‘AzureADOnlyAuthentication’:
+	// Set property "AzureADOnlyAuthentication":
 	if administrator.AzureADOnlyAuthentication != nil {
 		azureADOnlyAuthentication := *administrator.AzureADOnlyAuthentication
 		result.AzureADOnlyAuthentication = &azureADOnlyAuthentication
 	}
 
-	// Set property ‘Login’:
+	// Set property "Login":
 	if administrator.Login != nil {
 		login := *administrator.Login
 		result.Login = &login
 	}
 
-	// Set property ‘PrincipalType’:
+	// Set property "PrincipalType":
 	if administrator.PrincipalType != nil {
 		principalType := *administrator.PrincipalType
 		result.PrincipalType = &principalType
 	}
 
-	// Set property ‘Sid’:
+	// Set property "Sid":
 	if administrator.Sid != nil {
 		sid := *administrator.Sid
 		result.Sid = &sid
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if administrator.TenantId != nil {
 		tenantId := *administrator.TenantId
 		result.TenantId = &tenantId
@@ -1979,37 +1979,37 @@ func (administrator *ServerExternalAdministrator) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerExternalAdministrator_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorType’:
+	// Set property "AdministratorType":
 	if typedInput.AdministratorType != nil {
 		administratorType := *typedInput.AdministratorType
 		administrator.AdministratorType = &administratorType
 	}
 
-	// Set property ‘AzureADOnlyAuthentication’:
+	// Set property "AzureADOnlyAuthentication":
 	if typedInput.AzureADOnlyAuthentication != nil {
 		azureADOnlyAuthentication := *typedInput.AzureADOnlyAuthentication
 		administrator.AzureADOnlyAuthentication = &azureADOnlyAuthentication
 	}
 
-	// Set property ‘Login’:
+	// Set property "Login":
 	if typedInput.Login != nil {
 		login := *typedInput.Login
 		administrator.Login = &login
 	}
 
-	// Set property ‘PrincipalType’:
+	// Set property "PrincipalType":
 	if typedInput.PrincipalType != nil {
 		principalType := *typedInput.PrincipalType
 		administrator.PrincipalType = &principalType
 	}
 
-	// Set property ‘Sid’:
+	// Set property "Sid":
 	if typedInput.Sid != nil {
 		sid := *typedInput.Sid
 		administrator.Sid = &sid
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		administrator.TenantId = &tenantId
@@ -2213,37 +2213,37 @@ func (administrator *ServerExternalAdministrator_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerExternalAdministrator_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorType’:
+	// Set property "AdministratorType":
 	if typedInput.AdministratorType != nil {
 		administratorType := *typedInput.AdministratorType
 		administrator.AdministratorType = &administratorType
 	}
 
-	// Set property ‘AzureADOnlyAuthentication’:
+	// Set property "AzureADOnlyAuthentication":
 	if typedInput.AzureADOnlyAuthentication != nil {
 		azureADOnlyAuthentication := *typedInput.AzureADOnlyAuthentication
 		administrator.AzureADOnlyAuthentication = &azureADOnlyAuthentication
 	}
 
-	// Set property ‘Login’:
+	// Set property "Login":
 	if typedInput.Login != nil {
 		login := *typedInput.Login
 		administrator.Login = &login
 	}
 
-	// Set property ‘PrincipalType’:
+	// Set property "PrincipalType":
 	if typedInput.PrincipalType != nil {
 		principalType := *typedInput.PrincipalType
 		administrator.PrincipalType = &principalType
 	}
 
-	// Set property ‘Sid’:
+	// Set property "Sid":
 	if typedInput.Sid != nil {
 		sid := *typedInput.Sid
 		administrator.Sid = &sid
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		administrator.TenantId = &tenantId
@@ -2418,13 +2418,13 @@ func (connection *ServerPrivateEndpointConnection_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ServerPrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 PrivateEndpointConnectionProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -2558,12 +2558,12 @@ func (properties *PrivateEndpointConnectionProperties_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnectionProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘GroupIds’:
+	// Set property "GroupIds":
 	for _, item := range typedInput.GroupIds {
 		properties.GroupIds = append(properties.GroupIds, item)
 	}
 
-	// Set property ‘PrivateEndpoint’:
+	// Set property "PrivateEndpoint":
 	if typedInput.PrivateEndpoint != nil {
 		var privateEndpoint1 PrivateEndpointProperty_STATUS
 		err := privateEndpoint1.PopulateFromARM(owner, *typedInput.PrivateEndpoint)
@@ -2574,7 +2574,7 @@ func (properties *PrivateEndpointConnectionProperties_STATUS) PopulateFromARM(ow
 		properties.PrivateEndpoint = &privateEndpoint
 	}
 
-	// Set property ‘PrivateLinkServiceConnectionState’:
+	// Set property "PrivateLinkServiceConnectionState":
 	if typedInput.PrivateLinkServiceConnectionState != nil {
 		var privateLinkServiceConnectionState1 PrivateLinkServiceConnectionStateProperty_STATUS
 		err := privateLinkServiceConnectionState1.PopulateFromARM(owner, *typedInput.PrivateLinkServiceConnectionState)
@@ -2585,7 +2585,7 @@ func (properties *PrivateEndpointConnectionProperties_STATUS) PopulateFromARM(ow
 		properties.PrivateLinkServiceConnectionState = &privateLinkServiceConnectionState
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		properties.ProvisioningState = &provisioningState
@@ -2816,13 +2816,13 @@ func (identity *UserIdentity_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
@@ -2896,7 +2896,7 @@ func (property *PrivateEndpointProperty_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		property.Id = &id
@@ -2960,19 +2960,19 @@ func (property *PrivateLinkServiceConnectionStateProperty_STATUS) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateLinkServiceConnectionStateProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionsRequired’:
+	// Set property "ActionsRequired":
 	if typedInput.ActionsRequired != nil {
 		actionsRequired := *typedInput.ActionsRequired
 		property.ActionsRequired = &actionsRequired
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		property.Description = &description
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		property.Status = &status

--- a/v2/api/sql/v1api20211101/servers_administrator_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_administrator_types_gen.go
@@ -355,10 +355,10 @@ func (administrator *Servers_Administrator_Spec) ConvertToARM(resolved genruntim
 	}
 	result := &Servers_Administrator_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if administrator.AdministratorType != nil ||
 		administrator.Login != nil ||
 		administrator.Sid != nil ||
@@ -414,7 +414,7 @@ func (administrator *Servers_Administrator_Spec) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Administrator_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorType’:
+	// Set property "AdministratorType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorType != nil {
@@ -423,7 +423,7 @@ func (administrator *Servers_Administrator_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Login’:
+	// Set property "Login":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Login != nil {
@@ -432,10 +432,10 @@ func (administrator *Servers_Administrator_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	administrator.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Sid’:
+	// Set property "Sid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sid != nil {
@@ -444,9 +444,9 @@ func (administrator *Servers_Administrator_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// no assignment for property ‘SidFromConfig’
+	// no assignment for property "SidFromConfig"
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantId != nil {
@@ -455,7 +455,7 @@ func (administrator *Servers_Administrator_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// no assignment for property ‘TenantIdFromConfig’
+	// no assignment for property "TenantIdFromConfig"
 
 	// No error
 	return nil
@@ -771,7 +771,7 @@ func (administrator *Servers_Administrator_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Administrator_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdministratorType’:
+	// Set property "AdministratorType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdministratorType != nil {
@@ -780,7 +780,7 @@ func (administrator *Servers_Administrator_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘AzureADOnlyAuthentication’:
+	// Set property "AzureADOnlyAuthentication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureADOnlyAuthentication != nil {
@@ -789,15 +789,15 @@ func (administrator *Servers_Administrator_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		administrator.Id = &id
 	}
 
-	// Set property ‘Login’:
+	// Set property "Login":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Login != nil {
@@ -806,13 +806,13 @@ func (administrator *Servers_Administrator_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		administrator.Name = &name
 	}
 
-	// Set property ‘Sid’:
+	// Set property "Sid":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Sid != nil {
@@ -821,7 +821,7 @@ func (administrator *Servers_Administrator_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TenantId != nil {
@@ -830,7 +830,7 @@ func (administrator *Servers_Administrator_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		administrator.Type = &typeVar

--- a/v2/api/sql/v1api20211101/servers_advanced_threat_protection_setting_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_advanced_threat_protection_setting_types_gen.go
@@ -325,10 +325,10 @@ func (setting *Servers_AdvancedThreatProtectionSetting_Spec) ConvertToARM(resolv
 	}
 	result := &Servers_AdvancedThreatProtectionSetting_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if setting.State != nil {
 		result.Properties = &AdvancedThreatProtectionProperties_ARM{}
 	}
@@ -351,10 +351,10 @@ func (setting *Servers_AdvancedThreatProtectionSetting_Spec) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_AdvancedThreatProtectionSetting_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -583,9 +583,9 @@ func (setting *Servers_AdvancedThreatProtectionSetting_STATUS) PopulateFromARM(o
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_AdvancedThreatProtectionSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationTime’:
+	// Set property "CreationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationTime != nil {
@@ -594,19 +594,19 @@ func (setting *Servers_AdvancedThreatProtectionSetting_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		setting.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		setting.Name = &name
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -615,7 +615,7 @@ func (setting *Servers_AdvancedThreatProtectionSetting_STATUS) PopulateFromARM(o
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -626,7 +626,7 @@ func (setting *Servers_AdvancedThreatProtectionSetting_STATUS) PopulateFromARM(o
 		setting.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar
@@ -781,37 +781,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType

--- a/v2/api/sql/v1api20211101/servers_auditing_setting_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_auditing_setting_types_gen.go
@@ -441,10 +441,10 @@ func (setting *Servers_AuditingSetting_Spec) ConvertToARM(resolved genruntime.Co
 	}
 	result := &Servers_AuditingSetting_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if setting.AuditActionsAndGroups != nil ||
 		setting.IsAzureMonitorTargetEnabled != nil ||
 		setting.IsDevopsAuditEnabled != nil ||
@@ -520,7 +520,7 @@ func (setting *Servers_AuditingSetting_Spec) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_AuditingSetting_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuditActionsAndGroups’:
+	// Set property "AuditActionsAndGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AuditActionsAndGroups {
@@ -528,7 +528,7 @@ func (setting *Servers_AuditingSetting_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘IsAzureMonitorTargetEnabled’:
+	// Set property "IsAzureMonitorTargetEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAzureMonitorTargetEnabled != nil {
@@ -537,7 +537,7 @@ func (setting *Servers_AuditingSetting_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘IsDevopsAuditEnabled’:
+	// Set property "IsDevopsAuditEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsDevopsAuditEnabled != nil {
@@ -546,7 +546,7 @@ func (setting *Servers_AuditingSetting_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘IsManagedIdentityInUse’:
+	// Set property "IsManagedIdentityInUse":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsManagedIdentityInUse != nil {
@@ -555,7 +555,7 @@ func (setting *Servers_AuditingSetting_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘IsStorageSecondaryKeyInUse’:
+	// Set property "IsStorageSecondaryKeyInUse":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsStorageSecondaryKeyInUse != nil {
@@ -564,10 +564,10 @@ func (setting *Servers_AuditingSetting_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘QueueDelayMs’:
+	// Set property "QueueDelayMs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.QueueDelayMs != nil {
@@ -576,7 +576,7 @@ func (setting *Servers_AuditingSetting_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘RetentionDays’:
+	// Set property "RetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionDays != nil {
@@ -585,7 +585,7 @@ func (setting *Servers_AuditingSetting_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -594,9 +594,9 @@ func (setting *Servers_AuditingSetting_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// no assignment for property ‘StorageAccountAccessKey’
+	// no assignment for property "StorageAccountAccessKey"
 
-	// Set property ‘StorageAccountSubscriptionId’:
+	// Set property "StorageAccountSubscriptionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageAccountSubscriptionId != nil {
@@ -605,7 +605,7 @@ func (setting *Servers_AuditingSetting_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘StorageEndpoint’:
+	// Set property "StorageEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageEndpoint != nil {
@@ -1104,7 +1104,7 @@ func (setting *Servers_AuditingSetting_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_AuditingSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuditActionsAndGroups’:
+	// Set property "AuditActionsAndGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AuditActionsAndGroups {
@@ -1112,15 +1112,15 @@ func (setting *Servers_AuditingSetting_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		setting.Id = &id
 	}
 
-	// Set property ‘IsAzureMonitorTargetEnabled’:
+	// Set property "IsAzureMonitorTargetEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAzureMonitorTargetEnabled != nil {
@@ -1129,7 +1129,7 @@ func (setting *Servers_AuditingSetting_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘IsDevopsAuditEnabled’:
+	// Set property "IsDevopsAuditEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsDevopsAuditEnabled != nil {
@@ -1138,7 +1138,7 @@ func (setting *Servers_AuditingSetting_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘IsManagedIdentityInUse’:
+	// Set property "IsManagedIdentityInUse":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsManagedIdentityInUse != nil {
@@ -1147,7 +1147,7 @@ func (setting *Servers_AuditingSetting_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘IsStorageSecondaryKeyInUse’:
+	// Set property "IsStorageSecondaryKeyInUse":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsStorageSecondaryKeyInUse != nil {
@@ -1156,13 +1156,13 @@ func (setting *Servers_AuditingSetting_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		setting.Name = &name
 	}
 
-	// Set property ‘QueueDelayMs’:
+	// Set property "QueueDelayMs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.QueueDelayMs != nil {
@@ -1171,7 +1171,7 @@ func (setting *Servers_AuditingSetting_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘RetentionDays’:
+	// Set property "RetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionDays != nil {
@@ -1180,7 +1180,7 @@ func (setting *Servers_AuditingSetting_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1189,7 +1189,7 @@ func (setting *Servers_AuditingSetting_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘StorageAccountSubscriptionId’:
+	// Set property "StorageAccountSubscriptionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageAccountSubscriptionId != nil {
@@ -1198,7 +1198,7 @@ func (setting *Servers_AuditingSetting_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘StorageEndpoint’:
+	// Set property "StorageEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageEndpoint != nil {
@@ -1207,7 +1207,7 @@ func (setting *Servers_AuditingSetting_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar

--- a/v2/api/sql/v1api20211101/servers_azure_ad_only_authentication_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_azure_ad_only_authentication_types_gen.go
@@ -324,10 +324,10 @@ func (authentication *Servers_AzureADOnlyAuthentication_Spec) ConvertToARM(resol
 	}
 	result := &Servers_AzureADOnlyAuthentication_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if authentication.AzureADOnlyAuthentication != nil {
 		result.Properties = &AzureADOnlyAuthProperties_ARM{}
 	}
@@ -350,7 +350,7 @@ func (authentication *Servers_AzureADOnlyAuthentication_Spec) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_AzureADOnlyAuthentication_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureADOnlyAuthentication’:
+	// Set property "AzureADOnlyAuthentication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureADOnlyAuthentication != nil {
@@ -359,7 +359,7 @@ func (authentication *Servers_AzureADOnlyAuthentication_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	authentication.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -575,7 +575,7 @@ func (authentication *Servers_AzureADOnlyAuthentication_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_AzureADOnlyAuthentication_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureADOnlyAuthentication’:
+	// Set property "AzureADOnlyAuthentication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureADOnlyAuthentication != nil {
@@ -584,21 +584,21 @@ func (authentication *Servers_AzureADOnlyAuthentication_STATUS) PopulateFromARM(
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		authentication.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		authentication.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		authentication.Type = &typeVar

--- a/v2/api/sql/v1api20211101/servers_connection_policy_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_connection_policy_types_gen.go
@@ -324,10 +324,10 @@ func (policy *Servers_ConnectionPolicy_Spec) ConvertToARM(resolved genruntime.Co
 	}
 	result := &Servers_ConnectionPolicy_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if policy.ConnectionType != nil {
 		result.Properties = &ServerConnectionPolicyProperties_ARM{}
 	}
@@ -350,7 +350,7 @@ func (policy *Servers_ConnectionPolicy_Spec) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_ConnectionPolicy_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConnectionType’:
+	// Set property "ConnectionType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConnectionType != nil {
@@ -359,7 +359,7 @@ func (policy *Servers_ConnectionPolicy_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	policy.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -581,9 +581,9 @@ func (policy *Servers_ConnectionPolicy_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_ConnectionPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ConnectionType’:
+	// Set property "ConnectionType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConnectionType != nil {
@@ -592,31 +592,31 @@ func (policy *Servers_ConnectionPolicy_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		policy.Id = &id
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		policy.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		policy.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		policy.Type = &typeVar

--- a/v2/api/sql/v1api20211101/servers_database_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_database_types_gen.go
@@ -471,7 +471,7 @@ func (database *Servers_Database_Spec) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &Servers_Database_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if database.Identity != nil {
 		identity_ARM, err := (*database.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -481,16 +481,16 @@ func (database *Servers_Database_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if database.Location != nil {
 		location := *database.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if database.AutoPauseDelay != nil ||
 		database.CatalogCollation != nil ||
 		database.Collation != nil ||
@@ -647,7 +647,7 @@ func (database *Servers_Database_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Properties.ZoneRedundant = &zoneRedundant
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if database.Sku != nil {
 		sku_ARM, err := (*database.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -657,7 +657,7 @@ func (database *Servers_Database_Spec) ConvertToARM(resolved genruntime.ConvertT
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if database.Tags != nil {
 		result.Tags = make(map[string]string, len(database.Tags))
 		for key, value := range database.Tags {
@@ -679,7 +679,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Database_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoPauseDelay’:
+	// Set property "AutoPauseDelay":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoPauseDelay != nil {
@@ -688,10 +688,10 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	database.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CatalogCollation’:
+	// Set property "CatalogCollation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CatalogCollation != nil {
@@ -700,7 +700,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -709,7 +709,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -718,9 +718,9 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘ElasticPoolReference’
+	// no assignment for property "ElasticPoolReference"
 
-	// Set property ‘FederatedClientId’:
+	// Set property "FederatedClientId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FederatedClientId != nil {
@@ -729,7 +729,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘HighAvailabilityReplicaCount’:
+	// Set property "HighAvailabilityReplicaCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailabilityReplicaCount != nil {
@@ -738,7 +738,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 DatabaseIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -749,7 +749,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		database.Identity = &identity
 	}
 
-	// Set property ‘IsLedgerOn’:
+	// Set property "IsLedgerOn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsLedgerOn != nil {
@@ -758,7 +758,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LicenseType != nil {
@@ -767,15 +767,15 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		database.Location = &location
 	}
 
-	// no assignment for property ‘LongTermRetentionBackupResourceReference’
+	// no assignment for property "LongTermRetentionBackupResourceReference"
 
-	// Set property ‘MaintenanceConfigurationId’:
+	// Set property "MaintenanceConfigurationId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceConfigurationId != nil {
@@ -784,7 +784,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘MaxSizeBytes’:
+	// Set property "MaxSizeBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxSizeBytes != nil {
@@ -793,7 +793,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘MinCapacity’:
+	// Set property "MinCapacity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinCapacity != nil {
@@ -802,10 +802,10 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ReadScale’:
+	// Set property "ReadScale":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReadScale != nil {
@@ -814,11 +814,11 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘RecoverableDatabaseReference’
+	// no assignment for property "RecoverableDatabaseReference"
 
-	// no assignment for property ‘RecoveryServicesRecoveryPointReference’
+	// no assignment for property "RecoveryServicesRecoveryPointReference"
 
-	// Set property ‘RequestedBackupStorageRedundancy’:
+	// Set property "RequestedBackupStorageRedundancy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequestedBackupStorageRedundancy != nil {
@@ -827,9 +827,9 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘RestorableDroppedDatabaseReference’
+	// no assignment for property "RestorableDroppedDatabaseReference"
 
-	// Set property ‘RestorePointInTime’:
+	// Set property "RestorePointInTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestorePointInTime != nil {
@@ -838,7 +838,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘SampleName’:
+	// Set property "SampleName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SampleName != nil {
@@ -847,7 +847,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘SecondaryType’:
+	// Set property "SecondaryType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecondaryType != nil {
@@ -856,7 +856,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -867,7 +867,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		database.Sku = &sku
 	}
 
-	// Set property ‘SourceDatabaseDeletionDate’:
+	// Set property "SourceDatabaseDeletionDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceDatabaseDeletionDate != nil {
@@ -876,11 +876,11 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// no assignment for property ‘SourceDatabaseReference’
+	// no assignment for property "SourceDatabaseReference"
 
-	// no assignment for property ‘SourceResourceReference’
+	// no assignment for property "SourceResourceReference"
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		database.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -888,7 +888,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -1865,7 +1865,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Database_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoPauseDelay’:
+	// Set property "AutoPauseDelay":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoPauseDelay != nil {
@@ -1874,7 +1874,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘CatalogCollation’:
+	// Set property "CatalogCollation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CatalogCollation != nil {
@@ -1883,7 +1883,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Collation’:
+	// Set property "Collation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Collation != nil {
@@ -1892,9 +1892,9 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreateMode’:
+	// Set property "CreateMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreateMode != nil {
@@ -1903,7 +1903,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘CreationDate’:
+	// Set property "CreationDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationDate != nil {
@@ -1912,7 +1912,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘CurrentBackupStorageRedundancy’:
+	// Set property "CurrentBackupStorageRedundancy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CurrentBackupStorageRedundancy != nil {
@@ -1921,7 +1921,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘CurrentServiceObjectiveName’:
+	// Set property "CurrentServiceObjectiveName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CurrentServiceObjectiveName != nil {
@@ -1930,7 +1930,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘CurrentSku’:
+	// Set property "CurrentSku":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CurrentSku != nil {
@@ -1944,7 +1944,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘DatabaseId’:
+	// Set property "DatabaseId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DatabaseId != nil {
@@ -1953,7 +1953,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘DefaultSecondaryLocation’:
+	// Set property "DefaultSecondaryLocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultSecondaryLocation != nil {
@@ -1962,7 +1962,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘EarliestRestoreDate’:
+	// Set property "EarliestRestoreDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EarliestRestoreDate != nil {
@@ -1971,7 +1971,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘ElasticPoolId’:
+	// Set property "ElasticPoolId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ElasticPoolId != nil {
@@ -1980,7 +1980,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘FailoverGroupId’:
+	// Set property "FailoverGroupId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FailoverGroupId != nil {
@@ -1989,7 +1989,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘FederatedClientId’:
+	// Set property "FederatedClientId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FederatedClientId != nil {
@@ -1998,7 +1998,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘HighAvailabilityReplicaCount’:
+	// Set property "HighAvailabilityReplicaCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailabilityReplicaCount != nil {
@@ -2007,13 +2007,13 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		database.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 DatabaseIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2024,7 +2024,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		database.Identity = &identity
 	}
 
-	// Set property ‘IsInfraEncryptionEnabled’:
+	// Set property "IsInfraEncryptionEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsInfraEncryptionEnabled != nil {
@@ -2033,7 +2033,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘IsLedgerOn’:
+	// Set property "IsLedgerOn":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsLedgerOn != nil {
@@ -2042,13 +2042,13 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		database.Kind = &kind
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LicenseType != nil {
@@ -2057,13 +2057,13 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		database.Location = &location
 	}
 
-	// Set property ‘LongTermRetentionBackupResourceId’:
+	// Set property "LongTermRetentionBackupResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LongTermRetentionBackupResourceId != nil {
@@ -2072,7 +2072,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘MaintenanceConfigurationId’:
+	// Set property "MaintenanceConfigurationId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceConfigurationId != nil {
@@ -2081,13 +2081,13 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘ManagedBy’:
+	// Set property "ManagedBy":
 	if typedInput.ManagedBy != nil {
 		managedBy := *typedInput.ManagedBy
 		database.ManagedBy = &managedBy
 	}
 
-	// Set property ‘MaxLogSizeBytes’:
+	// Set property "MaxLogSizeBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxLogSizeBytes != nil {
@@ -2096,7 +2096,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘MaxSizeBytes’:
+	// Set property "MaxSizeBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxSizeBytes != nil {
@@ -2105,7 +2105,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘MinCapacity’:
+	// Set property "MinCapacity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinCapacity != nil {
@@ -2114,13 +2114,13 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		database.Name = &name
 	}
 
-	// Set property ‘PausedDate’:
+	// Set property "PausedDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PausedDate != nil {
@@ -2129,7 +2129,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘ReadScale’:
+	// Set property "ReadScale":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReadScale != nil {
@@ -2138,7 +2138,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘RecoverableDatabaseId’:
+	// Set property "RecoverableDatabaseId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RecoverableDatabaseId != nil {
@@ -2147,7 +2147,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘RecoveryServicesRecoveryPointId’:
+	// Set property "RecoveryServicesRecoveryPointId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RecoveryServicesRecoveryPointId != nil {
@@ -2156,7 +2156,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘RequestedBackupStorageRedundancy’:
+	// Set property "RequestedBackupStorageRedundancy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequestedBackupStorageRedundancy != nil {
@@ -2165,7 +2165,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘RequestedServiceObjectiveName’:
+	// Set property "RequestedServiceObjectiveName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RequestedServiceObjectiveName != nil {
@@ -2174,7 +2174,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘RestorableDroppedDatabaseId’:
+	// Set property "RestorableDroppedDatabaseId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestorableDroppedDatabaseId != nil {
@@ -2183,7 +2183,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘RestorePointInTime’:
+	// Set property "RestorePointInTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestorePointInTime != nil {
@@ -2192,7 +2192,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘ResumedDate’:
+	// Set property "ResumedDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResumedDate != nil {
@@ -2201,7 +2201,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘SampleName’:
+	// Set property "SampleName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SampleName != nil {
@@ -2210,7 +2210,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘SecondaryType’:
+	// Set property "SecondaryType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecondaryType != nil {
@@ -2219,7 +2219,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -2230,7 +2230,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		database.Sku = &sku
 	}
 
-	// Set property ‘SourceDatabaseDeletionDate’:
+	// Set property "SourceDatabaseDeletionDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceDatabaseDeletionDate != nil {
@@ -2239,7 +2239,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘SourceDatabaseId’:
+	// Set property "SourceDatabaseId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceDatabaseId != nil {
@@ -2248,7 +2248,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘SourceResourceId’:
+	// Set property "SourceResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SourceResourceId != nil {
@@ -2257,7 +2257,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -2266,7 +2266,7 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		database.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -2274,13 +2274,13 @@ func (database *Servers_Database_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		database.Type = &typeVar
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -2812,13 +2812,13 @@ func (identity *DatabaseIdentity) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &DatabaseIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -2843,13 +2843,13 @@ func (identity *DatabaseIdentity) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -2983,19 +2983,19 @@ func (identity *DatabaseIdentity_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]DatabaseUserIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -3286,31 +3286,31 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if sku.Capacity != nil {
 		capacity := *sku.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if sku.Family != nil {
 		family := *sku.Family
 		result.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if sku.Size != nil {
 		size := *sku.Size
 		result.Size = &size
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -3330,31 +3330,31 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if typedInput.Size != nil {
 		size := *typedInput.Size
 		sku.Size = &size
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3471,31 +3471,31 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		sku.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		sku.Family = &family
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if typedInput.Size != nil {
 		size := *typedInput.Size
 		sku.Size = &size
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -3581,13 +3581,13 @@ func (identity *DatabaseUserIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DatabaseUserIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId

--- a/v2/api/sql/v1api20211101/servers_databases_advanced_threat_protection_setting_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_databases_advanced_threat_protection_setting_types_gen.go
@@ -325,10 +325,10 @@ func (setting *Servers_Databases_AdvancedThreatProtectionSetting_Spec) ConvertTo
 	}
 	result := &Servers_Databases_AdvancedThreatProtectionSetting_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if setting.State != nil {
 		result.Properties = &AdvancedThreatProtectionProperties_ARM{}
 	}
@@ -351,10 +351,10 @@ func (setting *Servers_Databases_AdvancedThreatProtectionSetting_Spec) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_AdvancedThreatProtectionSetting_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -583,9 +583,9 @@ func (setting *Servers_Databases_AdvancedThreatProtectionSetting_STATUS) Populat
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_AdvancedThreatProtectionSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationTime’:
+	// Set property "CreationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationTime != nil {
@@ -594,19 +594,19 @@ func (setting *Servers_Databases_AdvancedThreatProtectionSetting_STATUS) Populat
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		setting.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		setting.Name = &name
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -615,7 +615,7 @@ func (setting *Servers_Databases_AdvancedThreatProtectionSetting_STATUS) Populat
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -626,7 +626,7 @@ func (setting *Servers_Databases_AdvancedThreatProtectionSetting_STATUS) Populat
 		setting.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar

--- a/v2/api/sql/v1api20211101/servers_databases_auditing_setting_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_databases_auditing_setting_types_gen.go
@@ -428,10 +428,10 @@ func (setting *Servers_Databases_AuditingSetting_Spec) ConvertToARM(resolved gen
 	}
 	result := &Servers_Databases_AuditingSetting_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if setting.AuditActionsAndGroups != nil ||
 		setting.IsAzureMonitorTargetEnabled != nil ||
 		setting.IsManagedIdentityInUse != nil ||
@@ -502,7 +502,7 @@ func (setting *Servers_Databases_AuditingSetting_Spec) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_AuditingSetting_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuditActionsAndGroups’:
+	// Set property "AuditActionsAndGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AuditActionsAndGroups {
@@ -510,7 +510,7 @@ func (setting *Servers_Databases_AuditingSetting_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘IsAzureMonitorTargetEnabled’:
+	// Set property "IsAzureMonitorTargetEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAzureMonitorTargetEnabled != nil {
@@ -519,7 +519,7 @@ func (setting *Servers_Databases_AuditingSetting_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘IsManagedIdentityInUse’:
+	// Set property "IsManagedIdentityInUse":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsManagedIdentityInUse != nil {
@@ -528,7 +528,7 @@ func (setting *Servers_Databases_AuditingSetting_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘IsStorageSecondaryKeyInUse’:
+	// Set property "IsStorageSecondaryKeyInUse":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsStorageSecondaryKeyInUse != nil {
@@ -537,10 +537,10 @@ func (setting *Servers_Databases_AuditingSetting_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘QueueDelayMs’:
+	// Set property "QueueDelayMs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.QueueDelayMs != nil {
@@ -549,7 +549,7 @@ func (setting *Servers_Databases_AuditingSetting_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘RetentionDays’:
+	// Set property "RetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionDays != nil {
@@ -558,7 +558,7 @@ func (setting *Servers_Databases_AuditingSetting_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -567,9 +567,9 @@ func (setting *Servers_Databases_AuditingSetting_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// no assignment for property ‘StorageAccountAccessKey’
+	// no assignment for property "StorageAccountAccessKey"
 
-	// Set property ‘StorageAccountSubscriptionId’:
+	// Set property "StorageAccountSubscriptionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageAccountSubscriptionId != nil {
@@ -578,7 +578,7 @@ func (setting *Servers_Databases_AuditingSetting_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘StorageEndpoint’:
+	// Set property "StorageEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageEndpoint != nil {
@@ -1043,7 +1043,7 @@ func (setting *Servers_Databases_AuditingSetting_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_AuditingSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuditActionsAndGroups’:
+	// Set property "AuditActionsAndGroups":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.AuditActionsAndGroups {
@@ -1051,15 +1051,15 @@ func (setting *Servers_Databases_AuditingSetting_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		setting.Id = &id
 	}
 
-	// Set property ‘IsAzureMonitorTargetEnabled’:
+	// Set property "IsAzureMonitorTargetEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAzureMonitorTargetEnabled != nil {
@@ -1068,7 +1068,7 @@ func (setting *Servers_Databases_AuditingSetting_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘IsManagedIdentityInUse’:
+	// Set property "IsManagedIdentityInUse":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsManagedIdentityInUse != nil {
@@ -1077,7 +1077,7 @@ func (setting *Servers_Databases_AuditingSetting_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘IsStorageSecondaryKeyInUse’:
+	// Set property "IsStorageSecondaryKeyInUse":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsStorageSecondaryKeyInUse != nil {
@@ -1086,19 +1086,19 @@ func (setting *Servers_Databases_AuditingSetting_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		setting.Kind = &kind
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		setting.Name = &name
 	}
 
-	// Set property ‘QueueDelayMs’:
+	// Set property "QueueDelayMs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.QueueDelayMs != nil {
@@ -1107,7 +1107,7 @@ func (setting *Servers_Databases_AuditingSetting_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘RetentionDays’:
+	// Set property "RetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionDays != nil {
@@ -1116,7 +1116,7 @@ func (setting *Servers_Databases_AuditingSetting_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1125,7 +1125,7 @@ func (setting *Servers_Databases_AuditingSetting_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘StorageAccountSubscriptionId’:
+	// Set property "StorageAccountSubscriptionId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageAccountSubscriptionId != nil {
@@ -1134,7 +1134,7 @@ func (setting *Servers_Databases_AuditingSetting_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘StorageEndpoint’:
+	// Set property "StorageEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageEndpoint != nil {
@@ -1143,7 +1143,7 @@ func (setting *Servers_Databases_AuditingSetting_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		setting.Type = &typeVar

--- a/v2/api/sql/v1api20211101/servers_databases_backup_long_term_retention_policy_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_databases_backup_long_term_retention_policy_types_gen.go
@@ -332,10 +332,10 @@ func (policy *Servers_Databases_BackupLongTermRetentionPolicy_Spec) ConvertToARM
 	}
 	result := &Servers_Databases_BackupLongTermRetentionPolicy_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if policy.MonthlyRetention != nil ||
 		policy.WeekOfYear != nil ||
 		policy.WeeklyRetention != nil ||
@@ -373,7 +373,7 @@ func (policy *Servers_Databases_BackupLongTermRetentionPolicy_Spec) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_BackupLongTermRetentionPolicy_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MonthlyRetention’:
+	// Set property "MonthlyRetention":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MonthlyRetention != nil {
@@ -382,10 +382,10 @@ func (policy *Servers_Databases_BackupLongTermRetentionPolicy_Spec) PopulateFrom
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	policy.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘WeekOfYear’:
+	// Set property "WeekOfYear":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WeekOfYear != nil {
@@ -394,7 +394,7 @@ func (policy *Servers_Databases_BackupLongTermRetentionPolicy_Spec) PopulateFrom
 		}
 	}
 
-	// Set property ‘WeeklyRetention’:
+	// Set property "WeeklyRetention":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WeeklyRetention != nil {
@@ -403,7 +403,7 @@ func (policy *Servers_Databases_BackupLongTermRetentionPolicy_Spec) PopulateFrom
 		}
 	}
 
-	// Set property ‘YearlyRetention’:
+	// Set property "YearlyRetention":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.YearlyRetention != nil {
@@ -646,15 +646,15 @@ func (policy *Servers_Databases_BackupLongTermRetentionPolicy_STATUS) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_BackupLongTermRetentionPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		policy.Id = &id
 	}
 
-	// Set property ‘MonthlyRetention’:
+	// Set property "MonthlyRetention":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MonthlyRetention != nil {
@@ -663,19 +663,19 @@ func (policy *Servers_Databases_BackupLongTermRetentionPolicy_STATUS) PopulateFr
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		policy.Type = &typeVar
 	}
 
-	// Set property ‘WeekOfYear’:
+	// Set property "WeekOfYear":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WeekOfYear != nil {
@@ -684,7 +684,7 @@ func (policy *Servers_Databases_BackupLongTermRetentionPolicy_STATUS) PopulateFr
 		}
 	}
 
-	// Set property ‘WeeklyRetention’:
+	// Set property "WeeklyRetention":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WeeklyRetention != nil {
@@ -693,7 +693,7 @@ func (policy *Servers_Databases_BackupLongTermRetentionPolicy_STATUS) PopulateFr
 		}
 	}
 
-	// Set property ‘YearlyRetention’:
+	// Set property "YearlyRetention":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.YearlyRetention != nil {

--- a/v2/api/sql/v1api20211101/servers_databases_backup_short_term_retention_policy_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_databases_backup_short_term_retention_policy_types_gen.go
@@ -327,10 +327,10 @@ func (policy *Servers_Databases_BackupShortTermRetentionPolicy_Spec) ConvertToAR
 	}
 	result := &Servers_Databases_BackupShortTermRetentionPolicy_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if policy.DiffBackupIntervalInHours != nil || policy.RetentionDays != nil {
 		result.Properties = &BackupShortTermRetentionPolicyProperties_ARM{}
 	}
@@ -357,7 +357,7 @@ func (policy *Servers_Databases_BackupShortTermRetentionPolicy_Spec) PopulateFro
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_BackupShortTermRetentionPolicy_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DiffBackupIntervalInHours’:
+	// Set property "DiffBackupIntervalInHours":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiffBackupIntervalInHours != nil {
@@ -366,10 +366,10 @@ func (policy *Servers_Databases_BackupShortTermRetentionPolicy_Spec) PopulateFro
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	policy.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RetentionDays’:
+	// Set property "RetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionDays != nil {
@@ -604,9 +604,9 @@ func (policy *Servers_Databases_BackupShortTermRetentionPolicy_STATUS) PopulateF
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_BackupShortTermRetentionPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DiffBackupIntervalInHours’:
+	// Set property "DiffBackupIntervalInHours":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DiffBackupIntervalInHours != nil {
@@ -615,19 +615,19 @@ func (policy *Servers_Databases_BackupShortTermRetentionPolicy_STATUS) PopulateF
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		policy.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘RetentionDays’:
+	// Set property "RetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionDays != nil {
@@ -636,7 +636,7 @@ func (policy *Servers_Databases_BackupShortTermRetentionPolicy_STATUS) PopulateF
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		policy.Type = &typeVar

--- a/v2/api/sql/v1api20211101/servers_databases_security_alert_policy_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_databases_security_alert_policy_types_gen.go
@@ -345,10 +345,10 @@ func (policy *Servers_Databases_SecurityAlertPolicy_Spec) ConvertToARM(resolved 
 	}
 	result := &Servers_Databases_SecurityAlertPolicy_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if policy.DisabledAlerts != nil ||
 		policy.EmailAccountAdmins != nil ||
 		policy.EmailAddresses != nil ||
@@ -403,7 +403,7 @@ func (policy *Servers_Databases_SecurityAlertPolicy_Spec) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_SecurityAlertPolicy_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisabledAlerts’:
+	// Set property "DisabledAlerts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DisabledAlerts {
@@ -411,7 +411,7 @@ func (policy *Servers_Databases_SecurityAlertPolicy_Spec) PopulateFromARM(owner 
 		}
 	}
 
-	// Set property ‘EmailAccountAdmins’:
+	// Set property "EmailAccountAdmins":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EmailAccountAdmins != nil {
@@ -420,7 +420,7 @@ func (policy *Servers_Databases_SecurityAlertPolicy_Spec) PopulateFromARM(owner 
 		}
 	}
 
-	// Set property ‘EmailAddresses’:
+	// Set property "EmailAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EmailAddresses {
@@ -428,10 +428,10 @@ func (policy *Servers_Databases_SecurityAlertPolicy_Spec) PopulateFromARM(owner 
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	policy.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RetentionDays’:
+	// Set property "RetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionDays != nil {
@@ -440,7 +440,7 @@ func (policy *Servers_Databases_SecurityAlertPolicy_Spec) PopulateFromARM(owner 
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -449,9 +449,9 @@ func (policy *Servers_Databases_SecurityAlertPolicy_Spec) PopulateFromARM(owner 
 		}
 	}
 
-	// no assignment for property ‘StorageAccountAccessKey’
+	// no assignment for property "StorageAccountAccessKey"
 
-	// Set property ‘StorageEndpoint’:
+	// Set property "StorageEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageEndpoint != nil {
@@ -773,9 +773,9 @@ func (policy *Servers_Databases_SecurityAlertPolicy_STATUS) PopulateFromARM(owne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_SecurityAlertPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationTime’:
+	// Set property "CreationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationTime != nil {
@@ -784,7 +784,7 @@ func (policy *Servers_Databases_SecurityAlertPolicy_STATUS) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘DisabledAlerts’:
+	// Set property "DisabledAlerts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DisabledAlerts {
@@ -792,7 +792,7 @@ func (policy *Servers_Databases_SecurityAlertPolicy_STATUS) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘EmailAccountAdmins’:
+	// Set property "EmailAccountAdmins":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EmailAccountAdmins != nil {
@@ -801,7 +801,7 @@ func (policy *Servers_Databases_SecurityAlertPolicy_STATUS) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘EmailAddresses’:
+	// Set property "EmailAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EmailAddresses {
@@ -809,19 +809,19 @@ func (policy *Servers_Databases_SecurityAlertPolicy_STATUS) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		policy.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘RetentionDays’:
+	// Set property "RetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionDays != nil {
@@ -830,7 +830,7 @@ func (policy *Servers_Databases_SecurityAlertPolicy_STATUS) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -839,7 +839,7 @@ func (policy *Servers_Databases_SecurityAlertPolicy_STATUS) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘StorageEndpoint’:
+	// Set property "StorageEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageEndpoint != nil {
@@ -848,7 +848,7 @@ func (policy *Servers_Databases_SecurityAlertPolicy_STATUS) PopulateFromARM(owne
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -859,7 +859,7 @@ func (policy *Servers_Databases_SecurityAlertPolicy_STATUS) PopulateFromARM(owne
 		policy.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		policy.Type = &typeVar

--- a/v2/api/sql/v1api20211101/servers_databases_transparent_data_encryption_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_databases_transparent_data_encryption_types_gen.go
@@ -324,10 +324,10 @@ func (encryption *Servers_Databases_TransparentDataEncryption_Spec) ConvertToARM
 	}
 	result := &Servers_Databases_TransparentDataEncryption_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if encryption.State != nil {
 		result.Properties = &TransparentDataEncryptionProperties_ARM{}
 	}
@@ -350,10 +350,10 @@ func (encryption *Servers_Databases_TransparentDataEncryption_Spec) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_TransparentDataEncryption_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	encryption.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -575,21 +575,21 @@ func (encryption *Servers_Databases_TransparentDataEncryption_STATUS) PopulateFr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_TransparentDataEncryption_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		encryption.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		encryption.Name = &name
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -598,7 +598,7 @@ func (encryption *Servers_Databases_TransparentDataEncryption_STATUS) PopulateFr
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		encryption.Type = &typeVar

--- a/v2/api/sql/v1api20211101/servers_databases_vulnerability_assessment_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_databases_vulnerability_assessment_types_gen.go
@@ -356,10 +356,10 @@ func (assessment *Servers_Databases_VulnerabilityAssessment_Spec) ConvertToARM(r
 	}
 	result := &Servers_Databases_VulnerabilityAssessment_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if assessment.RecurringScans != nil ||
 		assessment.StorageAccountAccessKey != nil ||
 		assessment.StorageContainerPath != nil ||
@@ -418,10 +418,10 @@ func (assessment *Servers_Databases_VulnerabilityAssessment_Spec) PopulateFromAR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_VulnerabilityAssessment_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	assessment.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RecurringScans’:
+	// Set property "RecurringScans":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RecurringScans != nil {
@@ -435,9 +435,9 @@ func (assessment *Servers_Databases_VulnerabilityAssessment_Spec) PopulateFromAR
 		}
 	}
 
-	// no assignment for property ‘StorageAccountAccessKey’
+	// no assignment for property "StorageAccountAccessKey"
 
-	// Set property ‘StorageContainerPath’:
+	// Set property "StorageContainerPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageContainerPath != nil {
@@ -446,9 +446,9 @@ func (assessment *Servers_Databases_VulnerabilityAssessment_Spec) PopulateFromAR
 		}
 	}
 
-	// no assignment for property ‘StorageContainerPathFromConfig’
+	// no assignment for property "StorageContainerPathFromConfig"
 
-	// no assignment for property ‘StorageContainerSasKey’
+	// no assignment for property "StorageContainerSasKey"
 
 	// No error
 	return nil
@@ -737,21 +737,21 @@ func (assessment *Servers_Databases_VulnerabilityAssessment_STATUS) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Databases_VulnerabilityAssessment_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		assessment.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		assessment.Name = &name
 	}
 
-	// Set property ‘RecurringScans’:
+	// Set property "RecurringScans":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RecurringScans != nil {
@@ -765,7 +765,7 @@ func (assessment *Servers_Databases_VulnerabilityAssessment_STATUS) PopulateFrom
 		}
 	}
 
-	// Set property ‘StorageContainerPath’:
+	// Set property "StorageContainerPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageContainerPath != nil {
@@ -774,7 +774,7 @@ func (assessment *Servers_Databases_VulnerabilityAssessment_STATUS) PopulateFrom
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		assessment.Type = &typeVar
@@ -883,18 +883,18 @@ func (properties *VulnerabilityAssessmentRecurringScansProperties) ConvertToARM(
 	}
 	result := &VulnerabilityAssessmentRecurringScansProperties_ARM{}
 
-	// Set property ‘EmailSubscriptionAdmins’:
+	// Set property "EmailSubscriptionAdmins":
 	if properties.EmailSubscriptionAdmins != nil {
 		emailSubscriptionAdmins := *properties.EmailSubscriptionAdmins
 		result.EmailSubscriptionAdmins = &emailSubscriptionAdmins
 	}
 
-	// Set property ‘Emails’:
+	// Set property "Emails":
 	for _, item := range properties.Emails {
 		result.Emails = append(result.Emails, item)
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if properties.IsEnabled != nil {
 		isEnabled := *properties.IsEnabled
 		result.IsEnabled = &isEnabled
@@ -914,18 +914,18 @@ func (properties *VulnerabilityAssessmentRecurringScansProperties) PopulateFromA
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VulnerabilityAssessmentRecurringScansProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EmailSubscriptionAdmins’:
+	// Set property "EmailSubscriptionAdmins":
 	if typedInput.EmailSubscriptionAdmins != nil {
 		emailSubscriptionAdmins := *typedInput.EmailSubscriptionAdmins
 		properties.EmailSubscriptionAdmins = &emailSubscriptionAdmins
 	}
 
-	// Set property ‘Emails’:
+	// Set property "Emails":
 	for _, item := range typedInput.Emails {
 		properties.Emails = append(properties.Emails, item)
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if typedInput.IsEnabled != nil {
 		isEnabled := *typedInput.IsEnabled
 		properties.IsEnabled = &isEnabled
@@ -1049,18 +1049,18 @@ func (properties *VulnerabilityAssessmentRecurringScansProperties_STATUS) Popula
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VulnerabilityAssessmentRecurringScansProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EmailSubscriptionAdmins’:
+	// Set property "EmailSubscriptionAdmins":
 	if typedInput.EmailSubscriptionAdmins != nil {
 		emailSubscriptionAdmins := *typedInput.EmailSubscriptionAdmins
 		properties.EmailSubscriptionAdmins = &emailSubscriptionAdmins
 	}
 
-	// Set property ‘Emails’:
+	// Set property "Emails":
 	for _, item := range typedInput.Emails {
 		properties.Emails = append(properties.Emails, item)
 	}
 
-	// Set property ‘IsEnabled’:
+	// Set property "IsEnabled":
 	if typedInput.IsEnabled != nil {
 		isEnabled := *typedInput.IsEnabled
 		properties.IsEnabled = &isEnabled

--- a/v2/api/sql/v1api20211101/servers_elastic_pool_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_elastic_pool_types_gen.go
@@ -371,16 +371,16 @@ func (pool *Servers_ElasticPool_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &Servers_ElasticPool_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if pool.Location != nil {
 		location := *pool.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if pool.HighAvailabilityReplicaCount != nil ||
 		pool.LicenseType != nil ||
 		pool.MaintenanceConfigurationId != nil ||
@@ -423,7 +423,7 @@ func (pool *Servers_ElasticPool_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Properties.ZoneRedundant = &zoneRedundant
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if pool.Sku != nil {
 		sku_ARM, err := (*pool.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -433,7 +433,7 @@ func (pool *Servers_ElasticPool_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if pool.Tags != nil {
 		result.Tags = make(map[string]string, len(pool.Tags))
 		for key, value := range pool.Tags {
@@ -455,10 +455,10 @@ func (pool *Servers_ElasticPool_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_ElasticPool_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	pool.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘HighAvailabilityReplicaCount’:
+	// Set property "HighAvailabilityReplicaCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailabilityReplicaCount != nil {
@@ -467,7 +467,7 @@ func (pool *Servers_ElasticPool_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LicenseType != nil {
@@ -476,13 +476,13 @@ func (pool *Servers_ElasticPool_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		pool.Location = &location
 	}
 
-	// Set property ‘MaintenanceConfigurationId’:
+	// Set property "MaintenanceConfigurationId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceConfigurationId != nil {
@@ -491,7 +491,7 @@ func (pool *Servers_ElasticPool_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘MaxSizeBytes’:
+	// Set property "MaxSizeBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxSizeBytes != nil {
@@ -500,7 +500,7 @@ func (pool *Servers_ElasticPool_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘MinCapacity’:
+	// Set property "MinCapacity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinCapacity != nil {
@@ -509,10 +509,10 @@ func (pool *Servers_ElasticPool_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	pool.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PerDatabaseSettings’:
+	// Set property "PerDatabaseSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PerDatabaseSettings != nil {
@@ -526,7 +526,7 @@ func (pool *Servers_ElasticPool_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -537,7 +537,7 @@ func (pool *Servers_ElasticPool_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		pool.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		pool.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -545,7 +545,7 @@ func (pool *Servers_ElasticPool_Spec) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -986,9 +986,9 @@ func (pool *Servers_ElasticPool_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_ElasticPool_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationDate’:
+	// Set property "CreationDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationDate != nil {
@@ -997,7 +997,7 @@ func (pool *Servers_ElasticPool_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘HighAvailabilityReplicaCount’:
+	// Set property "HighAvailabilityReplicaCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HighAvailabilityReplicaCount != nil {
@@ -1006,19 +1006,19 @@ func (pool *Servers_ElasticPool_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		pool.Id = &id
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		pool.Kind = &kind
 	}
 
-	// Set property ‘LicenseType’:
+	// Set property "LicenseType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LicenseType != nil {
@@ -1027,13 +1027,13 @@ func (pool *Servers_ElasticPool_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		pool.Location = &location
 	}
 
-	// Set property ‘MaintenanceConfigurationId’:
+	// Set property "MaintenanceConfigurationId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaintenanceConfigurationId != nil {
@@ -1042,7 +1042,7 @@ func (pool *Servers_ElasticPool_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘MaxSizeBytes’:
+	// Set property "MaxSizeBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxSizeBytes != nil {
@@ -1051,7 +1051,7 @@ func (pool *Servers_ElasticPool_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘MinCapacity’:
+	// Set property "MinCapacity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinCapacity != nil {
@@ -1060,13 +1060,13 @@ func (pool *Servers_ElasticPool_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pool.Name = &name
 	}
 
-	// Set property ‘PerDatabaseSettings’:
+	// Set property "PerDatabaseSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PerDatabaseSettings != nil {
@@ -1080,7 +1080,7 @@ func (pool *Servers_ElasticPool_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1091,7 +1091,7 @@ func (pool *Servers_ElasticPool_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		pool.Sku = &sku
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1100,7 +1100,7 @@ func (pool *Servers_ElasticPool_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		pool.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1108,13 +1108,13 @@ func (pool *Servers_ElasticPool_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		pool.Type = &typeVar
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -1346,13 +1346,13 @@ func (settings *ElasticPoolPerDatabaseSettings) ConvertToARM(resolved genruntime
 	}
 	result := &ElasticPoolPerDatabaseSettings_ARM{}
 
-	// Set property ‘MaxCapacity’:
+	// Set property "MaxCapacity":
 	if settings.MaxCapacity != nil {
 		maxCapacity := *settings.MaxCapacity
 		result.MaxCapacity = &maxCapacity
 	}
 
-	// Set property ‘MinCapacity’:
+	// Set property "MinCapacity":
 	if settings.MinCapacity != nil {
 		minCapacity := *settings.MinCapacity
 		result.MinCapacity = &minCapacity
@@ -1372,13 +1372,13 @@ func (settings *ElasticPoolPerDatabaseSettings) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ElasticPoolPerDatabaseSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxCapacity’:
+	// Set property "MaxCapacity":
 	if typedInput.MaxCapacity != nil {
 		maxCapacity := *typedInput.MaxCapacity
 		settings.MaxCapacity = &maxCapacity
 	}
 
-	// Set property ‘MinCapacity’:
+	// Set property "MinCapacity":
 	if typedInput.MinCapacity != nil {
 		minCapacity := *typedInput.MinCapacity
 		settings.MinCapacity = &minCapacity
@@ -1489,13 +1489,13 @@ func (settings *ElasticPoolPerDatabaseSettings_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ElasticPoolPerDatabaseSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxCapacity’:
+	// Set property "MaxCapacity":
 	if typedInput.MaxCapacity != nil {
 		maxCapacity := *typedInput.MaxCapacity
 		settings.MaxCapacity = &maxCapacity
 	}
 
-	// Set property ‘MinCapacity’:
+	// Set property "MinCapacity":
 	if typedInput.MinCapacity != nil {
 		minCapacity := *typedInput.MinCapacity
 		settings.MinCapacity = &minCapacity

--- a/v2/api/sql/v1api20211101/servers_failover_group_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_failover_group_types_gen.go
@@ -348,10 +348,10 @@ func (group *Servers_FailoverGroup_Spec) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &Servers_FailoverGroup_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if group.DatabasesReferences != nil ||
 		group.PartnerServers != nil ||
 		group.ReadOnlyEndpoint != nil ||
@@ -389,7 +389,7 @@ func (group *Servers_FailoverGroup_Spec) ConvertToARM(resolved genruntime.Conver
 		result.Properties.ReadWriteEndpoint = &readWriteEndpoint
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if group.Tags != nil {
 		result.Tags = make(map[string]string, len(group.Tags))
 		for key, value := range group.Tags {
@@ -411,15 +411,15 @@ func (group *Servers_FailoverGroup_Spec) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_FailoverGroup_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	group.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// no assignment for property ‘DatabasesReferences’
+	// no assignment for property "DatabasesReferences"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	group.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PartnerServers’:
+	// Set property "PartnerServers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PartnerServers {
@@ -432,7 +432,7 @@ func (group *Servers_FailoverGroup_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘ReadOnlyEndpoint’:
+	// Set property "ReadOnlyEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReadOnlyEndpoint != nil {
@@ -446,7 +446,7 @@ func (group *Servers_FailoverGroup_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘ReadWriteEndpoint’:
+	// Set property "ReadWriteEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReadWriteEndpoint != nil {
@@ -460,7 +460,7 @@ func (group *Servers_FailoverGroup_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		group.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -848,9 +848,9 @@ func (group *Servers_FailoverGroup_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_FailoverGroup_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Databases’:
+	// Set property "Databases":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.Databases {
@@ -858,25 +858,25 @@ func (group *Servers_FailoverGroup_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		group.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		group.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		group.Name = &name
 	}
 
-	// Set property ‘PartnerServers’:
+	// Set property "PartnerServers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PartnerServers {
@@ -889,7 +889,7 @@ func (group *Servers_FailoverGroup_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘ReadOnlyEndpoint’:
+	// Set property "ReadOnlyEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReadOnlyEndpoint != nil {
@@ -903,7 +903,7 @@ func (group *Servers_FailoverGroup_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘ReadWriteEndpoint’:
+	// Set property "ReadWriteEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReadWriteEndpoint != nil {
@@ -917,7 +917,7 @@ func (group *Servers_FailoverGroup_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘ReplicationRole’:
+	// Set property "ReplicationRole":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicationRole != nil {
@@ -926,7 +926,7 @@ func (group *Servers_FailoverGroup_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘ReplicationState’:
+	// Set property "ReplicationState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ReplicationState != nil {
@@ -935,7 +935,7 @@ func (group *Servers_FailoverGroup_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		group.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -943,7 +943,7 @@ func (group *Servers_FailoverGroup_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		group.Type = &typeVar
@@ -1146,7 +1146,7 @@ func (endpoint *FailoverGroupReadOnlyEndpoint) ConvertToARM(resolved genruntime.
 	}
 	result := &FailoverGroupReadOnlyEndpoint_ARM{}
 
-	// Set property ‘FailoverPolicy’:
+	// Set property "FailoverPolicy":
 	if endpoint.FailoverPolicy != nil {
 		failoverPolicy := *endpoint.FailoverPolicy
 		result.FailoverPolicy = &failoverPolicy
@@ -1166,7 +1166,7 @@ func (endpoint *FailoverGroupReadOnlyEndpoint) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FailoverGroupReadOnlyEndpoint_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FailoverPolicy’:
+	// Set property "FailoverPolicy":
 	if typedInput.FailoverPolicy != nil {
 		failoverPolicy := *typedInput.FailoverPolicy
 		endpoint.FailoverPolicy = &failoverPolicy
@@ -1250,7 +1250,7 @@ func (endpoint *FailoverGroupReadOnlyEndpoint_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FailoverGroupReadOnlyEndpoint_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FailoverPolicy’:
+	// Set property "FailoverPolicy":
 	if typedInput.FailoverPolicy != nil {
 		failoverPolicy := *typedInput.FailoverPolicy
 		endpoint.FailoverPolicy = &failoverPolicy
@@ -1320,13 +1320,13 @@ func (endpoint *FailoverGroupReadWriteEndpoint) ConvertToARM(resolved genruntime
 	}
 	result := &FailoverGroupReadWriteEndpoint_ARM{}
 
-	// Set property ‘FailoverPolicy’:
+	// Set property "FailoverPolicy":
 	if endpoint.FailoverPolicy != nil {
 		failoverPolicy := *endpoint.FailoverPolicy
 		result.FailoverPolicy = &failoverPolicy
 	}
 
-	// Set property ‘FailoverWithDataLossGracePeriodMinutes’:
+	// Set property "FailoverWithDataLossGracePeriodMinutes":
 	if endpoint.FailoverWithDataLossGracePeriodMinutes != nil {
 		failoverWithDataLossGracePeriodMinutes := *endpoint.FailoverWithDataLossGracePeriodMinutes
 		result.FailoverWithDataLossGracePeriodMinutes = &failoverWithDataLossGracePeriodMinutes
@@ -1346,13 +1346,13 @@ func (endpoint *FailoverGroupReadWriteEndpoint) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FailoverGroupReadWriteEndpoint_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FailoverPolicy’:
+	// Set property "FailoverPolicy":
 	if typedInput.FailoverPolicy != nil {
 		failoverPolicy := *typedInput.FailoverPolicy
 		endpoint.FailoverPolicy = &failoverPolicy
 	}
 
-	// Set property ‘FailoverWithDataLossGracePeriodMinutes’:
+	// Set property "FailoverWithDataLossGracePeriodMinutes":
 	if typedInput.FailoverWithDataLossGracePeriodMinutes != nil {
 		failoverWithDataLossGracePeriodMinutes := *typedInput.FailoverWithDataLossGracePeriodMinutes
 		endpoint.FailoverWithDataLossGracePeriodMinutes = &failoverWithDataLossGracePeriodMinutes
@@ -1450,13 +1450,13 @@ func (endpoint *FailoverGroupReadWriteEndpoint_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FailoverGroupReadWriteEndpoint_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FailoverPolicy’:
+	// Set property "FailoverPolicy":
 	if typedInput.FailoverPolicy != nil {
 		failoverPolicy := *typedInput.FailoverPolicy
 		endpoint.FailoverPolicy = &failoverPolicy
 	}
 
-	// Set property ‘FailoverWithDataLossGracePeriodMinutes’:
+	// Set property "FailoverWithDataLossGracePeriodMinutes":
 	if typedInput.FailoverWithDataLossGracePeriodMinutes != nil {
 		failoverWithDataLossGracePeriodMinutes := *typedInput.FailoverWithDataLossGracePeriodMinutes
 		endpoint.FailoverWithDataLossGracePeriodMinutes = &failoverWithDataLossGracePeriodMinutes
@@ -1527,7 +1527,7 @@ func (info *PartnerInfo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &PartnerInfo_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if info.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*info.Reference)
 		if err != nil {
@@ -1551,7 +1551,7 @@ func (info *PartnerInfo) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PartnerInfo_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1637,19 +1637,19 @@ func (info *PartnerInfo_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PartnerInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		info.Id = &id
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		info.Location = &location
 	}
 
-	// Set property ‘ReplicationRole’:
+	// Set property "ReplicationRole":
 	if typedInput.ReplicationRole != nil {
 		replicationRole := *typedInput.ReplicationRole
 		info.ReplicationRole = &replicationRole

--- a/v2/api/sql/v1api20211101/servers_firewall_rule_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_firewall_rule_types_gen.go
@@ -339,10 +339,10 @@ func (rule *Servers_FirewallRule_Spec) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &Servers_FirewallRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.EndIpAddress != nil || rule.StartIpAddress != nil {
 		result.Properties = &ServerFirewallRuleProperties_ARM{}
 	}
@@ -369,10 +369,10 @@ func (rule *Servers_FirewallRule_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_FirewallRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -381,10 +381,10 @@ func (rule *Servers_FirewallRule_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -614,9 +614,9 @@ func (rule *Servers_FirewallRule_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_FirewallRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EndIpAddress’:
+	// Set property "EndIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIpAddress != nil {
@@ -625,19 +625,19 @@ func (rule *Servers_FirewallRule_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘StartIpAddress’:
+	// Set property "StartIpAddress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIpAddress != nil {
@@ -646,7 +646,7 @@ func (rule *Servers_FirewallRule_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/sql/v1api20211101/servers_ipv_6_firewall_rule_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_ipv_6_firewall_rule_types_gen.go
@@ -338,10 +338,10 @@ func (rule *Servers_Ipv6FirewallRule_Spec) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &Servers_Ipv6FirewallRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.EndIPv6Address != nil || rule.StartIPv6Address != nil {
 		result.Properties = &IPv6ServerFirewallRuleProperties_ARM{}
 	}
@@ -368,10 +368,10 @@ func (rule *Servers_Ipv6FirewallRule_Spec) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Ipv6FirewallRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EndIPv6Address’:
+	// Set property "EndIPv6Address":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIPv6Address != nil {
@@ -380,10 +380,10 @@ func (rule *Servers_Ipv6FirewallRule_Spec) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘StartIPv6Address’:
+	// Set property "StartIPv6Address":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIPv6Address != nil {
@@ -612,9 +612,9 @@ func (rule *Servers_Ipv6FirewallRule_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_Ipv6FirewallRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘EndIPv6Address’:
+	// Set property "EndIPv6Address":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EndIPv6Address != nil {
@@ -623,19 +623,19 @@ func (rule *Servers_Ipv6FirewallRule_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘StartIPv6Address’:
+	// Set property "StartIPv6Address":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StartIPv6Address != nil {
@@ -644,7 +644,7 @@ func (rule *Servers_Ipv6FirewallRule_STATUS) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/sql/v1api20211101/servers_outbound_firewall_rule_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_outbound_firewall_rule_types_gen.go
@@ -331,7 +331,7 @@ func (rule *Servers_OutboundFirewallRule_Spec) ConvertToARM(resolved genruntime.
 	}
 	result := &Servers_OutboundFirewallRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 	return result, nil
 }
@@ -348,10 +348,10 @@ func (rule *Servers_OutboundFirewallRule_Spec) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_OutboundFirewallRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -554,21 +554,21 @@ func (rule *Servers_OutboundFirewallRule_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_OutboundFirewallRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -577,7 +577,7 @@ func (rule *Servers_OutboundFirewallRule_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar

--- a/v2/api/sql/v1api20211101/servers_security_alert_policy_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_security_alert_policy_types_gen.go
@@ -345,10 +345,10 @@ func (policy *Servers_SecurityAlertPolicy_Spec) ConvertToARM(resolved genruntime
 	}
 	result := &Servers_SecurityAlertPolicy_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if policy.DisabledAlerts != nil ||
 		policy.EmailAccountAdmins != nil ||
 		policy.EmailAddresses != nil ||
@@ -403,7 +403,7 @@ func (policy *Servers_SecurityAlertPolicy_Spec) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_SecurityAlertPolicy_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DisabledAlerts’:
+	// Set property "DisabledAlerts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DisabledAlerts {
@@ -411,7 +411,7 @@ func (policy *Servers_SecurityAlertPolicy_Spec) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// Set property ‘EmailAccountAdmins’:
+	// Set property "EmailAccountAdmins":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EmailAccountAdmins != nil {
@@ -420,7 +420,7 @@ func (policy *Servers_SecurityAlertPolicy_Spec) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// Set property ‘EmailAddresses’:
+	// Set property "EmailAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EmailAddresses {
@@ -428,10 +428,10 @@ func (policy *Servers_SecurityAlertPolicy_Spec) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	policy.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RetentionDays’:
+	// Set property "RetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionDays != nil {
@@ -440,7 +440,7 @@ func (policy *Servers_SecurityAlertPolicy_Spec) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -449,9 +449,9 @@ func (policy *Servers_SecurityAlertPolicy_Spec) PopulateFromARM(owner genruntime
 		}
 	}
 
-	// no assignment for property ‘StorageAccountAccessKey’
+	// no assignment for property "StorageAccountAccessKey"
 
-	// Set property ‘StorageEndpoint’:
+	// Set property "StorageEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageEndpoint != nil {
@@ -773,9 +773,9 @@ func (policy *Servers_SecurityAlertPolicy_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_SecurityAlertPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationTime’:
+	// Set property "CreationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationTime != nil {
@@ -784,7 +784,7 @@ func (policy *Servers_SecurityAlertPolicy_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘DisabledAlerts’:
+	// Set property "DisabledAlerts":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.DisabledAlerts {
@@ -792,7 +792,7 @@ func (policy *Servers_SecurityAlertPolicy_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘EmailAccountAdmins’:
+	// Set property "EmailAccountAdmins":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EmailAccountAdmins != nil {
@@ -801,7 +801,7 @@ func (policy *Servers_SecurityAlertPolicy_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘EmailAddresses’:
+	// Set property "EmailAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EmailAddresses {
@@ -809,19 +809,19 @@ func (policy *Servers_SecurityAlertPolicy_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		policy.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘RetentionDays’:
+	// Set property "RetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RetentionDays != nil {
@@ -830,7 +830,7 @@ func (policy *Servers_SecurityAlertPolicy_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -839,7 +839,7 @@ func (policy *Servers_SecurityAlertPolicy_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘StorageEndpoint’:
+	// Set property "StorageEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageEndpoint != nil {
@@ -848,7 +848,7 @@ func (policy *Servers_SecurityAlertPolicy_STATUS) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -859,7 +859,7 @@ func (policy *Servers_SecurityAlertPolicy_STATUS) PopulateFromARM(owner genrunti
 		policy.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		policy.Type = &typeVar

--- a/v2/api/sql/v1api20211101/servers_virtual_network_rule_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_virtual_network_rule_types_gen.go
@@ -338,10 +338,10 @@ func (rule *Servers_VirtualNetworkRule_Spec) ConvertToARM(resolved genruntime.Co
 	}
 	result := &Servers_VirtualNetworkRule_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if rule.IgnoreMissingVnetServiceEndpoint != nil || rule.VirtualNetworkSubnetReference != nil {
 		result.Properties = &VirtualNetworkRuleProperties_ARM{}
 	}
@@ -372,10 +372,10 @@ func (rule *Servers_VirtualNetworkRule_Spec) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_VirtualNetworkRule_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	rule.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘IgnoreMissingVnetServiceEndpoint’:
+	// Set property "IgnoreMissingVnetServiceEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IgnoreMissingVnetServiceEndpoint != nil {
@@ -384,10 +384,10 @@ func (rule *Servers_VirtualNetworkRule_Spec) PopulateFromARM(owner genruntime.Ar
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// no assignment for property ‘VirtualNetworkSubnetReference’
+	// no assignment for property "VirtualNetworkSubnetReference"
 
 	// No error
 	return nil
@@ -643,15 +643,15 @@ func (rule *Servers_VirtualNetworkRule_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_VirtualNetworkRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘IgnoreMissingVnetServiceEndpoint’:
+	// Set property "IgnoreMissingVnetServiceEndpoint":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IgnoreMissingVnetServiceEndpoint != nil {
@@ -660,13 +660,13 @@ func (rule *Servers_VirtualNetworkRule_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -675,13 +675,13 @@ func (rule *Servers_VirtualNetworkRule_STATUS) PopulateFromARM(owner genruntime.
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
 	}
 
-	// Set property ‘VirtualNetworkSubnetId’:
+	// Set property "VirtualNetworkSubnetId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetworkSubnetId != nil {

--- a/v2/api/sql/v1api20211101/servers_vulnerability_assessment_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_vulnerability_assessment_types_gen.go
@@ -354,10 +354,10 @@ func (assessment *Servers_VulnerabilityAssessment_Spec) ConvertToARM(resolved ge
 	}
 	result := &Servers_VulnerabilityAssessment_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if assessment.RecurringScans != nil ||
 		assessment.StorageAccountAccessKey != nil ||
 		assessment.StorageContainerPath != nil ||
@@ -416,10 +416,10 @@ func (assessment *Servers_VulnerabilityAssessment_Spec) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_VulnerabilityAssessment_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	assessment.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RecurringScans’:
+	// Set property "RecurringScans":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RecurringScans != nil {
@@ -433,9 +433,9 @@ func (assessment *Servers_VulnerabilityAssessment_Spec) PopulateFromARM(owner ge
 		}
 	}
 
-	// no assignment for property ‘StorageAccountAccessKey’
+	// no assignment for property "StorageAccountAccessKey"
 
-	// Set property ‘StorageContainerPath’:
+	// Set property "StorageContainerPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageContainerPath != nil {
@@ -444,9 +444,9 @@ func (assessment *Servers_VulnerabilityAssessment_Spec) PopulateFromARM(owner ge
 		}
 	}
 
-	// no assignment for property ‘StorageContainerPathFromConfig’
+	// no assignment for property "StorageContainerPathFromConfig"
 
-	// no assignment for property ‘StorageContainerSasKey’
+	// no assignment for property "StorageContainerSasKey"
 
 	// No error
 	return nil
@@ -734,21 +734,21 @@ func (assessment *Servers_VulnerabilityAssessment_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Servers_VulnerabilityAssessment_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		assessment.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		assessment.Name = &name
 	}
 
-	// Set property ‘RecurringScans’:
+	// Set property "RecurringScans":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RecurringScans != nil {
@@ -762,7 +762,7 @@ func (assessment *Servers_VulnerabilityAssessment_STATUS) PopulateFromARM(owner 
 		}
 	}
 
-	// Set property ‘StorageContainerPath’:
+	// Set property "StorageContainerPath":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageContainerPath != nil {
@@ -771,7 +771,7 @@ func (assessment *Servers_VulnerabilityAssessment_STATUS) PopulateFromARM(owner 
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		assessment.Type = &typeVar

--- a/v2/api/storage/v1api20210401/storage_account_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_account_types_gen.go
@@ -533,7 +533,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &StorageAccount_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if account.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*account.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -543,7 +543,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if account.Identity != nil {
 		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -553,22 +553,22 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if account.Kind != nil {
 		kind := *account.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if account.Location != nil {
 		location := *account.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if account.AccessTier != nil ||
 		account.AllowBlobPublicAccess != nil ||
 		account.AllowCrossTenantReplication != nil ||
@@ -680,7 +680,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SupportsHttpsTrafficOnly = &supportsHttpsTrafficOnly
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if account.Sku != nil {
 		sku_ARM, err := (*account.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -690,7 +690,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if account.Tags != nil {
 		result.Tags = make(map[string]string, len(account.Tags))
 		for key, value := range account.Tags {
@@ -712,7 +712,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccount_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessTier’:
+	// Set property "AccessTier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessTier != nil {
@@ -721,7 +721,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AllowBlobPublicAccess’:
+	// Set property "AllowBlobPublicAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowBlobPublicAccess != nil {
@@ -730,7 +730,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AllowCrossTenantReplication’:
+	// Set property "AllowCrossTenantReplication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowCrossTenantReplication != nil {
@@ -739,7 +739,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AllowSharedKeyAccess’:
+	// Set property "AllowSharedKeyAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowSharedKeyAccess != nil {
@@ -748,7 +748,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureFilesIdentityBasedAuthentication’:
+	// Set property "AzureFilesIdentityBasedAuthentication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureFilesIdentityBasedAuthentication != nil {
@@ -762,10 +762,10 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	account.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CustomDomain’:
+	// Set property "CustomDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomDomain != nil {
@@ -779,7 +779,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -793,7 +793,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -804,7 +804,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		account.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -815,7 +815,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		account.Identity = &identity
 	}
 
-	// Set property ‘IsHnsEnabled’:
+	// Set property "IsHnsEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHnsEnabled != nil {
@@ -824,7 +824,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘IsNfsV3Enabled’:
+	// Set property "IsNfsV3Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsNfsV3Enabled != nil {
@@ -833,7 +833,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘KeyPolicy’:
+	// Set property "KeyPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyPolicy != nil {
@@ -847,13 +847,13 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		account.Kind = &kind
 	}
 
-	// Set property ‘LargeFileSharesState’:
+	// Set property "LargeFileSharesState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LargeFileSharesState != nil {
@@ -862,13 +862,13 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -877,7 +877,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘NetworkAcls’:
+	// Set property "NetworkAcls":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAcls != nil {
@@ -891,12 +891,12 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	account.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RoutingPreference’:
+	// Set property "RoutingPreference":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RoutingPreference != nil {
@@ -910,7 +910,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SasPolicy’:
+	// Set property "SasPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SasPolicy != nil {
@@ -924,7 +924,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -935,7 +935,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		account.Sku = &sku
 	}
 
-	// Set property ‘SupportsHttpsTrafficOnly’:
+	// Set property "SupportsHttpsTrafficOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SupportsHttpsTrafficOnly != nil {
@@ -944,7 +944,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1698,7 +1698,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccount_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessTier’:
+	// Set property "AccessTier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessTier != nil {
@@ -1707,7 +1707,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AllowBlobPublicAccess’:
+	// Set property "AllowBlobPublicAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowBlobPublicAccess != nil {
@@ -1716,7 +1716,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AllowCrossTenantReplication’:
+	// Set property "AllowCrossTenantReplication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowCrossTenantReplication != nil {
@@ -1725,7 +1725,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AllowSharedKeyAccess’:
+	// Set property "AllowSharedKeyAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowSharedKeyAccess != nil {
@@ -1734,7 +1734,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AzureFilesIdentityBasedAuthentication’:
+	// Set property "AzureFilesIdentityBasedAuthentication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureFilesIdentityBasedAuthentication != nil {
@@ -1748,7 +1748,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘BlobRestoreStatus’:
+	// Set property "BlobRestoreStatus":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BlobRestoreStatus != nil {
@@ -1762,9 +1762,9 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationTime’:
+	// Set property "CreationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationTime != nil {
@@ -1773,7 +1773,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘CustomDomain’:
+	// Set property "CustomDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomDomain != nil {
@@ -1787,7 +1787,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1801,7 +1801,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1812,7 +1812,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		account.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FailoverInProgress’:
+	// Set property "FailoverInProgress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FailoverInProgress != nil {
@@ -1821,7 +1821,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘GeoReplicationStats’:
+	// Set property "GeoReplicationStats":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GeoReplicationStats != nil {
@@ -1835,13 +1835,13 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		account.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1852,7 +1852,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		account.Identity = &identity
 	}
 
-	// Set property ‘IsHnsEnabled’:
+	// Set property "IsHnsEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHnsEnabled != nil {
@@ -1861,7 +1861,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘IsNfsV3Enabled’:
+	// Set property "IsNfsV3Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsNfsV3Enabled != nil {
@@ -1870,7 +1870,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘KeyCreationTime’:
+	// Set property "KeyCreationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyCreationTime != nil {
@@ -1884,7 +1884,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘KeyPolicy’:
+	// Set property "KeyPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyPolicy != nil {
@@ -1898,13 +1898,13 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		account.Kind = &kind
 	}
 
-	// Set property ‘LargeFileSharesState’:
+	// Set property "LargeFileSharesState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LargeFileSharesState != nil {
@@ -1913,7 +1913,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LastGeoFailoverTime’:
+	// Set property "LastGeoFailoverTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastGeoFailoverTime != nil {
@@ -1922,13 +1922,13 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -1937,13 +1937,13 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		account.Name = &name
 	}
 
-	// Set property ‘NetworkAcls’:
+	// Set property "NetworkAcls":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAcls != nil {
@@ -1957,7 +1957,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrimaryEndpoints’:
+	// Set property "PrimaryEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrimaryEndpoints != nil {
@@ -1971,7 +1971,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrimaryLocation’:
+	// Set property "PrimaryLocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrimaryLocation != nil {
@@ -1980,7 +1980,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1993,7 +1993,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2002,7 +2002,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘RoutingPreference’:
+	// Set property "RoutingPreference":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RoutingPreference != nil {
@@ -2016,7 +2016,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SasPolicy’:
+	// Set property "SasPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SasPolicy != nil {
@@ -2030,7 +2030,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SecondaryEndpoints’:
+	// Set property "SecondaryEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecondaryEndpoints != nil {
@@ -2044,7 +2044,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SecondaryLocation’:
+	// Set property "SecondaryLocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecondaryLocation != nil {
@@ -2053,7 +2053,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -2064,7 +2064,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		account.Sku = &sku
 	}
 
-	// Set property ‘StatusOfPrimary’:
+	// Set property "StatusOfPrimary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StatusOfPrimary != nil {
@@ -2073,7 +2073,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘StatusOfSecondary’:
+	// Set property "StatusOfSecondary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StatusOfSecondary != nil {
@@ -2082,7 +2082,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SupportsHttpsTrafficOnly’:
+	// Set property "SupportsHttpsTrafficOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SupportsHttpsTrafficOnly != nil {
@@ -2091,7 +2091,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -2099,7 +2099,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		account.Type = &typeVar
@@ -2834,7 +2834,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication) ConvertToARM(resolv
 	}
 	result := &AzureFilesIdentityBasedAuthentication_ARM{}
 
-	// Set property ‘ActiveDirectoryProperties’:
+	// Set property "ActiveDirectoryProperties":
 	if authentication.ActiveDirectoryProperties != nil {
 		activeDirectoryProperties_ARM, err := (*authentication.ActiveDirectoryProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -2844,13 +2844,13 @@ func (authentication *AzureFilesIdentityBasedAuthentication) ConvertToARM(resolv
 		result.ActiveDirectoryProperties = &activeDirectoryProperties
 	}
 
-	// Set property ‘DefaultSharePermission’:
+	// Set property "DefaultSharePermission":
 	if authentication.DefaultSharePermission != nil {
 		defaultSharePermission := *authentication.DefaultSharePermission
 		result.DefaultSharePermission = &defaultSharePermission
 	}
 
-	// Set property ‘DirectoryServiceOptions’:
+	// Set property "DirectoryServiceOptions":
 	if authentication.DirectoryServiceOptions != nil {
 		directoryServiceOptions := *authentication.DirectoryServiceOptions
 		result.DirectoryServiceOptions = &directoryServiceOptions
@@ -2870,7 +2870,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFilesIdentityBasedAuthentication_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActiveDirectoryProperties’:
+	// Set property "ActiveDirectoryProperties":
 	if typedInput.ActiveDirectoryProperties != nil {
 		var activeDirectoryProperties1 ActiveDirectoryProperties
 		err := activeDirectoryProperties1.PopulateFromARM(owner, *typedInput.ActiveDirectoryProperties)
@@ -2881,13 +2881,13 @@ func (authentication *AzureFilesIdentityBasedAuthentication) PopulateFromARM(own
 		authentication.ActiveDirectoryProperties = &activeDirectoryProperties
 	}
 
-	// Set property ‘DefaultSharePermission’:
+	// Set property "DefaultSharePermission":
 	if typedInput.DefaultSharePermission != nil {
 		defaultSharePermission := *typedInput.DefaultSharePermission
 		authentication.DefaultSharePermission = &defaultSharePermission
 	}
 
-	// Set property ‘DirectoryServiceOptions’:
+	// Set property "DirectoryServiceOptions":
 	if typedInput.DirectoryServiceOptions != nil {
 		directoryServiceOptions := *typedInput.DirectoryServiceOptions
 		authentication.DirectoryServiceOptions = &directoryServiceOptions
@@ -3002,7 +3002,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication_STATUS) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFilesIdentityBasedAuthentication_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActiveDirectoryProperties’:
+	// Set property "ActiveDirectoryProperties":
 	if typedInput.ActiveDirectoryProperties != nil {
 		var activeDirectoryProperties1 ActiveDirectoryProperties_STATUS
 		err := activeDirectoryProperties1.PopulateFromARM(owner, *typedInput.ActiveDirectoryProperties)
@@ -3013,13 +3013,13 @@ func (authentication *AzureFilesIdentityBasedAuthentication_STATUS) PopulateFrom
 		authentication.ActiveDirectoryProperties = &activeDirectoryProperties
 	}
 
-	// Set property ‘DefaultSharePermission’:
+	// Set property "DefaultSharePermission":
 	if typedInput.DefaultSharePermission != nil {
 		defaultSharePermission := *typedInput.DefaultSharePermission
 		authentication.DefaultSharePermission = &defaultSharePermission
 	}
 
-	// Set property ‘DirectoryServiceOptions’:
+	// Set property "DirectoryServiceOptions":
 	if typedInput.DirectoryServiceOptions != nil {
 		directoryServiceOptions := *typedInput.DirectoryServiceOptions
 		authentication.DirectoryServiceOptions = &directoryServiceOptions
@@ -3138,13 +3138,13 @@ func (status *BlobRestoreStatus_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BlobRestoreStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FailureReason’:
+	// Set property "FailureReason":
 	if typedInput.FailureReason != nil {
 		failureReason := *typedInput.FailureReason
 		status.FailureReason = &failureReason
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 BlobRestoreParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -3155,13 +3155,13 @@ func (status *BlobRestoreStatus_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		status.Parameters = &parameters
 	}
 
-	// Set property ‘RestoreId’:
+	// Set property "RestoreId":
 	if typedInput.RestoreId != nil {
 		restoreId := *typedInput.RestoreId
 		status.RestoreId = &restoreId
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status1 := *typedInput.Status
 		status.Status = &status1
@@ -3266,13 +3266,13 @@ func (domain *CustomDomain) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &CustomDomain_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if domain.Name != nil {
 		name := *domain.Name
 		result.Name = &name
 	}
 
-	// Set property ‘UseSubDomainName’:
+	// Set property "UseSubDomainName":
 	if domain.UseSubDomainName != nil {
 		useSubDomainName := *domain.UseSubDomainName
 		result.UseSubDomainName = &useSubDomainName
@@ -3292,13 +3292,13 @@ func (domain *CustomDomain) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CustomDomain_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		domain.Name = &name
 	}
 
-	// Set property ‘UseSubDomainName’:
+	// Set property "UseSubDomainName":
 	if typedInput.UseSubDomainName != nil {
 		useSubDomainName := *typedInput.UseSubDomainName
 		domain.UseSubDomainName = &useSubDomainName
@@ -3377,13 +3377,13 @@ func (domain *CustomDomain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CustomDomain_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		domain.Name = &name
 	}
 
-	// Set property ‘UseSubDomainName’:
+	// Set property "UseSubDomainName":
 	if typedInput.UseSubDomainName != nil {
 		useSubDomainName := *typedInput.UseSubDomainName
 		domain.UseSubDomainName = &useSubDomainName
@@ -3468,7 +3468,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Encryption_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if encryption.Identity != nil {
 		identity_ARM, err := (*encryption.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -3478,13 +3478,13 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Identity = &identity
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if encryption.KeySource != nil {
 		keySource := *encryption.KeySource
 		result.KeySource = &keySource
 	}
 
-	// Set property ‘Keyvaultproperties’:
+	// Set property "Keyvaultproperties":
 	if encryption.Keyvaultproperties != nil {
 		keyvaultproperties_ARM, err := (*encryption.Keyvaultproperties).ConvertToARM(resolved)
 		if err != nil {
@@ -3494,13 +3494,13 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Keyvaultproperties = &keyvaultproperties
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if encryption.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *encryption.RequireInfrastructureEncryption
 		result.RequireInfrastructureEncryption = &requireInfrastructureEncryption
 	}
 
-	// Set property ‘Services’:
+	// Set property "Services":
 	if encryption.Services != nil {
 		services_ARM, err := (*encryption.Services).ConvertToARM(resolved)
 		if err != nil {
@@ -3524,7 +3524,7 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 EncryptionIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -3535,13 +3535,13 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		encryption.Identity = &identity
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘Keyvaultproperties’:
+	// Set property "Keyvaultproperties":
 	if typedInput.Keyvaultproperties != nil {
 		var keyvaultproperties1 KeyVaultProperties
 		err := keyvaultproperties1.PopulateFromARM(owner, *typedInput.Keyvaultproperties)
@@ -3552,13 +3552,13 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		encryption.Keyvaultproperties = &keyvaultproperties
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
 	}
 
-	// Set property ‘Services’:
+	// Set property "Services":
 	if typedInput.Services != nil {
 		var services1 EncryptionServices
 		err := services1.PopulateFromARM(owner, *typedInput.Services)
@@ -3734,7 +3734,7 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 EncryptionIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -3745,13 +3745,13 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		encryption.Identity = &identity
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘Keyvaultproperties’:
+	// Set property "Keyvaultproperties":
 	if typedInput.Keyvaultproperties != nil {
 		var keyvaultproperties1 KeyVaultProperties_STATUS
 		err := keyvaultproperties1.PopulateFromARM(owner, *typedInput.Keyvaultproperties)
@@ -3762,13 +3762,13 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		encryption.Keyvaultproperties = &keyvaultproperties
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
 	}
 
-	// Set property ‘Services’:
+	// Set property "Services":
 	if typedInput.Services != nil {
 		var services1 EncryptionServices_STATUS
 		err := services1.PopulateFromARM(owner, *typedInput.Services)
@@ -3951,25 +3951,25 @@ func (endpoints *Endpoints_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Endpoints_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		blob := *typedInput.Blob
 		endpoints.Blob = &blob
 	}
 
-	// Set property ‘Dfs’:
+	// Set property "Dfs":
 	if typedInput.Dfs != nil {
 		dfs := *typedInput.Dfs
 		endpoints.Dfs = &dfs
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		file := *typedInput.File
 		endpoints.File = &file
 	}
 
-	// Set property ‘InternetEndpoints’:
+	// Set property "InternetEndpoints":
 	if typedInput.InternetEndpoints != nil {
 		var internetEndpoints1 StorageAccountInternetEndpoints_STATUS
 		err := internetEndpoints1.PopulateFromARM(owner, *typedInput.InternetEndpoints)
@@ -3980,7 +3980,7 @@ func (endpoints *Endpoints_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		endpoints.InternetEndpoints = &internetEndpoints
 	}
 
-	// Set property ‘MicrosoftEndpoints’:
+	// Set property "MicrosoftEndpoints":
 	if typedInput.MicrosoftEndpoints != nil {
 		var microsoftEndpoints1 StorageAccountMicrosoftEndpoints_STATUS
 		err := microsoftEndpoints1.PopulateFromARM(owner, *typedInput.MicrosoftEndpoints)
@@ -3991,19 +3991,19 @@ func (endpoints *Endpoints_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		endpoints.MicrosoftEndpoints = &microsoftEndpoints
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if typedInput.Queue != nil {
 		queue := *typedInput.Queue
 		endpoints.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if typedInput.Table != nil {
 		table := *typedInput.Table
 		endpoints.Table = &table
 	}
 
-	// Set property ‘Web’:
+	// Set property "Web":
 	if typedInput.Web != nil {
 		web := *typedInput.Web
 		endpoints.Web = &web
@@ -4138,13 +4138,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -4164,13 +4164,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -4248,13 +4248,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -4341,19 +4341,19 @@ func (stats *GeoReplicationStats_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GeoReplicationStats_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CanFailover’:
+	// Set property "CanFailover":
 	if typedInput.CanFailover != nil {
 		canFailover := *typedInput.CanFailover
 		stats.CanFailover = &canFailover
 	}
 
-	// Set property ‘LastSyncTime’:
+	// Set property "LastSyncTime":
 	if typedInput.LastSyncTime != nil {
 		lastSyncTime := *typedInput.LastSyncTime
 		stats.LastSyncTime = &lastSyncTime
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		stats.Status = &status
@@ -4445,13 +4445,13 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Identity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -4476,13 +4476,13 @@ func (identity *Identity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -4594,25 +4594,25 @@ func (identity *Identity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -4736,13 +4736,13 @@ func (time *KeyCreationTime_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyCreationTime_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key1’:
+	// Set property "Key1":
 	if typedInput.Key1 != nil {
 		key1 := *typedInput.Key1
 		time.Key1 = &key1
 	}
 
-	// Set property ‘Key2’:
+	// Set property "Key2":
 	if typedInput.Key2 != nil {
 		key2 := *typedInput.Key2
 		time.Key2 = &key2
@@ -4803,7 +4803,7 @@ func (policy *KeyPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &KeyPolicy_ARM{}
 
-	// Set property ‘KeyExpirationPeriodInDays’:
+	// Set property "KeyExpirationPeriodInDays":
 	if policy.KeyExpirationPeriodInDays != nil {
 		keyExpirationPeriodInDays := *policy.KeyExpirationPeriodInDays
 		result.KeyExpirationPeriodInDays = &keyExpirationPeriodInDays
@@ -4823,7 +4823,7 @@ func (policy *KeyPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyExpirationPeriodInDays’:
+	// Set property "KeyExpirationPeriodInDays":
 	if typedInput.KeyExpirationPeriodInDays != nil {
 		keyExpirationPeriodInDays := *typedInput.KeyExpirationPeriodInDays
 		policy.KeyExpirationPeriodInDays = &keyExpirationPeriodInDays
@@ -4882,7 +4882,7 @@ func (policy *KeyPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyExpirationPeriodInDays’:
+	// Set property "KeyExpirationPeriodInDays":
 	if typedInput.KeyExpirationPeriodInDays != nil {
 		keyExpirationPeriodInDays := *typedInput.KeyExpirationPeriodInDays
 		policy.KeyExpirationPeriodInDays = &keyExpirationPeriodInDays
@@ -4950,19 +4950,19 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &NetworkRuleSet_ARM{}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if ruleSet.Bypass != nil {
 		bypass := *ruleSet.Bypass
 		result.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if ruleSet.DefaultAction != nil {
 		defaultAction := *ruleSet.DefaultAction
 		result.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range ruleSet.IpRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4971,7 +4971,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.IpRules = append(result.IpRules, *item_ARM.(*IPRule_ARM))
 	}
 
-	// Set property ‘ResourceAccessRules’:
+	// Set property "ResourceAccessRules":
 	for _, item := range ruleSet.ResourceAccessRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4980,7 +4980,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.ResourceAccessRules = append(result.ResourceAccessRules, *item_ARM.(*ResourceAccessRule_ARM))
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range ruleSet.VirtualNetworkRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5003,19 +5003,19 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if typedInput.Bypass != nil {
 		bypass := *typedInput.Bypass
 		ruleSet.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule
 		err := item1.PopulateFromARM(owner, item)
@@ -5025,7 +5025,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		ruleSet.IpRules = append(ruleSet.IpRules, item1)
 	}
 
-	// Set property ‘ResourceAccessRules’:
+	// Set property "ResourceAccessRules":
 	for _, item := range typedInput.ResourceAccessRules {
 		var item1 ResourceAccessRule
 		err := item1.PopulateFromARM(owner, item)
@@ -5035,7 +5035,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		ruleSet.ResourceAccessRules = append(ruleSet.ResourceAccessRules, item1)
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range typedInput.VirtualNetworkRules {
 		var item1 VirtualNetworkRule
 		err := item1.PopulateFromARM(owner, item)
@@ -5245,19 +5245,19 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if typedInput.Bypass != nil {
 		bypass := *typedInput.Bypass
 		ruleSet.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5267,7 +5267,7 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		ruleSet.IpRules = append(ruleSet.IpRules, item1)
 	}
 
-	// Set property ‘ResourceAccessRules’:
+	// Set property "ResourceAccessRules":
 	for _, item := range typedInput.ResourceAccessRules {
 		var item1 ResourceAccessRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5277,7 +5277,7 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		ruleSet.ResourceAccessRules = append(ruleSet.ResourceAccessRules, item1)
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range typedInput.VirtualNetworkRules {
 		var item1 VirtualNetworkRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5475,7 +5475,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -5536,19 +5536,19 @@ func (preference *RoutingPreference) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &RoutingPreference_ARM{}
 
-	// Set property ‘PublishInternetEndpoints’:
+	// Set property "PublishInternetEndpoints":
 	if preference.PublishInternetEndpoints != nil {
 		publishInternetEndpoints := *preference.PublishInternetEndpoints
 		result.PublishInternetEndpoints = &publishInternetEndpoints
 	}
 
-	// Set property ‘PublishMicrosoftEndpoints’:
+	// Set property "PublishMicrosoftEndpoints":
 	if preference.PublishMicrosoftEndpoints != nil {
 		publishMicrosoftEndpoints := *preference.PublishMicrosoftEndpoints
 		result.PublishMicrosoftEndpoints = &publishMicrosoftEndpoints
 	}
 
-	// Set property ‘RoutingChoice’:
+	// Set property "RoutingChoice":
 	if preference.RoutingChoice != nil {
 		routingChoice := *preference.RoutingChoice
 		result.RoutingChoice = &routingChoice
@@ -5568,19 +5568,19 @@ func (preference *RoutingPreference) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingPreference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublishInternetEndpoints’:
+	// Set property "PublishInternetEndpoints":
 	if typedInput.PublishInternetEndpoints != nil {
 		publishInternetEndpoints := *typedInput.PublishInternetEndpoints
 		preference.PublishInternetEndpoints = &publishInternetEndpoints
 	}
 
-	// Set property ‘PublishMicrosoftEndpoints’:
+	// Set property "PublishMicrosoftEndpoints":
 	if typedInput.PublishMicrosoftEndpoints != nil {
 		publishMicrosoftEndpoints := *typedInput.PublishMicrosoftEndpoints
 		preference.PublishMicrosoftEndpoints = &publishMicrosoftEndpoints
 	}
 
-	// Set property ‘RoutingChoice’:
+	// Set property "RoutingChoice":
 	if typedInput.RoutingChoice != nil {
 		routingChoice := *typedInput.RoutingChoice
 		preference.RoutingChoice = &routingChoice
@@ -5688,19 +5688,19 @@ func (preference *RoutingPreference_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingPreference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublishInternetEndpoints’:
+	// Set property "PublishInternetEndpoints":
 	if typedInput.PublishInternetEndpoints != nil {
 		publishInternetEndpoints := *typedInput.PublishInternetEndpoints
 		preference.PublishInternetEndpoints = &publishInternetEndpoints
 	}
 
-	// Set property ‘PublishMicrosoftEndpoints’:
+	// Set property "PublishMicrosoftEndpoints":
 	if typedInput.PublishMicrosoftEndpoints != nil {
 		publishMicrosoftEndpoints := *typedInput.PublishMicrosoftEndpoints
 		preference.PublishMicrosoftEndpoints = &publishMicrosoftEndpoints
 	}
 
-	// Set property ‘RoutingChoice’:
+	// Set property "RoutingChoice":
 	if typedInput.RoutingChoice != nil {
 		routingChoice := *typedInput.RoutingChoice
 		preference.RoutingChoice = &routingChoice
@@ -5801,13 +5801,13 @@ func (policy *SasPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &SasPolicy_ARM{}
 
-	// Set property ‘ExpirationAction’:
+	// Set property "ExpirationAction":
 	if policy.ExpirationAction != nil {
 		expirationAction := *policy.ExpirationAction
 		result.ExpirationAction = &expirationAction
 	}
 
-	// Set property ‘SasExpirationPeriod’:
+	// Set property "SasExpirationPeriod":
 	if policy.SasExpirationPeriod != nil {
 		sasExpirationPeriod := *policy.SasExpirationPeriod
 		result.SasExpirationPeriod = &sasExpirationPeriod
@@ -5827,13 +5827,13 @@ func (policy *SasPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SasPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpirationAction’:
+	// Set property "ExpirationAction":
 	if typedInput.ExpirationAction != nil {
 		expirationAction := *typedInput.ExpirationAction
 		policy.ExpirationAction = &expirationAction
 	}
 
-	// Set property ‘SasExpirationPeriod’:
+	// Set property "SasExpirationPeriod":
 	if typedInput.SasExpirationPeriod != nil {
 		sasExpirationPeriod := *typedInput.SasExpirationPeriod
 		policy.SasExpirationPeriod = &sasExpirationPeriod
@@ -5911,13 +5911,13 @@ func (policy *SasPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SasPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpirationAction’:
+	// Set property "ExpirationAction":
 	if typedInput.ExpirationAction != nil {
 		expirationAction := *typedInput.ExpirationAction
 		policy.ExpirationAction = &expirationAction
 	}
 
-	// Set property ‘SasExpirationPeriod’:
+	// Set property "SasExpirationPeriod":
 	if typedInput.SasExpirationPeriod != nil {
 		sasExpirationPeriod := *typedInput.SasExpirationPeriod
 		policy.SasExpirationPeriod = &sasExpirationPeriod
@@ -5992,13 +5992,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -6018,13 +6018,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -6113,13 +6113,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -6369,37 +6369,37 @@ func (properties *ActiveDirectoryProperties) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ActiveDirectoryProperties_ARM{}
 
-	// Set property ‘AzureStorageSid’:
+	// Set property "AzureStorageSid":
 	if properties.AzureStorageSid != nil {
 		azureStorageSid := *properties.AzureStorageSid
 		result.AzureStorageSid = &azureStorageSid
 	}
 
-	// Set property ‘DomainGuid’:
+	// Set property "DomainGuid":
 	if properties.DomainGuid != nil {
 		domainGuid := *properties.DomainGuid
 		result.DomainGuid = &domainGuid
 	}
 
-	// Set property ‘DomainName’:
+	// Set property "DomainName":
 	if properties.DomainName != nil {
 		domainName := *properties.DomainName
 		result.DomainName = &domainName
 	}
 
-	// Set property ‘DomainSid’:
+	// Set property "DomainSid":
 	if properties.DomainSid != nil {
 		domainSid := *properties.DomainSid
 		result.DomainSid = &domainSid
 	}
 
-	// Set property ‘ForestName’:
+	// Set property "ForestName":
 	if properties.ForestName != nil {
 		forestName := *properties.ForestName
 		result.ForestName = &forestName
 	}
 
-	// Set property ‘NetBiosDomainName’:
+	// Set property "NetBiosDomainName":
 	if properties.NetBiosDomainName != nil {
 		netBiosDomainName := *properties.NetBiosDomainName
 		result.NetBiosDomainName = &netBiosDomainName
@@ -6419,37 +6419,37 @@ func (properties *ActiveDirectoryProperties) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ActiveDirectoryProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureStorageSid’:
+	// Set property "AzureStorageSid":
 	if typedInput.AzureStorageSid != nil {
 		azureStorageSid := *typedInput.AzureStorageSid
 		properties.AzureStorageSid = &azureStorageSid
 	}
 
-	// Set property ‘DomainGuid’:
+	// Set property "DomainGuid":
 	if typedInput.DomainGuid != nil {
 		domainGuid := *typedInput.DomainGuid
 		properties.DomainGuid = &domainGuid
 	}
 
-	// Set property ‘DomainName’:
+	// Set property "DomainName":
 	if typedInput.DomainName != nil {
 		domainName := *typedInput.DomainName
 		properties.DomainName = &domainName
 	}
 
-	// Set property ‘DomainSid’:
+	// Set property "DomainSid":
 	if typedInput.DomainSid != nil {
 		domainSid := *typedInput.DomainSid
 		properties.DomainSid = &domainSid
 	}
 
-	// Set property ‘ForestName’:
+	// Set property "ForestName":
 	if typedInput.ForestName != nil {
 		forestName := *typedInput.ForestName
 		properties.ForestName = &forestName
 	}
 
-	// Set property ‘NetBiosDomainName’:
+	// Set property "NetBiosDomainName":
 	if typedInput.NetBiosDomainName != nil {
 		netBiosDomainName := *typedInput.NetBiosDomainName
 		properties.NetBiosDomainName = &netBiosDomainName
@@ -6553,37 +6553,37 @@ func (properties *ActiveDirectoryProperties_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ActiveDirectoryProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureStorageSid’:
+	// Set property "AzureStorageSid":
 	if typedInput.AzureStorageSid != nil {
 		azureStorageSid := *typedInput.AzureStorageSid
 		properties.AzureStorageSid = &azureStorageSid
 	}
 
-	// Set property ‘DomainGuid’:
+	// Set property "DomainGuid":
 	if typedInput.DomainGuid != nil {
 		domainGuid := *typedInput.DomainGuid
 		properties.DomainGuid = &domainGuid
 	}
 
-	// Set property ‘DomainName’:
+	// Set property "DomainName":
 	if typedInput.DomainName != nil {
 		domainName := *typedInput.DomainName
 		properties.DomainName = &domainName
 	}
 
-	// Set property ‘DomainSid’:
+	// Set property "DomainSid":
 	if typedInput.DomainSid != nil {
 		domainSid := *typedInput.DomainSid
 		properties.DomainSid = &domainSid
 	}
 
-	// Set property ‘ForestName’:
+	// Set property "ForestName":
 	if typedInput.ForestName != nil {
 		forestName := *typedInput.ForestName
 		properties.ForestName = &forestName
 	}
 
-	// Set property ‘NetBiosDomainName’:
+	// Set property "NetBiosDomainName":
 	if typedInput.NetBiosDomainName != nil {
 		netBiosDomainName := *typedInput.NetBiosDomainName
 		properties.NetBiosDomainName = &netBiosDomainName
@@ -6713,7 +6713,7 @@ func (parameters *BlobRestoreParameters_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BlobRestoreParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobRanges’:
+	// Set property "BlobRanges":
 	for _, item := range typedInput.BlobRanges {
 		var item1 BlobRestoreRange_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6723,7 +6723,7 @@ func (parameters *BlobRestoreParameters_STATUS) PopulateFromARM(owner genruntime
 		parameters.BlobRanges = append(parameters.BlobRanges, item1)
 	}
 
-	// Set property ‘TimeToRestore’:
+	// Set property "TimeToRestore":
 	if typedInput.TimeToRestore != nil {
 		timeToRestore := *typedInput.TimeToRestore
 		parameters.TimeToRestore = &timeToRestore
@@ -6837,7 +6837,7 @@ func (identity *EncryptionIdentity) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &EncryptionIdentity_ARM{}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if identity.UserAssignedIdentityReference != nil {
 		userAssignedIdentityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*identity.UserAssignedIdentityReference)
 		if err != nil {
@@ -6861,7 +6861,7 @@ func (identity *EncryptionIdentity) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionIdentity_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘UserAssignedIdentityReference’
+	// no assignment for property "UserAssignedIdentityReference"
 
 	// No error
 	return nil
@@ -6927,7 +6927,7 @@ func (identity *EncryptionIdentity_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		identity.UserAssignedIdentity = &userAssignedIdentity
@@ -6990,7 +6990,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &EncryptionServices_ARM{}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if services.Blob != nil {
 		blob_ARM, err := (*services.Blob).ConvertToARM(resolved)
 		if err != nil {
@@ -7000,7 +7000,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Blob = &blob
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if services.File != nil {
 		file_ARM, err := (*services.File).ConvertToARM(resolved)
 		if err != nil {
@@ -7010,7 +7010,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		result.File = &file
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if services.Queue != nil {
 		queue_ARM, err := (*services.Queue).ConvertToARM(resolved)
 		if err != nil {
@@ -7020,7 +7020,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if services.Table != nil {
 		table_ARM, err := (*services.Table).ConvertToARM(resolved)
 		if err != nil {
@@ -7044,7 +7044,7 @@ func (services *EncryptionServices) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionServices_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		var blob1 EncryptionService
 		err := blob1.PopulateFromARM(owner, *typedInput.Blob)
@@ -7055,7 +7055,7 @@ func (services *EncryptionServices) PopulateFromARM(owner genruntime.ArbitraryOw
 		services.Blob = &blob
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		var file1 EncryptionService
 		err := file1.PopulateFromARM(owner, *typedInput.File)
@@ -7066,7 +7066,7 @@ func (services *EncryptionServices) PopulateFromARM(owner genruntime.ArbitraryOw
 		services.File = &file
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if typedInput.Queue != nil {
 		var queue1 EncryptionService
 		err := queue1.PopulateFromARM(owner, *typedInput.Queue)
@@ -7077,7 +7077,7 @@ func (services *EncryptionServices) PopulateFromARM(owner genruntime.ArbitraryOw
 		services.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if typedInput.Table != nil {
 		var table1 EncryptionService
 		err := table1.PopulateFromARM(owner, *typedInput.Table)
@@ -7240,7 +7240,7 @@ func (services *EncryptionServices_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionServices_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		var blob1 EncryptionService_STATUS
 		err := blob1.PopulateFromARM(owner, *typedInput.Blob)
@@ -7251,7 +7251,7 @@ func (services *EncryptionServices_STATUS) PopulateFromARM(owner genruntime.Arbi
 		services.Blob = &blob
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		var file1 EncryptionService_STATUS
 		err := file1.PopulateFromARM(owner, *typedInput.File)
@@ -7262,7 +7262,7 @@ func (services *EncryptionServices_STATUS) PopulateFromARM(owner genruntime.Arbi
 		services.File = &file
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if typedInput.Queue != nil {
 		var queue1 EncryptionService_STATUS
 		err := queue1.PopulateFromARM(owner, *typedInput.Queue)
@@ -7273,7 +7273,7 @@ func (services *EncryptionServices_STATUS) PopulateFromARM(owner genruntime.Arbi
 		services.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if typedInput.Table != nil {
 		var table1 EncryptionService_STATUS
 		err := table1.PopulateFromARM(owner, *typedInput.Table)
@@ -7434,13 +7434,13 @@ func (rule *IPRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &IPRule_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if rule.Action != nil {
 		action := *rule.Action
 		result.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if rule.Value != nil {
 		value := *rule.Value
 		result.Value = &value
@@ -7460,13 +7460,13 @@ func (rule *IPRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -7544,13 +7544,13 @@ func (rule *IPRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -7626,19 +7626,19 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘Keyname’:
+	// Set property "Keyname":
 	if properties.Keyname != nil {
 		keyname := *properties.Keyname
 		result.Keyname = &keyname
 	}
 
-	// Set property ‘Keyvaulturi’:
+	// Set property "Keyvaulturi":
 	if properties.Keyvaulturi != nil {
 		keyvaulturi := *properties.Keyvaulturi
 		result.Keyvaulturi = &keyvaulturi
 	}
 
-	// Set property ‘Keyversion’:
+	// Set property "Keyversion":
 	if properties.Keyversion != nil {
 		keyversion := *properties.Keyversion
 		result.Keyversion = &keyversion
@@ -7658,19 +7658,19 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Keyname’:
+	// Set property "Keyname":
 	if typedInput.Keyname != nil {
 		keyname := *typedInput.Keyname
 		properties.Keyname = &keyname
 	}
 
-	// Set property ‘Keyvaulturi’:
+	// Set property "Keyvaulturi":
 	if typedInput.Keyvaulturi != nil {
 		keyvaulturi := *typedInput.Keyvaulturi
 		properties.Keyvaulturi = &keyvaulturi
 	}
 
-	// Set property ‘Keyversion’:
+	// Set property "Keyversion":
 	if typedInput.Keyversion != nil {
 		keyversion := *typedInput.Keyversion
 		properties.Keyversion = &keyversion
@@ -7753,31 +7753,31 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CurrentVersionedKeyIdentifier’:
+	// Set property "CurrentVersionedKeyIdentifier":
 	if typedInput.CurrentVersionedKeyIdentifier != nil {
 		currentVersionedKeyIdentifier := *typedInput.CurrentVersionedKeyIdentifier
 		properties.CurrentVersionedKeyIdentifier = &currentVersionedKeyIdentifier
 	}
 
-	// Set property ‘Keyname’:
+	// Set property "Keyname":
 	if typedInput.Keyname != nil {
 		keyname := *typedInput.Keyname
 		properties.Keyname = &keyname
 	}
 
-	// Set property ‘Keyvaulturi’:
+	// Set property "Keyvaulturi":
 	if typedInput.Keyvaulturi != nil {
 		keyvaulturi := *typedInput.Keyvaulturi
 		properties.Keyvaulturi = &keyvaulturi
 	}
 
-	// Set property ‘Keyversion’:
+	// Set property "Keyversion":
 	if typedInput.Keyversion != nil {
 		keyversion := *typedInput.Keyversion
 		properties.Keyversion = &keyversion
 	}
 
-	// Set property ‘LastKeyRotationTimestamp’:
+	// Set property "LastKeyRotationTimestamp":
 	if typedInput.LastKeyRotationTimestamp != nil {
 		lastKeyRotationTimestamp := *typedInput.LastKeyRotationTimestamp
 		properties.LastKeyRotationTimestamp = &lastKeyRotationTimestamp
@@ -7892,7 +7892,7 @@ func (rule *ResourceAccessRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &ResourceAccessRule_ARM{}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if rule.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.ResourceReference)
 		if err != nil {
@@ -7902,7 +7902,7 @@ func (rule *ResourceAccessRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.ResourceId = &resourceReference
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if rule.TenantId != nil {
 		tenantId := *rule.TenantId
 		result.TenantId = &tenantId
@@ -7922,9 +7922,9 @@ func (rule *ResourceAccessRule) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceAccessRule_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		rule.TenantId = &tenantId
@@ -8002,13 +8002,13 @@ func (rule *ResourceAccessRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceAccessRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		rule.ResourceId = &resourceId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		rule.TenantId = &tenantId
@@ -8106,25 +8106,25 @@ func (endpoints *StorageAccountInternetEndpoints_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccountInternetEndpoints_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		blob := *typedInput.Blob
 		endpoints.Blob = &blob
 	}
 
-	// Set property ‘Dfs’:
+	// Set property "Dfs":
 	if typedInput.Dfs != nil {
 		dfs := *typedInput.Dfs
 		endpoints.Dfs = &dfs
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		file := *typedInput.File
 		endpoints.File = &file
 	}
 
-	// Set property ‘Web’:
+	// Set property "Web":
 	if typedInput.Web != nil {
 		web := *typedInput.Web
 		endpoints.Web = &web
@@ -8217,37 +8217,37 @@ func (endpoints *StorageAccountMicrosoftEndpoints_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccountMicrosoftEndpoints_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		blob := *typedInput.Blob
 		endpoints.Blob = &blob
 	}
 
-	// Set property ‘Dfs’:
+	// Set property "Dfs":
 	if typedInput.Dfs != nil {
 		dfs := *typedInput.Dfs
 		endpoints.Dfs = &dfs
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		file := *typedInput.File
 		endpoints.File = &file
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if typedInput.Queue != nil {
 		queue := *typedInput.Queue
 		endpoints.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if typedInput.Table != nil {
 		table := *typedInput.Table
 		endpoints.Table = &table
 	}
 
-	// Set property ‘Web’:
+	// Set property "Web":
 	if typedInput.Web != nil {
 		web := *typedInput.Web
 		endpoints.Web = &web
@@ -8661,13 +8661,13 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
@@ -8769,13 +8769,13 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &VirtualNetworkRule_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if rule.Action != nil {
 		action := *rule.Action
 		result.Action = &action
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if rule.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.Reference)
 		if err != nil {
@@ -8785,7 +8785,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.Id = &reference
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if rule.State != nil {
 		state := *rule.State
 		result.State = &state
@@ -8805,15 +8805,15 @@ func (rule *VirtualNetworkRule) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		rule.State = &state
@@ -8921,19 +8921,19 @@ func (rule *VirtualNetworkRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		rule.State = &state
@@ -9027,13 +9027,13 @@ func (restoreRange *BlobRestoreRange_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BlobRestoreRange_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndRange’:
+	// Set property "EndRange":
 	if typedInput.EndRange != nil {
 		endRange := *typedInput.EndRange
 		restoreRange.EndRange = &endRange
 	}
 
-	// Set property ‘StartRange’:
+	// Set property "StartRange":
 	if typedInput.StartRange != nil {
 		startRange := *typedInput.StartRange
 		restoreRange.StartRange = &startRange
@@ -9097,13 +9097,13 @@ func (service *EncryptionService) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &EncryptionService_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if service.Enabled != nil {
 		enabled := *service.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘KeyType’:
+	// Set property "KeyType":
 	if service.KeyType != nil {
 		keyType := *service.KeyType
 		result.KeyType = &keyType
@@ -9123,13 +9123,13 @@ func (service *EncryptionService) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionService_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		service.Enabled = &enabled
 	}
 
-	// Set property ‘KeyType’:
+	// Set property "KeyType":
 	if typedInput.KeyType != nil {
 		keyType := *typedInput.KeyType
 		service.KeyType = &keyType
@@ -9223,19 +9223,19 @@ func (service *EncryptionService_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionService_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		service.Enabled = &enabled
 	}
 
-	// Set property ‘KeyType’:
+	// Set property "KeyType":
 	if typedInput.KeyType != nil {
 		keyType := *typedInput.KeyType
 		service.KeyType = &keyType
 	}
 
-	// Set property ‘LastEnabledTime’:
+	// Set property "LastEnabledTime":
 	if typedInput.LastEnabledTime != nil {
 		lastEnabledTime := *typedInput.LastEnabledTime
 		service.LastEnabledTime = &lastEnabledTime

--- a/v2/api/storage/v1api20210401/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_accounts_blob_service_types_gen.go
@@ -353,10 +353,10 @@ func (service *StorageAccounts_BlobService_Spec) ConvertToARM(resolved genruntim
 	}
 	result := &StorageAccounts_BlobService_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if service.AutomaticSnapshotPolicyEnabled != nil ||
 		service.ChangeFeed != nil ||
 		service.ContainerDeleteRetentionPolicy != nil ||
@@ -443,7 +443,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_BlobService_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticSnapshotPolicyEnabled’:
+	// Set property "AutomaticSnapshotPolicyEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticSnapshotPolicyEnabled != nil {
@@ -452,7 +452,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ChangeFeed’:
+	// Set property "ChangeFeed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ChangeFeed != nil {
@@ -466,7 +466,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ContainerDeleteRetentionPolicy’:
+	// Set property "ContainerDeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ContainerDeleteRetentionPolicy != nil {
@@ -480,7 +480,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -494,7 +494,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘DefaultServiceVersion’:
+	// Set property "DefaultServiceVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultServiceVersion != nil {
@@ -503,7 +503,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘DeleteRetentionPolicy’:
+	// Set property "DeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteRetentionPolicy != nil {
@@ -517,7 +517,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘IsVersioningEnabled’:
+	// Set property "IsVersioningEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsVersioningEnabled != nil {
@@ -526,7 +526,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘LastAccessTimeTrackingPolicy’:
+	// Set property "LastAccessTimeTrackingPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastAccessTimeTrackingPolicy != nil {
@@ -540,10 +540,10 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RestorePolicy’:
+	// Set property "RestorePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestorePolicy != nil {
@@ -952,7 +952,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_BlobService_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticSnapshotPolicyEnabled’:
+	// Set property "AutomaticSnapshotPolicyEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticSnapshotPolicyEnabled != nil {
@@ -961,7 +961,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘ChangeFeed’:
+	// Set property "ChangeFeed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ChangeFeed != nil {
@@ -975,9 +975,9 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ContainerDeleteRetentionPolicy’:
+	// Set property "ContainerDeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ContainerDeleteRetentionPolicy != nil {
@@ -991,7 +991,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -1005,7 +1005,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘DefaultServiceVersion’:
+	// Set property "DefaultServiceVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultServiceVersion != nil {
@@ -1014,7 +1014,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘DeleteRetentionPolicy’:
+	// Set property "DeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteRetentionPolicy != nil {
@@ -1028,13 +1028,13 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		service.Id = &id
 	}
 
-	// Set property ‘IsVersioningEnabled’:
+	// Set property "IsVersioningEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsVersioningEnabled != nil {
@@ -1043,7 +1043,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘LastAccessTimeTrackingPolicy’:
+	// Set property "LastAccessTimeTrackingPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastAccessTimeTrackingPolicy != nil {
@@ -1057,13 +1057,13 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		service.Name = &name
 	}
 
-	// Set property ‘RestorePolicy’:
+	// Set property "RestorePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestorePolicy != nil {
@@ -1077,7 +1077,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1088,7 +1088,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		service.Sku = &sku
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		service.Type = &typeVar
@@ -1372,13 +1372,13 @@ func (feed *ChangeFeed) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &ChangeFeed_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if feed.Enabled != nil {
 		enabled := *feed.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	if feed.RetentionInDays != nil {
 		retentionInDays := *feed.RetentionInDays
 		result.RetentionInDays = &retentionInDays
@@ -1398,13 +1398,13 @@ func (feed *ChangeFeed) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ChangeFeed_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		feed.Enabled = &enabled
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	if typedInput.RetentionInDays != nil {
 		retentionInDays := *typedInput.RetentionInDays
 		feed.RetentionInDays = &retentionInDays
@@ -1493,13 +1493,13 @@ func (feed *ChangeFeed_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ChangeFeed_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		feed.Enabled = &enabled
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	if typedInput.RetentionInDays != nil {
 		retentionInDays := *typedInput.RetentionInDays
 		feed.RetentionInDays = &retentionInDays
@@ -1569,7 +1569,7 @@ func (rules *CorsRules) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &CorsRules_ARM{}
 
-	// Set property ‘CorsRules’:
+	// Set property "CorsRules":
 	for _, item := range rules.CorsRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1592,7 +1592,7 @@ func (rules *CorsRules) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsRules_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CorsRules’:
+	// Set property "CorsRules":
 	for _, item := range typedInput.CorsRules {
 		var item1 CorsRule
 		err := item1.PopulateFromARM(owner, item)
@@ -1685,7 +1685,7 @@ func (rules *CorsRules_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsRules_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CorsRules’:
+	// Set property "CorsRules":
 	for _, item := range typedInput.CorsRules {
 		var item1 CorsRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1779,13 +1779,13 @@ func (policy *DeleteRetentionPolicy) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &DeleteRetentionPolicy_ARM{}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if policy.Days != nil {
 		days := *policy.Days
 		result.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if policy.Enabled != nil {
 		enabled := *policy.Enabled
 		result.Enabled = &enabled
@@ -1805,13 +1805,13 @@ func (policy *DeleteRetentionPolicy) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeleteRetentionPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		policy.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
@@ -1900,13 +1900,13 @@ func (policy *DeleteRetentionPolicy_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeleteRetentionPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		policy.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
@@ -1988,24 +1988,24 @@ func (policy *LastAccessTimeTrackingPolicy) ConvertToARM(resolved genruntime.Con
 	}
 	result := &LastAccessTimeTrackingPolicy_ARM{}
 
-	// Set property ‘BlobType’:
+	// Set property "BlobType":
 	for _, item := range policy.BlobType {
 		result.BlobType = append(result.BlobType, item)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if policy.Enable != nil {
 		enable := *policy.Enable
 		result.Enable = &enable
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if policy.Name != nil {
 		name := *policy.Name
 		result.Name = &name
 	}
 
-	// Set property ‘TrackingGranularityInDays’:
+	// Set property "TrackingGranularityInDays":
 	if policy.TrackingGranularityInDays != nil {
 		trackingGranularityInDays := *policy.TrackingGranularityInDays
 		result.TrackingGranularityInDays = &trackingGranularityInDays
@@ -2025,24 +2025,24 @@ func (policy *LastAccessTimeTrackingPolicy) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LastAccessTimeTrackingPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobType’:
+	// Set property "BlobType":
 	for _, item := range typedInput.BlobType {
 		policy.BlobType = append(policy.BlobType, item)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		policy.Enable = &enable
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘TrackingGranularityInDays’:
+	// Set property "TrackingGranularityInDays":
 	if typedInput.TrackingGranularityInDays != nil {
 		trackingGranularityInDays := *typedInput.TrackingGranularityInDays
 		policy.TrackingGranularityInDays = &trackingGranularityInDays
@@ -2150,24 +2150,24 @@ func (policy *LastAccessTimeTrackingPolicy_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LastAccessTimeTrackingPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobType’:
+	// Set property "BlobType":
 	for _, item := range typedInput.BlobType {
 		policy.BlobType = append(policy.BlobType, item)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		policy.Enable = &enable
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘TrackingGranularityInDays’:
+	// Set property "TrackingGranularityInDays":
 	if typedInput.TrackingGranularityInDays != nil {
 		trackingGranularityInDays := *typedInput.TrackingGranularityInDays
 		policy.TrackingGranularityInDays = &trackingGranularityInDays
@@ -2265,13 +2265,13 @@ func (properties *RestorePolicyProperties) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &RestorePolicyProperties_ARM{}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if properties.Days != nil {
 		days := *properties.Days
 		result.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if properties.Enabled != nil {
 		enabled := *properties.Enabled
 		result.Enabled = &enabled
@@ -2291,13 +2291,13 @@ func (properties *RestorePolicyProperties) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RestorePolicyProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		properties.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
@@ -2391,25 +2391,25 @@ func (properties *RestorePolicyProperties_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RestorePolicyProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		properties.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
 	}
 
-	// Set property ‘LastEnabledTime’:
+	// Set property "LastEnabledTime":
 	if typedInput.LastEnabledTime != nil {
 		lastEnabledTime := *typedInput.LastEnabledTime
 		properties.LastEnabledTime = &lastEnabledTime
 	}
 
-	// Set property ‘MinRestoreTime’:
+	// Set property "MinRestoreTime":
 	if typedInput.MinRestoreTime != nil {
 		minRestoreTime := *typedInput.MinRestoreTime
 		properties.MinRestoreTime = &minRestoreTime
@@ -2512,27 +2512,27 @@ func (rule *CorsRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &CorsRule_ARM{}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	for _, item := range rule.AllowedHeaders {
 		result.AllowedHeaders = append(result.AllowedHeaders, item)
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	for _, item := range rule.AllowedMethods {
 		result.AllowedMethods = append(result.AllowedMethods, item)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range rule.AllowedOrigins {
 		result.AllowedOrigins = append(result.AllowedOrigins, item)
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	for _, item := range rule.ExposedHeaders {
 		result.ExposedHeaders = append(result.ExposedHeaders, item)
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if rule.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *rule.MaxAgeInSeconds
 		result.MaxAgeInSeconds = &maxAgeInSeconds
@@ -2552,27 +2552,27 @@ func (rule *CorsRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	for _, item := range typedInput.AllowedHeaders {
 		rule.AllowedHeaders = append(rule.AllowedHeaders, item)
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	for _, item := range typedInput.AllowedMethods {
 		rule.AllowedMethods = append(rule.AllowedMethods, item)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		rule.AllowedOrigins = append(rule.AllowedOrigins, item)
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	for _, item := range typedInput.ExposedHeaders {
 		rule.ExposedHeaders = append(rule.ExposedHeaders, item)
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if typedInput.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *typedInput.MaxAgeInSeconds
 		rule.MaxAgeInSeconds = &maxAgeInSeconds
@@ -2691,27 +2691,27 @@ func (rule *CorsRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	for _, item := range typedInput.AllowedHeaders {
 		rule.AllowedHeaders = append(rule.AllowedHeaders, item)
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	for _, item := range typedInput.AllowedMethods {
 		rule.AllowedMethods = append(rule.AllowedMethods, item)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		rule.AllowedOrigins = append(rule.AllowedOrigins, item)
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	for _, item := range typedInput.ExposedHeaders {
 		rule.ExposedHeaders = append(rule.ExposedHeaders, item)
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if typedInput.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *typedInput.MaxAgeInSeconds
 		rule.MaxAgeInSeconds = &maxAgeInSeconds

--- a/v2/api/storage/v1api20210401/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_accounts_blob_services_container_types_gen.go
@@ -352,10 +352,10 @@ func (container *StorageAccounts_BlobServices_Container_Spec) ConvertToARM(resol
 	}
 	result := &StorageAccounts_BlobServices_Container_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if container.DefaultEncryptionScope != nil ||
 		container.DenyEncryptionScopeOverride != nil ||
 		container.ImmutableStorageWithVersioning != nil ||
@@ -404,10 +404,10 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_BlobServices_Container_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	container.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DefaultEncryptionScope’:
+	// Set property "DefaultEncryptionScope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultEncryptionScope != nil {
@@ -416,7 +416,7 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘DenyEncryptionScopeOverride’:
+	// Set property "DenyEncryptionScopeOverride":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DenyEncryptionScopeOverride != nil {
@@ -425,7 +425,7 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘ImmutableStorageWithVersioning’:
+	// Set property "ImmutableStorageWithVersioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutableStorageWithVersioning != nil {
@@ -439,7 +439,7 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -450,10 +450,10 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	container.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicAccess’:
+	// Set property "PublicAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicAccess != nil {
@@ -781,9 +781,9 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_BlobServices_Container_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DefaultEncryptionScope’:
+	// Set property "DefaultEncryptionScope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultEncryptionScope != nil {
@@ -792,7 +792,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Deleted’:
+	// Set property "Deleted":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Deleted != nil {
@@ -801,7 +801,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘DeletedTime’:
+	// Set property "DeletedTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeletedTime != nil {
@@ -810,7 +810,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘DenyEncryptionScopeOverride’:
+	// Set property "DenyEncryptionScopeOverride":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DenyEncryptionScopeOverride != nil {
@@ -819,13 +819,13 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		container.Etag = &etag
 	}
 
-	// Set property ‘HasImmutabilityPolicy’:
+	// Set property "HasImmutabilityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HasImmutabilityPolicy != nil {
@@ -834,7 +834,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘HasLegalHold’:
+	// Set property "HasLegalHold":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HasLegalHold != nil {
@@ -843,13 +843,13 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		container.Id = &id
 	}
 
-	// Set property ‘ImmutabilityPolicy’:
+	// Set property "ImmutabilityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutabilityPolicy != nil {
@@ -863,7 +863,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘ImmutableStorageWithVersioning’:
+	// Set property "ImmutableStorageWithVersioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutableStorageWithVersioning != nil {
@@ -877,7 +877,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastModifiedTime != nil {
@@ -886,7 +886,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LeaseDuration’:
+	// Set property "LeaseDuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LeaseDuration != nil {
@@ -895,7 +895,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LeaseState’:
+	// Set property "LeaseState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LeaseState != nil {
@@ -904,7 +904,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LeaseStatus’:
+	// Set property "LeaseStatus":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LeaseStatus != nil {
@@ -913,7 +913,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LegalHold’:
+	// Set property "LegalHold":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LegalHold != nil {
@@ -927,7 +927,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -938,13 +938,13 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		container.Name = &name
 	}
 
-	// Set property ‘PublicAccess’:
+	// Set property "PublicAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicAccess != nil {
@@ -953,7 +953,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘RemainingRetentionDays’:
+	// Set property "RemainingRetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemainingRetentionDays != nil {
@@ -962,13 +962,13 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		container.Type = &typeVar
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1347,7 +1347,7 @@ func (properties *ImmutabilityPolicyProperties_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmutabilityPolicyProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowProtectedAppendWrites’:
+	// Set property "AllowProtectedAppendWrites":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowProtectedAppendWrites != nil {
@@ -1356,13 +1356,13 @@ func (properties *ImmutabilityPolicyProperties_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		properties.Etag = &etag
 	}
 
-	// Set property ‘ImmutabilityPeriodSinceCreationInDays’:
+	// Set property "ImmutabilityPeriodSinceCreationInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutabilityPeriodSinceCreationInDays != nil {
@@ -1371,7 +1371,7 @@ func (properties *ImmutabilityPolicyProperties_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1380,7 +1380,7 @@ func (properties *ImmutabilityPolicyProperties_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘UpdateHistory’:
+	// Set property "UpdateHistory":
 	for _, item := range typedInput.UpdateHistory {
 		var item1 UpdateHistoryProperty_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1512,7 +1512,7 @@ func (versioning *ImmutableStorageWithVersioning) ConvertToARM(resolved genrunti
 	}
 	result := &ImmutableStorageWithVersioning_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if versioning.Enabled != nil {
 		enabled := *versioning.Enabled
 		result.Enabled = &enabled
@@ -1532,7 +1532,7 @@ func (versioning *ImmutableStorageWithVersioning) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmutableStorageWithVersioning_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		versioning.Enabled = &enabled
@@ -1607,19 +1607,19 @@ func (versioning *ImmutableStorageWithVersioning_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmutableStorageWithVersioning_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		versioning.Enabled = &enabled
 	}
 
-	// Set property ‘MigrationState’:
+	// Set property "MigrationState":
 	if typedInput.MigrationState != nil {
 		migrationState := *typedInput.MigrationState
 		versioning.MigrationState = &migrationState
 	}
 
-	// Set property ‘TimeStamp’:
+	// Set property "TimeStamp":
 	if typedInput.TimeStamp != nil {
 		timeStamp := *typedInput.TimeStamp
 		versioning.TimeStamp = &timeStamp
@@ -1715,13 +1715,13 @@ func (properties *LegalHoldProperties_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LegalHoldProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HasLegalHold’:
+	// Set property "HasLegalHold":
 	if typedInput.HasLegalHold != nil {
 		hasLegalHold := *typedInput.HasLegalHold
 		properties.HasLegalHold = &hasLegalHold
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	for _, item := range typedInput.Tags {
 		var item1 TagProperty_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1856,31 +1856,31 @@ func (property *TagProperty_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TagProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectIdentifier’:
+	// Set property "ObjectIdentifier":
 	if typedInput.ObjectIdentifier != nil {
 		objectIdentifier := *typedInput.ObjectIdentifier
 		property.ObjectIdentifier = &objectIdentifier
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		property.Tag = &tag
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		property.TenantId = &tenantId
 	}
 
-	// Set property ‘Timestamp’:
+	// Set property "Timestamp":
 	if typedInput.Timestamp != nil {
 		timestamp := *typedInput.Timestamp
 		property.Timestamp = &timestamp
 	}
 
-	// Set property ‘Upn’:
+	// Set property "Upn":
 	if typedInput.Upn != nil {
 		upn := *typedInput.Upn
 		property.Upn = &upn
@@ -1979,37 +1979,37 @@ func (property *UpdateHistoryProperty_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpdateHistoryProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ImmutabilityPeriodSinceCreationInDays’:
+	// Set property "ImmutabilityPeriodSinceCreationInDays":
 	if typedInput.ImmutabilityPeriodSinceCreationInDays != nil {
 		immutabilityPeriodSinceCreationInDays := *typedInput.ImmutabilityPeriodSinceCreationInDays
 		property.ImmutabilityPeriodSinceCreationInDays = &immutabilityPeriodSinceCreationInDays
 	}
 
-	// Set property ‘ObjectIdentifier’:
+	// Set property "ObjectIdentifier":
 	if typedInput.ObjectIdentifier != nil {
 		objectIdentifier := *typedInput.ObjectIdentifier
 		property.ObjectIdentifier = &objectIdentifier
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		property.TenantId = &tenantId
 	}
 
-	// Set property ‘Timestamp’:
+	// Set property "Timestamp":
 	if typedInput.Timestamp != nil {
 		timestamp := *typedInput.Timestamp
 		property.Timestamp = &timestamp
 	}
 
-	// Set property ‘Update’:
+	// Set property "Update":
 	if typedInput.Update != nil {
 		update := *typedInput.Update
 		property.Update = &update
 	}
 
-	// Set property ‘Upn’:
+	// Set property "Upn":
 	if typedInput.Upn != nil {
 		upn := *typedInput.Upn
 		property.Upn = &upn

--- a/v2/api/storage/v1api20210401/storage_accounts_management_policy_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_accounts_management_policy_types_gen.go
@@ -328,10 +328,10 @@ func (policy *StorageAccounts_ManagementPolicy_Spec) ConvertToARM(resolved genru
 	}
 	result := &StorageAccounts_ManagementPolicy_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if policy.Policy != nil {
 		result.Properties = &ManagementPolicyProperties_ARM{}
 	}
@@ -358,10 +358,10 @@ func (policy *StorageAccounts_ManagementPolicy_Spec) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_ManagementPolicy_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	policy.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Policy’:
+	// Set property "Policy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Policy != nil {
@@ -586,15 +586,15 @@ func (policy *StorageAccounts_ManagementPolicy_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_ManagementPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		policy.Id = &id
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastModifiedTime != nil {
@@ -603,13 +603,13 @@ func (policy *StorageAccounts_ManagementPolicy_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘Policy’:
+	// Set property "Policy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Policy != nil {
@@ -623,7 +623,7 @@ func (policy *StorageAccounts_ManagementPolicy_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		policy.Type = &typeVar
@@ -728,7 +728,7 @@ func (schema *ManagementPolicySchema) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicySchema_ARM{}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range schema.Rules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -751,7 +751,7 @@ func (schema *ManagementPolicySchema) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicySchema_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		var item1 ManagementPolicyRule
 		err := item1.PopulateFromARM(owner, item)
@@ -846,7 +846,7 @@ func (schema *ManagementPolicySchema_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicySchema_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		var item1 ManagementPolicyRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -947,7 +947,7 @@ func (rule *ManagementPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ManagementPolicyRule_ARM{}
 
-	// Set property ‘Definition’:
+	// Set property "Definition":
 	if rule.Definition != nil {
 		definition_ARM, err := (*rule.Definition).ConvertToARM(resolved)
 		if err != nil {
@@ -957,19 +957,19 @@ func (rule *ManagementPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Definition = &definition
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if rule.Enabled != nil {
 		enabled := *rule.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if rule.Name != nil {
 		name := *rule.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if rule.Type != nil {
 		typeVar := *rule.Type
 		result.Type = &typeVar
@@ -989,7 +989,7 @@ func (rule *ManagementPolicyRule) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Definition’:
+	// Set property "Definition":
 	if typedInput.Definition != nil {
 		var definition1 ManagementPolicyDefinition
 		err := definition1.PopulateFromARM(owner, *typedInput.Definition)
@@ -1000,19 +1000,19 @@ func (rule *ManagementPolicyRule) PopulateFromARM(owner genruntime.ArbitraryOwne
 		rule.Definition = &definition
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		rule.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -1137,7 +1137,7 @@ func (rule *ManagementPolicyRule_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Definition’:
+	// Set property "Definition":
 	if typedInput.Definition != nil {
 		var definition1 ManagementPolicyDefinition_STATUS
 		err := definition1.PopulateFromARM(owner, *typedInput.Definition)
@@ -1148,19 +1148,19 @@ func (rule *ManagementPolicyRule_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		rule.Definition = &definition
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		rule.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -1274,7 +1274,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 	}
 	result := &ManagementPolicyDefinition_ARM{}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if definition.Actions != nil {
 		actions_ARM, err := (*definition.Actions).ConvertToARM(resolved)
 		if err != nil {
@@ -1284,7 +1284,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 		result.Actions = &actions
 	}
 
-	// Set property ‘Filters’:
+	// Set property "Filters":
 	if definition.Filters != nil {
 		filters_ARM, err := (*definition.Filters).ConvertToARM(resolved)
 		if err != nil {
@@ -1308,7 +1308,7 @@ func (definition *ManagementPolicyDefinition) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyDefinition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if typedInput.Actions != nil {
 		var actions1 ManagementPolicyAction
 		err := actions1.PopulateFromARM(owner, *typedInput.Actions)
@@ -1319,7 +1319,7 @@ func (definition *ManagementPolicyDefinition) PopulateFromARM(owner genruntime.A
 		definition.Actions = &actions
 	}
 
-	// Set property ‘Filters’:
+	// Set property "Filters":
 	if typedInput.Filters != nil {
 		var filters1 ManagementPolicyFilter
 		err := filters1.PopulateFromARM(owner, *typedInput.Filters)
@@ -1428,7 +1428,7 @@ func (definition *ManagementPolicyDefinition_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyDefinition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if typedInput.Actions != nil {
 		var actions1 ManagementPolicyAction_STATUS
 		err := actions1.PopulateFromARM(owner, *typedInput.Actions)
@@ -1439,7 +1439,7 @@ func (definition *ManagementPolicyDefinition_STATUS) PopulateFromARM(owner genru
 		definition.Actions = &actions
 	}
 
-	// Set property ‘Filters’:
+	// Set property "Filters":
 	if typedInput.Filters != nil {
 		var filters1 ManagementPolicyFilter_STATUS
 		err := filters1.PopulateFromARM(owner, *typedInput.Filters)
@@ -1555,7 +1555,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicyAction_ARM{}
 
-	// Set property ‘BaseBlob’:
+	// Set property "BaseBlob":
 	if action.BaseBlob != nil {
 		baseBlob_ARM, err := (*action.BaseBlob).ConvertToARM(resolved)
 		if err != nil {
@@ -1565,7 +1565,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 		result.BaseBlob = &baseBlob
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if action.Snapshot != nil {
 		snapshot_ARM, err := (*action.Snapshot).ConvertToARM(resolved)
 		if err != nil {
@@ -1575,7 +1575,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 		result.Snapshot = &snapshot
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if action.Version != nil {
 		version_ARM, err := (*action.Version).ConvertToARM(resolved)
 		if err != nil {
@@ -1599,7 +1599,7 @@ func (action *ManagementPolicyAction) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BaseBlob’:
+	// Set property "BaseBlob":
 	if typedInput.BaseBlob != nil {
 		var baseBlob1 ManagementPolicyBaseBlob
 		err := baseBlob1.PopulateFromARM(owner, *typedInput.BaseBlob)
@@ -1610,7 +1610,7 @@ func (action *ManagementPolicyAction) PopulateFromARM(owner genruntime.Arbitrary
 		action.BaseBlob = &baseBlob
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 ManagementPolicySnapShot
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -1621,7 +1621,7 @@ func (action *ManagementPolicyAction) PopulateFromARM(owner genruntime.Arbitrary
 		action.Snapshot = &snapshot
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		var version1 ManagementPolicyVersion
 		err := version1.PopulateFromARM(owner, *typedInput.Version)
@@ -1757,7 +1757,7 @@ func (action *ManagementPolicyAction_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BaseBlob’:
+	// Set property "BaseBlob":
 	if typedInput.BaseBlob != nil {
 		var baseBlob1 ManagementPolicyBaseBlob_STATUS
 		err := baseBlob1.PopulateFromARM(owner, *typedInput.BaseBlob)
@@ -1768,7 +1768,7 @@ func (action *ManagementPolicyAction_STATUS) PopulateFromARM(owner genruntime.Ar
 		action.BaseBlob = &baseBlob
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 ManagementPolicySnapShot_STATUS
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -1779,7 +1779,7 @@ func (action *ManagementPolicyAction_STATUS) PopulateFromARM(owner genruntime.Ar
 		action.Snapshot = &snapshot
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		var version1 ManagementPolicyVersion_STATUS
 		err := version1.PopulateFromARM(owner, *typedInput.Version)
@@ -1913,7 +1913,7 @@ func (filter *ManagementPolicyFilter) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicyFilter_ARM{}
 
-	// Set property ‘BlobIndexMatch’:
+	// Set property "BlobIndexMatch":
 	for _, item := range filter.BlobIndexMatch {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1922,12 +1922,12 @@ func (filter *ManagementPolicyFilter) ConvertToARM(resolved genruntime.ConvertTo
 		result.BlobIndexMatch = append(result.BlobIndexMatch, *item_ARM.(*TagFilter_ARM))
 	}
 
-	// Set property ‘BlobTypes’:
+	// Set property "BlobTypes":
 	for _, item := range filter.BlobTypes {
 		result.BlobTypes = append(result.BlobTypes, item)
 	}
 
-	// Set property ‘PrefixMatch’:
+	// Set property "PrefixMatch":
 	for _, item := range filter.PrefixMatch {
 		result.PrefixMatch = append(result.PrefixMatch, item)
 	}
@@ -1946,7 +1946,7 @@ func (filter *ManagementPolicyFilter) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobIndexMatch’:
+	// Set property "BlobIndexMatch":
 	for _, item := range typedInput.BlobIndexMatch {
 		var item1 TagFilter
 		err := item1.PopulateFromARM(owner, item)
@@ -1956,12 +1956,12 @@ func (filter *ManagementPolicyFilter) PopulateFromARM(owner genruntime.Arbitrary
 		filter.BlobIndexMatch = append(filter.BlobIndexMatch, item1)
 	}
 
-	// Set property ‘BlobTypes’:
+	// Set property "BlobTypes":
 	for _, item := range typedInput.BlobTypes {
 		filter.BlobTypes = append(filter.BlobTypes, item)
 	}
 
-	// Set property ‘PrefixMatch’:
+	// Set property "PrefixMatch":
 	for _, item := range typedInput.PrefixMatch {
 		filter.PrefixMatch = append(filter.PrefixMatch, item)
 	}
@@ -2069,7 +2069,7 @@ func (filter *ManagementPolicyFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobIndexMatch’:
+	// Set property "BlobIndexMatch":
 	for _, item := range typedInput.BlobIndexMatch {
 		var item1 TagFilter_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2079,12 +2079,12 @@ func (filter *ManagementPolicyFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 		filter.BlobIndexMatch = append(filter.BlobIndexMatch, item1)
 	}
 
-	// Set property ‘BlobTypes’:
+	// Set property "BlobTypes":
 	for _, item := range typedInput.BlobTypes {
 		filter.BlobTypes = append(filter.BlobTypes, item)
 	}
 
-	// Set property ‘PrefixMatch’:
+	// Set property "PrefixMatch":
 	for _, item := range typedInput.PrefixMatch {
 		filter.PrefixMatch = append(filter.PrefixMatch, item)
 	}
@@ -2189,7 +2189,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicyBaseBlob_ARM{}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if blob.Delete != nil {
 		delete_ARM, err := (*blob.Delete).ConvertToARM(resolved)
 		if err != nil {
@@ -2199,13 +2199,13 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 		result.Delete = &delete
 	}
 
-	// Set property ‘EnableAutoTierToHotFromCool’:
+	// Set property "EnableAutoTierToHotFromCool":
 	if blob.EnableAutoTierToHotFromCool != nil {
 		enableAutoTierToHotFromCool := *blob.EnableAutoTierToHotFromCool
 		result.EnableAutoTierToHotFromCool = &enableAutoTierToHotFromCool
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if blob.TierToArchive != nil {
 		tierToArchive_ARM, err := (*blob.TierToArchive).ConvertToARM(resolved)
 		if err != nil {
@@ -2215,7 +2215,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 		result.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if blob.TierToCool != nil {
 		tierToCool_ARM, err := (*blob.TierToCool).ConvertToARM(resolved)
 		if err != nil {
@@ -2239,7 +2239,7 @@ func (blob *ManagementPolicyBaseBlob) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyBaseBlob_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterModification
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -2250,13 +2250,13 @@ func (blob *ManagementPolicyBaseBlob) PopulateFromARM(owner genruntime.Arbitrary
 		blob.Delete = &delete
 	}
 
-	// Set property ‘EnableAutoTierToHotFromCool’:
+	// Set property "EnableAutoTierToHotFromCool":
 	if typedInput.EnableAutoTierToHotFromCool != nil {
 		enableAutoTierToHotFromCool := *typedInput.EnableAutoTierToHotFromCool
 		blob.EnableAutoTierToHotFromCool = &enableAutoTierToHotFromCool
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterModification
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -2267,7 +2267,7 @@ func (blob *ManagementPolicyBaseBlob) PopulateFromARM(owner genruntime.Arbitrary
 		blob.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterModification
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -2423,7 +2423,7 @@ func (blob *ManagementPolicyBaseBlob_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyBaseBlob_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterModification_STATUS
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -2434,13 +2434,13 @@ func (blob *ManagementPolicyBaseBlob_STATUS) PopulateFromARM(owner genruntime.Ar
 		blob.Delete = &delete
 	}
 
-	// Set property ‘EnableAutoTierToHotFromCool’:
+	// Set property "EnableAutoTierToHotFromCool":
 	if typedInput.EnableAutoTierToHotFromCool != nil {
 		enableAutoTierToHotFromCool := *typedInput.EnableAutoTierToHotFromCool
 		blob.EnableAutoTierToHotFromCool = &enableAutoTierToHotFromCool
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterModification_STATUS
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -2451,7 +2451,7 @@ func (blob *ManagementPolicyBaseBlob_STATUS) PopulateFromARM(owner genruntime.Ar
 		blob.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterModification_STATUS
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -2598,7 +2598,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicySnapShot_ARM{}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if shot.Delete != nil {
 		delete_ARM, err := (*shot.Delete).ConvertToARM(resolved)
 		if err != nil {
@@ -2608,7 +2608,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 		result.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if shot.TierToArchive != nil {
 		tierToArchive_ARM, err := (*shot.TierToArchive).ConvertToARM(resolved)
 		if err != nil {
@@ -2618,7 +2618,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 		result.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if shot.TierToCool != nil {
 		tierToCool_ARM, err := (*shot.TierToCool).ConvertToARM(resolved)
 		if err != nil {
@@ -2642,7 +2642,7 @@ func (shot *ManagementPolicySnapShot) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicySnapShot_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterCreation
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -2653,7 +2653,7 @@ func (shot *ManagementPolicySnapShot) PopulateFromARM(owner genruntime.Arbitrary
 		shot.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterCreation
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -2664,7 +2664,7 @@ func (shot *ManagementPolicySnapShot) PopulateFromARM(owner genruntime.Arbitrary
 		shot.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterCreation
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -2800,7 +2800,7 @@ func (shot *ManagementPolicySnapShot_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicySnapShot_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterCreation_STATUS
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -2811,7 +2811,7 @@ func (shot *ManagementPolicySnapShot_STATUS) PopulateFromARM(owner genruntime.Ar
 		shot.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterCreation_STATUS
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -2822,7 +2822,7 @@ func (shot *ManagementPolicySnapShot_STATUS) PopulateFromARM(owner genruntime.Ar
 		shot.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterCreation_STATUS
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -2953,7 +2953,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ManagementPolicyVersion_ARM{}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if version.Delete != nil {
 		delete_ARM, err := (*version.Delete).ConvertToARM(resolved)
 		if err != nil {
@@ -2963,7 +2963,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 		result.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if version.TierToArchive != nil {
 		tierToArchive_ARM, err := (*version.TierToArchive).ConvertToARM(resolved)
 		if err != nil {
@@ -2973,7 +2973,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 		result.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if version.TierToCool != nil {
 		tierToCool_ARM, err := (*version.TierToCool).ConvertToARM(resolved)
 		if err != nil {
@@ -2997,7 +2997,7 @@ func (version *ManagementPolicyVersion) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyVersion_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterCreation
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -3008,7 +3008,7 @@ func (version *ManagementPolicyVersion) PopulateFromARM(owner genruntime.Arbitra
 		version.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterCreation
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -3019,7 +3019,7 @@ func (version *ManagementPolicyVersion) PopulateFromARM(owner genruntime.Arbitra
 		version.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterCreation
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -3155,7 +3155,7 @@ func (version *ManagementPolicyVersion_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyVersion_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterCreation_STATUS
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -3166,7 +3166,7 @@ func (version *ManagementPolicyVersion_STATUS) PopulateFromARM(owner genruntime.
 		version.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterCreation_STATUS
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -3177,7 +3177,7 @@ func (version *ManagementPolicyVersion_STATUS) PopulateFromARM(owner genruntime.
 		version.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterCreation_STATUS
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -3316,19 +3316,19 @@ func (filter *TagFilter) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &TagFilter_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if filter.Name != nil {
 		name := *filter.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Op’:
+	// Set property "Op":
 	if filter.Op != nil {
 		op := *filter.Op
 		result.Op = &op
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if filter.Value != nil {
 		value := *filter.Value
 		result.Value = &value
@@ -3348,19 +3348,19 @@ func (filter *TagFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TagFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		filter.Name = &name
 	}
 
-	// Set property ‘Op’:
+	// Set property "Op":
 	if typedInput.Op != nil {
 		op := *typedInput.Op
 		filter.Op = &op
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -3458,19 +3458,19 @@ func (filter *TagFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TagFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		filter.Name = &name
 	}
 
-	// Set property ‘Op’:
+	// Set property "Op":
 	if typedInput.Op != nil {
 		op := *typedInput.Op
 		filter.Op = &op
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -3539,7 +3539,7 @@ func (creation *DateAfterCreation) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &DateAfterCreation_ARM{}
 
-	// Set property ‘DaysAfterCreationGreaterThan’:
+	// Set property "DaysAfterCreationGreaterThan":
 	if creation.DaysAfterCreationGreaterThan != nil {
 		daysAfterCreationGreaterThan := *creation.DaysAfterCreationGreaterThan
 		result.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
@@ -3559,7 +3559,7 @@ func (creation *DateAfterCreation) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DateAfterCreation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DaysAfterCreationGreaterThan’:
+	// Set property "DaysAfterCreationGreaterThan":
 	if typedInput.DaysAfterCreationGreaterThan != nil {
 		daysAfterCreationGreaterThan := *typedInput.DaysAfterCreationGreaterThan
 		creation.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
@@ -3628,7 +3628,7 @@ func (creation *DateAfterCreation_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DateAfterCreation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DaysAfterCreationGreaterThan’:
+	// Set property "DaysAfterCreationGreaterThan":
 	if typedInput.DaysAfterCreationGreaterThan != nil {
 		daysAfterCreationGreaterThan := *typedInput.DaysAfterCreationGreaterThan
 		creation.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
@@ -3701,13 +3701,13 @@ func (modification *DateAfterModification) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &DateAfterModification_ARM{}
 
-	// Set property ‘DaysAfterLastAccessTimeGreaterThan’:
+	// Set property "DaysAfterLastAccessTimeGreaterThan":
 	if modification.DaysAfterLastAccessTimeGreaterThan != nil {
 		daysAfterLastAccessTimeGreaterThan := *modification.DaysAfterLastAccessTimeGreaterThan
 		result.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
 	}
 
-	// Set property ‘DaysAfterModificationGreaterThan’:
+	// Set property "DaysAfterModificationGreaterThan":
 	if modification.DaysAfterModificationGreaterThan != nil {
 		daysAfterModificationGreaterThan := *modification.DaysAfterModificationGreaterThan
 		result.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan
@@ -3727,13 +3727,13 @@ func (modification *DateAfterModification) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DateAfterModification_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DaysAfterLastAccessTimeGreaterThan’:
+	// Set property "DaysAfterLastAccessTimeGreaterThan":
 	if typedInput.DaysAfterLastAccessTimeGreaterThan != nil {
 		daysAfterLastAccessTimeGreaterThan := *typedInput.DaysAfterLastAccessTimeGreaterThan
 		modification.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
 	}
 
-	// Set property ‘DaysAfterModificationGreaterThan’:
+	// Set property "DaysAfterModificationGreaterThan":
 	if typedInput.DaysAfterModificationGreaterThan != nil {
 		daysAfterModificationGreaterThan := *typedInput.DaysAfterModificationGreaterThan
 		modification.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan
@@ -3823,13 +3823,13 @@ func (modification *DateAfterModification_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DateAfterModification_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DaysAfterLastAccessTimeGreaterThan’:
+	// Set property "DaysAfterLastAccessTimeGreaterThan":
 	if typedInput.DaysAfterLastAccessTimeGreaterThan != nil {
 		daysAfterLastAccessTimeGreaterThan := *typedInput.DaysAfterLastAccessTimeGreaterThan
 		modification.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
 	}
 
-	// Set property ‘DaysAfterModificationGreaterThan’:
+	// Set property "DaysAfterModificationGreaterThan":
 	if typedInput.DaysAfterModificationGreaterThan != nil {
 		daysAfterModificationGreaterThan := *typedInput.DaysAfterModificationGreaterThan
 		modification.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan

--- a/v2/api/storage/v1api20210401/storage_accounts_queue_service_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_accounts_queue_service_types_gen.go
@@ -328,10 +328,10 @@ func (service *StorageAccounts_QueueService_Spec) ConvertToARM(resolved genrunti
 	}
 	result := &StorageAccounts_QueueService_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if service.Cors != nil {
 		result.Properties = &StorageAccounts_QueueService_Properties_Spec_ARM{}
 	}
@@ -358,7 +358,7 @@ func (service *StorageAccounts_QueueService_Spec) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_QueueService_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -372,7 +372,7 @@ func (service *StorageAccounts_QueueService_Spec) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -584,9 +584,9 @@ func (service *StorageAccounts_QueueService_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_QueueService_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -600,19 +600,19 @@ func (service *StorageAccounts_QueueService_STATUS) PopulateFromARM(owner genrun
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		service.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		service.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		service.Type = &typeVar

--- a/v2/api/storage/v1api20210401/storage_accounts_queue_services_queue_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_accounts_queue_services_queue_types_gen.go
@@ -339,10 +339,10 @@ func (queue *StorageAccounts_QueueServices_Queue_Spec) ConvertToARM(resolved gen
 	}
 	result := &StorageAccounts_QueueServices_Queue_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if queue.Metadata != nil {
 		result.Properties = &QueueProperties_ARM{}
 	}
@@ -367,10 +367,10 @@ func (queue *StorageAccounts_QueueServices_Queue_Spec) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_QueueServices_Queue_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	queue.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -381,7 +381,7 @@ func (queue *StorageAccounts_QueueServices_Queue_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	queue.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -588,7 +588,7 @@ func (queue *StorageAccounts_QueueServices_Queue_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_QueueServices_Queue_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApproximateMessageCount’:
+	// Set property "ApproximateMessageCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApproximateMessageCount != nil {
@@ -597,15 +597,15 @@ func (queue *StorageAccounts_QueueServices_Queue_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		queue.Id = &id
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -616,13 +616,13 @@ func (queue *StorageAccounts_QueueServices_Queue_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		queue.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		queue.Type = &typeVar

--- a/v2/api/storage/v1api20220901/storage_account_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_account_types_gen.go
@@ -558,7 +558,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &StorageAccount_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if account.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*account.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -568,7 +568,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if account.Identity != nil {
 		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -578,22 +578,22 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if account.Kind != nil {
 		kind := *account.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if account.Location != nil {
 		location := *account.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if account.AccessTier != nil ||
 		account.AllowBlobPublicAccess != nil ||
 		account.AllowCrossTenantReplication != nil ||
@@ -744,7 +744,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SupportsHttpsTrafficOnly = &supportsHttpsTrafficOnly
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if account.Sku != nil {
 		sku_ARM, err := (*account.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -754,7 +754,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if account.Tags != nil {
 		result.Tags = make(map[string]string, len(account.Tags))
 		for key, value := range account.Tags {
@@ -776,7 +776,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccount_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessTier’:
+	// Set property "AccessTier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessTier != nil {
@@ -785,7 +785,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AllowBlobPublicAccess’:
+	// Set property "AllowBlobPublicAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowBlobPublicAccess != nil {
@@ -794,7 +794,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AllowCrossTenantReplication’:
+	// Set property "AllowCrossTenantReplication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowCrossTenantReplication != nil {
@@ -803,7 +803,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AllowSharedKeyAccess’:
+	// Set property "AllowSharedKeyAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowSharedKeyAccess != nil {
@@ -812,7 +812,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AllowedCopyScope’:
+	// Set property "AllowedCopyScope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowedCopyScope != nil {
@@ -821,7 +821,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureFilesIdentityBasedAuthentication’:
+	// Set property "AzureFilesIdentityBasedAuthentication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureFilesIdentityBasedAuthentication != nil {
@@ -835,10 +835,10 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	account.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CustomDomain’:
+	// Set property "CustomDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomDomain != nil {
@@ -852,7 +852,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DefaultToOAuthAuthentication’:
+	// Set property "DefaultToOAuthAuthentication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultToOAuthAuthentication != nil {
@@ -861,7 +861,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘DnsEndpointType’:
+	// Set property "DnsEndpointType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsEndpointType != nil {
@@ -870,7 +870,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -884,7 +884,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -895,7 +895,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		account.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -906,7 +906,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		account.Identity = &identity
 	}
 
-	// Set property ‘ImmutableStorageWithVersioning’:
+	// Set property "ImmutableStorageWithVersioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutableStorageWithVersioning != nil {
@@ -920,7 +920,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘IsHnsEnabled’:
+	// Set property "IsHnsEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHnsEnabled != nil {
@@ -929,7 +929,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘IsLocalUserEnabled’:
+	// Set property "IsLocalUserEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsLocalUserEnabled != nil {
@@ -938,7 +938,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘IsNfsV3Enabled’:
+	// Set property "IsNfsV3Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsNfsV3Enabled != nil {
@@ -947,7 +947,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘IsSftpEnabled’:
+	// Set property "IsSftpEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsSftpEnabled != nil {
@@ -956,7 +956,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘KeyPolicy’:
+	// Set property "KeyPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyPolicy != nil {
@@ -970,13 +970,13 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		account.Kind = &kind
 	}
 
-	// Set property ‘LargeFileSharesState’:
+	// Set property "LargeFileSharesState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LargeFileSharesState != nil {
@@ -985,13 +985,13 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -1000,7 +1000,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘NetworkAcls’:
+	// Set property "NetworkAcls":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAcls != nil {
@@ -1014,12 +1014,12 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	account.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1028,7 +1028,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘RoutingPreference’:
+	// Set property "RoutingPreference":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RoutingPreference != nil {
@@ -1042,7 +1042,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SasPolicy’:
+	// Set property "SasPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SasPolicy != nil {
@@ -1056,7 +1056,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1067,7 +1067,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		account.Sku = &sku
 	}
 
-	// Set property ‘SupportsHttpsTrafficOnly’:
+	// Set property "SupportsHttpsTrafficOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SupportsHttpsTrafficOnly != nil {
@@ -1076,7 +1076,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -2255,7 +2255,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccount_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessTier’:
+	// Set property "AccessTier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessTier != nil {
@@ -2264,7 +2264,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AllowBlobPublicAccess’:
+	// Set property "AllowBlobPublicAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowBlobPublicAccess != nil {
@@ -2273,7 +2273,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AllowCrossTenantReplication’:
+	// Set property "AllowCrossTenantReplication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowCrossTenantReplication != nil {
@@ -2282,7 +2282,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AllowSharedKeyAccess’:
+	// Set property "AllowSharedKeyAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowSharedKeyAccess != nil {
@@ -2291,7 +2291,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AllowedCopyScope’:
+	// Set property "AllowedCopyScope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowedCopyScope != nil {
@@ -2300,7 +2300,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AzureFilesIdentityBasedAuthentication’:
+	// Set property "AzureFilesIdentityBasedAuthentication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureFilesIdentityBasedAuthentication != nil {
@@ -2314,7 +2314,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘BlobRestoreStatus’:
+	// Set property "BlobRestoreStatus":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BlobRestoreStatus != nil {
@@ -2328,9 +2328,9 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationTime’:
+	// Set property "CreationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationTime != nil {
@@ -2339,7 +2339,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘CustomDomain’:
+	// Set property "CustomDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomDomain != nil {
@@ -2353,7 +2353,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DefaultToOAuthAuthentication’:
+	// Set property "DefaultToOAuthAuthentication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultToOAuthAuthentication != nil {
@@ -2362,7 +2362,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘DnsEndpointType’:
+	// Set property "DnsEndpointType":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DnsEndpointType != nil {
@@ -2371,7 +2371,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -2385,7 +2385,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -2396,7 +2396,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		account.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FailoverInProgress’:
+	// Set property "FailoverInProgress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FailoverInProgress != nil {
@@ -2405,7 +2405,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘GeoReplicationStats’:
+	// Set property "GeoReplicationStats":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GeoReplicationStats != nil {
@@ -2419,13 +2419,13 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		account.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2436,7 +2436,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		account.Identity = &identity
 	}
 
-	// Set property ‘ImmutableStorageWithVersioning’:
+	// Set property "ImmutableStorageWithVersioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutableStorageWithVersioning != nil {
@@ -2450,7 +2450,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘IsHnsEnabled’:
+	// Set property "IsHnsEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHnsEnabled != nil {
@@ -2459,7 +2459,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘IsLocalUserEnabled’:
+	// Set property "IsLocalUserEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsLocalUserEnabled != nil {
@@ -2468,7 +2468,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘IsNfsV3Enabled’:
+	// Set property "IsNfsV3Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsNfsV3Enabled != nil {
@@ -2477,7 +2477,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘IsSftpEnabled’:
+	// Set property "IsSftpEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsSftpEnabled != nil {
@@ -2486,7 +2486,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘KeyCreationTime’:
+	// Set property "KeyCreationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyCreationTime != nil {
@@ -2500,7 +2500,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘KeyPolicy’:
+	// Set property "KeyPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyPolicy != nil {
@@ -2514,13 +2514,13 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		account.Kind = &kind
 	}
 
-	// Set property ‘LargeFileSharesState’:
+	// Set property "LargeFileSharesState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LargeFileSharesState != nil {
@@ -2529,7 +2529,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LastGeoFailoverTime’:
+	// Set property "LastGeoFailoverTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastGeoFailoverTime != nil {
@@ -2538,13 +2538,13 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -2553,13 +2553,13 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		account.Name = &name
 	}
 
-	// Set property ‘NetworkAcls’:
+	// Set property "NetworkAcls":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAcls != nil {
@@ -2573,7 +2573,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrimaryEndpoints’:
+	// Set property "PrimaryEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrimaryEndpoints != nil {
@@ -2587,7 +2587,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrimaryLocation’:
+	// Set property "PrimaryLocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrimaryLocation != nil {
@@ -2596,7 +2596,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -2609,7 +2609,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -2618,7 +2618,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -2627,7 +2627,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘RoutingPreference’:
+	// Set property "RoutingPreference":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RoutingPreference != nil {
@@ -2641,7 +2641,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SasPolicy’:
+	// Set property "SasPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SasPolicy != nil {
@@ -2655,7 +2655,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SecondaryEndpoints’:
+	// Set property "SecondaryEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecondaryEndpoints != nil {
@@ -2669,7 +2669,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SecondaryLocation’:
+	// Set property "SecondaryLocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecondaryLocation != nil {
@@ -2678,7 +2678,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -2689,7 +2689,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		account.Sku = &sku
 	}
 
-	// Set property ‘StatusOfPrimary’:
+	// Set property "StatusOfPrimary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StatusOfPrimary != nil {
@@ -2698,7 +2698,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘StatusOfSecondary’:
+	// Set property "StatusOfSecondary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StatusOfSecondary != nil {
@@ -2707,7 +2707,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘StorageAccountSkuConversionStatus’:
+	// Set property "StorageAccountSkuConversionStatus":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageAccountSkuConversionStatus != nil {
@@ -2721,7 +2721,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SupportsHttpsTrafficOnly’:
+	// Set property "SupportsHttpsTrafficOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SupportsHttpsTrafficOnly != nil {
@@ -2730,7 +2730,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -2738,7 +2738,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		account.Type = &typeVar
@@ -3617,7 +3617,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication) ConvertToARM(resolv
 	}
 	result := &AzureFilesIdentityBasedAuthentication_ARM{}
 
-	// Set property ‘ActiveDirectoryProperties’:
+	// Set property "ActiveDirectoryProperties":
 	if authentication.ActiveDirectoryProperties != nil {
 		activeDirectoryProperties_ARM, err := (*authentication.ActiveDirectoryProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -3627,13 +3627,13 @@ func (authentication *AzureFilesIdentityBasedAuthentication) ConvertToARM(resolv
 		result.ActiveDirectoryProperties = &activeDirectoryProperties
 	}
 
-	// Set property ‘DefaultSharePermission’:
+	// Set property "DefaultSharePermission":
 	if authentication.DefaultSharePermission != nil {
 		defaultSharePermission := *authentication.DefaultSharePermission
 		result.DefaultSharePermission = &defaultSharePermission
 	}
 
-	// Set property ‘DirectoryServiceOptions’:
+	// Set property "DirectoryServiceOptions":
 	if authentication.DirectoryServiceOptions != nil {
 		directoryServiceOptions := *authentication.DirectoryServiceOptions
 		result.DirectoryServiceOptions = &directoryServiceOptions
@@ -3653,7 +3653,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFilesIdentityBasedAuthentication_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActiveDirectoryProperties’:
+	// Set property "ActiveDirectoryProperties":
 	if typedInput.ActiveDirectoryProperties != nil {
 		var activeDirectoryProperties1 ActiveDirectoryProperties
 		err := activeDirectoryProperties1.PopulateFromARM(owner, *typedInput.ActiveDirectoryProperties)
@@ -3664,13 +3664,13 @@ func (authentication *AzureFilesIdentityBasedAuthentication) PopulateFromARM(own
 		authentication.ActiveDirectoryProperties = &activeDirectoryProperties
 	}
 
-	// Set property ‘DefaultSharePermission’:
+	// Set property "DefaultSharePermission":
 	if typedInput.DefaultSharePermission != nil {
 		defaultSharePermission := *typedInput.DefaultSharePermission
 		authentication.DefaultSharePermission = &defaultSharePermission
 	}
 
-	// Set property ‘DirectoryServiceOptions’:
+	// Set property "DirectoryServiceOptions":
 	if typedInput.DirectoryServiceOptions != nil {
 		directoryServiceOptions := *typedInput.DirectoryServiceOptions
 		authentication.DirectoryServiceOptions = &directoryServiceOptions
@@ -3820,7 +3820,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication_STATUS) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFilesIdentityBasedAuthentication_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActiveDirectoryProperties’:
+	// Set property "ActiveDirectoryProperties":
 	if typedInput.ActiveDirectoryProperties != nil {
 		var activeDirectoryProperties1 ActiveDirectoryProperties_STATUS
 		err := activeDirectoryProperties1.PopulateFromARM(owner, *typedInput.ActiveDirectoryProperties)
@@ -3831,13 +3831,13 @@ func (authentication *AzureFilesIdentityBasedAuthentication_STATUS) PopulateFrom
 		authentication.ActiveDirectoryProperties = &activeDirectoryProperties
 	}
 
-	// Set property ‘DefaultSharePermission’:
+	// Set property "DefaultSharePermission":
 	if typedInput.DefaultSharePermission != nil {
 		defaultSharePermission := *typedInput.DefaultSharePermission
 		authentication.DefaultSharePermission = &defaultSharePermission
 	}
 
-	// Set property ‘DirectoryServiceOptions’:
+	// Set property "DirectoryServiceOptions":
 	if typedInput.DirectoryServiceOptions != nil {
 		directoryServiceOptions := *typedInput.DirectoryServiceOptions
 		authentication.DirectoryServiceOptions = &directoryServiceOptions
@@ -3956,13 +3956,13 @@ func (status *BlobRestoreStatus_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BlobRestoreStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FailureReason’:
+	// Set property "FailureReason":
 	if typedInput.FailureReason != nil {
 		failureReason := *typedInput.FailureReason
 		status.FailureReason = &failureReason
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 BlobRestoreParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -3973,13 +3973,13 @@ func (status *BlobRestoreStatus_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		status.Parameters = &parameters
 	}
 
-	// Set property ‘RestoreId’:
+	// Set property "RestoreId":
 	if typedInput.RestoreId != nil {
 		restoreId := *typedInput.RestoreId
 		status.RestoreId = &restoreId
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status1 := *typedInput.Status
 		status.Status = &status1
@@ -4084,13 +4084,13 @@ func (domain *CustomDomain) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &CustomDomain_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if domain.Name != nil {
 		name := *domain.Name
 		result.Name = &name
 	}
 
-	// Set property ‘UseSubDomainName’:
+	// Set property "UseSubDomainName":
 	if domain.UseSubDomainName != nil {
 		useSubDomainName := *domain.UseSubDomainName
 		result.UseSubDomainName = &useSubDomainName
@@ -4110,13 +4110,13 @@ func (domain *CustomDomain) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CustomDomain_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		domain.Name = &name
 	}
 
-	// Set property ‘UseSubDomainName’:
+	// Set property "UseSubDomainName":
 	if typedInput.UseSubDomainName != nil {
 		useSubDomainName := *typedInput.UseSubDomainName
 		domain.UseSubDomainName = &useSubDomainName
@@ -4213,13 +4213,13 @@ func (domain *CustomDomain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CustomDomain_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		domain.Name = &name
 	}
 
-	// Set property ‘UseSubDomainName’:
+	// Set property "UseSubDomainName":
 	if typedInput.UseSubDomainName != nil {
 		useSubDomainName := *typedInput.UseSubDomainName
 		domain.UseSubDomainName = &useSubDomainName
@@ -4303,7 +4303,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Encryption_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if encryption.Identity != nil {
 		identity_ARM, err := (*encryption.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -4313,13 +4313,13 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Identity = &identity
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if encryption.KeySource != nil {
 		keySource := *encryption.KeySource
 		result.KeySource = &keySource
 	}
 
-	// Set property ‘Keyvaultproperties’:
+	// Set property "Keyvaultproperties":
 	if encryption.Keyvaultproperties != nil {
 		keyvaultproperties_ARM, err := (*encryption.Keyvaultproperties).ConvertToARM(resolved)
 		if err != nil {
@@ -4329,13 +4329,13 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Keyvaultproperties = &keyvaultproperties
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if encryption.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *encryption.RequireInfrastructureEncryption
 		result.RequireInfrastructureEncryption = &requireInfrastructureEncryption
 	}
 
-	// Set property ‘Services’:
+	// Set property "Services":
 	if encryption.Services != nil {
 		services_ARM, err := (*encryption.Services).ConvertToARM(resolved)
 		if err != nil {
@@ -4359,7 +4359,7 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 EncryptionIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -4370,13 +4370,13 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		encryption.Identity = &identity
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘Keyvaultproperties’:
+	// Set property "Keyvaultproperties":
 	if typedInput.Keyvaultproperties != nil {
 		var keyvaultproperties1 KeyVaultProperties
 		err := keyvaultproperties1.PopulateFromARM(owner, *typedInput.Keyvaultproperties)
@@ -4387,13 +4387,13 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		encryption.Keyvaultproperties = &keyvaultproperties
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
 	}
 
-	// Set property ‘Services’:
+	// Set property "Services":
 	if typedInput.Services != nil {
 		var services1 EncryptionServices
 		err := services1.PopulateFromARM(owner, *typedInput.Services)
@@ -4628,7 +4628,7 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 EncryptionIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -4639,13 +4639,13 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		encryption.Identity = &identity
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘Keyvaultproperties’:
+	// Set property "Keyvaultproperties":
 	if typedInput.Keyvaultproperties != nil {
 		var keyvaultproperties1 KeyVaultProperties_STATUS
 		err := keyvaultproperties1.PopulateFromARM(owner, *typedInput.Keyvaultproperties)
@@ -4656,13 +4656,13 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		encryption.Keyvaultproperties = &keyvaultproperties
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
 	}
 
-	// Set property ‘Services’:
+	// Set property "Services":
 	if typedInput.Services != nil {
 		var services1 EncryptionServices_STATUS
 		err := services1.PopulateFromARM(owner, *typedInput.Services)
@@ -4845,25 +4845,25 @@ func (endpoints *Endpoints_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Endpoints_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		blob := *typedInput.Blob
 		endpoints.Blob = &blob
 	}
 
-	// Set property ‘Dfs’:
+	// Set property "Dfs":
 	if typedInput.Dfs != nil {
 		dfs := *typedInput.Dfs
 		endpoints.Dfs = &dfs
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		file := *typedInput.File
 		endpoints.File = &file
 	}
 
-	// Set property ‘InternetEndpoints’:
+	// Set property "InternetEndpoints":
 	if typedInput.InternetEndpoints != nil {
 		var internetEndpoints1 StorageAccountInternetEndpoints_STATUS
 		err := internetEndpoints1.PopulateFromARM(owner, *typedInput.InternetEndpoints)
@@ -4874,7 +4874,7 @@ func (endpoints *Endpoints_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		endpoints.InternetEndpoints = &internetEndpoints
 	}
 
-	// Set property ‘MicrosoftEndpoints’:
+	// Set property "MicrosoftEndpoints":
 	if typedInput.MicrosoftEndpoints != nil {
 		var microsoftEndpoints1 StorageAccountMicrosoftEndpoints_STATUS
 		err := microsoftEndpoints1.PopulateFromARM(owner, *typedInput.MicrosoftEndpoints)
@@ -4885,19 +4885,19 @@ func (endpoints *Endpoints_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		endpoints.MicrosoftEndpoints = &microsoftEndpoints
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if typedInput.Queue != nil {
 		queue := *typedInput.Queue
 		endpoints.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if typedInput.Table != nil {
 		table := *typedInput.Table
 		endpoints.Table = &table
 	}
 
-	// Set property ‘Web’:
+	// Set property "Web":
 	if typedInput.Web != nil {
 		web := *typedInput.Web
 		endpoints.Web = &web
@@ -5032,13 +5032,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -5058,13 +5058,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -5160,13 +5160,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -5253,19 +5253,19 @@ func (stats *GeoReplicationStats_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GeoReplicationStats_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CanFailover’:
+	// Set property "CanFailover":
 	if typedInput.CanFailover != nil {
 		canFailover := *typedInput.CanFailover
 		stats.CanFailover = &canFailover
 	}
 
-	// Set property ‘LastSyncTime’:
+	// Set property "LastSyncTime":
 	if typedInput.LastSyncTime != nil {
 		lastSyncTime := *typedInput.LastSyncTime
 		stats.LastSyncTime = &lastSyncTime
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		stats.Status = &status
@@ -5357,13 +5357,13 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Identity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -5388,13 +5388,13 @@ func (identity *Identity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -5533,25 +5533,25 @@ func (identity *Identity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -5677,13 +5677,13 @@ func (account *ImmutableStorageAccount) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ImmutableStorageAccount_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if account.Enabled != nil {
 		enabled := *account.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘ImmutabilityPolicy’:
+	// Set property "ImmutabilityPolicy":
 	if account.ImmutabilityPolicy != nil {
 		immutabilityPolicy_ARM, err := (*account.ImmutabilityPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -5707,13 +5707,13 @@ func (account *ImmutableStorageAccount) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmutableStorageAccount_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		account.Enabled = &enabled
 	}
 
-	// Set property ‘ImmutabilityPolicy’:
+	// Set property "ImmutabilityPolicy":
 	if typedInput.ImmutabilityPolicy != nil {
 		var immutabilityPolicy1 AccountImmutabilityPolicyProperties
 		err := immutabilityPolicy1.PopulateFromARM(owner, *typedInput.ImmutabilityPolicy)
@@ -5845,13 +5845,13 @@ func (account *ImmutableStorageAccount_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmutableStorageAccount_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		account.Enabled = &enabled
 	}
 
-	// Set property ‘ImmutabilityPolicy’:
+	// Set property "ImmutabilityPolicy":
 	if typedInput.ImmutabilityPolicy != nil {
 		var immutabilityPolicy1 AccountImmutabilityPolicyProperties_STATUS
 		err := immutabilityPolicy1.PopulateFromARM(owner, *typedInput.ImmutabilityPolicy)
@@ -5949,13 +5949,13 @@ func (time *KeyCreationTime_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyCreationTime_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key1’:
+	// Set property "Key1":
 	if typedInput.Key1 != nil {
 		key1 := *typedInput.Key1
 		time.Key1 = &key1
 	}
 
-	// Set property ‘Key2’:
+	// Set property "Key2":
 	if typedInput.Key2 != nil {
 		key2 := *typedInput.Key2
 		time.Key2 = &key2
@@ -6016,7 +6016,7 @@ func (policy *KeyPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &KeyPolicy_ARM{}
 
-	// Set property ‘KeyExpirationPeriodInDays’:
+	// Set property "KeyExpirationPeriodInDays":
 	if policy.KeyExpirationPeriodInDays != nil {
 		keyExpirationPeriodInDays := *policy.KeyExpirationPeriodInDays
 		result.KeyExpirationPeriodInDays = &keyExpirationPeriodInDays
@@ -6036,7 +6036,7 @@ func (policy *KeyPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyExpirationPeriodInDays’:
+	// Set property "KeyExpirationPeriodInDays":
 	if typedInput.KeyExpirationPeriodInDays != nil {
 		keyExpirationPeriodInDays := *typedInput.KeyExpirationPeriodInDays
 		policy.KeyExpirationPeriodInDays = &keyExpirationPeriodInDays
@@ -6105,7 +6105,7 @@ func (policy *KeyPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyExpirationPeriodInDays’:
+	// Set property "KeyExpirationPeriodInDays":
 	if typedInput.KeyExpirationPeriodInDays != nil {
 		keyExpirationPeriodInDays := *typedInput.KeyExpirationPeriodInDays
 		policy.KeyExpirationPeriodInDays = &keyExpirationPeriodInDays
@@ -6173,19 +6173,19 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &NetworkRuleSet_ARM{}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if ruleSet.Bypass != nil {
 		bypass := *ruleSet.Bypass
 		result.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if ruleSet.DefaultAction != nil {
 		defaultAction := *ruleSet.DefaultAction
 		result.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range ruleSet.IpRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -6194,7 +6194,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.IpRules = append(result.IpRules, *item_ARM.(*IPRule_ARM))
 	}
 
-	// Set property ‘ResourceAccessRules’:
+	// Set property "ResourceAccessRules":
 	for _, item := range ruleSet.ResourceAccessRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -6203,7 +6203,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.ResourceAccessRules = append(result.ResourceAccessRules, *item_ARM.(*ResourceAccessRule_ARM))
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range ruleSet.VirtualNetworkRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -6226,19 +6226,19 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if typedInput.Bypass != nil {
 		bypass := *typedInput.Bypass
 		ruleSet.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule
 		err := item1.PopulateFromARM(owner, item)
@@ -6248,7 +6248,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		ruleSet.IpRules = append(ruleSet.IpRules, item1)
 	}
 
-	// Set property ‘ResourceAccessRules’:
+	// Set property "ResourceAccessRules":
 	for _, item := range typedInput.ResourceAccessRules {
 		var item1 ResourceAccessRule
 		err := item1.PopulateFromARM(owner, item)
@@ -6258,7 +6258,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		ruleSet.ResourceAccessRules = append(ruleSet.ResourceAccessRules, item1)
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range typedInput.VirtualNetworkRules {
 		var item1 VirtualNetworkRule
 		err := item1.PopulateFromARM(owner, item)
@@ -6545,19 +6545,19 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if typedInput.Bypass != nil {
 		bypass := *typedInput.Bypass
 		ruleSet.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6567,7 +6567,7 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		ruleSet.IpRules = append(ruleSet.IpRules, item1)
 	}
 
-	// Set property ‘ResourceAccessRules’:
+	// Set property "ResourceAccessRules":
 	for _, item := range typedInput.ResourceAccessRules {
 		var item1 ResourceAccessRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6577,7 +6577,7 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		ruleSet.ResourceAccessRules = append(ruleSet.ResourceAccessRules, item1)
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range typedInput.VirtualNetworkRules {
 		var item1 VirtualNetworkRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6775,7 +6775,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -6836,19 +6836,19 @@ func (preference *RoutingPreference) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &RoutingPreference_ARM{}
 
-	// Set property ‘PublishInternetEndpoints’:
+	// Set property "PublishInternetEndpoints":
 	if preference.PublishInternetEndpoints != nil {
 		publishInternetEndpoints := *preference.PublishInternetEndpoints
 		result.PublishInternetEndpoints = &publishInternetEndpoints
 	}
 
-	// Set property ‘PublishMicrosoftEndpoints’:
+	// Set property "PublishMicrosoftEndpoints":
 	if preference.PublishMicrosoftEndpoints != nil {
 		publishMicrosoftEndpoints := *preference.PublishMicrosoftEndpoints
 		result.PublishMicrosoftEndpoints = &publishMicrosoftEndpoints
 	}
 
-	// Set property ‘RoutingChoice’:
+	// Set property "RoutingChoice":
 	if preference.RoutingChoice != nil {
 		routingChoice := *preference.RoutingChoice
 		result.RoutingChoice = &routingChoice
@@ -6868,19 +6868,19 @@ func (preference *RoutingPreference) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingPreference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublishInternetEndpoints’:
+	// Set property "PublishInternetEndpoints":
 	if typedInput.PublishInternetEndpoints != nil {
 		publishInternetEndpoints := *typedInput.PublishInternetEndpoints
 		preference.PublishInternetEndpoints = &publishInternetEndpoints
 	}
 
-	// Set property ‘PublishMicrosoftEndpoints’:
+	// Set property "PublishMicrosoftEndpoints":
 	if typedInput.PublishMicrosoftEndpoints != nil {
 		publishMicrosoftEndpoints := *typedInput.PublishMicrosoftEndpoints
 		preference.PublishMicrosoftEndpoints = &publishMicrosoftEndpoints
 	}
 
-	// Set property ‘RoutingChoice’:
+	// Set property "RoutingChoice":
 	if typedInput.RoutingChoice != nil {
 		routingChoice := *typedInput.RoutingChoice
 		preference.RoutingChoice = &routingChoice
@@ -7019,19 +7019,19 @@ func (preference *RoutingPreference_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingPreference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublishInternetEndpoints’:
+	// Set property "PublishInternetEndpoints":
 	if typedInput.PublishInternetEndpoints != nil {
 		publishInternetEndpoints := *typedInput.PublishInternetEndpoints
 		preference.PublishInternetEndpoints = &publishInternetEndpoints
 	}
 
-	// Set property ‘PublishMicrosoftEndpoints’:
+	// Set property "PublishMicrosoftEndpoints":
 	if typedInput.PublishMicrosoftEndpoints != nil {
 		publishMicrosoftEndpoints := *typedInput.PublishMicrosoftEndpoints
 		preference.PublishMicrosoftEndpoints = &publishMicrosoftEndpoints
 	}
 
-	// Set property ‘RoutingChoice’:
+	// Set property "RoutingChoice":
 	if typedInput.RoutingChoice != nil {
 		routingChoice := *typedInput.RoutingChoice
 		preference.RoutingChoice = &routingChoice
@@ -7132,13 +7132,13 @@ func (policy *SasPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &SasPolicy_ARM{}
 
-	// Set property ‘ExpirationAction’:
+	// Set property "ExpirationAction":
 	if policy.ExpirationAction != nil {
 		expirationAction := *policy.ExpirationAction
 		result.ExpirationAction = &expirationAction
 	}
 
-	// Set property ‘SasExpirationPeriod’:
+	// Set property "SasExpirationPeriod":
 	if policy.SasExpirationPeriod != nil {
 		sasExpirationPeriod := *policy.SasExpirationPeriod
 		result.SasExpirationPeriod = &sasExpirationPeriod
@@ -7158,13 +7158,13 @@ func (policy *SasPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SasPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpirationAction’:
+	// Set property "ExpirationAction":
 	if typedInput.ExpirationAction != nil {
 		expirationAction := *typedInput.ExpirationAction
 		policy.ExpirationAction = &expirationAction
 	}
 
-	// Set property ‘SasExpirationPeriod’:
+	// Set property "SasExpirationPeriod":
 	if typedInput.SasExpirationPeriod != nil {
 		sasExpirationPeriod := *typedInput.SasExpirationPeriod
 		policy.SasExpirationPeriod = &sasExpirationPeriod
@@ -7260,13 +7260,13 @@ func (policy *SasPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SasPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpirationAction’:
+	// Set property "ExpirationAction":
 	if typedInput.ExpirationAction != nil {
 		expirationAction := *typedInput.ExpirationAction
 		policy.ExpirationAction = &expirationAction
 	}
 
-	// Set property ‘SasExpirationPeriod’:
+	// Set property "SasExpirationPeriod":
 	if typedInput.SasExpirationPeriod != nil {
 		sasExpirationPeriod := *typedInput.SasExpirationPeriod
 		policy.SasExpirationPeriod = &sasExpirationPeriod
@@ -7341,13 +7341,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -7367,13 +7367,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -7485,13 +7485,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -7781,25 +7781,25 @@ func (status *StorageAccountSkuConversionStatus_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccountSkuConversionStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndTime’:
+	// Set property "EndTime":
 	if typedInput.EndTime != nil {
 		endTime := *typedInput.EndTime
 		status.EndTime = &endTime
 	}
 
-	// Set property ‘SkuConversionStatus’:
+	// Set property "SkuConversionStatus":
 	if typedInput.SkuConversionStatus != nil {
 		skuConversionStatus := *typedInput.SkuConversionStatus
 		status.SkuConversionStatus = &skuConversionStatus
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		status.StartTime = &startTime
 	}
 
-	// Set property ‘TargetSkuName’:
+	// Set property "TargetSkuName":
 	if typedInput.TargetSkuName != nil {
 		targetSkuName := *typedInput.TargetSkuName
 		status.TargetSkuName = &targetSkuName
@@ -7906,19 +7906,19 @@ func (properties *AccountImmutabilityPolicyProperties) ConvertToARM(resolved gen
 	}
 	result := &AccountImmutabilityPolicyProperties_ARM{}
 
-	// Set property ‘AllowProtectedAppendWrites’:
+	// Set property "AllowProtectedAppendWrites":
 	if properties.AllowProtectedAppendWrites != nil {
 		allowProtectedAppendWrites := *properties.AllowProtectedAppendWrites
 		result.AllowProtectedAppendWrites = &allowProtectedAppendWrites
 	}
 
-	// Set property ‘ImmutabilityPeriodSinceCreationInDays’:
+	// Set property "ImmutabilityPeriodSinceCreationInDays":
 	if properties.ImmutabilityPeriodSinceCreationInDays != nil {
 		immutabilityPeriodSinceCreationInDays := *properties.ImmutabilityPeriodSinceCreationInDays
 		result.ImmutabilityPeriodSinceCreationInDays = &immutabilityPeriodSinceCreationInDays
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if properties.State != nil {
 		state := *properties.State
 		result.State = &state
@@ -7938,19 +7938,19 @@ func (properties *AccountImmutabilityPolicyProperties) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AccountImmutabilityPolicyProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowProtectedAppendWrites’:
+	// Set property "AllowProtectedAppendWrites":
 	if typedInput.AllowProtectedAppendWrites != nil {
 		allowProtectedAppendWrites := *typedInput.AllowProtectedAppendWrites
 		properties.AllowProtectedAppendWrites = &allowProtectedAppendWrites
 	}
 
-	// Set property ‘ImmutabilityPeriodSinceCreationInDays’:
+	// Set property "ImmutabilityPeriodSinceCreationInDays":
 	if typedInput.ImmutabilityPeriodSinceCreationInDays != nil {
 		immutabilityPeriodSinceCreationInDays := *typedInput.ImmutabilityPeriodSinceCreationInDays
 		properties.ImmutabilityPeriodSinceCreationInDays = &immutabilityPeriodSinceCreationInDays
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		properties.State = &state
@@ -8095,19 +8095,19 @@ func (properties *AccountImmutabilityPolicyProperties_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AccountImmutabilityPolicyProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowProtectedAppendWrites’:
+	// Set property "AllowProtectedAppendWrites":
 	if typedInput.AllowProtectedAppendWrites != nil {
 		allowProtectedAppendWrites := *typedInput.AllowProtectedAppendWrites
 		properties.AllowProtectedAppendWrites = &allowProtectedAppendWrites
 	}
 
-	// Set property ‘ImmutabilityPeriodSinceCreationInDays’:
+	// Set property "ImmutabilityPeriodSinceCreationInDays":
 	if typedInput.ImmutabilityPeriodSinceCreationInDays != nil {
 		immutabilityPeriodSinceCreationInDays := *typedInput.ImmutabilityPeriodSinceCreationInDays
 		properties.ImmutabilityPeriodSinceCreationInDays = &immutabilityPeriodSinceCreationInDays
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		properties.State = &state
@@ -8216,49 +8216,49 @@ func (properties *ActiveDirectoryProperties) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ActiveDirectoryProperties_ARM{}
 
-	// Set property ‘AccountType’:
+	// Set property "AccountType":
 	if properties.AccountType != nil {
 		accountType := *properties.AccountType
 		result.AccountType = &accountType
 	}
 
-	// Set property ‘AzureStorageSid’:
+	// Set property "AzureStorageSid":
 	if properties.AzureStorageSid != nil {
 		azureStorageSid := *properties.AzureStorageSid
 		result.AzureStorageSid = &azureStorageSid
 	}
 
-	// Set property ‘DomainGuid’:
+	// Set property "DomainGuid":
 	if properties.DomainGuid != nil {
 		domainGuid := *properties.DomainGuid
 		result.DomainGuid = &domainGuid
 	}
 
-	// Set property ‘DomainName’:
+	// Set property "DomainName":
 	if properties.DomainName != nil {
 		domainName := *properties.DomainName
 		result.DomainName = &domainName
 	}
 
-	// Set property ‘DomainSid’:
+	// Set property "DomainSid":
 	if properties.DomainSid != nil {
 		domainSid := *properties.DomainSid
 		result.DomainSid = &domainSid
 	}
 
-	// Set property ‘ForestName’:
+	// Set property "ForestName":
 	if properties.ForestName != nil {
 		forestName := *properties.ForestName
 		result.ForestName = &forestName
 	}
 
-	// Set property ‘NetBiosDomainName’:
+	// Set property "NetBiosDomainName":
 	if properties.NetBiosDomainName != nil {
 		netBiosDomainName := *properties.NetBiosDomainName
 		result.NetBiosDomainName = &netBiosDomainName
 	}
 
-	// Set property ‘SamAccountName’:
+	// Set property "SamAccountName":
 	if properties.SamAccountName != nil {
 		samAccountName := *properties.SamAccountName
 		result.SamAccountName = &samAccountName
@@ -8278,49 +8278,49 @@ func (properties *ActiveDirectoryProperties) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ActiveDirectoryProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountType’:
+	// Set property "AccountType":
 	if typedInput.AccountType != nil {
 		accountType := *typedInput.AccountType
 		properties.AccountType = &accountType
 	}
 
-	// Set property ‘AzureStorageSid’:
+	// Set property "AzureStorageSid":
 	if typedInput.AzureStorageSid != nil {
 		azureStorageSid := *typedInput.AzureStorageSid
 		properties.AzureStorageSid = &azureStorageSid
 	}
 
-	// Set property ‘DomainGuid’:
+	// Set property "DomainGuid":
 	if typedInput.DomainGuid != nil {
 		domainGuid := *typedInput.DomainGuid
 		properties.DomainGuid = &domainGuid
 	}
 
-	// Set property ‘DomainName’:
+	// Set property "DomainName":
 	if typedInput.DomainName != nil {
 		domainName := *typedInput.DomainName
 		properties.DomainName = &domainName
 	}
 
-	// Set property ‘DomainSid’:
+	// Set property "DomainSid":
 	if typedInput.DomainSid != nil {
 		domainSid := *typedInput.DomainSid
 		properties.DomainSid = &domainSid
 	}
 
-	// Set property ‘ForestName’:
+	// Set property "ForestName":
 	if typedInput.ForestName != nil {
 		forestName := *typedInput.ForestName
 		properties.ForestName = &forestName
 	}
 
-	// Set property ‘NetBiosDomainName’:
+	// Set property "NetBiosDomainName":
 	if typedInput.NetBiosDomainName != nil {
 		netBiosDomainName := *typedInput.NetBiosDomainName
 		properties.NetBiosDomainName = &netBiosDomainName
 	}
 
-	// Set property ‘SamAccountName’:
+	// Set property "SamAccountName":
 	if typedInput.SamAccountName != nil {
 		samAccountName := *typedInput.SamAccountName
 		properties.SamAccountName = &samAccountName
@@ -8488,49 +8488,49 @@ func (properties *ActiveDirectoryProperties_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ActiveDirectoryProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountType’:
+	// Set property "AccountType":
 	if typedInput.AccountType != nil {
 		accountType := *typedInput.AccountType
 		properties.AccountType = &accountType
 	}
 
-	// Set property ‘AzureStorageSid’:
+	// Set property "AzureStorageSid":
 	if typedInput.AzureStorageSid != nil {
 		azureStorageSid := *typedInput.AzureStorageSid
 		properties.AzureStorageSid = &azureStorageSid
 	}
 
-	// Set property ‘DomainGuid’:
+	// Set property "DomainGuid":
 	if typedInput.DomainGuid != nil {
 		domainGuid := *typedInput.DomainGuid
 		properties.DomainGuid = &domainGuid
 	}
 
-	// Set property ‘DomainName’:
+	// Set property "DomainName":
 	if typedInput.DomainName != nil {
 		domainName := *typedInput.DomainName
 		properties.DomainName = &domainName
 	}
 
-	// Set property ‘DomainSid’:
+	// Set property "DomainSid":
 	if typedInput.DomainSid != nil {
 		domainSid := *typedInput.DomainSid
 		properties.DomainSid = &domainSid
 	}
 
-	// Set property ‘ForestName’:
+	// Set property "ForestName":
 	if typedInput.ForestName != nil {
 		forestName := *typedInput.ForestName
 		properties.ForestName = &forestName
 	}
 
-	// Set property ‘NetBiosDomainName’:
+	// Set property "NetBiosDomainName":
 	if typedInput.NetBiosDomainName != nil {
 		netBiosDomainName := *typedInput.NetBiosDomainName
 		properties.NetBiosDomainName = &netBiosDomainName
 	}
 
-	// Set property ‘SamAccountName’:
+	// Set property "SamAccountName":
 	if typedInput.SamAccountName != nil {
 		samAccountName := *typedInput.SamAccountName
 		properties.SamAccountName = &samAccountName
@@ -8682,7 +8682,7 @@ func (parameters *BlobRestoreParameters_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BlobRestoreParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobRanges’:
+	// Set property "BlobRanges":
 	for _, item := range typedInput.BlobRanges {
 		var item1 BlobRestoreRange_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -8692,7 +8692,7 @@ func (parameters *BlobRestoreParameters_STATUS) PopulateFromARM(owner genruntime
 		parameters.BlobRanges = append(parameters.BlobRanges, item1)
 	}
 
-	// Set property ‘TimeToRestore’:
+	// Set property "TimeToRestore":
 	if typedInput.TimeToRestore != nil {
 		timeToRestore := *typedInput.TimeToRestore
 		parameters.TimeToRestore = &timeToRestore
@@ -8810,13 +8810,13 @@ func (identity *EncryptionIdentity) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &EncryptionIdentity_ARM{}
 
-	// Set property ‘FederatedIdentityClientId’:
+	// Set property "FederatedIdentityClientId":
 	if identity.FederatedIdentityClientId != nil {
 		federatedIdentityClientId := *identity.FederatedIdentityClientId
 		result.FederatedIdentityClientId = &federatedIdentityClientId
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if identity.UserAssignedIdentityReference != nil {
 		userAssignedIdentityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*identity.UserAssignedIdentityReference)
 		if err != nil {
@@ -8840,13 +8840,13 @@ func (identity *EncryptionIdentity) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FederatedIdentityClientId’:
+	// Set property "FederatedIdentityClientId":
 	if typedInput.FederatedIdentityClientId != nil {
 		federatedIdentityClientId := *typedInput.FederatedIdentityClientId
 		identity.FederatedIdentityClientId = &federatedIdentityClientId
 	}
 
-	// no assignment for property ‘UserAssignedIdentityReference’
+	// no assignment for property "UserAssignedIdentityReference"
 
 	// No error
 	return nil
@@ -8932,13 +8932,13 @@ func (identity *EncryptionIdentity_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FederatedIdentityClientId’:
+	// Set property "FederatedIdentityClientId":
 	if typedInput.FederatedIdentityClientId != nil {
 		federatedIdentityClientId := *typedInput.FederatedIdentityClientId
 		identity.FederatedIdentityClientId = &federatedIdentityClientId
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		identity.UserAssignedIdentity = &userAssignedIdentity
@@ -9007,7 +9007,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &EncryptionServices_ARM{}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if services.Blob != nil {
 		blob_ARM, err := (*services.Blob).ConvertToARM(resolved)
 		if err != nil {
@@ -9017,7 +9017,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Blob = &blob
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if services.File != nil {
 		file_ARM, err := (*services.File).ConvertToARM(resolved)
 		if err != nil {
@@ -9027,7 +9027,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		result.File = &file
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if services.Queue != nil {
 		queue_ARM, err := (*services.Queue).ConvertToARM(resolved)
 		if err != nil {
@@ -9037,7 +9037,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if services.Table != nil {
 		table_ARM, err := (*services.Table).ConvertToARM(resolved)
 		if err != nil {
@@ -9061,7 +9061,7 @@ func (services *EncryptionServices) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionServices_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		var blob1 EncryptionService
 		err := blob1.PopulateFromARM(owner, *typedInput.Blob)
@@ -9072,7 +9072,7 @@ func (services *EncryptionServices) PopulateFromARM(owner genruntime.ArbitraryOw
 		services.Blob = &blob
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		var file1 EncryptionService
 		err := file1.PopulateFromARM(owner, *typedInput.File)
@@ -9083,7 +9083,7 @@ func (services *EncryptionServices) PopulateFromARM(owner genruntime.ArbitraryOw
 		services.File = &file
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if typedInput.Queue != nil {
 		var queue1 EncryptionService
 		err := queue1.PopulateFromARM(owner, *typedInput.Queue)
@@ -9094,7 +9094,7 @@ func (services *EncryptionServices) PopulateFromARM(owner genruntime.ArbitraryOw
 		services.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if typedInput.Table != nil {
 		var table1 EncryptionService
 		err := table1.PopulateFromARM(owner, *typedInput.Table)
@@ -9312,7 +9312,7 @@ func (services *EncryptionServices_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionServices_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		var blob1 EncryptionService_STATUS
 		err := blob1.PopulateFromARM(owner, *typedInput.Blob)
@@ -9323,7 +9323,7 @@ func (services *EncryptionServices_STATUS) PopulateFromARM(owner genruntime.Arbi
 		services.Blob = &blob
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		var file1 EncryptionService_STATUS
 		err := file1.PopulateFromARM(owner, *typedInput.File)
@@ -9334,7 +9334,7 @@ func (services *EncryptionServices_STATUS) PopulateFromARM(owner genruntime.Arbi
 		services.File = &file
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if typedInput.Queue != nil {
 		var queue1 EncryptionService_STATUS
 		err := queue1.PopulateFromARM(owner, *typedInput.Queue)
@@ -9345,7 +9345,7 @@ func (services *EncryptionServices_STATUS) PopulateFromARM(owner genruntime.Arbi
 		services.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if typedInput.Table != nil {
 		var table1 EncryptionService_STATUS
 		err := table1.PopulateFromARM(owner, *typedInput.Table)
@@ -9506,13 +9506,13 @@ func (rule *IPRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &IPRule_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if rule.Action != nil {
 		action := *rule.Action
 		result.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if rule.Value != nil {
 		value := *rule.Value
 		result.Value = &value
@@ -9532,13 +9532,13 @@ func (rule *IPRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -9634,13 +9634,13 @@ func (rule *IPRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -9716,19 +9716,19 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘Keyname’:
+	// Set property "Keyname":
 	if properties.Keyname != nil {
 		keyname := *properties.Keyname
 		result.Keyname = &keyname
 	}
 
-	// Set property ‘Keyvaulturi’:
+	// Set property "Keyvaulturi":
 	if properties.Keyvaulturi != nil {
 		keyvaulturi := *properties.Keyvaulturi
 		result.Keyvaulturi = &keyvaulturi
 	}
 
-	// Set property ‘Keyversion’:
+	// Set property "Keyversion":
 	if properties.Keyversion != nil {
 		keyversion := *properties.Keyversion
 		result.Keyversion = &keyversion
@@ -9748,19 +9748,19 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Keyname’:
+	// Set property "Keyname":
 	if typedInput.Keyname != nil {
 		keyname := *typedInput.Keyname
 		properties.Keyname = &keyname
 	}
 
-	// Set property ‘Keyvaulturi’:
+	// Set property "Keyvaulturi":
 	if typedInput.Keyvaulturi != nil {
 		keyvaulturi := *typedInput.Keyvaulturi
 		properties.Keyvaulturi = &keyvaulturi
 	}
 
-	// Set property ‘Keyversion’:
+	// Set property "Keyversion":
 	if typedInput.Keyversion != nil {
 		keyversion := *typedInput.Keyversion
 		properties.Keyversion = &keyversion
@@ -9863,37 +9863,37 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CurrentVersionedKeyExpirationTimestamp’:
+	// Set property "CurrentVersionedKeyExpirationTimestamp":
 	if typedInput.CurrentVersionedKeyExpirationTimestamp != nil {
 		currentVersionedKeyExpirationTimestamp := *typedInput.CurrentVersionedKeyExpirationTimestamp
 		properties.CurrentVersionedKeyExpirationTimestamp = &currentVersionedKeyExpirationTimestamp
 	}
 
-	// Set property ‘CurrentVersionedKeyIdentifier’:
+	// Set property "CurrentVersionedKeyIdentifier":
 	if typedInput.CurrentVersionedKeyIdentifier != nil {
 		currentVersionedKeyIdentifier := *typedInput.CurrentVersionedKeyIdentifier
 		properties.CurrentVersionedKeyIdentifier = &currentVersionedKeyIdentifier
 	}
 
-	// Set property ‘Keyname’:
+	// Set property "Keyname":
 	if typedInput.Keyname != nil {
 		keyname := *typedInput.Keyname
 		properties.Keyname = &keyname
 	}
 
-	// Set property ‘Keyvaulturi’:
+	// Set property "Keyvaulturi":
 	if typedInput.Keyvaulturi != nil {
 		keyvaulturi := *typedInput.Keyvaulturi
 		properties.Keyvaulturi = &keyvaulturi
 	}
 
-	// Set property ‘Keyversion’:
+	// Set property "Keyversion":
 	if typedInput.Keyversion != nil {
 		keyversion := *typedInput.Keyversion
 		properties.Keyversion = &keyversion
 	}
 
-	// Set property ‘LastKeyRotationTimestamp’:
+	// Set property "LastKeyRotationTimestamp":
 	if typedInput.LastKeyRotationTimestamp != nil {
 		lastKeyRotationTimestamp := *typedInput.LastKeyRotationTimestamp
 		properties.LastKeyRotationTimestamp = &lastKeyRotationTimestamp
@@ -10014,7 +10014,7 @@ func (rule *ResourceAccessRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &ResourceAccessRule_ARM{}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if rule.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.ResourceReference)
 		if err != nil {
@@ -10024,7 +10024,7 @@ func (rule *ResourceAccessRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.ResourceId = &resourceReference
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if rule.TenantId != nil {
 		tenantId := *rule.TenantId
 		result.TenantId = &tenantId
@@ -10044,9 +10044,9 @@ func (rule *ResourceAccessRule) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceAccessRule_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		rule.TenantId = &tenantId
@@ -10142,13 +10142,13 @@ func (rule *ResourceAccessRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceAccessRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		rule.ResourceId = &resourceId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		rule.TenantId = &tenantId
@@ -10246,25 +10246,25 @@ func (endpoints *StorageAccountInternetEndpoints_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccountInternetEndpoints_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		blob := *typedInput.Blob
 		endpoints.Blob = &blob
 	}
 
-	// Set property ‘Dfs’:
+	// Set property "Dfs":
 	if typedInput.Dfs != nil {
 		dfs := *typedInput.Dfs
 		endpoints.Dfs = &dfs
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		file := *typedInput.File
 		endpoints.File = &file
 	}
 
-	// Set property ‘Web’:
+	// Set property "Web":
 	if typedInput.Web != nil {
 		web := *typedInput.Web
 		endpoints.Web = &web
@@ -10357,37 +10357,37 @@ func (endpoints *StorageAccountMicrosoftEndpoints_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccountMicrosoftEndpoints_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		blob := *typedInput.Blob
 		endpoints.Blob = &blob
 	}
 
-	// Set property ‘Dfs’:
+	// Set property "Dfs":
 	if typedInput.Dfs != nil {
 		dfs := *typedInput.Dfs
 		endpoints.Dfs = &dfs
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		file := *typedInput.File
 		endpoints.File = &file
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if typedInput.Queue != nil {
 		queue := *typedInput.Queue
 		endpoints.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if typedInput.Table != nil {
 		table := *typedInput.Table
 		endpoints.Table = &table
 	}
 
-	// Set property ‘Web’:
+	// Set property "Web":
 	if typedInput.Web != nil {
 		web := *typedInput.Web
 		endpoints.Web = &web
@@ -10809,13 +10809,13 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
@@ -10917,13 +10917,13 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &VirtualNetworkRule_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if rule.Action != nil {
 		action := *rule.Action
 		result.Action = &action
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if rule.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.Reference)
 		if err != nil {
@@ -10933,7 +10933,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.Id = &reference
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if rule.State != nil {
 		state := *rule.State
 		result.State = &state
@@ -10953,15 +10953,15 @@ func (rule *VirtualNetworkRule) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		rule.State = &state
@@ -11100,19 +11100,19 @@ func (rule *VirtualNetworkRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		rule.State = &state
@@ -11238,13 +11238,13 @@ func (restoreRange *BlobRestoreRange_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BlobRestoreRange_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndRange’:
+	// Set property "EndRange":
 	if typedInput.EndRange != nil {
 		endRange := *typedInput.EndRange
 		restoreRange.EndRange = &endRange
 	}
 
-	// Set property ‘StartRange’:
+	// Set property "StartRange":
 	if typedInput.StartRange != nil {
 		startRange := *typedInput.StartRange
 		restoreRange.StartRange = &startRange
@@ -11309,13 +11309,13 @@ func (service *EncryptionService) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &EncryptionService_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if service.Enabled != nil {
 		enabled := *service.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘KeyType’:
+	// Set property "KeyType":
 	if service.KeyType != nil {
 		keyType := *service.KeyType
 		result.KeyType = &keyType
@@ -11335,13 +11335,13 @@ func (service *EncryptionService) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionService_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		service.Enabled = &enabled
 	}
 
-	// Set property ‘KeyType’:
+	// Set property "KeyType":
 	if typedInput.KeyType != nil {
 		keyType := *typedInput.KeyType
 		service.KeyType = &keyType
@@ -11458,19 +11458,19 @@ func (service *EncryptionService_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionService_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		service.Enabled = &enabled
 	}
 
-	// Set property ‘KeyType’:
+	// Set property "KeyType":
 	if typedInput.KeyType != nil {
 		keyType := *typedInput.KeyType
 		service.KeyType = &keyType
 	}
 
-	// Set property ‘LastEnabledTime’:
+	// Set property "LastEnabledTime":
 	if typedInput.LastEnabledTime != nil {
 		lastEnabledTime := *typedInput.LastEnabledTime
 		service.LastEnabledTime = &lastEnabledTime

--- a/v2/api/storage/v1api20220901/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_blob_service_types_gen.go
@@ -350,10 +350,10 @@ func (service *StorageAccounts_BlobService_Spec) ConvertToARM(resolved genruntim
 	}
 	result := &StorageAccounts_BlobService_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if service.AutomaticSnapshotPolicyEnabled != nil ||
 		service.ChangeFeed != nil ||
 		service.ContainerDeleteRetentionPolicy != nil ||
@@ -440,7 +440,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_BlobService_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticSnapshotPolicyEnabled’:
+	// Set property "AutomaticSnapshotPolicyEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticSnapshotPolicyEnabled != nil {
@@ -449,7 +449,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ChangeFeed’:
+	// Set property "ChangeFeed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ChangeFeed != nil {
@@ -463,7 +463,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ContainerDeleteRetentionPolicy’:
+	// Set property "ContainerDeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ContainerDeleteRetentionPolicy != nil {
@@ -477,7 +477,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -491,7 +491,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘DefaultServiceVersion’:
+	// Set property "DefaultServiceVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultServiceVersion != nil {
@@ -500,7 +500,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘DeleteRetentionPolicy’:
+	// Set property "DeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteRetentionPolicy != nil {
@@ -514,7 +514,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘IsVersioningEnabled’:
+	// Set property "IsVersioningEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsVersioningEnabled != nil {
@@ -523,7 +523,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘LastAccessTimeTrackingPolicy’:
+	// Set property "LastAccessTimeTrackingPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastAccessTimeTrackingPolicy != nil {
@@ -537,10 +537,10 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RestorePolicy’:
+	// Set property "RestorePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestorePolicy != nil {
@@ -1047,7 +1047,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_BlobService_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticSnapshotPolicyEnabled’:
+	// Set property "AutomaticSnapshotPolicyEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticSnapshotPolicyEnabled != nil {
@@ -1056,7 +1056,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘ChangeFeed’:
+	// Set property "ChangeFeed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ChangeFeed != nil {
@@ -1070,9 +1070,9 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ContainerDeleteRetentionPolicy’:
+	// Set property "ContainerDeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ContainerDeleteRetentionPolicy != nil {
@@ -1086,7 +1086,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -1100,7 +1100,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘DefaultServiceVersion’:
+	// Set property "DefaultServiceVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultServiceVersion != nil {
@@ -1109,7 +1109,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘DeleteRetentionPolicy’:
+	// Set property "DeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteRetentionPolicy != nil {
@@ -1123,13 +1123,13 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		service.Id = &id
 	}
 
-	// Set property ‘IsVersioningEnabled’:
+	// Set property "IsVersioningEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsVersioningEnabled != nil {
@@ -1138,7 +1138,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘LastAccessTimeTrackingPolicy’:
+	// Set property "LastAccessTimeTrackingPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastAccessTimeTrackingPolicy != nil {
@@ -1152,13 +1152,13 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		service.Name = &name
 	}
 
-	// Set property ‘RestorePolicy’:
+	// Set property "RestorePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestorePolicy != nil {
@@ -1172,7 +1172,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1183,7 +1183,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		service.Sku = &sku
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		service.Type = &typeVar
@@ -1467,13 +1467,13 @@ func (feed *ChangeFeed) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &ChangeFeed_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if feed.Enabled != nil {
 		enabled := *feed.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	if feed.RetentionInDays != nil {
 		retentionInDays := *feed.RetentionInDays
 		result.RetentionInDays = &retentionInDays
@@ -1493,13 +1493,13 @@ func (feed *ChangeFeed) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ChangeFeed_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		feed.Enabled = &enabled
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	if typedInput.RetentionInDays != nil {
 		retentionInDays := *typedInput.RetentionInDays
 		feed.RetentionInDays = &retentionInDays
@@ -1611,13 +1611,13 @@ func (feed *ChangeFeed_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ChangeFeed_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		feed.Enabled = &enabled
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	if typedInput.RetentionInDays != nil {
 		retentionInDays := *typedInput.RetentionInDays
 		feed.RetentionInDays = &retentionInDays
@@ -1687,7 +1687,7 @@ func (rules *CorsRules) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &CorsRules_ARM{}
 
-	// Set property ‘CorsRules’:
+	// Set property "CorsRules":
 	for _, item := range rules.CorsRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1710,7 +1710,7 @@ func (rules *CorsRules) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsRules_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CorsRules’:
+	// Set property "CorsRules":
 	for _, item := range typedInput.CorsRules {
 		var item1 CorsRule
 		err := item1.PopulateFromARM(owner, item)
@@ -1828,7 +1828,7 @@ func (rules *CorsRules_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsRules_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CorsRules’:
+	// Set property "CorsRules":
 	for _, item := range typedInput.CorsRules {
 		var item1 CorsRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1927,19 +1927,19 @@ func (policy *DeleteRetentionPolicy) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &DeleteRetentionPolicy_ARM{}
 
-	// Set property ‘AllowPermanentDelete’:
+	// Set property "AllowPermanentDelete":
 	if policy.AllowPermanentDelete != nil {
 		allowPermanentDelete := *policy.AllowPermanentDelete
 		result.AllowPermanentDelete = &allowPermanentDelete
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if policy.Days != nil {
 		days := *policy.Days
 		result.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if policy.Enabled != nil {
 		enabled := *policy.Enabled
 		result.Enabled = &enabled
@@ -1959,19 +1959,19 @@ func (policy *DeleteRetentionPolicy) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeleteRetentionPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowPermanentDelete’:
+	// Set property "AllowPermanentDelete":
 	if typedInput.AllowPermanentDelete != nil {
 		allowPermanentDelete := *typedInput.AllowPermanentDelete
 		policy.AllowPermanentDelete = &allowPermanentDelete
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		policy.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
@@ -2112,19 +2112,19 @@ func (policy *DeleteRetentionPolicy_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeleteRetentionPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowPermanentDelete’:
+	// Set property "AllowPermanentDelete":
 	if typedInput.AllowPermanentDelete != nil {
 		allowPermanentDelete := *typedInput.AllowPermanentDelete
 		policy.AllowPermanentDelete = &allowPermanentDelete
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		policy.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
@@ -2222,24 +2222,24 @@ func (policy *LastAccessTimeTrackingPolicy) ConvertToARM(resolved genruntime.Con
 	}
 	result := &LastAccessTimeTrackingPolicy_ARM{}
 
-	// Set property ‘BlobType’:
+	// Set property "BlobType":
 	for _, item := range policy.BlobType {
 		result.BlobType = append(result.BlobType, item)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if policy.Enable != nil {
 		enable := *policy.Enable
 		result.Enable = &enable
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if policy.Name != nil {
 		name := *policy.Name
 		result.Name = &name
 	}
 
-	// Set property ‘TrackingGranularityInDays’:
+	// Set property "TrackingGranularityInDays":
 	if policy.TrackingGranularityInDays != nil {
 		trackingGranularityInDays := *policy.TrackingGranularityInDays
 		result.TrackingGranularityInDays = &trackingGranularityInDays
@@ -2259,24 +2259,24 @@ func (policy *LastAccessTimeTrackingPolicy) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LastAccessTimeTrackingPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobType’:
+	// Set property "BlobType":
 	for _, item := range typedInput.BlobType {
 		policy.BlobType = append(policy.BlobType, item)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		policy.Enable = &enable
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘TrackingGranularityInDays’:
+	// Set property "TrackingGranularityInDays":
 	if typedInput.TrackingGranularityInDays != nil {
 		trackingGranularityInDays := *typedInput.TrackingGranularityInDays
 		policy.TrackingGranularityInDays = &trackingGranularityInDays
@@ -2413,24 +2413,24 @@ func (policy *LastAccessTimeTrackingPolicy_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LastAccessTimeTrackingPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobType’:
+	// Set property "BlobType":
 	for _, item := range typedInput.BlobType {
 		policy.BlobType = append(policy.BlobType, item)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		policy.Enable = &enable
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘TrackingGranularityInDays’:
+	// Set property "TrackingGranularityInDays":
 	if typedInput.TrackingGranularityInDays != nil {
 		trackingGranularityInDays := *typedInput.TrackingGranularityInDays
 		policy.TrackingGranularityInDays = &trackingGranularityInDays
@@ -2528,13 +2528,13 @@ func (properties *RestorePolicyProperties) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &RestorePolicyProperties_ARM{}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if properties.Days != nil {
 		days := *properties.Days
 		result.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if properties.Enabled != nil {
 		enabled := *properties.Enabled
 		result.Enabled = &enabled
@@ -2554,13 +2554,13 @@ func (properties *RestorePolicyProperties) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RestorePolicyProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		properties.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
@@ -2677,25 +2677,25 @@ func (properties *RestorePolicyProperties_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RestorePolicyProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		properties.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
 	}
 
-	// Set property ‘LastEnabledTime’:
+	// Set property "LastEnabledTime":
 	if typedInput.LastEnabledTime != nil {
 		lastEnabledTime := *typedInput.LastEnabledTime
 		properties.LastEnabledTime = &lastEnabledTime
 	}
 
-	// Set property ‘MinRestoreTime’:
+	// Set property "MinRestoreTime":
 	if typedInput.MinRestoreTime != nil {
 		minRestoreTime := *typedInput.MinRestoreTime
 		properties.MinRestoreTime = &minRestoreTime
@@ -2798,27 +2798,27 @@ func (rule *CorsRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &CorsRule_ARM{}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	for _, item := range rule.AllowedHeaders {
 		result.AllowedHeaders = append(result.AllowedHeaders, item)
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	for _, item := range rule.AllowedMethods {
 		result.AllowedMethods = append(result.AllowedMethods, item)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range rule.AllowedOrigins {
 		result.AllowedOrigins = append(result.AllowedOrigins, item)
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	for _, item := range rule.ExposedHeaders {
 		result.ExposedHeaders = append(result.ExposedHeaders, item)
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if rule.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *rule.MaxAgeInSeconds
 		result.MaxAgeInSeconds = &maxAgeInSeconds
@@ -2838,27 +2838,27 @@ func (rule *CorsRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	for _, item := range typedInput.AllowedHeaders {
 		rule.AllowedHeaders = append(rule.AllowedHeaders, item)
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	for _, item := range typedInput.AllowedMethods {
 		rule.AllowedMethods = append(rule.AllowedMethods, item)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		rule.AllowedOrigins = append(rule.AllowedOrigins, item)
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	for _, item := range typedInput.ExposedHeaders {
 		rule.ExposedHeaders = append(rule.ExposedHeaders, item)
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if typedInput.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *typedInput.MaxAgeInSeconds
 		rule.MaxAgeInSeconds = &maxAgeInSeconds
@@ -3010,27 +3010,27 @@ func (rule *CorsRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	for _, item := range typedInput.AllowedHeaders {
 		rule.AllowedHeaders = append(rule.AllowedHeaders, item)
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	for _, item := range typedInput.AllowedMethods {
 		rule.AllowedMethods = append(rule.AllowedMethods, item)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		rule.AllowedOrigins = append(rule.AllowedOrigins, item)
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	for _, item := range typedInput.ExposedHeaders {
 		rule.ExposedHeaders = append(rule.ExposedHeaders, item)
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if typedInput.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *typedInput.MaxAgeInSeconds
 		rule.MaxAgeInSeconds = &maxAgeInSeconds

--- a/v2/api/storage/v1api20220901/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_blob_services_container_types_gen.go
@@ -355,10 +355,10 @@ func (container *StorageAccounts_BlobServices_Container_Spec) ConvertToARM(resol
 	}
 	result := &StorageAccounts_BlobServices_Container_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if container.DefaultEncryptionScope != nil ||
 		container.DenyEncryptionScopeOverride != nil ||
 		container.EnableNfsV3AllSquash != nil ||
@@ -417,10 +417,10 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_BlobServices_Container_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	container.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DefaultEncryptionScope’:
+	// Set property "DefaultEncryptionScope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultEncryptionScope != nil {
@@ -429,7 +429,7 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘DenyEncryptionScopeOverride’:
+	// Set property "DenyEncryptionScopeOverride":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DenyEncryptionScopeOverride != nil {
@@ -438,7 +438,7 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘EnableNfsV3AllSquash’:
+	// Set property "EnableNfsV3AllSquash":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNfsV3AllSquash != nil {
@@ -447,7 +447,7 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘EnableNfsV3RootSquash’:
+	// Set property "EnableNfsV3RootSquash":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNfsV3RootSquash != nil {
@@ -456,7 +456,7 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘ImmutableStorageWithVersioning’:
+	// Set property "ImmutableStorageWithVersioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutableStorageWithVersioning != nil {
@@ -470,7 +470,7 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -481,10 +481,10 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	container.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicAccess’:
+	// Set property "PublicAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicAccess != nil {
@@ -907,9 +907,9 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_BlobServices_Container_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DefaultEncryptionScope’:
+	// Set property "DefaultEncryptionScope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultEncryptionScope != nil {
@@ -918,7 +918,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Deleted’:
+	// Set property "Deleted":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Deleted != nil {
@@ -927,7 +927,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘DeletedTime’:
+	// Set property "DeletedTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeletedTime != nil {
@@ -936,7 +936,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘DenyEncryptionScopeOverride’:
+	// Set property "DenyEncryptionScopeOverride":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DenyEncryptionScopeOverride != nil {
@@ -945,7 +945,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘EnableNfsV3AllSquash’:
+	// Set property "EnableNfsV3AllSquash":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNfsV3AllSquash != nil {
@@ -954,7 +954,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘EnableNfsV3RootSquash’:
+	// Set property "EnableNfsV3RootSquash":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnableNfsV3RootSquash != nil {
@@ -963,13 +963,13 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		container.Etag = &etag
 	}
 
-	// Set property ‘HasImmutabilityPolicy’:
+	// Set property "HasImmutabilityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HasImmutabilityPolicy != nil {
@@ -978,7 +978,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘HasLegalHold’:
+	// Set property "HasLegalHold":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HasLegalHold != nil {
@@ -987,13 +987,13 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		container.Id = &id
 	}
 
-	// Set property ‘ImmutabilityPolicy’:
+	// Set property "ImmutabilityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutabilityPolicy != nil {
@@ -1007,7 +1007,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘ImmutableStorageWithVersioning’:
+	// Set property "ImmutableStorageWithVersioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutableStorageWithVersioning != nil {
@@ -1021,7 +1021,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastModifiedTime != nil {
@@ -1030,7 +1030,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LeaseDuration’:
+	// Set property "LeaseDuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LeaseDuration != nil {
@@ -1039,7 +1039,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LeaseState’:
+	// Set property "LeaseState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LeaseState != nil {
@@ -1048,7 +1048,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LeaseStatus’:
+	// Set property "LeaseStatus":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LeaseStatus != nil {
@@ -1057,7 +1057,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LegalHold’:
+	// Set property "LegalHold":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LegalHold != nil {
@@ -1071,7 +1071,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1082,13 +1082,13 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		container.Name = &name
 	}
 
-	// Set property ‘PublicAccess’:
+	// Set property "PublicAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicAccess != nil {
@@ -1097,7 +1097,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘RemainingRetentionDays’:
+	// Set property "RemainingRetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemainingRetentionDays != nil {
@@ -1106,13 +1106,13 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		container.Type = &typeVar
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1530,7 +1530,7 @@ func (properties *ImmutabilityPolicyProperties_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmutabilityPolicyProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowProtectedAppendWrites’:
+	// Set property "AllowProtectedAppendWrites":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowProtectedAppendWrites != nil {
@@ -1539,7 +1539,7 @@ func (properties *ImmutabilityPolicyProperties_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘AllowProtectedAppendWritesAll’:
+	// Set property "AllowProtectedAppendWritesAll":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowProtectedAppendWritesAll != nil {
@@ -1548,13 +1548,13 @@ func (properties *ImmutabilityPolicyProperties_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		properties.Etag = &etag
 	}
 
-	// Set property ‘ImmutabilityPeriodSinceCreationInDays’:
+	// Set property "ImmutabilityPeriodSinceCreationInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutabilityPeriodSinceCreationInDays != nil {
@@ -1563,7 +1563,7 @@ func (properties *ImmutabilityPolicyProperties_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1572,7 +1572,7 @@ func (properties *ImmutabilityPolicyProperties_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘UpdateHistory’:
+	// Set property "UpdateHistory":
 	for _, item := range typedInput.UpdateHistory {
 		var item1 UpdateHistoryProperty_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1720,7 +1720,7 @@ func (versioning *ImmutableStorageWithVersioning) ConvertToARM(resolved genrunti
 	}
 	result := &ImmutableStorageWithVersioning_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if versioning.Enabled != nil {
 		enabled := *versioning.Enabled
 		result.Enabled = &enabled
@@ -1740,7 +1740,7 @@ func (versioning *ImmutableStorageWithVersioning) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmutableStorageWithVersioning_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		versioning.Enabled = &enabled
@@ -1830,19 +1830,19 @@ func (versioning *ImmutableStorageWithVersioning_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmutableStorageWithVersioning_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		versioning.Enabled = &enabled
 	}
 
-	// Set property ‘MigrationState’:
+	// Set property "MigrationState":
 	if typedInput.MigrationState != nil {
 		migrationState := *typedInput.MigrationState
 		versioning.MigrationState = &migrationState
 	}
 
-	// Set property ‘TimeStamp’:
+	// Set property "TimeStamp":
 	if typedInput.TimeStamp != nil {
 		timeStamp := *typedInput.TimeStamp
 		versioning.TimeStamp = &timeStamp
@@ -1941,13 +1941,13 @@ func (properties *LegalHoldProperties_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LegalHoldProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HasLegalHold’:
+	// Set property "HasLegalHold":
 	if typedInput.HasLegalHold != nil {
 		hasLegalHold := *typedInput.HasLegalHold
 		properties.HasLegalHold = &hasLegalHold
 	}
 
-	// Set property ‘ProtectedAppendWritesHistory’:
+	// Set property "ProtectedAppendWritesHistory":
 	if typedInput.ProtectedAppendWritesHistory != nil {
 		var protectedAppendWritesHistory1 ProtectedAppendWritesHistory_STATUS
 		err := protectedAppendWritesHistory1.PopulateFromARM(owner, *typedInput.ProtectedAppendWritesHistory)
@@ -1958,7 +1958,7 @@ func (properties *LegalHoldProperties_STATUS) PopulateFromARM(owner genruntime.A
 		properties.ProtectedAppendWritesHistory = &protectedAppendWritesHistory
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	for _, item := range typedInput.Tags {
 		var item1 TagProperty_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2109,13 +2109,13 @@ func (history *ProtectedAppendWritesHistory_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ProtectedAppendWritesHistory_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowProtectedAppendWritesAll’:
+	// Set property "AllowProtectedAppendWritesAll":
 	if typedInput.AllowProtectedAppendWritesAll != nil {
 		allowProtectedAppendWritesAll := *typedInput.AllowProtectedAppendWritesAll
 		history.AllowProtectedAppendWritesAll = &allowProtectedAppendWritesAll
 	}
 
-	// Set property ‘Timestamp’:
+	// Set property "Timestamp":
 	if typedInput.Timestamp != nil {
 		timestamp := *typedInput.Timestamp
 		history.Timestamp = &timestamp
@@ -2202,31 +2202,31 @@ func (property *TagProperty_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TagProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectIdentifier’:
+	// Set property "ObjectIdentifier":
 	if typedInput.ObjectIdentifier != nil {
 		objectIdentifier := *typedInput.ObjectIdentifier
 		property.ObjectIdentifier = &objectIdentifier
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		property.Tag = &tag
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		property.TenantId = &tenantId
 	}
 
-	// Set property ‘Timestamp’:
+	// Set property "Timestamp":
 	if typedInput.Timestamp != nil {
 		timestamp := *typedInput.Timestamp
 		property.Timestamp = &timestamp
 	}
 
-	// Set property ‘Upn’:
+	// Set property "Upn":
 	if typedInput.Upn != nil {
 		upn := *typedInput.Upn
 		property.Upn = &upn
@@ -2338,49 +2338,49 @@ func (property *UpdateHistoryProperty_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpdateHistoryProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowProtectedAppendWrites’:
+	// Set property "AllowProtectedAppendWrites":
 	if typedInput.AllowProtectedAppendWrites != nil {
 		allowProtectedAppendWrites := *typedInput.AllowProtectedAppendWrites
 		property.AllowProtectedAppendWrites = &allowProtectedAppendWrites
 	}
 
-	// Set property ‘AllowProtectedAppendWritesAll’:
+	// Set property "AllowProtectedAppendWritesAll":
 	if typedInput.AllowProtectedAppendWritesAll != nil {
 		allowProtectedAppendWritesAll := *typedInput.AllowProtectedAppendWritesAll
 		property.AllowProtectedAppendWritesAll = &allowProtectedAppendWritesAll
 	}
 
-	// Set property ‘ImmutabilityPeriodSinceCreationInDays’:
+	// Set property "ImmutabilityPeriodSinceCreationInDays":
 	if typedInput.ImmutabilityPeriodSinceCreationInDays != nil {
 		immutabilityPeriodSinceCreationInDays := *typedInput.ImmutabilityPeriodSinceCreationInDays
 		property.ImmutabilityPeriodSinceCreationInDays = &immutabilityPeriodSinceCreationInDays
 	}
 
-	// Set property ‘ObjectIdentifier’:
+	// Set property "ObjectIdentifier":
 	if typedInput.ObjectIdentifier != nil {
 		objectIdentifier := *typedInput.ObjectIdentifier
 		property.ObjectIdentifier = &objectIdentifier
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		property.TenantId = &tenantId
 	}
 
-	// Set property ‘Timestamp’:
+	// Set property "Timestamp":
 	if typedInput.Timestamp != nil {
 		timestamp := *typedInput.Timestamp
 		property.Timestamp = &timestamp
 	}
 
-	// Set property ‘Update’:
+	// Set property "Update":
 	if typedInput.Update != nil {
 		update := *typedInput.Update
 		property.Update = &update
 	}
 
-	// Set property ‘Upn’:
+	// Set property "Upn":
 	if typedInput.Upn != nil {
 		upn := *typedInput.Upn
 		property.Upn = &upn

--- a/v2/api/storage/v1api20220901/storage_accounts_file_service_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_file_service_types_gen.go
@@ -331,10 +331,10 @@ func (service *StorageAccounts_FileService_Spec) ConvertToARM(resolved genruntim
 	}
 	result := &StorageAccounts_FileService_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if service.Cors != nil ||
 		service.ProtocolSettings != nil ||
 		service.ShareDeleteRetentionPolicy != nil {
@@ -379,7 +379,7 @@ func (service *StorageAccounts_FileService_Spec) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_FileService_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -393,10 +393,10 @@ func (service *StorageAccounts_FileService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ProtocolSettings’:
+	// Set property "ProtocolSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtocolSettings != nil {
@@ -410,7 +410,7 @@ func (service *StorageAccounts_FileService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ShareDeleteRetentionPolicy’:
+	// Set property "ShareDeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ShareDeleteRetentionPolicy != nil {
@@ -733,9 +733,9 @@ func (service *StorageAccounts_FileService_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_FileService_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -749,19 +749,19 @@ func (service *StorageAccounts_FileService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		service.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		service.Name = &name
 	}
 
-	// Set property ‘ProtocolSettings’:
+	// Set property "ProtocolSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProtocolSettings != nil {
@@ -775,7 +775,7 @@ func (service *StorageAccounts_FileService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘ShareDeleteRetentionPolicy’:
+	// Set property "ShareDeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ShareDeleteRetentionPolicy != nil {
@@ -789,7 +789,7 @@ func (service *StorageAccounts_FileService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -800,7 +800,7 @@ func (service *StorageAccounts_FileService_STATUS) PopulateFromARM(owner genrunt
 		service.Sku = &sku
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		service.Type = &typeVar
@@ -968,7 +968,7 @@ func (settings *ProtocolSettings) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ProtocolSettings_ARM{}
 
-	// Set property ‘Smb’:
+	// Set property "Smb":
 	if settings.Smb != nil {
 		smb_ARM, err := (*settings.Smb).ConvertToARM(resolved)
 		if err != nil {
@@ -992,7 +992,7 @@ func (settings *ProtocolSettings) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ProtocolSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Smb’:
+	// Set property "Smb":
 	if typedInput.Smb != nil {
 		var smb1 SmbSetting
 		err := smb1.PopulateFromARM(owner, *typedInput.Smb)
@@ -1093,7 +1093,7 @@ func (settings *ProtocolSettings_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ProtocolSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Smb’:
+	// Set property "Smb":
 	if typedInput.Smb != nil {
 		var smb1 SmbSetting_STATUS
 		err := smb1.PopulateFromARM(owner, *typedInput.Smb)
@@ -1186,25 +1186,25 @@ func (setting *SmbSetting) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &SmbSetting_ARM{}
 
-	// Set property ‘AuthenticationMethods’:
+	// Set property "AuthenticationMethods":
 	if setting.AuthenticationMethods != nil {
 		authenticationMethods := *setting.AuthenticationMethods
 		result.AuthenticationMethods = &authenticationMethods
 	}
 
-	// Set property ‘ChannelEncryption’:
+	// Set property "ChannelEncryption":
 	if setting.ChannelEncryption != nil {
 		channelEncryption := *setting.ChannelEncryption
 		result.ChannelEncryption = &channelEncryption
 	}
 
-	// Set property ‘KerberosTicketEncryption’:
+	// Set property "KerberosTicketEncryption":
 	if setting.KerberosTicketEncryption != nil {
 		kerberosTicketEncryption := *setting.KerberosTicketEncryption
 		result.KerberosTicketEncryption = &kerberosTicketEncryption
 	}
 
-	// Set property ‘Multichannel’:
+	// Set property "Multichannel":
 	if setting.Multichannel != nil {
 		multichannel_ARM, err := (*setting.Multichannel).ConvertToARM(resolved)
 		if err != nil {
@@ -1214,7 +1214,7 @@ func (setting *SmbSetting) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		result.Multichannel = &multichannel
 	}
 
-	// Set property ‘Versions’:
+	// Set property "Versions":
 	if setting.Versions != nil {
 		versions := *setting.Versions
 		result.Versions = &versions
@@ -1234,25 +1234,25 @@ func (setting *SmbSetting) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SmbSetting_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthenticationMethods’:
+	// Set property "AuthenticationMethods":
 	if typedInput.AuthenticationMethods != nil {
 		authenticationMethods := *typedInput.AuthenticationMethods
 		setting.AuthenticationMethods = &authenticationMethods
 	}
 
-	// Set property ‘ChannelEncryption’:
+	// Set property "ChannelEncryption":
 	if typedInput.ChannelEncryption != nil {
 		channelEncryption := *typedInput.ChannelEncryption
 		setting.ChannelEncryption = &channelEncryption
 	}
 
-	// Set property ‘KerberosTicketEncryption’:
+	// Set property "KerberosTicketEncryption":
 	if typedInput.KerberosTicketEncryption != nil {
 		kerberosTicketEncryption := *typedInput.KerberosTicketEncryption
 		setting.KerberosTicketEncryption = &kerberosTicketEncryption
 	}
 
-	// Set property ‘Multichannel’:
+	// Set property "Multichannel":
 	if typedInput.Multichannel != nil {
 		var multichannel1 Multichannel
 		err := multichannel1.PopulateFromARM(owner, *typedInput.Multichannel)
@@ -1263,7 +1263,7 @@ func (setting *SmbSetting) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		setting.Multichannel = &multichannel
 	}
 
-	// Set property ‘Versions’:
+	// Set property "Versions":
 	if typedInput.Versions != nil {
 		versions := *typedInput.Versions
 		setting.Versions = &versions
@@ -1411,25 +1411,25 @@ func (setting *SmbSetting_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SmbSetting_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AuthenticationMethods’:
+	// Set property "AuthenticationMethods":
 	if typedInput.AuthenticationMethods != nil {
 		authenticationMethods := *typedInput.AuthenticationMethods
 		setting.AuthenticationMethods = &authenticationMethods
 	}
 
-	// Set property ‘ChannelEncryption’:
+	// Set property "ChannelEncryption":
 	if typedInput.ChannelEncryption != nil {
 		channelEncryption := *typedInput.ChannelEncryption
 		setting.ChannelEncryption = &channelEncryption
 	}
 
-	// Set property ‘KerberosTicketEncryption’:
+	// Set property "KerberosTicketEncryption":
 	if typedInput.KerberosTicketEncryption != nil {
 		kerberosTicketEncryption := *typedInput.KerberosTicketEncryption
 		setting.KerberosTicketEncryption = &kerberosTicketEncryption
 	}
 
-	// Set property ‘Multichannel’:
+	// Set property "Multichannel":
 	if typedInput.Multichannel != nil {
 		var multichannel1 Multichannel_STATUS
 		err := multichannel1.PopulateFromARM(owner, *typedInput.Multichannel)
@@ -1440,7 +1440,7 @@ func (setting *SmbSetting_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		setting.Multichannel = &multichannel
 	}
 
-	// Set property ‘Versions’:
+	// Set property "Versions":
 	if typedInput.Versions != nil {
 		versions := *typedInput.Versions
 		setting.Versions = &versions
@@ -1536,7 +1536,7 @@ func (multichannel *Multichannel) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &Multichannel_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if multichannel.Enabled != nil {
 		enabled := *multichannel.Enabled
 		result.Enabled = &enabled
@@ -1556,7 +1556,7 @@ func (multichannel *Multichannel) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Multichannel_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		multichannel.Enabled = &enabled
@@ -1640,7 +1640,7 @@ func (multichannel *Multichannel_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Multichannel_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		multichannel.Enabled = &enabled

--- a/v2/api/storage/v1api20220901/storage_accounts_file_services_share_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_file_services_share_types_gen.go
@@ -356,10 +356,10 @@ func (share *StorageAccounts_FileServices_Share_Spec) ConvertToARM(resolved genr
 	}
 	result := &StorageAccounts_FileServices_Share_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if share.AccessTier != nil ||
 		share.EnabledProtocols != nil ||
 		share.Metadata != nil ||
@@ -412,7 +412,7 @@ func (share *StorageAccounts_FileServices_Share_Spec) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_FileServices_Share_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessTier’:
+	// Set property "AccessTier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessTier != nil {
@@ -421,10 +421,10 @@ func (share *StorageAccounts_FileServices_Share_Spec) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	share.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘EnabledProtocols’:
+	// Set property "EnabledProtocols":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnabledProtocols != nil {
@@ -433,7 +433,7 @@ func (share *StorageAccounts_FileServices_Share_Spec) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -444,10 +444,10 @@ func (share *StorageAccounts_FileServices_Share_Spec) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	share.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RootSquash’:
+	// Set property "RootSquash":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RootSquash != nil {
@@ -456,7 +456,7 @@ func (share *StorageAccounts_FileServices_Share_Spec) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘ShareQuota’:
+	// Set property "ShareQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ShareQuota != nil {
@@ -465,7 +465,7 @@ func (share *StorageAccounts_FileServices_Share_Spec) PopulateFromARM(owner genr
 		}
 	}
 
-	// Set property ‘SignedIdentifiers’:
+	// Set property "SignedIdentifiers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SignedIdentifiers {
@@ -896,7 +896,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_FileServices_Share_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessTier’:
+	// Set property "AccessTier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessTier != nil {
@@ -905,7 +905,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘AccessTierChangeTime’:
+	// Set property "AccessTierChangeTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessTierChangeTime != nil {
@@ -914,7 +914,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘AccessTierStatus’:
+	// Set property "AccessTierStatus":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessTierStatus != nil {
@@ -923,9 +923,9 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Deleted’:
+	// Set property "Deleted":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Deleted != nil {
@@ -934,7 +934,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘DeletedTime’:
+	// Set property "DeletedTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeletedTime != nil {
@@ -943,7 +943,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘EnabledProtocols’:
+	// Set property "EnabledProtocols":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.EnabledProtocols != nil {
@@ -952,19 +952,19 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		share.Etag = &etag
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		share.Id = &id
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastModifiedTime != nil {
@@ -973,7 +973,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘LeaseDuration’:
+	// Set property "LeaseDuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LeaseDuration != nil {
@@ -982,7 +982,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘LeaseState’:
+	// Set property "LeaseState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LeaseState != nil {
@@ -991,7 +991,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘LeaseStatus’:
+	// Set property "LeaseStatus":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LeaseStatus != nil {
@@ -1000,7 +1000,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -1011,13 +1011,13 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		share.Name = &name
 	}
 
-	// Set property ‘RemainingRetentionDays’:
+	// Set property "RemainingRetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemainingRetentionDays != nil {
@@ -1026,7 +1026,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘RootSquash’:
+	// Set property "RootSquash":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RootSquash != nil {
@@ -1035,7 +1035,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘ShareQuota’:
+	// Set property "ShareQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ShareQuota != nil {
@@ -1044,7 +1044,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘ShareUsageBytes’:
+	// Set property "ShareUsageBytes":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ShareUsageBytes != nil {
@@ -1053,7 +1053,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘SignedIdentifiers’:
+	// Set property "SignedIdentifiers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SignedIdentifiers {
@@ -1066,7 +1066,7 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘SnapshotTime’:
+	// Set property "SnapshotTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SnapshotTime != nil {
@@ -1075,13 +1075,13 @@ func (share *StorageAccounts_FileServices_Share_STATUS) PopulateFromARM(owner ge
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		share.Type = &typeVar
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1447,7 +1447,7 @@ func (identifier *SignedIdentifier) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &SignedIdentifier_ARM{}
 
-	// Set property ‘AccessPolicy’:
+	// Set property "AccessPolicy":
 	if identifier.AccessPolicy != nil {
 		accessPolicy_ARM, err := (*identifier.AccessPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -1457,7 +1457,7 @@ func (identifier *SignedIdentifier) ConvertToARM(resolved genruntime.ConvertToAR
 		result.AccessPolicy = &accessPolicy
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if identifier.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*identifier.Reference)
 		if err != nil {
@@ -1481,7 +1481,7 @@ func (identifier *SignedIdentifier) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignedIdentifier_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessPolicy’:
+	// Set property "AccessPolicy":
 	if typedInput.AccessPolicy != nil {
 		var accessPolicy1 AccessPolicy
 		err := accessPolicy1.PopulateFromARM(owner, *typedInput.AccessPolicy)
@@ -1492,7 +1492,7 @@ func (identifier *SignedIdentifier) PopulateFromARM(owner genruntime.ArbitraryOw
 		identifier.AccessPolicy = &accessPolicy
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -1610,7 +1610,7 @@ func (identifier *SignedIdentifier_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SignedIdentifier_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessPolicy’:
+	// Set property "AccessPolicy":
 	if typedInput.AccessPolicy != nil {
 		var accessPolicy1 AccessPolicy_STATUS
 		err := accessPolicy1.PopulateFromARM(owner, *typedInput.AccessPolicy)
@@ -1621,7 +1621,7 @@ func (identifier *SignedIdentifier_STATUS) PopulateFromARM(owner genruntime.Arbi
 		identifier.AccessPolicy = &accessPolicy
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		identifier.Id = &id
@@ -1704,19 +1704,19 @@ func (policy *AccessPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &AccessPolicy_ARM{}
 
-	// Set property ‘ExpiryTime’:
+	// Set property "ExpiryTime":
 	if policy.ExpiryTime != nil {
 		expiryTime := *policy.ExpiryTime
 		result.ExpiryTime = &expiryTime
 	}
 
-	// Set property ‘Permission’:
+	// Set property "Permission":
 	if policy.Permission != nil {
 		permission := *policy.Permission
 		result.Permission = &permission
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if policy.StartTime != nil {
 		startTime := *policy.StartTime
 		result.StartTime = &startTime
@@ -1736,19 +1736,19 @@ func (policy *AccessPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AccessPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpiryTime’:
+	// Set property "ExpiryTime":
 	if typedInput.ExpiryTime != nil {
 		expiryTime := *typedInput.ExpiryTime
 		policy.ExpiryTime = &expiryTime
 	}
 
-	// Set property ‘Permission’:
+	// Set property "Permission":
 	if typedInput.Permission != nil {
 		permission := *typedInput.Permission
 		policy.Permission = &permission
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		policy.StartTime = &startTime
@@ -1840,19 +1840,19 @@ func (policy *AccessPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AccessPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpiryTime’:
+	// Set property "ExpiryTime":
 	if typedInput.ExpiryTime != nil {
 		expiryTime := *typedInput.ExpiryTime
 		policy.ExpiryTime = &expiryTime
 	}
 
-	// Set property ‘Permission’:
+	// Set property "Permission":
 	if typedInput.Permission != nil {
 		permission := *typedInput.Permission
 		policy.Permission = &permission
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		policy.StartTime = &startTime

--- a/v2/api/storage/v1api20220901/storage_accounts_management_policy_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_management_policy_types_gen.go
@@ -325,10 +325,10 @@ func (policy *StorageAccounts_ManagementPolicy_Spec) ConvertToARM(resolved genru
 	}
 	result := &StorageAccounts_ManagementPolicy_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if policy.Policy != nil {
 		result.Properties = &ManagementPolicyProperties_ARM{}
 	}
@@ -355,10 +355,10 @@ func (policy *StorageAccounts_ManagementPolicy_Spec) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_ManagementPolicy_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	policy.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Policy’:
+	// Set property "Policy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Policy != nil {
@@ -602,15 +602,15 @@ func (policy *StorageAccounts_ManagementPolicy_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_ManagementPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		policy.Id = &id
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastModifiedTime != nil {
@@ -619,13 +619,13 @@ func (policy *StorageAccounts_ManagementPolicy_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘Policy’:
+	// Set property "Policy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Policy != nil {
@@ -639,7 +639,7 @@ func (policy *StorageAccounts_ManagementPolicy_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		policy.Type = &typeVar
@@ -744,7 +744,7 @@ func (schema *ManagementPolicySchema) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicySchema_ARM{}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range schema.Rules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -767,7 +767,7 @@ func (schema *ManagementPolicySchema) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicySchema_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		var item1 ManagementPolicyRule
 		err := item1.PopulateFromARM(owner, item)
@@ -887,7 +887,7 @@ func (schema *ManagementPolicySchema_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicySchema_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		var item1 ManagementPolicyRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -988,7 +988,7 @@ func (rule *ManagementPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ManagementPolicyRule_ARM{}
 
-	// Set property ‘Definition’:
+	// Set property "Definition":
 	if rule.Definition != nil {
 		definition_ARM, err := (*rule.Definition).ConvertToARM(resolved)
 		if err != nil {
@@ -998,19 +998,19 @@ func (rule *ManagementPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Definition = &definition
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if rule.Enabled != nil {
 		enabled := *rule.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if rule.Name != nil {
 		name := *rule.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if rule.Type != nil {
 		typeVar := *rule.Type
 		result.Type = &typeVar
@@ -1030,7 +1030,7 @@ func (rule *ManagementPolicyRule) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Definition’:
+	// Set property "Definition":
 	if typedInput.Definition != nil {
 		var definition1 ManagementPolicyDefinition
 		err := definition1.PopulateFromARM(owner, *typedInput.Definition)
@@ -1041,19 +1041,19 @@ func (rule *ManagementPolicyRule) PopulateFromARM(owner genruntime.ArbitraryOwne
 		rule.Definition = &definition
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		rule.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -1216,7 +1216,7 @@ func (rule *ManagementPolicyRule_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Definition’:
+	// Set property "Definition":
 	if typedInput.Definition != nil {
 		var definition1 ManagementPolicyDefinition_STATUS
 		err := definition1.PopulateFromARM(owner, *typedInput.Definition)
@@ -1227,19 +1227,19 @@ func (rule *ManagementPolicyRule_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		rule.Definition = &definition
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		rule.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -1353,7 +1353,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 	}
 	result := &ManagementPolicyDefinition_ARM{}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if definition.Actions != nil {
 		actions_ARM, err := (*definition.Actions).ConvertToARM(resolved)
 		if err != nil {
@@ -1363,7 +1363,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 		result.Actions = &actions
 	}
 
-	// Set property ‘Filters’:
+	// Set property "Filters":
 	if definition.Filters != nil {
 		filters_ARM, err := (*definition.Filters).ConvertToARM(resolved)
 		if err != nil {
@@ -1387,7 +1387,7 @@ func (definition *ManagementPolicyDefinition) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyDefinition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if typedInput.Actions != nil {
 		var actions1 ManagementPolicyAction
 		err := actions1.PopulateFromARM(owner, *typedInput.Actions)
@@ -1398,7 +1398,7 @@ func (definition *ManagementPolicyDefinition) PopulateFromARM(owner genruntime.A
 		definition.Actions = &actions
 	}
 
-	// Set property ‘Filters’:
+	// Set property "Filters":
 	if typedInput.Filters != nil {
 		var filters1 ManagementPolicyFilter
 		err := filters1.PopulateFromARM(owner, *typedInput.Filters)
@@ -1538,7 +1538,7 @@ func (definition *ManagementPolicyDefinition_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyDefinition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if typedInput.Actions != nil {
 		var actions1 ManagementPolicyAction_STATUS
 		err := actions1.PopulateFromARM(owner, *typedInput.Actions)
@@ -1549,7 +1549,7 @@ func (definition *ManagementPolicyDefinition_STATUS) PopulateFromARM(owner genru
 		definition.Actions = &actions
 	}
 
-	// Set property ‘Filters’:
+	// Set property "Filters":
 	if typedInput.Filters != nil {
 		var filters1 ManagementPolicyFilter_STATUS
 		err := filters1.PopulateFromARM(owner, *typedInput.Filters)
@@ -1665,7 +1665,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicyAction_ARM{}
 
-	// Set property ‘BaseBlob’:
+	// Set property "BaseBlob":
 	if action.BaseBlob != nil {
 		baseBlob_ARM, err := (*action.BaseBlob).ConvertToARM(resolved)
 		if err != nil {
@@ -1675,7 +1675,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 		result.BaseBlob = &baseBlob
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if action.Snapshot != nil {
 		snapshot_ARM, err := (*action.Snapshot).ConvertToARM(resolved)
 		if err != nil {
@@ -1685,7 +1685,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 		result.Snapshot = &snapshot
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if action.Version != nil {
 		version_ARM, err := (*action.Version).ConvertToARM(resolved)
 		if err != nil {
@@ -1709,7 +1709,7 @@ func (action *ManagementPolicyAction) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BaseBlob’:
+	// Set property "BaseBlob":
 	if typedInput.BaseBlob != nil {
 		var baseBlob1 ManagementPolicyBaseBlob
 		err := baseBlob1.PopulateFromARM(owner, *typedInput.BaseBlob)
@@ -1720,7 +1720,7 @@ func (action *ManagementPolicyAction) PopulateFromARM(owner genruntime.Arbitrary
 		action.BaseBlob = &baseBlob
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 ManagementPolicySnapShot
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -1731,7 +1731,7 @@ func (action *ManagementPolicyAction) PopulateFromARM(owner genruntime.Arbitrary
 		action.Snapshot = &snapshot
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		var version1 ManagementPolicyVersion
 		err := version1.PopulateFromARM(owner, *typedInput.Version)
@@ -1910,7 +1910,7 @@ func (action *ManagementPolicyAction_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BaseBlob’:
+	// Set property "BaseBlob":
 	if typedInput.BaseBlob != nil {
 		var baseBlob1 ManagementPolicyBaseBlob_STATUS
 		err := baseBlob1.PopulateFromARM(owner, *typedInput.BaseBlob)
@@ -1921,7 +1921,7 @@ func (action *ManagementPolicyAction_STATUS) PopulateFromARM(owner genruntime.Ar
 		action.BaseBlob = &baseBlob
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 ManagementPolicySnapShot_STATUS
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -1932,7 +1932,7 @@ func (action *ManagementPolicyAction_STATUS) PopulateFromARM(owner genruntime.Ar
 		action.Snapshot = &snapshot
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		var version1 ManagementPolicyVersion_STATUS
 		err := version1.PopulateFromARM(owner, *typedInput.Version)
@@ -2066,7 +2066,7 @@ func (filter *ManagementPolicyFilter) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicyFilter_ARM{}
 
-	// Set property ‘BlobIndexMatch’:
+	// Set property "BlobIndexMatch":
 	for _, item := range filter.BlobIndexMatch {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2075,12 +2075,12 @@ func (filter *ManagementPolicyFilter) ConvertToARM(resolved genruntime.ConvertTo
 		result.BlobIndexMatch = append(result.BlobIndexMatch, *item_ARM.(*TagFilter_ARM))
 	}
 
-	// Set property ‘BlobTypes’:
+	// Set property "BlobTypes":
 	for _, item := range filter.BlobTypes {
 		result.BlobTypes = append(result.BlobTypes, item)
 	}
 
-	// Set property ‘PrefixMatch’:
+	// Set property "PrefixMatch":
 	for _, item := range filter.PrefixMatch {
 		result.PrefixMatch = append(result.PrefixMatch, item)
 	}
@@ -2099,7 +2099,7 @@ func (filter *ManagementPolicyFilter) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobIndexMatch’:
+	// Set property "BlobIndexMatch":
 	for _, item := range typedInput.BlobIndexMatch {
 		var item1 TagFilter
 		err := item1.PopulateFromARM(owner, item)
@@ -2109,12 +2109,12 @@ func (filter *ManagementPolicyFilter) PopulateFromARM(owner genruntime.Arbitrary
 		filter.BlobIndexMatch = append(filter.BlobIndexMatch, item1)
 	}
 
-	// Set property ‘BlobTypes’:
+	// Set property "BlobTypes":
 	for _, item := range typedInput.BlobTypes {
 		filter.BlobTypes = append(filter.BlobTypes, item)
 	}
 
-	// Set property ‘PrefixMatch’:
+	// Set property "PrefixMatch":
 	for _, item := range typedInput.PrefixMatch {
 		filter.PrefixMatch = append(filter.PrefixMatch, item)
 	}
@@ -2253,7 +2253,7 @@ func (filter *ManagementPolicyFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobIndexMatch’:
+	// Set property "BlobIndexMatch":
 	for _, item := range typedInput.BlobIndexMatch {
 		var item1 TagFilter_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2263,12 +2263,12 @@ func (filter *ManagementPolicyFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 		filter.BlobIndexMatch = append(filter.BlobIndexMatch, item1)
 	}
 
-	// Set property ‘BlobTypes’:
+	// Set property "BlobTypes":
 	for _, item := range typedInput.BlobTypes {
 		filter.BlobTypes = append(filter.BlobTypes, item)
 	}
 
-	// Set property ‘PrefixMatch’:
+	// Set property "PrefixMatch":
 	for _, item := range typedInput.PrefixMatch {
 		filter.PrefixMatch = append(filter.PrefixMatch, item)
 	}
@@ -2380,7 +2380,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicyBaseBlob_ARM{}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if blob.Delete != nil {
 		delete_ARM, err := (*blob.Delete).ConvertToARM(resolved)
 		if err != nil {
@@ -2390,13 +2390,13 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 		result.Delete = &delete
 	}
 
-	// Set property ‘EnableAutoTierToHotFromCool’:
+	// Set property "EnableAutoTierToHotFromCool":
 	if blob.EnableAutoTierToHotFromCool != nil {
 		enableAutoTierToHotFromCool := *blob.EnableAutoTierToHotFromCool
 		result.EnableAutoTierToHotFromCool = &enableAutoTierToHotFromCool
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if blob.TierToArchive != nil {
 		tierToArchive_ARM, err := (*blob.TierToArchive).ConvertToARM(resolved)
 		if err != nil {
@@ -2406,7 +2406,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 		result.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCold’:
+	// Set property "TierToCold":
 	if blob.TierToCold != nil {
 		tierToCold_ARM, err := (*blob.TierToCold).ConvertToARM(resolved)
 		if err != nil {
@@ -2416,7 +2416,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 		result.TierToCold = &tierToCold
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if blob.TierToCool != nil {
 		tierToCool_ARM, err := (*blob.TierToCool).ConvertToARM(resolved)
 		if err != nil {
@@ -2426,7 +2426,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 		result.TierToCool = &tierToCool
 	}
 
-	// Set property ‘TierToHot’:
+	// Set property "TierToHot":
 	if blob.TierToHot != nil {
 		tierToHot_ARM, err := (*blob.TierToHot).ConvertToARM(resolved)
 		if err != nil {
@@ -2450,7 +2450,7 @@ func (blob *ManagementPolicyBaseBlob) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyBaseBlob_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterModification
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -2461,13 +2461,13 @@ func (blob *ManagementPolicyBaseBlob) PopulateFromARM(owner genruntime.Arbitrary
 		blob.Delete = &delete
 	}
 
-	// Set property ‘EnableAutoTierToHotFromCool’:
+	// Set property "EnableAutoTierToHotFromCool":
 	if typedInput.EnableAutoTierToHotFromCool != nil {
 		enableAutoTierToHotFromCool := *typedInput.EnableAutoTierToHotFromCool
 		blob.EnableAutoTierToHotFromCool = &enableAutoTierToHotFromCool
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterModification
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -2478,7 +2478,7 @@ func (blob *ManagementPolicyBaseBlob) PopulateFromARM(owner genruntime.Arbitrary
 		blob.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCold’:
+	// Set property "TierToCold":
 	if typedInput.TierToCold != nil {
 		var tierToCold1 DateAfterModification
 		err := tierToCold1.PopulateFromARM(owner, *typedInput.TierToCold)
@@ -2489,7 +2489,7 @@ func (blob *ManagementPolicyBaseBlob) PopulateFromARM(owner genruntime.Arbitrary
 		blob.TierToCold = &tierToCold
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterModification
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -2500,7 +2500,7 @@ func (blob *ManagementPolicyBaseBlob) PopulateFromARM(owner genruntime.Arbitrary
 		blob.TierToCool = &tierToCool
 	}
 
-	// Set property ‘TierToHot’:
+	// Set property "TierToHot":
 	if typedInput.TierToHot != nil {
 		var tierToHot1 DateAfterModification
 		err := tierToHot1.PopulateFromARM(owner, *typedInput.TierToHot)
@@ -2786,7 +2786,7 @@ func (blob *ManagementPolicyBaseBlob_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyBaseBlob_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterModification_STATUS
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -2797,13 +2797,13 @@ func (blob *ManagementPolicyBaseBlob_STATUS) PopulateFromARM(owner genruntime.Ar
 		blob.Delete = &delete
 	}
 
-	// Set property ‘EnableAutoTierToHotFromCool’:
+	// Set property "EnableAutoTierToHotFromCool":
 	if typedInput.EnableAutoTierToHotFromCool != nil {
 		enableAutoTierToHotFromCool := *typedInput.EnableAutoTierToHotFromCool
 		blob.EnableAutoTierToHotFromCool = &enableAutoTierToHotFromCool
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterModification_STATUS
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -2814,7 +2814,7 @@ func (blob *ManagementPolicyBaseBlob_STATUS) PopulateFromARM(owner genruntime.Ar
 		blob.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCold’:
+	// Set property "TierToCold":
 	if typedInput.TierToCold != nil {
 		var tierToCold1 DateAfterModification_STATUS
 		err := tierToCold1.PopulateFromARM(owner, *typedInput.TierToCold)
@@ -2825,7 +2825,7 @@ func (blob *ManagementPolicyBaseBlob_STATUS) PopulateFromARM(owner genruntime.Ar
 		blob.TierToCold = &tierToCold
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterModification_STATUS
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -2836,7 +2836,7 @@ func (blob *ManagementPolicyBaseBlob_STATUS) PopulateFromARM(owner genruntime.Ar
 		blob.TierToCool = &tierToCool
 	}
 
-	// Set property ‘TierToHot’:
+	// Set property "TierToHot":
 	if typedInput.TierToHot != nil {
 		var tierToHot1 DateAfterModification_STATUS
 		err := tierToHot1.PopulateFromARM(owner, *typedInput.TierToHot)
@@ -3038,7 +3038,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicySnapShot_ARM{}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if shot.Delete != nil {
 		delete_ARM, err := (*shot.Delete).ConvertToARM(resolved)
 		if err != nil {
@@ -3048,7 +3048,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 		result.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if shot.TierToArchive != nil {
 		tierToArchive_ARM, err := (*shot.TierToArchive).ConvertToARM(resolved)
 		if err != nil {
@@ -3058,7 +3058,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 		result.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCold’:
+	// Set property "TierToCold":
 	if shot.TierToCold != nil {
 		tierToCold_ARM, err := (*shot.TierToCold).ConvertToARM(resolved)
 		if err != nil {
@@ -3068,7 +3068,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 		result.TierToCold = &tierToCold
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if shot.TierToCool != nil {
 		tierToCool_ARM, err := (*shot.TierToCool).ConvertToARM(resolved)
 		if err != nil {
@@ -3078,7 +3078,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 		result.TierToCool = &tierToCool
 	}
 
-	// Set property ‘TierToHot’:
+	// Set property "TierToHot":
 	if shot.TierToHot != nil {
 		tierToHot_ARM, err := (*shot.TierToHot).ConvertToARM(resolved)
 		if err != nil {
@@ -3102,7 +3102,7 @@ func (shot *ManagementPolicySnapShot) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicySnapShot_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterCreation
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -3113,7 +3113,7 @@ func (shot *ManagementPolicySnapShot) PopulateFromARM(owner genruntime.Arbitrary
 		shot.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterCreation
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -3124,7 +3124,7 @@ func (shot *ManagementPolicySnapShot) PopulateFromARM(owner genruntime.Arbitrary
 		shot.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCold’:
+	// Set property "TierToCold":
 	if typedInput.TierToCold != nil {
 		var tierToCold1 DateAfterCreation
 		err := tierToCold1.PopulateFromARM(owner, *typedInput.TierToCold)
@@ -3135,7 +3135,7 @@ func (shot *ManagementPolicySnapShot) PopulateFromARM(owner genruntime.Arbitrary
 		shot.TierToCold = &tierToCold
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterCreation
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -3146,7 +3146,7 @@ func (shot *ManagementPolicySnapShot) PopulateFromARM(owner genruntime.Arbitrary
 		shot.TierToCool = &tierToCool
 	}
 
-	// Set property ‘TierToHot’:
+	// Set property "TierToHot":
 	if typedInput.TierToHot != nil {
 		var tierToHot1 DateAfterCreation
 		err := tierToHot1.PopulateFromARM(owner, *typedInput.TierToHot)
@@ -3404,7 +3404,7 @@ func (shot *ManagementPolicySnapShot_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicySnapShot_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterCreation_STATUS
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -3415,7 +3415,7 @@ func (shot *ManagementPolicySnapShot_STATUS) PopulateFromARM(owner genruntime.Ar
 		shot.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterCreation_STATUS
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -3426,7 +3426,7 @@ func (shot *ManagementPolicySnapShot_STATUS) PopulateFromARM(owner genruntime.Ar
 		shot.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCold’:
+	// Set property "TierToCold":
 	if typedInput.TierToCold != nil {
 		var tierToCold1 DateAfterCreation_STATUS
 		err := tierToCold1.PopulateFromARM(owner, *typedInput.TierToCold)
@@ -3437,7 +3437,7 @@ func (shot *ManagementPolicySnapShot_STATUS) PopulateFromARM(owner genruntime.Ar
 		shot.TierToCold = &tierToCold
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterCreation_STATUS
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -3448,7 +3448,7 @@ func (shot *ManagementPolicySnapShot_STATUS) PopulateFromARM(owner genruntime.Ar
 		shot.TierToCool = &tierToCool
 	}
 
-	// Set property ‘TierToHot’:
+	// Set property "TierToHot":
 	if typedInput.TierToHot != nil {
 		var tierToHot1 DateAfterCreation_STATUS
 		err := tierToHot1.PopulateFromARM(owner, *typedInput.TierToHot)
@@ -3634,7 +3634,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ManagementPolicyVersion_ARM{}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if version.Delete != nil {
 		delete_ARM, err := (*version.Delete).ConvertToARM(resolved)
 		if err != nil {
@@ -3644,7 +3644,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 		result.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if version.TierToArchive != nil {
 		tierToArchive_ARM, err := (*version.TierToArchive).ConvertToARM(resolved)
 		if err != nil {
@@ -3654,7 +3654,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 		result.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCold’:
+	// Set property "TierToCold":
 	if version.TierToCold != nil {
 		tierToCold_ARM, err := (*version.TierToCold).ConvertToARM(resolved)
 		if err != nil {
@@ -3664,7 +3664,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 		result.TierToCold = &tierToCold
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if version.TierToCool != nil {
 		tierToCool_ARM, err := (*version.TierToCool).ConvertToARM(resolved)
 		if err != nil {
@@ -3674,7 +3674,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 		result.TierToCool = &tierToCool
 	}
 
-	// Set property ‘TierToHot’:
+	// Set property "TierToHot":
 	if version.TierToHot != nil {
 		tierToHot_ARM, err := (*version.TierToHot).ConvertToARM(resolved)
 		if err != nil {
@@ -3698,7 +3698,7 @@ func (version *ManagementPolicyVersion) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyVersion_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterCreation
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -3709,7 +3709,7 @@ func (version *ManagementPolicyVersion) PopulateFromARM(owner genruntime.Arbitra
 		version.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterCreation
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -3720,7 +3720,7 @@ func (version *ManagementPolicyVersion) PopulateFromARM(owner genruntime.Arbitra
 		version.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCold’:
+	// Set property "TierToCold":
 	if typedInput.TierToCold != nil {
 		var tierToCold1 DateAfterCreation
 		err := tierToCold1.PopulateFromARM(owner, *typedInput.TierToCold)
@@ -3731,7 +3731,7 @@ func (version *ManagementPolicyVersion) PopulateFromARM(owner genruntime.Arbitra
 		version.TierToCold = &tierToCold
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterCreation
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -3742,7 +3742,7 @@ func (version *ManagementPolicyVersion) PopulateFromARM(owner genruntime.Arbitra
 		version.TierToCool = &tierToCool
 	}
 
-	// Set property ‘TierToHot’:
+	// Set property "TierToHot":
 	if typedInput.TierToHot != nil {
 		var tierToHot1 DateAfterCreation
 		err := tierToHot1.PopulateFromARM(owner, *typedInput.TierToHot)
@@ -4000,7 +4000,7 @@ func (version *ManagementPolicyVersion_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyVersion_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterCreation_STATUS
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -4011,7 +4011,7 @@ func (version *ManagementPolicyVersion_STATUS) PopulateFromARM(owner genruntime.
 		version.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterCreation_STATUS
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -4022,7 +4022,7 @@ func (version *ManagementPolicyVersion_STATUS) PopulateFromARM(owner genruntime.
 		version.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCold’:
+	// Set property "TierToCold":
 	if typedInput.TierToCold != nil {
 		var tierToCold1 DateAfterCreation_STATUS
 		err := tierToCold1.PopulateFromARM(owner, *typedInput.TierToCold)
@@ -4033,7 +4033,7 @@ func (version *ManagementPolicyVersion_STATUS) PopulateFromARM(owner genruntime.
 		version.TierToCold = &tierToCold
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterCreation_STATUS
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -4044,7 +4044,7 @@ func (version *ManagementPolicyVersion_STATUS) PopulateFromARM(owner genruntime.
 		version.TierToCool = &tierToCool
 	}
 
-	// Set property ‘TierToHot’:
+	// Set property "TierToHot":
 	if typedInput.TierToHot != nil {
 		var tierToHot1 DateAfterCreation_STATUS
 		err := tierToHot1.PopulateFromARM(owner, *typedInput.TierToHot)
@@ -4231,19 +4231,19 @@ func (filter *TagFilter) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &TagFilter_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if filter.Name != nil {
 		name := *filter.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Op’:
+	// Set property "Op":
 	if filter.Op != nil {
 		op := *filter.Op
 		result.Op = &op
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if filter.Value != nil {
 		value := *filter.Value
 		result.Value = &value
@@ -4263,19 +4263,19 @@ func (filter *TagFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TagFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		filter.Name = &name
 	}
 
-	// Set property ‘Op’:
+	// Set property "Op":
 	if typedInput.Op != nil {
 		op := *typedInput.Op
 		filter.Op = &op
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -4399,19 +4399,19 @@ func (filter *TagFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TagFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		filter.Name = &name
 	}
 
-	// Set property ‘Op’:
+	// Set property "Op":
 	if typedInput.Op != nil {
 		op := *typedInput.Op
 		filter.Op = &op
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -4487,13 +4487,13 @@ func (creation *DateAfterCreation) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &DateAfterCreation_ARM{}
 
-	// Set property ‘DaysAfterCreationGreaterThan’:
+	// Set property "DaysAfterCreationGreaterThan":
 	if creation.DaysAfterCreationGreaterThan != nil {
 		daysAfterCreationGreaterThan := *creation.DaysAfterCreationGreaterThan
 		result.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
 	}
 
-	// Set property ‘DaysAfterLastTierChangeGreaterThan’:
+	// Set property "DaysAfterLastTierChangeGreaterThan":
 	if creation.DaysAfterLastTierChangeGreaterThan != nil {
 		daysAfterLastTierChangeGreaterThan := *creation.DaysAfterLastTierChangeGreaterThan
 		result.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
@@ -4513,13 +4513,13 @@ func (creation *DateAfterCreation) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DateAfterCreation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DaysAfterCreationGreaterThan’:
+	// Set property "DaysAfterCreationGreaterThan":
 	if typedInput.DaysAfterCreationGreaterThan != nil {
 		daysAfterCreationGreaterThan := *typedInput.DaysAfterCreationGreaterThan
 		creation.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
 	}
 
-	// Set property ‘DaysAfterLastTierChangeGreaterThan’:
+	// Set property "DaysAfterLastTierChangeGreaterThan":
 	if typedInput.DaysAfterLastTierChangeGreaterThan != nil {
 		daysAfterLastTierChangeGreaterThan := *typedInput.DaysAfterLastTierChangeGreaterThan
 		creation.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
@@ -4632,13 +4632,13 @@ func (creation *DateAfterCreation_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DateAfterCreation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DaysAfterCreationGreaterThan’:
+	// Set property "DaysAfterCreationGreaterThan":
 	if typedInput.DaysAfterCreationGreaterThan != nil {
 		daysAfterCreationGreaterThan := *typedInput.DaysAfterCreationGreaterThan
 		creation.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
 	}
 
-	// Set property ‘DaysAfterLastTierChangeGreaterThan’:
+	// Set property "DaysAfterLastTierChangeGreaterThan":
 	if typedInput.DaysAfterLastTierChangeGreaterThan != nil {
 		daysAfterLastTierChangeGreaterThan := *typedInput.DaysAfterLastTierChangeGreaterThan
 		creation.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
@@ -4742,25 +4742,25 @@ func (modification *DateAfterModification) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &DateAfterModification_ARM{}
 
-	// Set property ‘DaysAfterCreationGreaterThan’:
+	// Set property "DaysAfterCreationGreaterThan":
 	if modification.DaysAfterCreationGreaterThan != nil {
 		daysAfterCreationGreaterThan := *modification.DaysAfterCreationGreaterThan
 		result.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
 	}
 
-	// Set property ‘DaysAfterLastAccessTimeGreaterThan’:
+	// Set property "DaysAfterLastAccessTimeGreaterThan":
 	if modification.DaysAfterLastAccessTimeGreaterThan != nil {
 		daysAfterLastAccessTimeGreaterThan := *modification.DaysAfterLastAccessTimeGreaterThan
 		result.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
 	}
 
-	// Set property ‘DaysAfterLastTierChangeGreaterThan’:
+	// Set property "DaysAfterLastTierChangeGreaterThan":
 	if modification.DaysAfterLastTierChangeGreaterThan != nil {
 		daysAfterLastTierChangeGreaterThan := *modification.DaysAfterLastTierChangeGreaterThan
 		result.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
 	}
 
-	// Set property ‘DaysAfterModificationGreaterThan’:
+	// Set property "DaysAfterModificationGreaterThan":
 	if modification.DaysAfterModificationGreaterThan != nil {
 		daysAfterModificationGreaterThan := *modification.DaysAfterModificationGreaterThan
 		result.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan
@@ -4780,25 +4780,25 @@ func (modification *DateAfterModification) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DateAfterModification_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DaysAfterCreationGreaterThan’:
+	// Set property "DaysAfterCreationGreaterThan":
 	if typedInput.DaysAfterCreationGreaterThan != nil {
 		daysAfterCreationGreaterThan := *typedInput.DaysAfterCreationGreaterThan
 		modification.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
 	}
 
-	// Set property ‘DaysAfterLastAccessTimeGreaterThan’:
+	// Set property "DaysAfterLastAccessTimeGreaterThan":
 	if typedInput.DaysAfterLastAccessTimeGreaterThan != nil {
 		daysAfterLastAccessTimeGreaterThan := *typedInput.DaysAfterLastAccessTimeGreaterThan
 		modification.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
 	}
 
-	// Set property ‘DaysAfterLastTierChangeGreaterThan’:
+	// Set property "DaysAfterLastTierChangeGreaterThan":
 	if typedInput.DaysAfterLastTierChangeGreaterThan != nil {
 		daysAfterLastTierChangeGreaterThan := *typedInput.DaysAfterLastTierChangeGreaterThan
 		modification.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
 	}
 
-	// Set property ‘DaysAfterModificationGreaterThan’:
+	// Set property "DaysAfterModificationGreaterThan":
 	if typedInput.DaysAfterModificationGreaterThan != nil {
 		daysAfterModificationGreaterThan := *typedInput.DaysAfterModificationGreaterThan
 		modification.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan
@@ -4970,25 +4970,25 @@ func (modification *DateAfterModification_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DateAfterModification_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DaysAfterCreationGreaterThan’:
+	// Set property "DaysAfterCreationGreaterThan":
 	if typedInput.DaysAfterCreationGreaterThan != nil {
 		daysAfterCreationGreaterThan := *typedInput.DaysAfterCreationGreaterThan
 		modification.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
 	}
 
-	// Set property ‘DaysAfterLastAccessTimeGreaterThan’:
+	// Set property "DaysAfterLastAccessTimeGreaterThan":
 	if typedInput.DaysAfterLastAccessTimeGreaterThan != nil {
 		daysAfterLastAccessTimeGreaterThan := *typedInput.DaysAfterLastAccessTimeGreaterThan
 		modification.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
 	}
 
-	// Set property ‘DaysAfterLastTierChangeGreaterThan’:
+	// Set property "DaysAfterLastTierChangeGreaterThan":
 	if typedInput.DaysAfterLastTierChangeGreaterThan != nil {
 		daysAfterLastTierChangeGreaterThan := *typedInput.DaysAfterLastTierChangeGreaterThan
 		modification.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
 	}
 
-	// Set property ‘DaysAfterModificationGreaterThan’:
+	// Set property "DaysAfterModificationGreaterThan":
 	if typedInput.DaysAfterModificationGreaterThan != nil {
 		daysAfterModificationGreaterThan := *typedInput.DaysAfterModificationGreaterThan
 		modification.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan

--- a/v2/api/storage/v1api20220901/storage_accounts_queue_service_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_queue_service_types_gen.go
@@ -325,10 +325,10 @@ func (service *StorageAccounts_QueueService_Spec) ConvertToARM(resolved genrunti
 	}
 	result := &StorageAccounts_QueueService_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if service.Cors != nil {
 		result.Properties = &StorageAccounts_QueueService_Properties_Spec_ARM{}
 	}
@@ -355,7 +355,7 @@ func (service *StorageAccounts_QueueService_Spec) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_QueueService_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -369,7 +369,7 @@ func (service *StorageAccounts_QueueService_Spec) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -600,9 +600,9 @@ func (service *StorageAccounts_QueueService_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_QueueService_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -616,19 +616,19 @@ func (service *StorageAccounts_QueueService_STATUS) PopulateFromARM(owner genrun
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		service.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		service.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		service.Type = &typeVar

--- a/v2/api/storage/v1api20220901/storage_accounts_queue_services_queue_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_queue_services_queue_types_gen.go
@@ -336,10 +336,10 @@ func (queue *StorageAccounts_QueueServices_Queue_Spec) ConvertToARM(resolved gen
 	}
 	result := &StorageAccounts_QueueServices_Queue_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if queue.Metadata != nil {
 		result.Properties = &QueueProperties_ARM{}
 	}
@@ -364,10 +364,10 @@ func (queue *StorageAccounts_QueueServices_Queue_Spec) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_QueueServices_Queue_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	queue.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -378,7 +378,7 @@ func (queue *StorageAccounts_QueueServices_Queue_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	queue.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -595,7 +595,7 @@ func (queue *StorageAccounts_QueueServices_Queue_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_QueueServices_Queue_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApproximateMessageCount’:
+	// Set property "ApproximateMessageCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApproximateMessageCount != nil {
@@ -604,15 +604,15 @@ func (queue *StorageAccounts_QueueServices_Queue_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		queue.Id = &id
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -623,13 +623,13 @@ func (queue *StorageAccounts_QueueServices_Queue_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		queue.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		queue.Type = &typeVar

--- a/v2/api/storage/v1api20220901/storage_accounts_table_service_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_table_service_types_gen.go
@@ -325,10 +325,10 @@ func (service *StorageAccounts_TableService_Spec) ConvertToARM(resolved genrunti
 	}
 	result := &StorageAccounts_TableService_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if service.Cors != nil {
 		result.Properties = &StorageAccounts_TableService_Properties_Spec_ARM{}
 	}
@@ -355,7 +355,7 @@ func (service *StorageAccounts_TableService_Spec) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_TableService_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -369,7 +369,7 @@ func (service *StorageAccounts_TableService_Spec) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -600,9 +600,9 @@ func (service *StorageAccounts_TableService_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_TableService_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -616,19 +616,19 @@ func (service *StorageAccounts_TableService_STATUS) PopulateFromARM(owner genrun
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		service.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		service.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		service.Type = &typeVar

--- a/v2/api/storage/v1api20220901/storage_accounts_table_services_table_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_table_services_table_types_gen.go
@@ -337,10 +337,10 @@ func (table *StorageAccounts_TableServices_Table_Spec) ConvertToARM(resolved gen
 	}
 	result := &StorageAccounts_TableServices_Table_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if table.SignedIdentifiers != nil {
 		result.Properties = &TableProperties_ARM{}
 	}
@@ -366,13 +366,13 @@ func (table *StorageAccounts_TableServices_Table_Spec) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_TableServices_Table_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	table.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	table.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘SignedIdentifiers’:
+	// Set property "SignedIdentifiers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SignedIdentifiers {
@@ -643,21 +643,21 @@ func (table *StorageAccounts_TableServices_Table_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_TableServices_Table_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		table.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		table.Name = &name
 	}
 
-	// Set property ‘SignedIdentifiers’:
+	// Set property "SignedIdentifiers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.SignedIdentifiers {
@@ -670,7 +670,7 @@ func (table *StorageAccounts_TableServices_Table_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘TableName’:
+	// Set property "TableName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TableName != nil {
@@ -679,7 +679,7 @@ func (table *StorageAccounts_TableServices_Table_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		table.Type = &typeVar
@@ -797,7 +797,7 @@ func (identifier *TableSignedIdentifier) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &TableSignedIdentifier_ARM{}
 
-	// Set property ‘AccessPolicy’:
+	// Set property "AccessPolicy":
 	if identifier.AccessPolicy != nil {
 		accessPolicy_ARM, err := (*identifier.AccessPolicy).ConvertToARM(resolved)
 		if err != nil {
@@ -807,7 +807,7 @@ func (identifier *TableSignedIdentifier) ConvertToARM(resolved genruntime.Conver
 		result.AccessPolicy = &accessPolicy
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if identifier.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*identifier.Reference)
 		if err != nil {
@@ -831,7 +831,7 @@ func (identifier *TableSignedIdentifier) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TableSignedIdentifier_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessPolicy’:
+	// Set property "AccessPolicy":
 	if typedInput.AccessPolicy != nil {
 		var accessPolicy1 TableAccessPolicy
 		err := accessPolicy1.PopulateFromARM(owner, *typedInput.AccessPolicy)
@@ -842,7 +842,7 @@ func (identifier *TableSignedIdentifier) PopulateFromARM(owner genruntime.Arbitr
 		identifier.AccessPolicy = &accessPolicy
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -961,7 +961,7 @@ func (identifier *TableSignedIdentifier_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TableSignedIdentifier_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessPolicy’:
+	// Set property "AccessPolicy":
 	if typedInput.AccessPolicy != nil {
 		var accessPolicy1 TableAccessPolicy_STATUS
 		err := accessPolicy1.PopulateFromARM(owner, *typedInput.AccessPolicy)
@@ -972,7 +972,7 @@ func (identifier *TableSignedIdentifier_STATUS) PopulateFromARM(owner genruntime
 		identifier.AccessPolicy = &accessPolicy
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		identifier.Id = &id
@@ -1057,19 +1057,19 @@ func (policy *TableAccessPolicy) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &TableAccessPolicy_ARM{}
 
-	// Set property ‘ExpiryTime’:
+	// Set property "ExpiryTime":
 	if policy.ExpiryTime != nil {
 		expiryTime := *policy.ExpiryTime
 		result.ExpiryTime = &expiryTime
 	}
 
-	// Set property ‘Permission’:
+	// Set property "Permission":
 	if policy.Permission != nil {
 		permission := *policy.Permission
 		result.Permission = &permission
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if policy.StartTime != nil {
 		startTime := *policy.StartTime
 		result.StartTime = &startTime
@@ -1089,19 +1089,19 @@ func (policy *TableAccessPolicy) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TableAccessPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpiryTime’:
+	// Set property "ExpiryTime":
 	if typedInput.ExpiryTime != nil {
 		expiryTime := *typedInput.ExpiryTime
 		policy.ExpiryTime = &expiryTime
 	}
 
-	// Set property ‘Permission’:
+	// Set property "Permission":
 	if typedInput.Permission != nil {
 		permission := *typedInput.Permission
 		policy.Permission = &permission
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		policy.StartTime = &startTime
@@ -1194,19 +1194,19 @@ func (policy *TableAccessPolicy_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TableAccessPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpiryTime’:
+	// Set property "ExpiryTime":
 	if typedInput.ExpiryTime != nil {
 		expiryTime := *typedInput.ExpiryTime
 		policy.ExpiryTime = &expiryTime
 	}
 
-	// Set property ‘Permission’:
+	// Set property "Permission":
 	if typedInput.Permission != nil {
 		permission := *typedInput.Permission
 		policy.Permission = &permission
 	}
 
-	// Set property ‘StartTime’:
+	// Set property "StartTime":
 	if typedInput.StartTime != nil {
 		startTime := *typedInput.StartTime
 		policy.StartTime = &startTime

--- a/v2/api/storage/v1beta20210401/storage_account_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_account_types_gen.go
@@ -477,7 +477,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &StorageAccount_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if account.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*account.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -487,7 +487,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if account.Identity != nil {
 		identity_ARM, err := (*account.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -497,22 +497,22 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Identity = &identity
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if account.Kind != nil {
 		kind := *account.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if account.Location != nil {
 		location := *account.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if account.AccessTier != nil ||
 		account.AllowBlobPublicAccess != nil ||
 		account.AllowCrossTenantReplication != nil ||
@@ -624,7 +624,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Properties.SupportsHttpsTrafficOnly = &supportsHttpsTrafficOnly
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if account.Sku != nil {
 		sku_ARM, err := (*account.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -634,7 +634,7 @@ func (account *StorageAccount_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if account.Tags != nil {
 		result.Tags = make(map[string]string, len(account.Tags))
 		for key, value := range account.Tags {
@@ -656,7 +656,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccount_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessTier’:
+	// Set property "AccessTier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessTier != nil {
@@ -665,7 +665,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AllowBlobPublicAccess’:
+	// Set property "AllowBlobPublicAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowBlobPublicAccess != nil {
@@ -674,7 +674,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AllowCrossTenantReplication’:
+	// Set property "AllowCrossTenantReplication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowCrossTenantReplication != nil {
@@ -683,7 +683,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AllowSharedKeyAccess’:
+	// Set property "AllowSharedKeyAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowSharedKeyAccess != nil {
@@ -692,7 +692,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureFilesIdentityBasedAuthentication’:
+	// Set property "AzureFilesIdentityBasedAuthentication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureFilesIdentityBasedAuthentication != nil {
@@ -706,10 +706,10 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	account.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CustomDomain’:
+	// Set property "CustomDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomDomain != nil {
@@ -723,7 +723,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -737,7 +737,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -748,7 +748,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		account.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -759,7 +759,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		account.Identity = &identity
 	}
 
-	// Set property ‘IsHnsEnabled’:
+	// Set property "IsHnsEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHnsEnabled != nil {
@@ -768,7 +768,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘IsNfsV3Enabled’:
+	// Set property "IsNfsV3Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsNfsV3Enabled != nil {
@@ -777,7 +777,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘KeyPolicy’:
+	// Set property "KeyPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyPolicy != nil {
@@ -791,13 +791,13 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		account.Kind = &kind
 	}
 
-	// Set property ‘LargeFileSharesState’:
+	// Set property "LargeFileSharesState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LargeFileSharesState != nil {
@@ -806,13 +806,13 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -821,7 +821,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘NetworkAcls’:
+	// Set property "NetworkAcls":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAcls != nil {
@@ -835,12 +835,12 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// no assignment for property ‘OperatorSpec’
+	// no assignment for property "OperatorSpec"
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	account.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RoutingPreference’:
+	// Set property "RoutingPreference":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RoutingPreference != nil {
@@ -854,7 +854,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘SasPolicy’:
+	// Set property "SasPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SasPolicy != nil {
@@ -868,7 +868,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -879,7 +879,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		account.Sku = &sku
 	}
 
-	// Set property ‘SupportsHttpsTrafficOnly’:
+	// Set property "SupportsHttpsTrafficOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SupportsHttpsTrafficOnly != nil {
@@ -888,7 +888,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1552,7 +1552,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccount_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccessTier’:
+	// Set property "AccessTier":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AccessTier != nil {
@@ -1561,7 +1561,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AllowBlobPublicAccess’:
+	// Set property "AllowBlobPublicAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowBlobPublicAccess != nil {
@@ -1570,7 +1570,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AllowCrossTenantReplication’:
+	// Set property "AllowCrossTenantReplication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowCrossTenantReplication != nil {
@@ -1579,7 +1579,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AllowSharedKeyAccess’:
+	// Set property "AllowSharedKeyAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowSharedKeyAccess != nil {
@@ -1588,7 +1588,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘AzureFilesIdentityBasedAuthentication’:
+	// Set property "AzureFilesIdentityBasedAuthentication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureFilesIdentityBasedAuthentication != nil {
@@ -1602,7 +1602,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘BlobRestoreStatus’:
+	// Set property "BlobRestoreStatus":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.BlobRestoreStatus != nil {
@@ -1616,9 +1616,9 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationTime’:
+	// Set property "CreationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationTime != nil {
@@ -1627,7 +1627,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘CustomDomain’:
+	// Set property "CustomDomain":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomDomain != nil {
@@ -1641,7 +1641,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1655,7 +1655,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1666,7 +1666,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		account.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FailoverInProgress’:
+	// Set property "FailoverInProgress":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FailoverInProgress != nil {
@@ -1675,7 +1675,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘GeoReplicationStats’:
+	// Set property "GeoReplicationStats":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GeoReplicationStats != nil {
@@ -1689,13 +1689,13 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		account.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 Identity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1706,7 +1706,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		account.Identity = &identity
 	}
 
-	// Set property ‘IsHnsEnabled’:
+	// Set property "IsHnsEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsHnsEnabled != nil {
@@ -1715,7 +1715,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘IsNfsV3Enabled’:
+	// Set property "IsNfsV3Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsNfsV3Enabled != nil {
@@ -1724,7 +1724,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘KeyCreationTime’:
+	// Set property "KeyCreationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyCreationTime != nil {
@@ -1738,7 +1738,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘KeyPolicy’:
+	// Set property "KeyPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyPolicy != nil {
@@ -1752,13 +1752,13 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		account.Kind = &kind
 	}
 
-	// Set property ‘LargeFileSharesState’:
+	// Set property "LargeFileSharesState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LargeFileSharesState != nil {
@@ -1767,7 +1767,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘LastGeoFailoverTime’:
+	// Set property "LastGeoFailoverTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastGeoFailoverTime != nil {
@@ -1776,13 +1776,13 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		account.Location = &location
 	}
 
-	// Set property ‘MinimumTlsVersion’:
+	// Set property "MinimumTlsVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MinimumTlsVersion != nil {
@@ -1791,13 +1791,13 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		account.Name = &name
 	}
 
-	// Set property ‘NetworkAcls’:
+	// Set property "NetworkAcls":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NetworkAcls != nil {
@@ -1811,7 +1811,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrimaryEndpoints’:
+	// Set property "PrimaryEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrimaryEndpoints != nil {
@@ -1825,7 +1825,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrimaryLocation’:
+	// Set property "PrimaryLocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PrimaryLocation != nil {
@@ -1834,7 +1834,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1847,7 +1847,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1856,7 +1856,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘RoutingPreference’:
+	// Set property "RoutingPreference":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RoutingPreference != nil {
@@ -1870,7 +1870,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SasPolicy’:
+	// Set property "SasPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SasPolicy != nil {
@@ -1884,7 +1884,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SecondaryEndpoints’:
+	// Set property "SecondaryEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecondaryEndpoints != nil {
@@ -1898,7 +1898,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SecondaryLocation’:
+	// Set property "SecondaryLocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SecondaryLocation != nil {
@@ -1907,7 +1907,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1918,7 +1918,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		account.Sku = &sku
 	}
 
-	// Set property ‘StatusOfPrimary’:
+	// Set property "StatusOfPrimary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StatusOfPrimary != nil {
@@ -1927,7 +1927,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘StatusOfSecondary’:
+	// Set property "StatusOfSecondary":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StatusOfSecondary != nil {
@@ -1936,7 +1936,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘SupportsHttpsTrafficOnly’:
+	// Set property "SupportsHttpsTrafficOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SupportsHttpsTrafficOnly != nil {
@@ -1945,7 +1945,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		account.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1953,7 +1953,7 @@ func (account *StorageAccount_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		account.Type = &typeVar
@@ -2684,7 +2684,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication) ConvertToARM(resolv
 	}
 	result := &AzureFilesIdentityBasedAuthentication_ARM{}
 
-	// Set property ‘ActiveDirectoryProperties’:
+	// Set property "ActiveDirectoryProperties":
 	if authentication.ActiveDirectoryProperties != nil {
 		activeDirectoryProperties_ARM, err := (*authentication.ActiveDirectoryProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -2694,13 +2694,13 @@ func (authentication *AzureFilesIdentityBasedAuthentication) ConvertToARM(resolv
 		result.ActiveDirectoryProperties = &activeDirectoryProperties
 	}
 
-	// Set property ‘DefaultSharePermission’:
+	// Set property "DefaultSharePermission":
 	if authentication.DefaultSharePermission != nil {
 		defaultSharePermission := *authentication.DefaultSharePermission
 		result.DefaultSharePermission = &defaultSharePermission
 	}
 
-	// Set property ‘DirectoryServiceOptions’:
+	// Set property "DirectoryServiceOptions":
 	if authentication.DirectoryServiceOptions != nil {
 		directoryServiceOptions := *authentication.DirectoryServiceOptions
 		result.DirectoryServiceOptions = &directoryServiceOptions
@@ -2720,7 +2720,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication) PopulateFromARM(own
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFilesIdentityBasedAuthentication_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActiveDirectoryProperties’:
+	// Set property "ActiveDirectoryProperties":
 	if typedInput.ActiveDirectoryProperties != nil {
 		var activeDirectoryProperties1 ActiveDirectoryProperties
 		err := activeDirectoryProperties1.PopulateFromARM(owner, *typedInput.ActiveDirectoryProperties)
@@ -2731,13 +2731,13 @@ func (authentication *AzureFilesIdentityBasedAuthentication) PopulateFromARM(own
 		authentication.ActiveDirectoryProperties = &activeDirectoryProperties
 	}
 
-	// Set property ‘DefaultSharePermission’:
+	// Set property "DefaultSharePermission":
 	if typedInput.DefaultSharePermission != nil {
 		defaultSharePermission := *typedInput.DefaultSharePermission
 		authentication.DefaultSharePermission = &defaultSharePermission
 	}
 
-	// Set property ‘DirectoryServiceOptions’:
+	// Set property "DirectoryServiceOptions":
 	if typedInput.DirectoryServiceOptions != nil {
 		directoryServiceOptions := *typedInput.DirectoryServiceOptions
 		authentication.DirectoryServiceOptions = &directoryServiceOptions
@@ -2847,7 +2847,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication_STATUS) PopulateFrom
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureFilesIdentityBasedAuthentication_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActiveDirectoryProperties’:
+	// Set property "ActiveDirectoryProperties":
 	if typedInput.ActiveDirectoryProperties != nil {
 		var activeDirectoryProperties1 ActiveDirectoryProperties_STATUS
 		err := activeDirectoryProperties1.PopulateFromARM(owner, *typedInput.ActiveDirectoryProperties)
@@ -2858,13 +2858,13 @@ func (authentication *AzureFilesIdentityBasedAuthentication_STATUS) PopulateFrom
 		authentication.ActiveDirectoryProperties = &activeDirectoryProperties
 	}
 
-	// Set property ‘DefaultSharePermission’:
+	// Set property "DefaultSharePermission":
 	if typedInput.DefaultSharePermission != nil {
 		defaultSharePermission := *typedInput.DefaultSharePermission
 		authentication.DefaultSharePermission = &defaultSharePermission
 	}
 
-	// Set property ‘DirectoryServiceOptions’:
+	// Set property "DirectoryServiceOptions":
 	if typedInput.DirectoryServiceOptions != nil {
 		directoryServiceOptions := *typedInput.DirectoryServiceOptions
 		authentication.DirectoryServiceOptions = &directoryServiceOptions
@@ -2975,13 +2975,13 @@ func (status *BlobRestoreStatus_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BlobRestoreStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FailureReason’:
+	// Set property "FailureReason":
 	if typedInput.FailureReason != nil {
 		failureReason := *typedInput.FailureReason
 		status.FailureReason = &failureReason
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		var parameters1 BlobRestoreParameters_STATUS
 		err := parameters1.PopulateFromARM(owner, *typedInput.Parameters)
@@ -2992,13 +2992,13 @@ func (status *BlobRestoreStatus_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		status.Parameters = &parameters
 	}
 
-	// Set property ‘RestoreId’:
+	// Set property "RestoreId":
 	if typedInput.RestoreId != nil {
 		restoreId := *typedInput.RestoreId
 		status.RestoreId = &restoreId
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status1 := *typedInput.Status
 		status.Status = &status1
@@ -3099,13 +3099,13 @@ func (domain *CustomDomain) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &CustomDomain_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if domain.Name != nil {
 		name := *domain.Name
 		result.Name = &name
 	}
 
-	// Set property ‘UseSubDomainName’:
+	// Set property "UseSubDomainName":
 	if domain.UseSubDomainName != nil {
 		useSubDomainName := *domain.UseSubDomainName
 		result.UseSubDomainName = &useSubDomainName
@@ -3125,13 +3125,13 @@ func (domain *CustomDomain) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CustomDomain_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		domain.Name = &name
 	}
 
-	// Set property ‘UseSubDomainName’:
+	// Set property "UseSubDomainName":
 	if typedInput.UseSubDomainName != nil {
 		useSubDomainName := *typedInput.UseSubDomainName
 		domain.UseSubDomainName = &useSubDomainName
@@ -3206,13 +3206,13 @@ func (domain *CustomDomain_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CustomDomain_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		domain.Name = &name
 	}
 
-	// Set property ‘UseSubDomainName’:
+	// Set property "UseSubDomainName":
 	if typedInput.UseSubDomainName != nil {
 		useSubDomainName := *typedInput.UseSubDomainName
 		domain.UseSubDomainName = &useSubDomainName
@@ -3287,7 +3287,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Encryption_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if encryption.Identity != nil {
 		identity_ARM, err := (*encryption.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -3297,13 +3297,13 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Identity = &identity
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if encryption.KeySource != nil {
 		keySource := *encryption.KeySource
 		result.KeySource = &keySource
 	}
 
-	// Set property ‘Keyvaultproperties’:
+	// Set property "Keyvaultproperties":
 	if encryption.Keyvaultproperties != nil {
 		keyvaultproperties_ARM, err := (*encryption.Keyvaultproperties).ConvertToARM(resolved)
 		if err != nil {
@@ -3313,13 +3313,13 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		result.Keyvaultproperties = &keyvaultproperties
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if encryption.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *encryption.RequireInfrastructureEncryption
 		result.RequireInfrastructureEncryption = &requireInfrastructureEncryption
 	}
 
-	// Set property ‘Services’:
+	// Set property "Services":
 	if encryption.Services != nil {
 		services_ARM, err := (*encryption.Services).ConvertToARM(resolved)
 		if err != nil {
@@ -3343,7 +3343,7 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 EncryptionIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -3354,13 +3354,13 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		encryption.Identity = &identity
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘Keyvaultproperties’:
+	// Set property "Keyvaultproperties":
 	if typedInput.Keyvaultproperties != nil {
 		var keyvaultproperties1 KeyVaultProperties
 		err := keyvaultproperties1.PopulateFromARM(owner, *typedInput.Keyvaultproperties)
@@ -3371,13 +3371,13 @@ func (encryption *Encryption) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		encryption.Keyvaultproperties = &keyvaultproperties
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
 	}
 
-	// Set property ‘Services’:
+	// Set property "Services":
 	if typedInput.Services != nil {
 		var services1 EncryptionServices
 		err := services1.PopulateFromARM(owner, *typedInput.Services)
@@ -3542,7 +3542,7 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Encryption_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 EncryptionIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -3553,13 +3553,13 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		encryption.Identity = &identity
 	}
 
-	// Set property ‘KeySource’:
+	// Set property "KeySource":
 	if typedInput.KeySource != nil {
 		keySource := *typedInput.KeySource
 		encryption.KeySource = &keySource
 	}
 
-	// Set property ‘Keyvaultproperties’:
+	// Set property "Keyvaultproperties":
 	if typedInput.Keyvaultproperties != nil {
 		var keyvaultproperties1 KeyVaultProperties_STATUS
 		err := keyvaultproperties1.PopulateFromARM(owner, *typedInput.Keyvaultproperties)
@@ -3570,13 +3570,13 @@ func (encryption *Encryption_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		encryption.Keyvaultproperties = &keyvaultproperties
 	}
 
-	// Set property ‘RequireInfrastructureEncryption’:
+	// Set property "RequireInfrastructureEncryption":
 	if typedInput.RequireInfrastructureEncryption != nil {
 		requireInfrastructureEncryption := *typedInput.RequireInfrastructureEncryption
 		encryption.RequireInfrastructureEncryption = &requireInfrastructureEncryption
 	}
 
-	// Set property ‘Services’:
+	// Set property "Services":
 	if typedInput.Services != nil {
 		var services1 EncryptionServices_STATUS
 		err := services1.PopulateFromARM(owner, *typedInput.Services)
@@ -3744,25 +3744,25 @@ func (endpoints *Endpoints_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Endpoints_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		blob := *typedInput.Blob
 		endpoints.Blob = &blob
 	}
 
-	// Set property ‘Dfs’:
+	// Set property "Dfs":
 	if typedInput.Dfs != nil {
 		dfs := *typedInput.Dfs
 		endpoints.Dfs = &dfs
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		file := *typedInput.File
 		endpoints.File = &file
 	}
 
-	// Set property ‘InternetEndpoints’:
+	// Set property "InternetEndpoints":
 	if typedInput.InternetEndpoints != nil {
 		var internetEndpoints1 StorageAccountInternetEndpoints_STATUS
 		err := internetEndpoints1.PopulateFromARM(owner, *typedInput.InternetEndpoints)
@@ -3773,7 +3773,7 @@ func (endpoints *Endpoints_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		endpoints.InternetEndpoints = &internetEndpoints
 	}
 
-	// Set property ‘MicrosoftEndpoints’:
+	// Set property "MicrosoftEndpoints":
 	if typedInput.MicrosoftEndpoints != nil {
 		var microsoftEndpoints1 StorageAccountMicrosoftEndpoints_STATUS
 		err := microsoftEndpoints1.PopulateFromARM(owner, *typedInput.MicrosoftEndpoints)
@@ -3784,19 +3784,19 @@ func (endpoints *Endpoints_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		endpoints.MicrosoftEndpoints = &microsoftEndpoints
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if typedInput.Queue != nil {
 		queue := *typedInput.Queue
 		endpoints.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if typedInput.Table != nil {
 		table := *typedInput.Table
 		endpoints.Table = &table
 	}
 
-	// Set property ‘Web’:
+	// Set property "Web":
 	if typedInput.Web != nil {
 		web := *typedInput.Web
 		endpoints.Web = &web
@@ -3928,13 +3928,13 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if location.Type != nil {
 		typeVar := *location.Type
 		result.Type = &typeVar
@@ -3954,13 +3954,13 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -4035,13 +4035,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -4117,19 +4117,19 @@ func (stats *GeoReplicationStats_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected GeoReplicationStats_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CanFailover’:
+	// Set property "CanFailover":
 	if typedInput.CanFailover != nil {
 		canFailover := *typedInput.CanFailover
 		stats.CanFailover = &canFailover
 	}
 
-	// Set property ‘LastSyncTime’:
+	// Set property "LastSyncTime":
 	if typedInput.LastSyncTime != nil {
 		lastSyncTime := *typedInput.LastSyncTime
 		stats.LastSyncTime = &lastSyncTime
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		stats.Status = &status
@@ -4216,13 +4216,13 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &Identity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -4247,13 +4247,13 @@ func (identity *Identity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -4356,25 +4356,25 @@ func (identity *Identity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Identity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -4498,13 +4498,13 @@ func (time *KeyCreationTime_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyCreationTime_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Key1’:
+	// Set property "Key1":
 	if typedInput.Key1 != nil {
 		key1 := *typedInput.Key1
 		time.Key1 = &key1
 	}
 
-	// Set property ‘Key2’:
+	// Set property "Key2":
 	if typedInput.Key2 != nil {
 		key2 := *typedInput.Key2
 		time.Key2 = &key2
@@ -4564,7 +4564,7 @@ func (policy *KeyPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &KeyPolicy_ARM{}
 
-	// Set property ‘KeyExpirationPeriodInDays’:
+	// Set property "KeyExpirationPeriodInDays":
 	if policy.KeyExpirationPeriodInDays != nil {
 		keyExpirationPeriodInDays := *policy.KeyExpirationPeriodInDays
 		result.KeyExpirationPeriodInDays = &keyExpirationPeriodInDays
@@ -4584,7 +4584,7 @@ func (policy *KeyPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyExpirationPeriodInDays’:
+	// Set property "KeyExpirationPeriodInDays":
 	if typedInput.KeyExpirationPeriodInDays != nil {
 		keyExpirationPeriodInDays := *typedInput.KeyExpirationPeriodInDays
 		policy.KeyExpirationPeriodInDays = &keyExpirationPeriodInDays
@@ -4642,7 +4642,7 @@ func (policy *KeyPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyExpirationPeriodInDays’:
+	// Set property "KeyExpirationPeriodInDays":
 	if typedInput.KeyExpirationPeriodInDays != nil {
 		keyExpirationPeriodInDays := *typedInput.KeyExpirationPeriodInDays
 		policy.KeyExpirationPeriodInDays = &keyExpirationPeriodInDays
@@ -4701,19 +4701,19 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &NetworkRuleSet_ARM{}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if ruleSet.Bypass != nil {
 		bypass := *ruleSet.Bypass
 		result.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if ruleSet.DefaultAction != nil {
 		defaultAction := *ruleSet.DefaultAction
 		result.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range ruleSet.IpRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4722,7 +4722,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.IpRules = append(result.IpRules, *item_ARM.(*IPRule_ARM))
 	}
 
-	// Set property ‘ResourceAccessRules’:
+	// Set property "ResourceAccessRules":
 	for _, item := range ruleSet.ResourceAccessRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4731,7 +4731,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		result.ResourceAccessRules = append(result.ResourceAccessRules, *item_ARM.(*ResourceAccessRule_ARM))
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range ruleSet.VirtualNetworkRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4754,19 +4754,19 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if typedInput.Bypass != nil {
 		bypass := *typedInput.Bypass
 		ruleSet.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule
 		err := item1.PopulateFromARM(owner, item)
@@ -4776,7 +4776,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		ruleSet.IpRules = append(ruleSet.IpRules, item1)
 	}
 
-	// Set property ‘ResourceAccessRules’:
+	// Set property "ResourceAccessRules":
 	for _, item := range typedInput.ResourceAccessRules {
 		var item1 ResourceAccessRule
 		err := item1.PopulateFromARM(owner, item)
@@ -4786,7 +4786,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		ruleSet.ResourceAccessRules = append(ruleSet.ResourceAccessRules, item1)
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range typedInput.VirtualNetworkRules {
 		var item1 VirtualNetworkRule
 		err := item1.PopulateFromARM(owner, item)
@@ -4986,19 +4986,19 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NetworkRuleSet_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Bypass’:
+	// Set property "Bypass":
 	if typedInput.Bypass != nil {
 		bypass := *typedInput.Bypass
 		ruleSet.Bypass = &bypass
 	}
 
-	// Set property ‘DefaultAction’:
+	// Set property "DefaultAction":
 	if typedInput.DefaultAction != nil {
 		defaultAction := *typedInput.DefaultAction
 		ruleSet.DefaultAction = &defaultAction
 	}
 
-	// Set property ‘IpRules’:
+	// Set property "IpRules":
 	for _, item := range typedInput.IpRules {
 		var item1 IPRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5008,7 +5008,7 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		ruleSet.IpRules = append(ruleSet.IpRules, item1)
 	}
 
-	// Set property ‘ResourceAccessRules’:
+	// Set property "ResourceAccessRules":
 	for _, item := range typedInput.ResourceAccessRules {
 		var item1 ResourceAccessRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5018,7 +5018,7 @@ func (ruleSet *NetworkRuleSet_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		ruleSet.ResourceAccessRules = append(ruleSet.ResourceAccessRules, item1)
 	}
 
-	// Set property ‘VirtualNetworkRules’:
+	// Set property "VirtualNetworkRules":
 	for _, item := range typedInput.VirtualNetworkRules {
 		var item1 VirtualNetworkRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -5214,7 +5214,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -5269,19 +5269,19 @@ func (preference *RoutingPreference) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &RoutingPreference_ARM{}
 
-	// Set property ‘PublishInternetEndpoints’:
+	// Set property "PublishInternetEndpoints":
 	if preference.PublishInternetEndpoints != nil {
 		publishInternetEndpoints := *preference.PublishInternetEndpoints
 		result.PublishInternetEndpoints = &publishInternetEndpoints
 	}
 
-	// Set property ‘PublishMicrosoftEndpoints’:
+	// Set property "PublishMicrosoftEndpoints":
 	if preference.PublishMicrosoftEndpoints != nil {
 		publishMicrosoftEndpoints := *preference.PublishMicrosoftEndpoints
 		result.PublishMicrosoftEndpoints = &publishMicrosoftEndpoints
 	}
 
-	// Set property ‘RoutingChoice’:
+	// Set property "RoutingChoice":
 	if preference.RoutingChoice != nil {
 		routingChoice := *preference.RoutingChoice
 		result.RoutingChoice = &routingChoice
@@ -5301,19 +5301,19 @@ func (preference *RoutingPreference) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingPreference_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublishInternetEndpoints’:
+	// Set property "PublishInternetEndpoints":
 	if typedInput.PublishInternetEndpoints != nil {
 		publishInternetEndpoints := *typedInput.PublishInternetEndpoints
 		preference.PublishInternetEndpoints = &publishInternetEndpoints
 	}
 
-	// Set property ‘PublishMicrosoftEndpoints’:
+	// Set property "PublishMicrosoftEndpoints":
 	if typedInput.PublishMicrosoftEndpoints != nil {
 		publishMicrosoftEndpoints := *typedInput.PublishMicrosoftEndpoints
 		preference.PublishMicrosoftEndpoints = &publishMicrosoftEndpoints
 	}
 
-	// Set property ‘RoutingChoice’:
+	// Set property "RoutingChoice":
 	if typedInput.RoutingChoice != nil {
 		routingChoice := *typedInput.RoutingChoice
 		preference.RoutingChoice = &routingChoice
@@ -5415,19 +5415,19 @@ func (preference *RoutingPreference_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RoutingPreference_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PublishInternetEndpoints’:
+	// Set property "PublishInternetEndpoints":
 	if typedInput.PublishInternetEndpoints != nil {
 		publishInternetEndpoints := *typedInput.PublishInternetEndpoints
 		preference.PublishInternetEndpoints = &publishInternetEndpoints
 	}
 
-	// Set property ‘PublishMicrosoftEndpoints’:
+	// Set property "PublishMicrosoftEndpoints":
 	if typedInput.PublishMicrosoftEndpoints != nil {
 		publishMicrosoftEndpoints := *typedInput.PublishMicrosoftEndpoints
 		preference.PublishMicrosoftEndpoints = &publishMicrosoftEndpoints
 	}
 
-	// Set property ‘RoutingChoice’:
+	// Set property "RoutingChoice":
 	if typedInput.RoutingChoice != nil {
 		routingChoice := *typedInput.RoutingChoice
 		preference.RoutingChoice = &routingChoice
@@ -5526,13 +5526,13 @@ func (policy *SasPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &SasPolicy_ARM{}
 
-	// Set property ‘ExpirationAction’:
+	// Set property "ExpirationAction":
 	if policy.ExpirationAction != nil {
 		expirationAction := *policy.ExpirationAction
 		result.ExpirationAction = &expirationAction
 	}
 
-	// Set property ‘SasExpirationPeriod’:
+	// Set property "SasExpirationPeriod":
 	if policy.SasExpirationPeriod != nil {
 		sasExpirationPeriod := *policy.SasExpirationPeriod
 		result.SasExpirationPeriod = &sasExpirationPeriod
@@ -5552,13 +5552,13 @@ func (policy *SasPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SasPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpirationAction’:
+	// Set property "ExpirationAction":
 	if typedInput.ExpirationAction != nil {
 		expirationAction := *typedInput.ExpirationAction
 		policy.ExpirationAction = &expirationAction
 	}
 
-	// Set property ‘SasExpirationPeriod’:
+	// Set property "SasExpirationPeriod":
 	if typedInput.SasExpirationPeriod != nil {
 		sasExpirationPeriod := *typedInput.SasExpirationPeriod
 		policy.SasExpirationPeriod = &sasExpirationPeriod
@@ -5633,13 +5633,13 @@ func (policy *SasPolicy_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SasPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ExpirationAction’:
+	// Set property "ExpirationAction":
 	if typedInput.ExpirationAction != nil {
 		expirationAction := *typedInput.ExpirationAction
 		policy.ExpirationAction = &expirationAction
 	}
 
-	// Set property ‘SasExpirationPeriod’:
+	// Set property "SasExpirationPeriod":
 	if typedInput.SasExpirationPeriod != nil {
 		sasExpirationPeriod := *typedInput.SasExpirationPeriod
 		policy.SasExpirationPeriod = &sasExpirationPeriod
@@ -5710,13 +5710,13 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Sku_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if sku.Name != nil {
 		name := *sku.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if sku.Tier != nil {
 		tier := *sku.Tier
 		result.Tier = &tier
@@ -5736,13 +5736,13 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -5827,13 +5827,13 @@ func (sku *Sku_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Sku_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		sku.Name = &name
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		sku.Tier = &tier
@@ -6095,37 +6095,37 @@ func (properties *ActiveDirectoryProperties) ConvertToARM(resolved genruntime.Co
 	}
 	result := &ActiveDirectoryProperties_ARM{}
 
-	// Set property ‘AzureStorageSid’:
+	// Set property "AzureStorageSid":
 	if properties.AzureStorageSid != nil {
 		azureStorageSid := *properties.AzureStorageSid
 		result.AzureStorageSid = &azureStorageSid
 	}
 
-	// Set property ‘DomainGuid’:
+	// Set property "DomainGuid":
 	if properties.DomainGuid != nil {
 		domainGuid := *properties.DomainGuid
 		result.DomainGuid = &domainGuid
 	}
 
-	// Set property ‘DomainName’:
+	// Set property "DomainName":
 	if properties.DomainName != nil {
 		domainName := *properties.DomainName
 		result.DomainName = &domainName
 	}
 
-	// Set property ‘DomainSid’:
+	// Set property "DomainSid":
 	if properties.DomainSid != nil {
 		domainSid := *properties.DomainSid
 		result.DomainSid = &domainSid
 	}
 
-	// Set property ‘ForestName’:
+	// Set property "ForestName":
 	if properties.ForestName != nil {
 		forestName := *properties.ForestName
 		result.ForestName = &forestName
 	}
 
-	// Set property ‘NetBiosDomainName’:
+	// Set property "NetBiosDomainName":
 	if properties.NetBiosDomainName != nil {
 		netBiosDomainName := *properties.NetBiosDomainName
 		result.NetBiosDomainName = &netBiosDomainName
@@ -6145,37 +6145,37 @@ func (properties *ActiveDirectoryProperties) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ActiveDirectoryProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureStorageSid’:
+	// Set property "AzureStorageSid":
 	if typedInput.AzureStorageSid != nil {
 		azureStorageSid := *typedInput.AzureStorageSid
 		properties.AzureStorageSid = &azureStorageSid
 	}
 
-	// Set property ‘DomainGuid’:
+	// Set property "DomainGuid":
 	if typedInput.DomainGuid != nil {
 		domainGuid := *typedInput.DomainGuid
 		properties.DomainGuid = &domainGuid
 	}
 
-	// Set property ‘DomainName’:
+	// Set property "DomainName":
 	if typedInput.DomainName != nil {
 		domainName := *typedInput.DomainName
 		properties.DomainName = &domainName
 	}
 
-	// Set property ‘DomainSid’:
+	// Set property "DomainSid":
 	if typedInput.DomainSid != nil {
 		domainSid := *typedInput.DomainSid
 		properties.DomainSid = &domainSid
 	}
 
-	// Set property ‘ForestName’:
+	// Set property "ForestName":
 	if typedInput.ForestName != nil {
 		forestName := *typedInput.ForestName
 		properties.ForestName = &forestName
 	}
 
-	// Set property ‘NetBiosDomainName’:
+	// Set property "NetBiosDomainName":
 	if typedInput.NetBiosDomainName != nil {
 		netBiosDomainName := *typedInput.NetBiosDomainName
 		properties.NetBiosDomainName = &netBiosDomainName
@@ -6268,37 +6268,37 @@ func (properties *ActiveDirectoryProperties_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ActiveDirectoryProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureStorageSid’:
+	// Set property "AzureStorageSid":
 	if typedInput.AzureStorageSid != nil {
 		azureStorageSid := *typedInput.AzureStorageSid
 		properties.AzureStorageSid = &azureStorageSid
 	}
 
-	// Set property ‘DomainGuid’:
+	// Set property "DomainGuid":
 	if typedInput.DomainGuid != nil {
 		domainGuid := *typedInput.DomainGuid
 		properties.DomainGuid = &domainGuid
 	}
 
-	// Set property ‘DomainName’:
+	// Set property "DomainName":
 	if typedInput.DomainName != nil {
 		domainName := *typedInput.DomainName
 		properties.DomainName = &domainName
 	}
 
-	// Set property ‘DomainSid’:
+	// Set property "DomainSid":
 	if typedInput.DomainSid != nil {
 		domainSid := *typedInput.DomainSid
 		properties.DomainSid = &domainSid
 	}
 
-	// Set property ‘ForestName’:
+	// Set property "ForestName":
 	if typedInput.ForestName != nil {
 		forestName := *typedInput.ForestName
 		properties.ForestName = &forestName
 	}
 
-	// Set property ‘NetBiosDomainName’:
+	// Set property "NetBiosDomainName":
 	if typedInput.NetBiosDomainName != nil {
 		netBiosDomainName := *typedInput.NetBiosDomainName
 		properties.NetBiosDomainName = &netBiosDomainName
@@ -6433,7 +6433,7 @@ func (parameters *BlobRestoreParameters_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BlobRestoreParameters_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobRanges’:
+	// Set property "BlobRanges":
 	for _, item := range typedInput.BlobRanges {
 		var item1 BlobRestoreRange_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6443,7 +6443,7 @@ func (parameters *BlobRestoreParameters_STATUS) PopulateFromARM(owner genruntime
 		parameters.BlobRanges = append(parameters.BlobRanges, item1)
 	}
 
-	// Set property ‘TimeToRestore’:
+	// Set property "TimeToRestore":
 	if typedInput.TimeToRestore != nil {
 		timeToRestore := *typedInput.TimeToRestore
 		parameters.TimeToRestore = &timeToRestore
@@ -6558,7 +6558,7 @@ func (identity *EncryptionIdentity) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &EncryptionIdentity_ARM{}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if identity.UserAssignedIdentityReference != nil {
 		userAssignedIdentityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*identity.UserAssignedIdentityReference)
 		if err != nil {
@@ -6582,7 +6582,7 @@ func (identity *EncryptionIdentity) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionIdentity_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘UserAssignedIdentityReference’
+	// no assignment for property "UserAssignedIdentityReference"
 
 	// No error
 	return nil
@@ -6646,7 +6646,7 @@ func (identity *EncryptionIdentity_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		identity.UserAssignedIdentity = &userAssignedIdentity
@@ -6702,7 +6702,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &EncryptionServices_ARM{}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if services.Blob != nil {
 		blob_ARM, err := (*services.Blob).ConvertToARM(resolved)
 		if err != nil {
@@ -6712,7 +6712,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Blob = &blob
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if services.File != nil {
 		file_ARM, err := (*services.File).ConvertToARM(resolved)
 		if err != nil {
@@ -6722,7 +6722,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		result.File = &file
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if services.Queue != nil {
 		queue_ARM, err := (*services.Queue).ConvertToARM(resolved)
 		if err != nil {
@@ -6732,7 +6732,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		result.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if services.Table != nil {
 		table_ARM, err := (*services.Table).ConvertToARM(resolved)
 		if err != nil {
@@ -6756,7 +6756,7 @@ func (services *EncryptionServices) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionServices_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		var blob1 EncryptionService
 		err := blob1.PopulateFromARM(owner, *typedInput.Blob)
@@ -6767,7 +6767,7 @@ func (services *EncryptionServices) PopulateFromARM(owner genruntime.ArbitraryOw
 		services.Blob = &blob
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		var file1 EncryptionService
 		err := file1.PopulateFromARM(owner, *typedInput.File)
@@ -6778,7 +6778,7 @@ func (services *EncryptionServices) PopulateFromARM(owner genruntime.ArbitraryOw
 		services.File = &file
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if typedInput.Queue != nil {
 		var queue1 EncryptionService
 		err := queue1.PopulateFromARM(owner, *typedInput.Queue)
@@ -6789,7 +6789,7 @@ func (services *EncryptionServices) PopulateFromARM(owner genruntime.ArbitraryOw
 		services.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if typedInput.Table != nil {
 		var table1 EncryptionService
 		err := table1.PopulateFromARM(owner, *typedInput.Table)
@@ -6945,7 +6945,7 @@ func (services *EncryptionServices_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionServices_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		var blob1 EncryptionService_STATUS
 		err := blob1.PopulateFromARM(owner, *typedInput.Blob)
@@ -6956,7 +6956,7 @@ func (services *EncryptionServices_STATUS) PopulateFromARM(owner genruntime.Arbi
 		services.Blob = &blob
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		var file1 EncryptionService_STATUS
 		err := file1.PopulateFromARM(owner, *typedInput.File)
@@ -6967,7 +6967,7 @@ func (services *EncryptionServices_STATUS) PopulateFromARM(owner genruntime.Arbi
 		services.File = &file
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if typedInput.Queue != nil {
 		var queue1 EncryptionService_STATUS
 		err := queue1.PopulateFromARM(owner, *typedInput.Queue)
@@ -6978,7 +6978,7 @@ func (services *EncryptionServices_STATUS) PopulateFromARM(owner genruntime.Arbi
 		services.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if typedInput.Table != nil {
 		var table1 EncryptionService_STATUS
 		err := table1.PopulateFromARM(owner, *typedInput.Table)
@@ -7138,13 +7138,13 @@ func (rule *IPRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	}
 	result := &IPRule_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if rule.Action != nil {
 		action := *rule.Action
 		result.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if rule.Value != nil {
 		value := *rule.Value
 		result.Value = &value
@@ -7164,13 +7164,13 @@ func (rule *IPRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -7245,13 +7245,13 @@ func (rule *IPRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IPRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		rule.Value = &value
@@ -7322,19 +7322,19 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &KeyVaultProperties_ARM{}
 
-	// Set property ‘Keyname’:
+	// Set property "Keyname":
 	if properties.Keyname != nil {
 		keyname := *properties.Keyname
 		result.Keyname = &keyname
 	}
 
-	// Set property ‘Keyvaulturi’:
+	// Set property "Keyvaulturi":
 	if properties.Keyvaulturi != nil {
 		keyvaulturi := *properties.Keyvaulturi
 		result.Keyvaulturi = &keyvaulturi
 	}
 
-	// Set property ‘Keyversion’:
+	// Set property "Keyversion":
 	if properties.Keyversion != nil {
 		keyversion := *properties.Keyversion
 		result.Keyversion = &keyversion
@@ -7354,19 +7354,19 @@ func (properties *KeyVaultProperties) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Keyname’:
+	// Set property "Keyname":
 	if typedInput.Keyname != nil {
 		keyname := *typedInput.Keyname
 		properties.Keyname = &keyname
 	}
 
-	// Set property ‘Keyvaulturi’:
+	// Set property "Keyvaulturi":
 	if typedInput.Keyvaulturi != nil {
 		keyvaulturi := *typedInput.Keyvaulturi
 		properties.Keyvaulturi = &keyvaulturi
 	}
 
-	// Set property ‘Keyversion’:
+	// Set property "Keyversion":
 	if typedInput.Keyversion != nil {
 		keyversion := *typedInput.Keyversion
 		properties.Keyversion = &keyversion
@@ -7440,31 +7440,31 @@ func (properties *KeyVaultProperties_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KeyVaultProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CurrentVersionedKeyIdentifier’:
+	// Set property "CurrentVersionedKeyIdentifier":
 	if typedInput.CurrentVersionedKeyIdentifier != nil {
 		currentVersionedKeyIdentifier := *typedInput.CurrentVersionedKeyIdentifier
 		properties.CurrentVersionedKeyIdentifier = &currentVersionedKeyIdentifier
 	}
 
-	// Set property ‘Keyname’:
+	// Set property "Keyname":
 	if typedInput.Keyname != nil {
 		keyname := *typedInput.Keyname
 		properties.Keyname = &keyname
 	}
 
-	// Set property ‘Keyvaulturi’:
+	// Set property "Keyvaulturi":
 	if typedInput.Keyvaulturi != nil {
 		keyvaulturi := *typedInput.Keyvaulturi
 		properties.Keyvaulturi = &keyvaulturi
 	}
 
-	// Set property ‘Keyversion’:
+	// Set property "Keyversion":
 	if typedInput.Keyversion != nil {
 		keyversion := *typedInput.Keyversion
 		properties.Keyversion = &keyversion
 	}
 
-	// Set property ‘LastKeyRotationTimestamp’:
+	// Set property "LastKeyRotationTimestamp":
 	if typedInput.LastKeyRotationTimestamp != nil {
 		lastKeyRotationTimestamp := *typedInput.LastKeyRotationTimestamp
 		properties.LastKeyRotationTimestamp = &lastKeyRotationTimestamp
@@ -7580,7 +7580,7 @@ func (rule *ResourceAccessRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &ResourceAccessRule_ARM{}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if rule.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.ResourceReference)
 		if err != nil {
@@ -7590,7 +7590,7 @@ func (rule *ResourceAccessRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.ResourceId = &resourceReference
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if rule.TenantId != nil {
 		tenantId := *rule.TenantId
 		result.TenantId = &tenantId
@@ -7610,9 +7610,9 @@ func (rule *ResourceAccessRule) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceAccessRule_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		rule.TenantId = &tenantId
@@ -7687,13 +7687,13 @@ func (rule *ResourceAccessRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ResourceAccessRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		rule.ResourceId = &resourceId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		rule.TenantId = &tenantId
@@ -7789,25 +7789,25 @@ func (endpoints *StorageAccountInternetEndpoints_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccountInternetEndpoints_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		blob := *typedInput.Blob
 		endpoints.Blob = &blob
 	}
 
-	// Set property ‘Dfs’:
+	// Set property "Dfs":
 	if typedInput.Dfs != nil {
 		dfs := *typedInput.Dfs
 		endpoints.Dfs = &dfs
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		file := *typedInput.File
 		endpoints.File = &file
 	}
 
-	// Set property ‘Web’:
+	// Set property "Web":
 	if typedInput.Web != nil {
 		web := *typedInput.Web
 		endpoints.Web = &web
@@ -7888,37 +7888,37 @@ func (endpoints *StorageAccountMicrosoftEndpoints_STATUS) PopulateFromARM(owner 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccountMicrosoftEndpoints_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Blob’:
+	// Set property "Blob":
 	if typedInput.Blob != nil {
 		blob := *typedInput.Blob
 		endpoints.Blob = &blob
 	}
 
-	// Set property ‘Dfs’:
+	// Set property "Dfs":
 	if typedInput.Dfs != nil {
 		dfs := *typedInput.Dfs
 		endpoints.Dfs = &dfs
 	}
 
-	// Set property ‘File’:
+	// Set property "File":
 	if typedInput.File != nil {
 		file := *typedInput.File
 		endpoints.File = &file
 	}
 
-	// Set property ‘Queue’:
+	// Set property "Queue":
 	if typedInput.Queue != nil {
 		queue := *typedInput.Queue
 		endpoints.Queue = &queue
 	}
 
-	// Set property ‘Table’:
+	// Set property "Table":
 	if typedInput.Table != nil {
 		table := *typedInput.Table
 		endpoints.Table = &table
 	}
 
-	// Set property ‘Web’:
+	// Set property "Web":
 	if typedInput.Web != nil {
 		web := *typedInput.Web
 		endpoints.Web = &web
@@ -8329,13 +8329,13 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
@@ -8432,13 +8432,13 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &VirtualNetworkRule_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if rule.Action != nil {
 		action := *rule.Action
 		result.Action = &action
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if rule.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*rule.Reference)
 		if err != nil {
@@ -8448,7 +8448,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.Id = &reference
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if rule.State != nil {
 		state := *rule.State
 		result.State = &state
@@ -8468,15 +8468,15 @@ func (rule *VirtualNetworkRule) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		rule.State = &state
@@ -8578,19 +8578,19 @@ func (rule *VirtualNetworkRule_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		rule.Action = &action
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		rule.Id = &id
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		rule.State = &state
@@ -8681,13 +8681,13 @@ func (restoreRange *BlobRestoreRange_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BlobRestoreRange_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘EndRange’:
+	// Set property "EndRange":
 	if typedInput.EndRange != nil {
 		endRange := *typedInput.EndRange
 		restoreRange.EndRange = &endRange
 	}
 
-	// Set property ‘StartRange’:
+	// Set property "StartRange":
 	if typedInput.StartRange != nil {
 		startRange := *typedInput.StartRange
 		restoreRange.StartRange = &startRange
@@ -8747,13 +8747,13 @@ func (service *EncryptionService) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &EncryptionService_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if service.Enabled != nil {
 		enabled := *service.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘KeyType’:
+	// Set property "KeyType":
 	if service.KeyType != nil {
 		keyType := *service.KeyType
 		result.KeyType = &keyType
@@ -8773,13 +8773,13 @@ func (service *EncryptionService) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionService_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		service.Enabled = &enabled
 	}
 
-	// Set property ‘KeyType’:
+	// Set property "KeyType":
 	if typedInput.KeyType != nil {
 		keyType := *typedInput.KeyType
 		service.KeyType = &keyType
@@ -8865,19 +8865,19 @@ func (service *EncryptionService_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionService_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		service.Enabled = &enabled
 	}
 
-	// Set property ‘KeyType’:
+	// Set property "KeyType":
 	if typedInput.KeyType != nil {
 		keyType := *typedInput.KeyType
 		service.KeyType = &keyType
 	}
 
-	// Set property ‘LastEnabledTime’:
+	// Set property "LastEnabledTime":
 	if typedInput.LastEnabledTime != nil {
 		lastEnabledTime := *typedInput.LastEnabledTime
 		service.LastEnabledTime = &lastEnabledTime

--- a/v2/api/storage/v1beta20210401/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_blob_service_types_gen.go
@@ -329,10 +329,10 @@ func (service *StorageAccounts_BlobService_Spec) ConvertToARM(resolved genruntim
 	}
 	result := &StorageAccounts_BlobService_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if service.AutomaticSnapshotPolicyEnabled != nil ||
 		service.ChangeFeed != nil ||
 		service.ContainerDeleteRetentionPolicy != nil ||
@@ -419,7 +419,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_BlobService_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticSnapshotPolicyEnabled’:
+	// Set property "AutomaticSnapshotPolicyEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticSnapshotPolicyEnabled != nil {
@@ -428,7 +428,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ChangeFeed’:
+	// Set property "ChangeFeed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ChangeFeed != nil {
@@ -442,7 +442,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘ContainerDeleteRetentionPolicy’:
+	// Set property "ContainerDeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ContainerDeleteRetentionPolicy != nil {
@@ -456,7 +456,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -470,7 +470,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘DefaultServiceVersion’:
+	// Set property "DefaultServiceVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultServiceVersion != nil {
@@ -479,7 +479,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘DeleteRetentionPolicy’:
+	// Set property "DeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteRetentionPolicy != nil {
@@ -493,7 +493,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘IsVersioningEnabled’:
+	// Set property "IsVersioningEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsVersioningEnabled != nil {
@@ -502,7 +502,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘LastAccessTimeTrackingPolicy’:
+	// Set property "LastAccessTimeTrackingPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastAccessTimeTrackingPolicy != nil {
@@ -516,10 +516,10 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘RestorePolicy’:
+	// Set property "RestorePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestorePolicy != nil {
@@ -900,7 +900,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_BlobService_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutomaticSnapshotPolicyEnabled’:
+	// Set property "AutomaticSnapshotPolicyEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutomaticSnapshotPolicyEnabled != nil {
@@ -909,7 +909,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘ChangeFeed’:
+	// Set property "ChangeFeed":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ChangeFeed != nil {
@@ -923,9 +923,9 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ContainerDeleteRetentionPolicy’:
+	// Set property "ContainerDeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ContainerDeleteRetentionPolicy != nil {
@@ -939,7 +939,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -953,7 +953,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘DefaultServiceVersion’:
+	// Set property "DefaultServiceVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultServiceVersion != nil {
@@ -962,7 +962,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘DeleteRetentionPolicy’:
+	// Set property "DeleteRetentionPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeleteRetentionPolicy != nil {
@@ -976,13 +976,13 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		service.Id = &id
 	}
 
-	// Set property ‘IsVersioningEnabled’:
+	// Set property "IsVersioningEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsVersioningEnabled != nil {
@@ -991,7 +991,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘LastAccessTimeTrackingPolicy’:
+	// Set property "LastAccessTimeTrackingPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastAccessTimeTrackingPolicy != nil {
@@ -1005,13 +1005,13 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		service.Name = &name
 	}
 
-	// Set property ‘RestorePolicy’:
+	// Set property "RestorePolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RestorePolicy != nil {
@@ -1025,7 +1025,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 Sku_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1036,7 +1036,7 @@ func (service *StorageAccounts_BlobService_STATUS) PopulateFromARM(owner genrunt
 		service.Sku = &sku
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		service.Type = &typeVar
@@ -1317,13 +1317,13 @@ func (feed *ChangeFeed) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &ChangeFeed_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if feed.Enabled != nil {
 		enabled := *feed.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	if feed.RetentionInDays != nil {
 		retentionInDays := *feed.RetentionInDays
 		result.RetentionInDays = &retentionInDays
@@ -1343,13 +1343,13 @@ func (feed *ChangeFeed) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ChangeFeed_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		feed.Enabled = &enabled
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	if typedInput.RetentionInDays != nil {
 		retentionInDays := *typedInput.RetentionInDays
 		feed.RetentionInDays = &retentionInDays
@@ -1434,13 +1434,13 @@ func (feed *ChangeFeed_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ChangeFeed_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		feed.Enabled = &enabled
 	}
 
-	// Set property ‘RetentionInDays’:
+	// Set property "RetentionInDays":
 	if typedInput.RetentionInDays != nil {
 		retentionInDays := *typedInput.RetentionInDays
 		feed.RetentionInDays = &retentionInDays
@@ -1509,7 +1509,7 @@ func (rules *CorsRules) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &CorsRules_ARM{}
 
-	// Set property ‘CorsRules’:
+	// Set property "CorsRules":
 	for _, item := range rules.CorsRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1532,7 +1532,7 @@ func (rules *CorsRules) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsRules_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CorsRules’:
+	// Set property "CorsRules":
 	for _, item := range typedInput.CorsRules {
 		var item1 CorsRule
 		err := item1.PopulateFromARM(owner, item)
@@ -1624,7 +1624,7 @@ func (rules *CorsRules_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsRules_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CorsRules’:
+	// Set property "CorsRules":
 	for _, item := range typedInput.CorsRules {
 		var item1 CorsRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1714,13 +1714,13 @@ func (policy *DeleteRetentionPolicy) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &DeleteRetentionPolicy_ARM{}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if policy.Days != nil {
 		days := *policy.Days
 		result.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if policy.Enabled != nil {
 		enabled := *policy.Enabled
 		result.Enabled = &enabled
@@ -1740,13 +1740,13 @@ func (policy *DeleteRetentionPolicy) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeleteRetentionPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		policy.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
@@ -1831,13 +1831,13 @@ func (policy *DeleteRetentionPolicy_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DeleteRetentionPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		policy.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		policy.Enabled = &enabled
@@ -1911,24 +1911,24 @@ func (policy *LastAccessTimeTrackingPolicy) ConvertToARM(resolved genruntime.Con
 	}
 	result := &LastAccessTimeTrackingPolicy_ARM{}
 
-	// Set property ‘BlobType’:
+	// Set property "BlobType":
 	for _, item := range policy.BlobType {
 		result.BlobType = append(result.BlobType, item)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if policy.Enable != nil {
 		enable := *policy.Enable
 		result.Enable = &enable
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if policy.Name != nil {
 		name := *policy.Name
 		result.Name = &name
 	}
 
-	// Set property ‘TrackingGranularityInDays’:
+	// Set property "TrackingGranularityInDays":
 	if policy.TrackingGranularityInDays != nil {
 		trackingGranularityInDays := *policy.TrackingGranularityInDays
 		result.TrackingGranularityInDays = &trackingGranularityInDays
@@ -1948,24 +1948,24 @@ func (policy *LastAccessTimeTrackingPolicy) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LastAccessTimeTrackingPolicy_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobType’:
+	// Set property "BlobType":
 	for _, item := range typedInput.BlobType {
 		policy.BlobType = append(policy.BlobType, item)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		policy.Enable = &enable
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘TrackingGranularityInDays’:
+	// Set property "TrackingGranularityInDays":
 	if typedInput.TrackingGranularityInDays != nil {
 		trackingGranularityInDays := *typedInput.TrackingGranularityInDays
 		policy.TrackingGranularityInDays = &trackingGranularityInDays
@@ -2064,24 +2064,24 @@ func (policy *LastAccessTimeTrackingPolicy_STATUS) PopulateFromARM(owner genrunt
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LastAccessTimeTrackingPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobType’:
+	// Set property "BlobType":
 	for _, item := range typedInput.BlobType {
 		policy.BlobType = append(policy.BlobType, item)
 	}
 
-	// Set property ‘Enable’:
+	// Set property "Enable":
 	if typedInput.Enable != nil {
 		enable := *typedInput.Enable
 		policy.Enable = &enable
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘TrackingGranularityInDays’:
+	// Set property "TrackingGranularityInDays":
 	if typedInput.TrackingGranularityInDays != nil {
 		trackingGranularityInDays := *typedInput.TrackingGranularityInDays
 		policy.TrackingGranularityInDays = &trackingGranularityInDays
@@ -2177,13 +2177,13 @@ func (properties *RestorePolicyProperties) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &RestorePolicyProperties_ARM{}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if properties.Days != nil {
 		days := *properties.Days
 		result.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if properties.Enabled != nil {
 		enabled := *properties.Enabled
 		result.Enabled = &enabled
@@ -2203,13 +2203,13 @@ func (properties *RestorePolicyProperties) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RestorePolicyProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		properties.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
@@ -2296,25 +2296,25 @@ func (properties *RestorePolicyProperties_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RestorePolicyProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Days’:
+	// Set property "Days":
 	if typedInput.Days != nil {
 		days := *typedInput.Days
 		properties.Days = &days
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
 	}
 
-	// Set property ‘LastEnabledTime’:
+	// Set property "LastEnabledTime":
 	if typedInput.LastEnabledTime != nil {
 		lastEnabledTime := *typedInput.LastEnabledTime
 		properties.LastEnabledTime = &lastEnabledTime
 	}
 
-	// Set property ‘MinRestoreTime’:
+	// Set property "MinRestoreTime":
 	if typedInput.MinRestoreTime != nil {
 		minRestoreTime := *typedInput.MinRestoreTime
 		properties.MinRestoreTime = &minRestoreTime
@@ -2408,27 +2408,27 @@ func (rule *CorsRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	}
 	result := &CorsRule_ARM{}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	for _, item := range rule.AllowedHeaders {
 		result.AllowedHeaders = append(result.AllowedHeaders, item)
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	for _, item := range rule.AllowedMethods {
 		result.AllowedMethods = append(result.AllowedMethods, item)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range rule.AllowedOrigins {
 		result.AllowedOrigins = append(result.AllowedOrigins, item)
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	for _, item := range rule.ExposedHeaders {
 		result.ExposedHeaders = append(result.ExposedHeaders, item)
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if rule.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *rule.MaxAgeInSeconds
 		result.MaxAgeInSeconds = &maxAgeInSeconds
@@ -2448,27 +2448,27 @@ func (rule *CorsRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, 
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	for _, item := range typedInput.AllowedHeaders {
 		rule.AllowedHeaders = append(rule.AllowedHeaders, item)
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	for _, item := range typedInput.AllowedMethods {
 		rule.AllowedMethods = append(rule.AllowedMethods, item)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		rule.AllowedOrigins = append(rule.AllowedOrigins, item)
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	for _, item := range typedInput.ExposedHeaders {
 		rule.ExposedHeaders = append(rule.ExposedHeaders, item)
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if typedInput.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *typedInput.MaxAgeInSeconds
 		rule.MaxAgeInSeconds = &maxAgeInSeconds
@@ -2574,27 +2574,27 @@ func (rule *CorsRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedHeaders’:
+	// Set property "AllowedHeaders":
 	for _, item := range typedInput.AllowedHeaders {
 		rule.AllowedHeaders = append(rule.AllowedHeaders, item)
 	}
 
-	// Set property ‘AllowedMethods’:
+	// Set property "AllowedMethods":
 	for _, item := range typedInput.AllowedMethods {
 		rule.AllowedMethods = append(rule.AllowedMethods, item)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		rule.AllowedOrigins = append(rule.AllowedOrigins, item)
 	}
 
-	// Set property ‘ExposedHeaders’:
+	// Set property "ExposedHeaders":
 	for _, item := range typedInput.ExposedHeaders {
 		rule.ExposedHeaders = append(rule.ExposedHeaders, item)
 	}
 
-	// Set property ‘MaxAgeInSeconds’:
+	// Set property "MaxAgeInSeconds":
 	if typedInput.MaxAgeInSeconds != nil {
 		maxAgeInSeconds := *typedInput.MaxAgeInSeconds
 		rule.MaxAgeInSeconds = &maxAgeInSeconds

--- a/v2/api/storage/v1beta20210401/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_blob_services_container_types_gen.go
@@ -337,10 +337,10 @@ func (container *StorageAccounts_BlobServices_Container_Spec) ConvertToARM(resol
 	}
 	result := &StorageAccounts_BlobServices_Container_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if container.DefaultEncryptionScope != nil ||
 		container.DenyEncryptionScopeOverride != nil ||
 		container.ImmutableStorageWithVersioning != nil ||
@@ -389,10 +389,10 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_BlobServices_Container_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	container.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘DefaultEncryptionScope’:
+	// Set property "DefaultEncryptionScope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultEncryptionScope != nil {
@@ -401,7 +401,7 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘DenyEncryptionScopeOverride’:
+	// Set property "DenyEncryptionScopeOverride":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DenyEncryptionScopeOverride != nil {
@@ -410,7 +410,7 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘ImmutableStorageWithVersioning’:
+	// Set property "ImmutableStorageWithVersioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutableStorageWithVersioning != nil {
@@ -424,7 +424,7 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -435,10 +435,10 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	container.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicAccess’:
+	// Set property "PublicAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicAccess != nil {
@@ -718,9 +718,9 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_BlobServices_Container_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘DefaultEncryptionScope’:
+	// Set property "DefaultEncryptionScope":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultEncryptionScope != nil {
@@ -729,7 +729,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Deleted’:
+	// Set property "Deleted":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Deleted != nil {
@@ -738,7 +738,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘DeletedTime’:
+	// Set property "DeletedTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DeletedTime != nil {
@@ -747,7 +747,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘DenyEncryptionScopeOverride’:
+	// Set property "DenyEncryptionScopeOverride":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DenyEncryptionScopeOverride != nil {
@@ -756,13 +756,13 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		container.Etag = &etag
 	}
 
-	// Set property ‘HasImmutabilityPolicy’:
+	// Set property "HasImmutabilityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HasImmutabilityPolicy != nil {
@@ -771,7 +771,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘HasLegalHold’:
+	// Set property "HasLegalHold":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HasLegalHold != nil {
@@ -780,13 +780,13 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		container.Id = &id
 	}
 
-	// Set property ‘ImmutabilityPolicy’:
+	// Set property "ImmutabilityPolicy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutabilityPolicy != nil {
@@ -800,7 +800,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘ImmutableStorageWithVersioning’:
+	// Set property "ImmutableStorageWithVersioning":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutableStorageWithVersioning != nil {
@@ -814,7 +814,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastModifiedTime != nil {
@@ -823,7 +823,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LeaseDuration’:
+	// Set property "LeaseDuration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LeaseDuration != nil {
@@ -832,7 +832,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LeaseState’:
+	// Set property "LeaseState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LeaseState != nil {
@@ -841,7 +841,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LeaseStatus’:
+	// Set property "LeaseStatus":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LeaseStatus != nil {
@@ -850,7 +850,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘LegalHold’:
+	// Set property "LegalHold":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LegalHold != nil {
@@ -864,7 +864,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -875,13 +875,13 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		container.Name = &name
 	}
 
-	// Set property ‘PublicAccess’:
+	// Set property "PublicAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicAccess != nil {
@@ -890,7 +890,7 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘RemainingRetentionDays’:
+	// Set property "RemainingRetentionDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RemainingRetentionDays != nil {
@@ -899,13 +899,13 @@ func (container *StorageAccounts_BlobServices_Container_STATUS) PopulateFromARM(
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		container.Type = &typeVar
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Version != nil {
@@ -1280,7 +1280,7 @@ func (properties *ImmutabilityPolicyProperties_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmutabilityPolicyProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowProtectedAppendWrites’:
+	// Set property "AllowProtectedAppendWrites":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AllowProtectedAppendWrites != nil {
@@ -1289,13 +1289,13 @@ func (properties *ImmutabilityPolicyProperties_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Etag’:
+	// Set property "Etag":
 	if typedInput.Etag != nil {
 		etag := *typedInput.Etag
 		properties.Etag = &etag
 	}
 
-	// Set property ‘ImmutabilityPeriodSinceCreationInDays’:
+	// Set property "ImmutabilityPeriodSinceCreationInDays":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ImmutabilityPeriodSinceCreationInDays != nil {
@@ -1304,7 +1304,7 @@ func (properties *ImmutabilityPolicyProperties_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1313,7 +1313,7 @@ func (properties *ImmutabilityPolicyProperties_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘UpdateHistory’:
+	// Set property "UpdateHistory":
 	for _, item := range typedInput.UpdateHistory {
 		var item1 UpdateHistoryProperty_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1444,7 +1444,7 @@ func (versioning *ImmutableStorageWithVersioning) ConvertToARM(resolved genrunti
 	}
 	result := &ImmutableStorageWithVersioning_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if versioning.Enabled != nil {
 		enabled := *versioning.Enabled
 		result.Enabled = &enabled
@@ -1464,7 +1464,7 @@ func (versioning *ImmutableStorageWithVersioning) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmutableStorageWithVersioning_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		versioning.Enabled = &enabled
@@ -1534,19 +1534,19 @@ func (versioning *ImmutableStorageWithVersioning_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ImmutableStorageWithVersioning_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		versioning.Enabled = &enabled
 	}
 
-	// Set property ‘MigrationState’:
+	// Set property "MigrationState":
 	if typedInput.MigrationState != nil {
 		migrationState := *typedInput.MigrationState
 		versioning.MigrationState = &migrationState
 	}
 
-	// Set property ‘TimeStamp’:
+	// Set property "TimeStamp":
 	if typedInput.TimeStamp != nil {
 		timeStamp := *typedInput.TimeStamp
 		versioning.TimeStamp = &timeStamp
@@ -1637,13 +1637,13 @@ func (properties *LegalHoldProperties_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LegalHoldProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HasLegalHold’:
+	// Set property "HasLegalHold":
 	if typedInput.HasLegalHold != nil {
 		hasLegalHold := *typedInput.HasLegalHold
 		properties.HasLegalHold = &hasLegalHold
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	for _, item := range typedInput.Tags {
 		var item1 TagProperty_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -1773,31 +1773,31 @@ func (property *TagProperty_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TagProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ObjectIdentifier’:
+	// Set property "ObjectIdentifier":
 	if typedInput.ObjectIdentifier != nil {
 		objectIdentifier := *typedInput.ObjectIdentifier
 		property.ObjectIdentifier = &objectIdentifier
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		property.Tag = &tag
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		property.TenantId = &tenantId
 	}
 
-	// Set property ‘Timestamp’:
+	// Set property "Timestamp":
 	if typedInput.Timestamp != nil {
 		timestamp := *typedInput.Timestamp
 		property.Timestamp = &timestamp
 	}
 
-	// Set property ‘Upn’:
+	// Set property "Upn":
 	if typedInput.Upn != nil {
 		upn := *typedInput.Upn
 		property.Upn = &upn
@@ -1884,37 +1884,37 @@ func (property *UpdateHistoryProperty_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UpdateHistoryProperty_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ImmutabilityPeriodSinceCreationInDays’:
+	// Set property "ImmutabilityPeriodSinceCreationInDays":
 	if typedInput.ImmutabilityPeriodSinceCreationInDays != nil {
 		immutabilityPeriodSinceCreationInDays := *typedInput.ImmutabilityPeriodSinceCreationInDays
 		property.ImmutabilityPeriodSinceCreationInDays = &immutabilityPeriodSinceCreationInDays
 	}
 
-	// Set property ‘ObjectIdentifier’:
+	// Set property "ObjectIdentifier":
 	if typedInput.ObjectIdentifier != nil {
 		objectIdentifier := *typedInput.ObjectIdentifier
 		property.ObjectIdentifier = &objectIdentifier
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		property.TenantId = &tenantId
 	}
 
-	// Set property ‘Timestamp’:
+	// Set property "Timestamp":
 	if typedInput.Timestamp != nil {
 		timestamp := *typedInput.Timestamp
 		property.Timestamp = &timestamp
 	}
 
-	// Set property ‘Update’:
+	// Set property "Update":
 	if typedInput.Update != nil {
 		update := *typedInput.Update
 		property.Update = &update
 	}
 
-	// Set property ‘Upn’:
+	// Set property "Upn":
 	if typedInput.Upn != nil {
 		upn := *typedInput.Upn
 		property.Upn = &upn

--- a/v2/api/storage/v1beta20210401/storage_accounts_management_policy_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_management_policy_types_gen.go
@@ -322,10 +322,10 @@ func (policy *StorageAccounts_ManagementPolicy_Spec) ConvertToARM(resolved genru
 	}
 	result := &StorageAccounts_ManagementPolicy_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if policy.Policy != nil {
 		result.Properties = &ManagementPolicyProperties_ARM{}
 	}
@@ -352,10 +352,10 @@ func (policy *StorageAccounts_ManagementPolicy_Spec) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_ManagementPolicy_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	policy.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Policy’:
+	// Set property "Policy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Policy != nil {
@@ -569,15 +569,15 @@ func (policy *StorageAccounts_ManagementPolicy_STATUS) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_ManagementPolicy_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		policy.Id = &id
 	}
 
-	// Set property ‘LastModifiedTime’:
+	// Set property "LastModifiedTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastModifiedTime != nil {
@@ -586,13 +586,13 @@ func (policy *StorageAccounts_ManagementPolicy_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		policy.Name = &name
 	}
 
-	// Set property ‘Policy’:
+	// Set property "Policy":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Policy != nil {
@@ -606,7 +606,7 @@ func (policy *StorageAccounts_ManagementPolicy_STATUS) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		policy.Type = &typeVar
@@ -708,7 +708,7 @@ func (schema *ManagementPolicySchema) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicySchema_ARM{}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range schema.Rules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -731,7 +731,7 @@ func (schema *ManagementPolicySchema) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicySchema_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		var item1 ManagementPolicyRule
 		err := item1.PopulateFromARM(owner, item)
@@ -823,7 +823,7 @@ func (schema *ManagementPolicySchema_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicySchema_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Rules’:
+	// Set property "Rules":
 	for _, item := range typedInput.Rules {
 		var item1 ManagementPolicyRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -918,7 +918,7 @@ func (rule *ManagementPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ManagementPolicyRule_ARM{}
 
-	// Set property ‘Definition’:
+	// Set property "Definition":
 	if rule.Definition != nil {
 		definition_ARM, err := (*rule.Definition).ConvertToARM(resolved)
 		if err != nil {
@@ -928,19 +928,19 @@ func (rule *ManagementPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Definition = &definition
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if rule.Enabled != nil {
 		enabled := *rule.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if rule.Name != nil {
 		name := *rule.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if rule.Type != nil {
 		typeVar := *rule.Type
 		result.Type = &typeVar
@@ -960,7 +960,7 @@ func (rule *ManagementPolicyRule) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Definition’:
+	// Set property "Definition":
 	if typedInput.Definition != nil {
 		var definition1 ManagementPolicyDefinition
 		err := definition1.PopulateFromARM(owner, *typedInput.Definition)
@@ -971,19 +971,19 @@ func (rule *ManagementPolicyRule) PopulateFromARM(owner genruntime.ArbitraryOwne
 		rule.Definition = &definition
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		rule.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -1100,7 +1100,7 @@ func (rule *ManagementPolicyRule_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Definition’:
+	// Set property "Definition":
 	if typedInput.Definition != nil {
 		var definition1 ManagementPolicyDefinition_STATUS
 		err := definition1.PopulateFromARM(owner, *typedInput.Definition)
@@ -1111,19 +1111,19 @@ func (rule *ManagementPolicyRule_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		rule.Definition = &definition
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		rule.Enabled = &enabled
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		rule.Type = &typeVar
@@ -1234,7 +1234,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 	}
 	result := &ManagementPolicyDefinition_ARM{}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if definition.Actions != nil {
 		actions_ARM, err := (*definition.Actions).ConvertToARM(resolved)
 		if err != nil {
@@ -1244,7 +1244,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 		result.Actions = &actions
 	}
 
-	// Set property ‘Filters’:
+	// Set property "Filters":
 	if definition.Filters != nil {
 		filters_ARM, err := (*definition.Filters).ConvertToARM(resolved)
 		if err != nil {
@@ -1268,7 +1268,7 @@ func (definition *ManagementPolicyDefinition) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyDefinition_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if typedInput.Actions != nil {
 		var actions1 ManagementPolicyAction
 		err := actions1.PopulateFromARM(owner, *typedInput.Actions)
@@ -1279,7 +1279,7 @@ func (definition *ManagementPolicyDefinition) PopulateFromARM(owner genruntime.A
 		definition.Actions = &actions
 	}
 
-	// Set property ‘Filters’:
+	// Set property "Filters":
 	if typedInput.Filters != nil {
 		var filters1 ManagementPolicyFilter
 		err := filters1.PopulateFromARM(owner, *typedInput.Filters)
@@ -1385,7 +1385,7 @@ func (definition *ManagementPolicyDefinition_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyDefinition_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if typedInput.Actions != nil {
 		var actions1 ManagementPolicyAction_STATUS
 		err := actions1.PopulateFromARM(owner, *typedInput.Actions)
@@ -1396,7 +1396,7 @@ func (definition *ManagementPolicyDefinition_STATUS) PopulateFromARM(owner genru
 		definition.Actions = &actions
 	}
 
-	// Set property ‘Filters’:
+	// Set property "Filters":
 	if typedInput.Filters != nil {
 		var filters1 ManagementPolicyFilter_STATUS
 		err := filters1.PopulateFromARM(owner, *typedInput.Filters)
@@ -1509,7 +1509,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicyAction_ARM{}
 
-	// Set property ‘BaseBlob’:
+	// Set property "BaseBlob":
 	if action.BaseBlob != nil {
 		baseBlob_ARM, err := (*action.BaseBlob).ConvertToARM(resolved)
 		if err != nil {
@@ -1519,7 +1519,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 		result.BaseBlob = &baseBlob
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if action.Snapshot != nil {
 		snapshot_ARM, err := (*action.Snapshot).ConvertToARM(resolved)
 		if err != nil {
@@ -1529,7 +1529,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 		result.Snapshot = &snapshot
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if action.Version != nil {
 		version_ARM, err := (*action.Version).ConvertToARM(resolved)
 		if err != nil {
@@ -1553,7 +1553,7 @@ func (action *ManagementPolicyAction) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BaseBlob’:
+	// Set property "BaseBlob":
 	if typedInput.BaseBlob != nil {
 		var baseBlob1 ManagementPolicyBaseBlob
 		err := baseBlob1.PopulateFromARM(owner, *typedInput.BaseBlob)
@@ -1564,7 +1564,7 @@ func (action *ManagementPolicyAction) PopulateFromARM(owner genruntime.Arbitrary
 		action.BaseBlob = &baseBlob
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 ManagementPolicySnapShot
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -1575,7 +1575,7 @@ func (action *ManagementPolicyAction) PopulateFromARM(owner genruntime.Arbitrary
 		action.Snapshot = &snapshot
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		var version1 ManagementPolicyVersion
 		err := version1.PopulateFromARM(owner, *typedInput.Version)
@@ -1706,7 +1706,7 @@ func (action *ManagementPolicyAction_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BaseBlob’:
+	// Set property "BaseBlob":
 	if typedInput.BaseBlob != nil {
 		var baseBlob1 ManagementPolicyBaseBlob_STATUS
 		err := baseBlob1.PopulateFromARM(owner, *typedInput.BaseBlob)
@@ -1717,7 +1717,7 @@ func (action *ManagementPolicyAction_STATUS) PopulateFromARM(owner genruntime.Ar
 		action.BaseBlob = &baseBlob
 	}
 
-	// Set property ‘Snapshot’:
+	// Set property "Snapshot":
 	if typedInput.Snapshot != nil {
 		var snapshot1 ManagementPolicySnapShot_STATUS
 		err := snapshot1.PopulateFromARM(owner, *typedInput.Snapshot)
@@ -1728,7 +1728,7 @@ func (action *ManagementPolicyAction_STATUS) PopulateFromARM(owner genruntime.Ar
 		action.Snapshot = &snapshot
 	}
 
-	// Set property ‘Version’:
+	// Set property "Version":
 	if typedInput.Version != nil {
 		var version1 ManagementPolicyVersion_STATUS
 		err := version1.PopulateFromARM(owner, *typedInput.Version)
@@ -1856,7 +1856,7 @@ func (filter *ManagementPolicyFilter) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicyFilter_ARM{}
 
-	// Set property ‘BlobIndexMatch’:
+	// Set property "BlobIndexMatch":
 	for _, item := range filter.BlobIndexMatch {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -1865,12 +1865,12 @@ func (filter *ManagementPolicyFilter) ConvertToARM(resolved genruntime.ConvertTo
 		result.BlobIndexMatch = append(result.BlobIndexMatch, *item_ARM.(*TagFilter_ARM))
 	}
 
-	// Set property ‘BlobTypes’:
+	// Set property "BlobTypes":
 	for _, item := range filter.BlobTypes {
 		result.BlobTypes = append(result.BlobTypes, item)
 	}
 
-	// Set property ‘PrefixMatch’:
+	// Set property "PrefixMatch":
 	for _, item := range filter.PrefixMatch {
 		result.PrefixMatch = append(result.PrefixMatch, item)
 	}
@@ -1889,7 +1889,7 @@ func (filter *ManagementPolicyFilter) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobIndexMatch’:
+	// Set property "BlobIndexMatch":
 	for _, item := range typedInput.BlobIndexMatch {
 		var item1 TagFilter
 		err := item1.PopulateFromARM(owner, item)
@@ -1899,12 +1899,12 @@ func (filter *ManagementPolicyFilter) PopulateFromARM(owner genruntime.Arbitrary
 		filter.BlobIndexMatch = append(filter.BlobIndexMatch, item1)
 	}
 
-	// Set property ‘BlobTypes’:
+	// Set property "BlobTypes":
 	for _, item := range typedInput.BlobTypes {
 		filter.BlobTypes = append(filter.BlobTypes, item)
 	}
 
-	// Set property ‘PrefixMatch’:
+	// Set property "PrefixMatch":
 	for _, item := range typedInput.PrefixMatch {
 		filter.PrefixMatch = append(filter.PrefixMatch, item)
 	}
@@ -2005,7 +2005,7 @@ func (filter *ManagementPolicyFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘BlobIndexMatch’:
+	// Set property "BlobIndexMatch":
 	for _, item := range typedInput.BlobIndexMatch {
 		var item1 TagFilter_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2015,12 +2015,12 @@ func (filter *ManagementPolicyFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 		filter.BlobIndexMatch = append(filter.BlobIndexMatch, item1)
 	}
 
-	// Set property ‘BlobTypes’:
+	// Set property "BlobTypes":
 	for _, item := range typedInput.BlobTypes {
 		filter.BlobTypes = append(filter.BlobTypes, item)
 	}
 
-	// Set property ‘PrefixMatch’:
+	// Set property "PrefixMatch":
 	for _, item := range typedInput.PrefixMatch {
 		filter.PrefixMatch = append(filter.PrefixMatch, item)
 	}
@@ -2117,7 +2117,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicyBaseBlob_ARM{}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if blob.Delete != nil {
 		delete_ARM, err := (*blob.Delete).ConvertToARM(resolved)
 		if err != nil {
@@ -2127,13 +2127,13 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 		result.Delete = &delete
 	}
 
-	// Set property ‘EnableAutoTierToHotFromCool’:
+	// Set property "EnableAutoTierToHotFromCool":
 	if blob.EnableAutoTierToHotFromCool != nil {
 		enableAutoTierToHotFromCool := *blob.EnableAutoTierToHotFromCool
 		result.EnableAutoTierToHotFromCool = &enableAutoTierToHotFromCool
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if blob.TierToArchive != nil {
 		tierToArchive_ARM, err := (*blob.TierToArchive).ConvertToARM(resolved)
 		if err != nil {
@@ -2143,7 +2143,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 		result.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if blob.TierToCool != nil {
 		tierToCool_ARM, err := (*blob.TierToCool).ConvertToARM(resolved)
 		if err != nil {
@@ -2167,7 +2167,7 @@ func (blob *ManagementPolicyBaseBlob) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyBaseBlob_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterModification
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -2178,13 +2178,13 @@ func (blob *ManagementPolicyBaseBlob) PopulateFromARM(owner genruntime.Arbitrary
 		blob.Delete = &delete
 	}
 
-	// Set property ‘EnableAutoTierToHotFromCool’:
+	// Set property "EnableAutoTierToHotFromCool":
 	if typedInput.EnableAutoTierToHotFromCool != nil {
 		enableAutoTierToHotFromCool := *typedInput.EnableAutoTierToHotFromCool
 		blob.EnableAutoTierToHotFromCool = &enableAutoTierToHotFromCool
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterModification
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -2195,7 +2195,7 @@ func (blob *ManagementPolicyBaseBlob) PopulateFromARM(owner genruntime.Arbitrary
 		blob.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterModification
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -2343,7 +2343,7 @@ func (blob *ManagementPolicyBaseBlob_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyBaseBlob_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterModification_STATUS
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -2354,13 +2354,13 @@ func (blob *ManagementPolicyBaseBlob_STATUS) PopulateFromARM(owner genruntime.Ar
 		blob.Delete = &delete
 	}
 
-	// Set property ‘EnableAutoTierToHotFromCool’:
+	// Set property "EnableAutoTierToHotFromCool":
 	if typedInput.EnableAutoTierToHotFromCool != nil {
 		enableAutoTierToHotFromCool := *typedInput.EnableAutoTierToHotFromCool
 		blob.EnableAutoTierToHotFromCool = &enableAutoTierToHotFromCool
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterModification_STATUS
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -2371,7 +2371,7 @@ func (blob *ManagementPolicyBaseBlob_STATUS) PopulateFromARM(owner genruntime.Ar
 		blob.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterModification_STATUS
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -2513,7 +2513,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &ManagementPolicySnapShot_ARM{}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if shot.Delete != nil {
 		delete_ARM, err := (*shot.Delete).ConvertToARM(resolved)
 		if err != nil {
@@ -2523,7 +2523,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 		result.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if shot.TierToArchive != nil {
 		tierToArchive_ARM, err := (*shot.TierToArchive).ConvertToARM(resolved)
 		if err != nil {
@@ -2533,7 +2533,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 		result.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if shot.TierToCool != nil {
 		tierToCool_ARM, err := (*shot.TierToCool).ConvertToARM(resolved)
 		if err != nil {
@@ -2557,7 +2557,7 @@ func (shot *ManagementPolicySnapShot) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicySnapShot_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterCreation
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -2568,7 +2568,7 @@ func (shot *ManagementPolicySnapShot) PopulateFromARM(owner genruntime.Arbitrary
 		shot.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterCreation
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -2579,7 +2579,7 @@ func (shot *ManagementPolicySnapShot) PopulateFromARM(owner genruntime.Arbitrary
 		shot.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterCreation
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -2710,7 +2710,7 @@ func (shot *ManagementPolicySnapShot_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicySnapShot_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterCreation_STATUS
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -2721,7 +2721,7 @@ func (shot *ManagementPolicySnapShot_STATUS) PopulateFromARM(owner genruntime.Ar
 		shot.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterCreation_STATUS
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -2732,7 +2732,7 @@ func (shot *ManagementPolicySnapShot_STATUS) PopulateFromARM(owner genruntime.Ar
 		shot.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterCreation_STATUS
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -2858,7 +2858,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ManagementPolicyVersion_ARM{}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if version.Delete != nil {
 		delete_ARM, err := (*version.Delete).ConvertToARM(resolved)
 		if err != nil {
@@ -2868,7 +2868,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 		result.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if version.TierToArchive != nil {
 		tierToArchive_ARM, err := (*version.TierToArchive).ConvertToARM(resolved)
 		if err != nil {
@@ -2878,7 +2878,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 		result.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if version.TierToCool != nil {
 		tierToCool_ARM, err := (*version.TierToCool).ConvertToARM(resolved)
 		if err != nil {
@@ -2902,7 +2902,7 @@ func (version *ManagementPolicyVersion) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyVersion_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterCreation
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -2913,7 +2913,7 @@ func (version *ManagementPolicyVersion) PopulateFromARM(owner genruntime.Arbitra
 		version.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterCreation
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -2924,7 +2924,7 @@ func (version *ManagementPolicyVersion) PopulateFromARM(owner genruntime.Arbitra
 		version.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterCreation
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -3055,7 +3055,7 @@ func (version *ManagementPolicyVersion_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagementPolicyVersion_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Delete’:
+	// Set property "Delete":
 	if typedInput.Delete != nil {
 		var delete1 DateAfterCreation_STATUS
 		err := delete1.PopulateFromARM(owner, *typedInput.Delete)
@@ -3066,7 +3066,7 @@ func (version *ManagementPolicyVersion_STATUS) PopulateFromARM(owner genruntime.
 		version.Delete = &delete
 	}
 
-	// Set property ‘TierToArchive’:
+	// Set property "TierToArchive":
 	if typedInput.TierToArchive != nil {
 		var tierToArchive1 DateAfterCreation_STATUS
 		err := tierToArchive1.PopulateFromARM(owner, *typedInput.TierToArchive)
@@ -3077,7 +3077,7 @@ func (version *ManagementPolicyVersion_STATUS) PopulateFromARM(owner genruntime.
 		version.TierToArchive = &tierToArchive
 	}
 
-	// Set property ‘TierToCool’:
+	// Set property "TierToCool":
 	if typedInput.TierToCool != nil {
 		var tierToCool1 DateAfterCreation_STATUS
 		err := tierToCool1.PopulateFromARM(owner, *typedInput.TierToCool)
@@ -3212,19 +3212,19 @@ func (filter *TagFilter) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &TagFilter_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if filter.Name != nil {
 		name := *filter.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Op’:
+	// Set property "Op":
 	if filter.Op != nil {
 		op := *filter.Op
 		result.Op = &op
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if filter.Value != nil {
 		value := *filter.Value
 		result.Value = &value
@@ -3244,19 +3244,19 @@ func (filter *TagFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TagFilter_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		filter.Name = &name
 	}
 
-	// Set property ‘Op’:
+	// Set property "Op":
 	if typedInput.Op != nil {
 		op := *typedInput.Op
 		filter.Op = &op
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -3348,19 +3348,19 @@ func (filter *TagFilter_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected TagFilter_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		filter.Name = &name
 	}
 
-	// Set property ‘Op’:
+	// Set property "Op":
 	if typedInput.Op != nil {
 		op := *typedInput.Op
 		filter.Op = &op
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		filter.Value = &value
@@ -3428,7 +3428,7 @@ func (creation *DateAfterCreation) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &DateAfterCreation_ARM{}
 
-	// Set property ‘DaysAfterCreationGreaterThan’:
+	// Set property "DaysAfterCreationGreaterThan":
 	if creation.DaysAfterCreationGreaterThan != nil {
 		daysAfterCreationGreaterThan := *creation.DaysAfterCreationGreaterThan
 		result.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
@@ -3448,7 +3448,7 @@ func (creation *DateAfterCreation) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DateAfterCreation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DaysAfterCreationGreaterThan’:
+	// Set property "DaysAfterCreationGreaterThan":
 	if typedInput.DaysAfterCreationGreaterThan != nil {
 		daysAfterCreationGreaterThan := *typedInput.DaysAfterCreationGreaterThan
 		creation.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
@@ -3516,7 +3516,7 @@ func (creation *DateAfterCreation_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DateAfterCreation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DaysAfterCreationGreaterThan’:
+	// Set property "DaysAfterCreationGreaterThan":
 	if typedInput.DaysAfterCreationGreaterThan != nil {
 		daysAfterCreationGreaterThan := *typedInput.DaysAfterCreationGreaterThan
 		creation.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
@@ -3585,13 +3585,13 @@ func (modification *DateAfterModification) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &DateAfterModification_ARM{}
 
-	// Set property ‘DaysAfterLastAccessTimeGreaterThan’:
+	// Set property "DaysAfterLastAccessTimeGreaterThan":
 	if modification.DaysAfterLastAccessTimeGreaterThan != nil {
 		daysAfterLastAccessTimeGreaterThan := *modification.DaysAfterLastAccessTimeGreaterThan
 		result.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
 	}
 
-	// Set property ‘DaysAfterModificationGreaterThan’:
+	// Set property "DaysAfterModificationGreaterThan":
 	if modification.DaysAfterModificationGreaterThan != nil {
 		daysAfterModificationGreaterThan := *modification.DaysAfterModificationGreaterThan
 		result.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan
@@ -3611,13 +3611,13 @@ func (modification *DateAfterModification) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DateAfterModification_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DaysAfterLastAccessTimeGreaterThan’:
+	// Set property "DaysAfterLastAccessTimeGreaterThan":
 	if typedInput.DaysAfterLastAccessTimeGreaterThan != nil {
 		daysAfterLastAccessTimeGreaterThan := *typedInput.DaysAfterLastAccessTimeGreaterThan
 		modification.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
 	}
 
-	// Set property ‘DaysAfterModificationGreaterThan’:
+	// Set property "DaysAfterModificationGreaterThan":
 	if typedInput.DaysAfterModificationGreaterThan != nil {
 		daysAfterModificationGreaterThan := *typedInput.DaysAfterModificationGreaterThan
 		modification.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan
@@ -3702,13 +3702,13 @@ func (modification *DateAfterModification_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DateAfterModification_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DaysAfterLastAccessTimeGreaterThan’:
+	// Set property "DaysAfterLastAccessTimeGreaterThan":
 	if typedInput.DaysAfterLastAccessTimeGreaterThan != nil {
 		daysAfterLastAccessTimeGreaterThan := *typedInput.DaysAfterLastAccessTimeGreaterThan
 		modification.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
 	}
 
-	// Set property ‘DaysAfterModificationGreaterThan’:
+	// Set property "DaysAfterModificationGreaterThan":
 	if typedInput.DaysAfterModificationGreaterThan != nil {
 		daysAfterModificationGreaterThan := *typedInput.DaysAfterModificationGreaterThan
 		modification.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan

--- a/v2/api/storage/v1beta20210401/storage_accounts_queue_service_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_queue_service_types_gen.go
@@ -321,10 +321,10 @@ func (service *StorageAccounts_QueueService_Spec) ConvertToARM(resolved genrunti
 	}
 	result := &StorageAccounts_QueueService_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if service.Cors != nil {
 		result.Properties = &StorageAccounts_QueueService_Properties_Spec_ARM{}
 	}
@@ -351,7 +351,7 @@ func (service *StorageAccounts_QueueService_Spec) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_QueueService_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -365,7 +365,7 @@ func (service *StorageAccounts_QueueService_Spec) PopulateFromARM(owner genrunti
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -567,9 +567,9 @@ func (service *StorageAccounts_QueueService_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_QueueService_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Cors != nil {
@@ -583,19 +583,19 @@ func (service *StorageAccounts_QueueService_STATUS) PopulateFromARM(owner genrun
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		service.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		service.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		service.Type = &typeVar

--- a/v2/api/storage/v1beta20210401/storage_accounts_queue_services_queue_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_queue_services_queue_types_gen.go
@@ -333,10 +333,10 @@ func (queue *StorageAccounts_QueueServices_Queue_Spec) ConvertToARM(resolved gen
 	}
 	result := &StorageAccounts_QueueServices_Queue_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if queue.Metadata != nil {
 		result.Properties = &QueueProperties_ARM{}
 	}
@@ -361,10 +361,10 @@ func (queue *StorageAccounts_QueueServices_Queue_Spec) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_QueueServices_Queue_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	queue.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -375,7 +375,7 @@ func (queue *StorageAccounts_QueueServices_Queue_Spec) PopulateFromARM(owner gen
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	queue.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
@@ -572,7 +572,7 @@ func (queue *StorageAccounts_QueueServices_Queue_STATUS) PopulateFromARM(owner g
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StorageAccounts_QueueServices_Queue_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ApproximateMessageCount’:
+	// Set property "ApproximateMessageCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ApproximateMessageCount != nil {
@@ -581,15 +581,15 @@ func (queue *StorageAccounts_QueueServices_Queue_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		queue.Id = &id
 	}
 
-	// Set property ‘Metadata’:
+	// Set property "Metadata":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Metadata != nil {
@@ -600,13 +600,13 @@ func (queue *StorageAccounts_QueueServices_Queue_STATUS) PopulateFromARM(owner g
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		queue.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		queue.Type = &typeVar

--- a/v2/api/subscription/v1api20211001/alias_types_gen.go
+++ b/v2/api/subscription/v1api20211001/alias_types_gen.go
@@ -323,10 +323,10 @@ func (alias *Alias_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &Alias_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if alias.Properties != nil {
 		properties_ARM, err := (*alias.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -350,10 +350,10 @@ func (alias *Alias_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Alias_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	alias.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 PutAliasRequestProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -585,21 +585,21 @@ func (alias *Alias_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Alias_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		alias.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		alias.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 SubscriptionAliasResponseProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -610,7 +610,7 @@ func (alias *Alias_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		alias.Properties = &properties
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -621,7 +621,7 @@ func (alias *Alias_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		alias.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		alias.Type = &typeVar
@@ -759,7 +759,7 @@ func (properties *PutAliasRequestProperties) ConvertToARM(resolved genruntime.Co
 	}
 	result := &PutAliasRequestProperties_ARM{}
 
-	// Set property ‘AdditionalProperties’:
+	// Set property "AdditionalProperties":
 	if properties.AdditionalProperties != nil {
 		additionalProperties_ARM, err := (*properties.AdditionalProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -769,31 +769,31 @@ func (properties *PutAliasRequestProperties) ConvertToARM(resolved genruntime.Co
 		result.AdditionalProperties = &additionalProperties
 	}
 
-	// Set property ‘BillingScope’:
+	// Set property "BillingScope":
 	if properties.BillingScope != nil {
 		billingScope := *properties.BillingScope
 		result.BillingScope = &billingScope
 	}
 
-	// Set property ‘DisplayName’:
+	// Set property "DisplayName":
 	if properties.DisplayName != nil {
 		displayName := *properties.DisplayName
 		result.DisplayName = &displayName
 	}
 
-	// Set property ‘ResellerId’:
+	// Set property "ResellerId":
 	if properties.ResellerId != nil {
 		resellerId := *properties.ResellerId
 		result.ResellerId = &resellerId
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if properties.SubscriptionId != nil {
 		subscriptionId := *properties.SubscriptionId
 		result.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘Workload’:
+	// Set property "Workload":
 	if properties.Workload != nil {
 		workload := *properties.Workload
 		result.Workload = &workload
@@ -813,7 +813,7 @@ func (properties *PutAliasRequestProperties) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PutAliasRequestProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalProperties’:
+	// Set property "AdditionalProperties":
 	if typedInput.AdditionalProperties != nil {
 		var additionalProperties1 PutAliasRequestAdditionalProperties
 		err := additionalProperties1.PopulateFromARM(owner, *typedInput.AdditionalProperties)
@@ -824,31 +824,31 @@ func (properties *PutAliasRequestProperties) PopulateFromARM(owner genruntime.Ar
 		properties.AdditionalProperties = &additionalProperties
 	}
 
-	// Set property ‘BillingScope’:
+	// Set property "BillingScope":
 	if typedInput.BillingScope != nil {
 		billingScope := *typedInput.BillingScope
 		properties.BillingScope = &billingScope
 	}
 
-	// Set property ‘DisplayName’:
+	// Set property "DisplayName":
 	if typedInput.DisplayName != nil {
 		displayName := *typedInput.DisplayName
 		properties.DisplayName = &displayName
 	}
 
-	// Set property ‘ResellerId’:
+	// Set property "ResellerId":
 	if typedInput.ResellerId != nil {
 		resellerId := *typedInput.ResellerId
 		properties.ResellerId = &resellerId
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘Workload’:
+	// Set property "Workload":
 	if typedInput.Workload != nil {
 		workload := *typedInput.Workload
 		properties.Workload = &workload
@@ -1023,67 +1023,67 @@ func (properties *SubscriptionAliasResponseProperties_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubscriptionAliasResponseProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AcceptOwnershipState’:
+	// Set property "AcceptOwnershipState":
 	if typedInput.AcceptOwnershipState != nil {
 		acceptOwnershipState := *typedInput.AcceptOwnershipState
 		properties.AcceptOwnershipState = &acceptOwnershipState
 	}
 
-	// Set property ‘AcceptOwnershipUrl’:
+	// Set property "AcceptOwnershipUrl":
 	if typedInput.AcceptOwnershipUrl != nil {
 		acceptOwnershipUrl := *typedInput.AcceptOwnershipUrl
 		properties.AcceptOwnershipUrl = &acceptOwnershipUrl
 	}
 
-	// Set property ‘BillingScope’:
+	// Set property "BillingScope":
 	if typedInput.BillingScope != nil {
 		billingScope := *typedInput.BillingScope
 		properties.BillingScope = &billingScope
 	}
 
-	// Set property ‘CreatedTime’:
+	// Set property "CreatedTime":
 	if typedInput.CreatedTime != nil {
 		createdTime := *typedInput.CreatedTime
 		properties.CreatedTime = &createdTime
 	}
 
-	// Set property ‘DisplayName’:
+	// Set property "DisplayName":
 	if typedInput.DisplayName != nil {
 		displayName := *typedInput.DisplayName
 		properties.DisplayName = &displayName
 	}
 
-	// Set property ‘ManagementGroupId’:
+	// Set property "ManagementGroupId":
 	if typedInput.ManagementGroupId != nil {
 		managementGroupId := *typedInput.ManagementGroupId
 		properties.ManagementGroupId = &managementGroupId
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		properties.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResellerId’:
+	// Set property "ResellerId":
 	if typedInput.ResellerId != nil {
 		resellerId := *typedInput.ResellerId
 		properties.ResellerId = &resellerId
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘SubscriptionOwnerId’:
+	// Set property "SubscriptionOwnerId":
 	if typedInput.SubscriptionOwnerId != nil {
 		subscriptionOwnerId := *typedInput.SubscriptionOwnerId
 		properties.SubscriptionOwnerId = &subscriptionOwnerId
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		properties.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1091,7 +1091,7 @@ func (properties *SubscriptionAliasResponseProperties_STATUS) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘Workload’:
+	// Set property "Workload":
 	if typedInput.Workload != nil {
 		workload := *typedInput.Workload
 		properties.Workload = &workload
@@ -1261,37 +1261,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -1404,25 +1404,25 @@ func (properties *PutAliasRequestAdditionalProperties) ConvertToARM(resolved gen
 	}
 	result := &PutAliasRequestAdditionalProperties_ARM{}
 
-	// Set property ‘ManagementGroupId’:
+	// Set property "ManagementGroupId":
 	if properties.ManagementGroupId != nil {
 		managementGroupId := *properties.ManagementGroupId
 		result.ManagementGroupId = &managementGroupId
 	}
 
-	// Set property ‘SubscriptionOwnerId’:
+	// Set property "SubscriptionOwnerId":
 	if properties.SubscriptionOwnerId != nil {
 		subscriptionOwnerId := *properties.SubscriptionOwnerId
 		result.SubscriptionOwnerId = &subscriptionOwnerId
 	}
 
-	// Set property ‘SubscriptionTenantId’:
+	// Set property "SubscriptionTenantId":
 	if properties.SubscriptionTenantId != nil {
 		subscriptionTenantId := *properties.SubscriptionTenantId
 		result.SubscriptionTenantId = &subscriptionTenantId
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if properties.Tags != nil {
 		result.Tags = make(map[string]string, len(properties.Tags))
 		for key, value := range properties.Tags {
@@ -1444,25 +1444,25 @@ func (properties *PutAliasRequestAdditionalProperties) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PutAliasRequestAdditionalProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ManagementGroupId’:
+	// Set property "ManagementGroupId":
 	if typedInput.ManagementGroupId != nil {
 		managementGroupId := *typedInput.ManagementGroupId
 		properties.ManagementGroupId = &managementGroupId
 	}
 
-	// Set property ‘SubscriptionOwnerId’:
+	// Set property "SubscriptionOwnerId":
 	if typedInput.SubscriptionOwnerId != nil {
 		subscriptionOwnerId := *typedInput.SubscriptionOwnerId
 		properties.SubscriptionOwnerId = &subscriptionOwnerId
 	}
 
-	// Set property ‘SubscriptionTenantId’:
+	// Set property "SubscriptionTenantId":
 	if typedInput.SubscriptionTenantId != nil {
 		subscriptionTenantId := *typedInput.SubscriptionTenantId
 		properties.SubscriptionTenantId = &subscriptionTenantId
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		properties.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {

--- a/v2/api/subscription/v1beta20211001/alias_types_gen.go
+++ b/v2/api/subscription/v1beta20211001/alias_types_gen.go
@@ -320,10 +320,10 @@ func (alias *Alias_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &Alias_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if alias.Properties != nil {
 		properties_ARM, err := (*alias.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -347,10 +347,10 @@ func (alias *Alias_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Alias_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	alias.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 PutAliasRequestProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -554,21 +554,21 @@ func (alias *Alias_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Alias_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		alias.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		alias.Name = &name
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 SubscriptionAliasResponseProperties_STATUS
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -579,7 +579,7 @@ func (alias *Alias_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		alias.Properties = &properties
 	}
 
-	// Set property ‘SystemData’:
+	// Set property "SystemData":
 	if typedInput.SystemData != nil {
 		var systemData1 SystemData_STATUS
 		err := systemData1.PopulateFromARM(owner, *typedInput.SystemData)
@@ -590,7 +590,7 @@ func (alias *Alias_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		alias.SystemData = &systemData
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		alias.Type = &typeVar
@@ -720,7 +720,7 @@ func (properties *PutAliasRequestProperties) ConvertToARM(resolved genruntime.Co
 	}
 	result := &PutAliasRequestProperties_ARM{}
 
-	// Set property ‘AdditionalProperties’:
+	// Set property "AdditionalProperties":
 	if properties.AdditionalProperties != nil {
 		additionalProperties_ARM, err := (*properties.AdditionalProperties).ConvertToARM(resolved)
 		if err != nil {
@@ -730,31 +730,31 @@ func (properties *PutAliasRequestProperties) ConvertToARM(resolved genruntime.Co
 		result.AdditionalProperties = &additionalProperties
 	}
 
-	// Set property ‘BillingScope’:
+	// Set property "BillingScope":
 	if properties.BillingScope != nil {
 		billingScope := *properties.BillingScope
 		result.BillingScope = &billingScope
 	}
 
-	// Set property ‘DisplayName’:
+	// Set property "DisplayName":
 	if properties.DisplayName != nil {
 		displayName := *properties.DisplayName
 		result.DisplayName = &displayName
 	}
 
-	// Set property ‘ResellerId’:
+	// Set property "ResellerId":
 	if properties.ResellerId != nil {
 		resellerId := *properties.ResellerId
 		result.ResellerId = &resellerId
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if properties.SubscriptionId != nil {
 		subscriptionId := *properties.SubscriptionId
 		result.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘Workload’:
+	// Set property "Workload":
 	if properties.Workload != nil {
 		workload := *properties.Workload
 		result.Workload = &workload
@@ -774,7 +774,7 @@ func (properties *PutAliasRequestProperties) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PutAliasRequestProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdditionalProperties’:
+	// Set property "AdditionalProperties":
 	if typedInput.AdditionalProperties != nil {
 		var additionalProperties1 PutAliasRequestAdditionalProperties
 		err := additionalProperties1.PopulateFromARM(owner, *typedInput.AdditionalProperties)
@@ -785,31 +785,31 @@ func (properties *PutAliasRequestProperties) PopulateFromARM(owner genruntime.Ar
 		properties.AdditionalProperties = &additionalProperties
 	}
 
-	// Set property ‘BillingScope’:
+	// Set property "BillingScope":
 	if typedInput.BillingScope != nil {
 		billingScope := *typedInput.BillingScope
 		properties.BillingScope = &billingScope
 	}
 
-	// Set property ‘DisplayName’:
+	// Set property "DisplayName":
 	if typedInput.DisplayName != nil {
 		displayName := *typedInput.DisplayName
 		properties.DisplayName = &displayName
 	}
 
-	// Set property ‘ResellerId’:
+	// Set property "ResellerId":
 	if typedInput.ResellerId != nil {
 		resellerId := *typedInput.ResellerId
 		properties.ResellerId = &resellerId
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘Workload’:
+	// Set property "Workload":
 	if typedInput.Workload != nil {
 		workload := *typedInput.Workload
 		properties.Workload = &workload
@@ -936,67 +936,67 @@ func (properties *SubscriptionAliasResponseProperties_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SubscriptionAliasResponseProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AcceptOwnershipState’:
+	// Set property "AcceptOwnershipState":
 	if typedInput.AcceptOwnershipState != nil {
 		acceptOwnershipState := *typedInput.AcceptOwnershipState
 		properties.AcceptOwnershipState = &acceptOwnershipState
 	}
 
-	// Set property ‘AcceptOwnershipUrl’:
+	// Set property "AcceptOwnershipUrl":
 	if typedInput.AcceptOwnershipUrl != nil {
 		acceptOwnershipUrl := *typedInput.AcceptOwnershipUrl
 		properties.AcceptOwnershipUrl = &acceptOwnershipUrl
 	}
 
-	// Set property ‘BillingScope’:
+	// Set property "BillingScope":
 	if typedInput.BillingScope != nil {
 		billingScope := *typedInput.BillingScope
 		properties.BillingScope = &billingScope
 	}
 
-	// Set property ‘CreatedTime’:
+	// Set property "CreatedTime":
 	if typedInput.CreatedTime != nil {
 		createdTime := *typedInput.CreatedTime
 		properties.CreatedTime = &createdTime
 	}
 
-	// Set property ‘DisplayName’:
+	// Set property "DisplayName":
 	if typedInput.DisplayName != nil {
 		displayName := *typedInput.DisplayName
 		properties.DisplayName = &displayName
 	}
 
-	// Set property ‘ManagementGroupId’:
+	// Set property "ManagementGroupId":
 	if typedInput.ManagementGroupId != nil {
 		managementGroupId := *typedInput.ManagementGroupId
 		properties.ManagementGroupId = &managementGroupId
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	if typedInput.ProvisioningState != nil {
 		provisioningState := *typedInput.ProvisioningState
 		properties.ProvisioningState = &provisioningState
 	}
 
-	// Set property ‘ResellerId’:
+	// Set property "ResellerId":
 	if typedInput.ResellerId != nil {
 		resellerId := *typedInput.ResellerId
 		properties.ResellerId = &resellerId
 	}
 
-	// Set property ‘SubscriptionId’:
+	// Set property "SubscriptionId":
 	if typedInput.SubscriptionId != nil {
 		subscriptionId := *typedInput.SubscriptionId
 		properties.SubscriptionId = &subscriptionId
 	}
 
-	// Set property ‘SubscriptionOwnerId’:
+	// Set property "SubscriptionOwnerId":
 	if typedInput.SubscriptionOwnerId != nil {
 		subscriptionOwnerId := *typedInput.SubscriptionOwnerId
 		properties.SubscriptionOwnerId = &subscriptionOwnerId
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		properties.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1004,7 +1004,7 @@ func (properties *SubscriptionAliasResponseProperties_STATUS) PopulateFromARM(ow
 		}
 	}
 
-	// Set property ‘Workload’:
+	// Set property "Workload":
 	if typedInput.Workload != nil {
 		workload := *typedInput.Workload
 		properties.Workload = &workload
@@ -1163,37 +1163,37 @@ func (data *SystemData_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SystemData_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘CreatedAt’:
+	// Set property "CreatedAt":
 	if typedInput.CreatedAt != nil {
 		createdAt := *typedInput.CreatedAt
 		data.CreatedAt = &createdAt
 	}
 
-	// Set property ‘CreatedBy’:
+	// Set property "CreatedBy":
 	if typedInput.CreatedBy != nil {
 		createdBy := *typedInput.CreatedBy
 		data.CreatedBy = &createdBy
 	}
 
-	// Set property ‘CreatedByType’:
+	// Set property "CreatedByType":
 	if typedInput.CreatedByType != nil {
 		createdByType := *typedInput.CreatedByType
 		data.CreatedByType = &createdByType
 	}
 
-	// Set property ‘LastModifiedAt’:
+	// Set property "LastModifiedAt":
 	if typedInput.LastModifiedAt != nil {
 		lastModifiedAt := *typedInput.LastModifiedAt
 		data.LastModifiedAt = &lastModifiedAt
 	}
 
-	// Set property ‘LastModifiedBy’:
+	// Set property "LastModifiedBy":
 	if typedInput.LastModifiedBy != nil {
 		lastModifiedBy := *typedInput.LastModifiedBy
 		data.LastModifiedBy = &lastModifiedBy
 	}
 
-	// Set property ‘LastModifiedByType’:
+	// Set property "LastModifiedByType":
 	if typedInput.LastModifiedByType != nil {
 		lastModifiedByType := *typedInput.LastModifiedByType
 		data.LastModifiedByType = &lastModifiedByType
@@ -1299,25 +1299,25 @@ func (properties *PutAliasRequestAdditionalProperties) ConvertToARM(resolved gen
 	}
 	result := &PutAliasRequestAdditionalProperties_ARM{}
 
-	// Set property ‘ManagementGroupId’:
+	// Set property "ManagementGroupId":
 	if properties.ManagementGroupId != nil {
 		managementGroupId := *properties.ManagementGroupId
 		result.ManagementGroupId = &managementGroupId
 	}
 
-	// Set property ‘SubscriptionOwnerId’:
+	// Set property "SubscriptionOwnerId":
 	if properties.SubscriptionOwnerId != nil {
 		subscriptionOwnerId := *properties.SubscriptionOwnerId
 		result.SubscriptionOwnerId = &subscriptionOwnerId
 	}
 
-	// Set property ‘SubscriptionTenantId’:
+	// Set property "SubscriptionTenantId":
 	if properties.SubscriptionTenantId != nil {
 		subscriptionTenantId := *properties.SubscriptionTenantId
 		result.SubscriptionTenantId = &subscriptionTenantId
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if properties.Tags != nil {
 		result.Tags = make(map[string]string, len(properties.Tags))
 		for key, value := range properties.Tags {
@@ -1339,25 +1339,25 @@ func (properties *PutAliasRequestAdditionalProperties) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PutAliasRequestAdditionalProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ManagementGroupId’:
+	// Set property "ManagementGroupId":
 	if typedInput.ManagementGroupId != nil {
 		managementGroupId := *typedInput.ManagementGroupId
 		properties.ManagementGroupId = &managementGroupId
 	}
 
-	// Set property ‘SubscriptionOwnerId’:
+	// Set property "SubscriptionOwnerId":
 	if typedInput.SubscriptionOwnerId != nil {
 		subscriptionOwnerId := *typedInput.SubscriptionOwnerId
 		properties.SubscriptionOwnerId = &subscriptionOwnerId
 	}
 
-	// Set property ‘SubscriptionTenantId’:
+	// Set property "SubscriptionTenantId":
 	if typedInput.SubscriptionTenantId != nil {
 		subscriptionTenantId := *typedInput.SubscriptionTenantId
 		properties.SubscriptionTenantId = &subscriptionTenantId
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		properties.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {

--- a/v2/api/synapse/v1api20210601/workspace_types_gen.go
+++ b/v2/api/synapse/v1api20210601/workspace_types_gen.go
@@ -405,7 +405,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &Workspace_Spec_ARM{}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if workspace.Identity != nil {
 		identity_ARM, err := (*workspace.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -415,16 +415,16 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if workspace.Location != nil {
 		location := *workspace.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if workspace.AzureADOnlyAuthentication != nil ||
 		workspace.CspWorkspaceAdminProperties != nil ||
 		workspace.DefaultDataLakeStorage != nil ||
@@ -530,7 +530,7 @@ func (workspace *Workspace_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		result.Properties.WorkspaceRepositoryConfiguration = &workspaceRepositoryConfiguration
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if workspace.Tags != nil {
 		result.Tags = make(map[string]string, len(workspace.Tags))
 		for key, value := range workspace.Tags {
@@ -552,7 +552,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspace_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureADOnlyAuthentication’:
+	// Set property "AzureADOnlyAuthentication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureADOnlyAuthentication != nil {
@@ -561,10 +561,10 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	workspace.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CspWorkspaceAdminProperties’:
+	// Set property "CspWorkspaceAdminProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CspWorkspaceAdminProperties != nil {
@@ -578,7 +578,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘DefaultDataLakeStorage’:
+	// Set property "DefaultDataLakeStorage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultDataLakeStorage != nil {
@@ -592,7 +592,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -606,7 +606,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -617,13 +617,13 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		workspace.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		workspace.Location = &location
 	}
 
-	// Set property ‘ManagedResourceGroupName’:
+	// Set property "ManagedResourceGroupName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ManagedResourceGroupName != nil {
@@ -632,7 +632,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ManagedVirtualNetwork’:
+	// Set property "ManagedVirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ManagedVirtualNetwork != nil {
@@ -641,7 +641,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ManagedVirtualNetworkSettings’:
+	// Set property "ManagedVirtualNetworkSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ManagedVirtualNetworkSettings != nil {
@@ -655,10 +655,10 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	workspace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -667,7 +667,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘PurviewConfiguration’:
+	// Set property "PurviewConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PurviewConfiguration != nil {
@@ -681,7 +681,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘SqlAdministratorLogin’:
+	// Set property "SqlAdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SqlAdministratorLogin != nil {
@@ -690,9 +690,9 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// no assignment for property ‘SqlAdministratorLoginPassword’
+	// no assignment for property "SqlAdministratorLoginPassword"
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		workspace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -700,7 +700,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘TrustedServiceBypassEnabled’:
+	// Set property "TrustedServiceBypassEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TrustedServiceBypassEnabled != nil {
@@ -709,7 +709,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘VirtualNetworkProfile’:
+	// Set property "VirtualNetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetworkProfile != nil {
@@ -723,7 +723,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘WorkspaceRepositoryConfiguration’:
+	// Set property "WorkspaceRepositoryConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkspaceRepositoryConfiguration != nil {
@@ -1427,7 +1427,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspace_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AdlaResourceId’:
+	// Set property "AdlaResourceId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AdlaResourceId != nil {
@@ -1436,7 +1436,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘AzureADOnlyAuthentication’:
+	// Set property "AzureADOnlyAuthentication":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AzureADOnlyAuthentication != nil {
@@ -1445,9 +1445,9 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ConnectivityEndpoints’:
+	// Set property "ConnectivityEndpoints":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ConnectivityEndpoints != nil {
@@ -1458,7 +1458,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘CspWorkspaceAdminProperties’:
+	// Set property "CspWorkspaceAdminProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CspWorkspaceAdminProperties != nil {
@@ -1472,7 +1472,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘DefaultDataLakeStorage’:
+	// Set property "DefaultDataLakeStorage":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultDataLakeStorage != nil {
@@ -1486,7 +1486,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Encryption’:
+	// Set property "Encryption":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Encryption != nil {
@@ -1500,7 +1500,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ExtraProperties’:
+	// Set property "ExtraProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ExtraProperties != nil {
@@ -1511,13 +1511,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		workspace.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1528,13 +1528,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		workspace.Identity = &identity
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		workspace.Location = &location
 	}
 
-	// Set property ‘ManagedResourceGroupName’:
+	// Set property "ManagedResourceGroupName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ManagedResourceGroupName != nil {
@@ -1543,7 +1543,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ManagedVirtualNetwork’:
+	// Set property "ManagedVirtualNetwork":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ManagedVirtualNetwork != nil {
@@ -1552,7 +1552,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ManagedVirtualNetworkSettings’:
+	// Set property "ManagedVirtualNetworkSettings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ManagedVirtualNetworkSettings != nil {
@@ -1566,13 +1566,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		workspace.Name = &name
 	}
 
-	// Set property ‘PrivateEndpointConnections’:
+	// Set property "PrivateEndpointConnections":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.PrivateEndpointConnections {
@@ -1585,7 +1585,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1594,7 +1594,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1603,7 +1603,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘PurviewConfiguration’:
+	// Set property "PurviewConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PurviewConfiguration != nil {
@@ -1617,7 +1617,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Settings’:
+	// Set property "Settings":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Settings != nil {
@@ -1628,7 +1628,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘SqlAdministratorLogin’:
+	// Set property "SqlAdministratorLogin":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SqlAdministratorLogin != nil {
@@ -1637,7 +1637,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		workspace.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1645,7 +1645,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TrustedServiceBypassEnabled’:
+	// Set property "TrustedServiceBypassEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TrustedServiceBypassEnabled != nil {
@@ -1654,13 +1654,13 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		workspace.Type = &typeVar
 	}
 
-	// Set property ‘VirtualNetworkProfile’:
+	// Set property "VirtualNetworkProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetworkProfile != nil {
@@ -1674,7 +1674,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘WorkspaceRepositoryConfiguration’:
+	// Set property "WorkspaceRepositoryConfiguration":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkspaceRepositoryConfiguration != nil {
@@ -1688,7 +1688,7 @@ func (workspace *Workspace_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘WorkspaceUID’:
+	// Set property "WorkspaceUID":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkspaceUID != nil {
@@ -2145,7 +2145,7 @@ func (properties *CspWorkspaceAdminProperties) ConvertToARM(resolved genruntime.
 	}
 	result := &CspWorkspaceAdminProperties_ARM{}
 
-	// Set property ‘InitialWorkspaceAdminObjectId’:
+	// Set property "InitialWorkspaceAdminObjectId":
 	if properties.InitialWorkspaceAdminObjectId != nil {
 		initialWorkspaceAdminObjectId := *properties.InitialWorkspaceAdminObjectId
 		result.InitialWorkspaceAdminObjectId = &initialWorkspaceAdminObjectId
@@ -2165,7 +2165,7 @@ func (properties *CspWorkspaceAdminProperties) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CspWorkspaceAdminProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘InitialWorkspaceAdminObjectId’:
+	// Set property "InitialWorkspaceAdminObjectId":
 	if typedInput.InitialWorkspaceAdminObjectId != nil {
 		initialWorkspaceAdminObjectId := *typedInput.InitialWorkspaceAdminObjectId
 		properties.InitialWorkspaceAdminObjectId = &initialWorkspaceAdminObjectId
@@ -2234,7 +2234,7 @@ func (properties *CspWorkspaceAdminProperties_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CspWorkspaceAdminProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘InitialWorkspaceAdminObjectId’:
+	// Set property "InitialWorkspaceAdminObjectId":
 	if typedInput.InitialWorkspaceAdminObjectId != nil {
 		initialWorkspaceAdminObjectId := *typedInput.InitialWorkspaceAdminObjectId
 		properties.InitialWorkspaceAdminObjectId = &initialWorkspaceAdminObjectId
@@ -2300,7 +2300,7 @@ func (details *DataLakeStorageAccountDetails) ConvertToARM(resolved genruntime.C
 	}
 	result := &DataLakeStorageAccountDetails_ARM{}
 
-	// Set property ‘AccountUrl’:
+	// Set property "AccountUrl":
 	if details.AccountUrl != nil {
 		accountUrl := *details.AccountUrl
 		result.AccountUrl = &accountUrl
@@ -2314,19 +2314,19 @@ func (details *DataLakeStorageAccountDetails) ConvertToARM(resolved genruntime.C
 		result.AccountUrl = &accountUrl
 	}
 
-	// Set property ‘CreateManagedPrivateEndpoint’:
+	// Set property "CreateManagedPrivateEndpoint":
 	if details.CreateManagedPrivateEndpoint != nil {
 		createManagedPrivateEndpoint := *details.CreateManagedPrivateEndpoint
 		result.CreateManagedPrivateEndpoint = &createManagedPrivateEndpoint
 	}
 
-	// Set property ‘Filesystem’:
+	// Set property "Filesystem":
 	if details.Filesystem != nil {
 		filesystem := *details.Filesystem
 		result.Filesystem = &filesystem
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if details.ResourceReference != nil {
 		resourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*details.ResourceReference)
 		if err != nil {
@@ -2350,27 +2350,27 @@ func (details *DataLakeStorageAccountDetails) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataLakeStorageAccountDetails_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountUrl’:
+	// Set property "AccountUrl":
 	if typedInput.AccountUrl != nil {
 		accountUrl := *typedInput.AccountUrl
 		details.AccountUrl = &accountUrl
 	}
 
-	// no assignment for property ‘AccountUrlFromConfig’
+	// no assignment for property "AccountUrlFromConfig"
 
-	// Set property ‘CreateManagedPrivateEndpoint’:
+	// Set property "CreateManagedPrivateEndpoint":
 	if typedInput.CreateManagedPrivateEndpoint != nil {
 		createManagedPrivateEndpoint := *typedInput.CreateManagedPrivateEndpoint
 		details.CreateManagedPrivateEndpoint = &createManagedPrivateEndpoint
 	}
 
-	// Set property ‘Filesystem’:
+	// Set property "Filesystem":
 	if typedInput.Filesystem != nil {
 		filesystem := *typedInput.Filesystem
 		details.Filesystem = &filesystem
 	}
 
-	// no assignment for property ‘ResourceReference’
+	// no assignment for property "ResourceReference"
 
 	// No error
 	return nil
@@ -2517,25 +2517,25 @@ func (details *DataLakeStorageAccountDetails_STATUS) PopulateFromARM(owner genru
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DataLakeStorageAccountDetails_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountUrl’:
+	// Set property "AccountUrl":
 	if typedInput.AccountUrl != nil {
 		accountUrl := *typedInput.AccountUrl
 		details.AccountUrl = &accountUrl
 	}
 
-	// Set property ‘CreateManagedPrivateEndpoint’:
+	// Set property "CreateManagedPrivateEndpoint":
 	if typedInput.CreateManagedPrivateEndpoint != nil {
 		createManagedPrivateEndpoint := *typedInput.CreateManagedPrivateEndpoint
 		details.CreateManagedPrivateEndpoint = &createManagedPrivateEndpoint
 	}
 
-	// Set property ‘Filesystem’:
+	// Set property "Filesystem":
 	if typedInput.Filesystem != nil {
 		filesystem := *typedInput.Filesystem
 		details.Filesystem = &filesystem
 	}
 
-	// Set property ‘ResourceId’:
+	// Set property "ResourceId":
 	if typedInput.ResourceId != nil {
 		resourceId := *typedInput.ResourceId
 		details.ResourceId = &resourceId
@@ -2617,7 +2617,7 @@ func (details *EncryptionDetails) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &EncryptionDetails_ARM{}
 
-	// Set property ‘Cmk’:
+	// Set property "Cmk":
 	if details.Cmk != nil {
 		cmk_ARM, err := (*details.Cmk).ConvertToARM(resolved)
 		if err != nil {
@@ -2641,7 +2641,7 @@ func (details *EncryptionDetails) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionDetails_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cmk’:
+	// Set property "Cmk":
 	if typedInput.Cmk != nil {
 		var cmk1 CustomerManagedKeyDetails
 		err := cmk1.PopulateFromARM(owner, *typedInput.Cmk)
@@ -2745,7 +2745,7 @@ func (details *EncryptionDetails_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EncryptionDetails_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Cmk’:
+	// Set property "Cmk":
 	if typedInput.Cmk != nil {
 		var cmk1 CustomerManagedKeyDetails_STATUS
 		err := cmk1.PopulateFromARM(owner, *typedInput.Cmk)
@@ -2756,7 +2756,7 @@ func (details *EncryptionDetails_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		details.Cmk = &cmk
 	}
 
-	// Set property ‘DoubleEncryptionEnabled’:
+	// Set property "DoubleEncryptionEnabled":
 	if typedInput.DoubleEncryptionEnabled != nil {
 		doubleEncryptionEnabled := *typedInput.DoubleEncryptionEnabled
 		details.DoubleEncryptionEnabled = &doubleEncryptionEnabled
@@ -2847,13 +2847,13 @@ func (identity *ManagedIdentity) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 	result := &ManagedIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -2878,13 +2878,13 @@ func (identity *ManagedIdentity) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -3021,25 +3021,25 @@ func (identity *ManagedIdentity_STATUS) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedManagedIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -3164,18 +3164,18 @@ func (settings *ManagedVirtualNetworkSettings) ConvertToARM(resolved genruntime.
 	}
 	result := &ManagedVirtualNetworkSettings_ARM{}
 
-	// Set property ‘AllowedAadTenantIdsForLinking’:
+	// Set property "AllowedAadTenantIdsForLinking":
 	for _, item := range settings.AllowedAadTenantIdsForLinking {
 		result.AllowedAadTenantIdsForLinking = append(result.AllowedAadTenantIdsForLinking, item)
 	}
 
-	// Set property ‘LinkedAccessCheckOnTargetResource’:
+	// Set property "LinkedAccessCheckOnTargetResource":
 	if settings.LinkedAccessCheckOnTargetResource != nil {
 		linkedAccessCheckOnTargetResource := *settings.LinkedAccessCheckOnTargetResource
 		result.LinkedAccessCheckOnTargetResource = &linkedAccessCheckOnTargetResource
 	}
 
-	// Set property ‘PreventDataExfiltration’:
+	// Set property "PreventDataExfiltration":
 	if settings.PreventDataExfiltration != nil {
 		preventDataExfiltration := *settings.PreventDataExfiltration
 		result.PreventDataExfiltration = &preventDataExfiltration
@@ -3195,18 +3195,18 @@ func (settings *ManagedVirtualNetworkSettings) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedVirtualNetworkSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedAadTenantIdsForLinking’:
+	// Set property "AllowedAadTenantIdsForLinking":
 	for _, item := range typedInput.AllowedAadTenantIdsForLinking {
 		settings.AllowedAadTenantIdsForLinking = append(settings.AllowedAadTenantIdsForLinking, item)
 	}
 
-	// Set property ‘LinkedAccessCheckOnTargetResource’:
+	// Set property "LinkedAccessCheckOnTargetResource":
 	if typedInput.LinkedAccessCheckOnTargetResource != nil {
 		linkedAccessCheckOnTargetResource := *typedInput.LinkedAccessCheckOnTargetResource
 		settings.LinkedAccessCheckOnTargetResource = &linkedAccessCheckOnTargetResource
 	}
 
-	// Set property ‘PreventDataExfiltration’:
+	// Set property "PreventDataExfiltration":
 	if typedInput.PreventDataExfiltration != nil {
 		preventDataExfiltration := *typedInput.PreventDataExfiltration
 		settings.PreventDataExfiltration = &preventDataExfiltration
@@ -3329,18 +3329,18 @@ func (settings *ManagedVirtualNetworkSettings_STATUS) PopulateFromARM(owner genr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedVirtualNetworkSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedAadTenantIdsForLinking’:
+	// Set property "AllowedAadTenantIdsForLinking":
 	for _, item := range typedInput.AllowedAadTenantIdsForLinking {
 		settings.AllowedAadTenantIdsForLinking = append(settings.AllowedAadTenantIdsForLinking, item)
 	}
 
-	// Set property ‘LinkedAccessCheckOnTargetResource’:
+	// Set property "LinkedAccessCheckOnTargetResource":
 	if typedInput.LinkedAccessCheckOnTargetResource != nil {
 		linkedAccessCheckOnTargetResource := *typedInput.LinkedAccessCheckOnTargetResource
 		settings.LinkedAccessCheckOnTargetResource = &linkedAccessCheckOnTargetResource
 	}
 
-	// Set property ‘PreventDataExfiltration’:
+	// Set property "PreventDataExfiltration":
 	if typedInput.PreventDataExfiltration != nil {
 		preventDataExfiltration := *typedInput.PreventDataExfiltration
 		settings.PreventDataExfiltration = &preventDataExfiltration
@@ -3432,7 +3432,7 @@ func (connection *PrivateEndpointConnection_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PrivateEndpointConnection_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		connection.Id = &id
@@ -3486,7 +3486,7 @@ func (configuration *PurviewConfiguration) ConvertToARM(resolved genruntime.Conv
 	}
 	result := &PurviewConfiguration_ARM{}
 
-	// Set property ‘PurviewResourceId’:
+	// Set property "PurviewResourceId":
 	if configuration.PurviewResourceReference != nil {
 		purviewResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*configuration.PurviewResourceReference)
 		if err != nil {
@@ -3510,7 +3510,7 @@ func (configuration *PurviewConfiguration) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PurviewConfiguration_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘PurviewResourceReference’
+	// no assignment for property "PurviewResourceReference"
 
 	// No error
 	return nil
@@ -3590,7 +3590,7 @@ func (configuration *PurviewConfiguration_STATUS) PopulateFromARM(owner genrunti
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PurviewConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PurviewResourceId’:
+	// Set property "PurviewResourceId":
 	if typedInput.PurviewResourceId != nil {
 		purviewResourceId := *typedInput.PurviewResourceId
 		configuration.PurviewResourceId = &purviewResourceId
@@ -3644,7 +3644,7 @@ func (profile *VirtualNetworkProfile) ConvertToARM(resolved genruntime.ConvertTo
 	}
 	result := &VirtualNetworkProfile_ARM{}
 
-	// Set property ‘ComputeSubnetId’:
+	// Set property "ComputeSubnetId":
 	if profile.ComputeSubnetId != nil {
 		computeSubnetId := *profile.ComputeSubnetId
 		result.ComputeSubnetId = &computeSubnetId
@@ -3664,7 +3664,7 @@ func (profile *VirtualNetworkProfile) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkProfile_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeSubnetId’:
+	// Set property "ComputeSubnetId":
 	if typedInput.ComputeSubnetId != nil {
 		computeSubnetId := *typedInput.ComputeSubnetId
 		profile.ComputeSubnetId = &computeSubnetId
@@ -3733,7 +3733,7 @@ func (profile *VirtualNetworkProfile_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualNetworkProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ComputeSubnetId’:
+	// Set property "ComputeSubnetId":
 	if typedInput.ComputeSubnetId != nil {
 		computeSubnetId := *typedInput.ComputeSubnetId
 		profile.ComputeSubnetId = &computeSubnetId
@@ -3827,55 +3827,55 @@ func (configuration *WorkspaceRepositoryConfiguration) ConvertToARM(resolved gen
 	}
 	result := &WorkspaceRepositoryConfiguration_ARM{}
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if configuration.AccountName != nil {
 		accountName := *configuration.AccountName
 		result.AccountName = &accountName
 	}
 
-	// Set property ‘CollaborationBranch’:
+	// Set property "CollaborationBranch":
 	if configuration.CollaborationBranch != nil {
 		collaborationBranch := *configuration.CollaborationBranch
 		result.CollaborationBranch = &collaborationBranch
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	if configuration.HostName != nil {
 		hostName := *configuration.HostName
 		result.HostName = &hostName
 	}
 
-	// Set property ‘LastCommitId’:
+	// Set property "LastCommitId":
 	if configuration.LastCommitId != nil {
 		lastCommitId := *configuration.LastCommitId
 		result.LastCommitId = &lastCommitId
 	}
 
-	// Set property ‘ProjectName’:
+	// Set property "ProjectName":
 	if configuration.ProjectName != nil {
 		projectName := *configuration.ProjectName
 		result.ProjectName = &projectName
 	}
 
-	// Set property ‘RepositoryName’:
+	// Set property "RepositoryName":
 	if configuration.RepositoryName != nil {
 		repositoryName := *configuration.RepositoryName
 		result.RepositoryName = &repositoryName
 	}
 
-	// Set property ‘RootFolder’:
+	// Set property "RootFolder":
 	if configuration.RootFolder != nil {
 		rootFolder := *configuration.RootFolder
 		result.RootFolder = &rootFolder
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if configuration.TenantId != nil {
 		tenantId := *configuration.TenantId
 		result.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if configuration.Type != nil {
 		typeVar := *configuration.Type
 		result.Type = &typeVar
@@ -3895,55 +3895,55 @@ func (configuration *WorkspaceRepositoryConfiguration) PopulateFromARM(owner gen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceRepositoryConfiguration_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if typedInput.AccountName != nil {
 		accountName := *typedInput.AccountName
 		configuration.AccountName = &accountName
 	}
 
-	// Set property ‘CollaborationBranch’:
+	// Set property "CollaborationBranch":
 	if typedInput.CollaborationBranch != nil {
 		collaborationBranch := *typedInput.CollaborationBranch
 		configuration.CollaborationBranch = &collaborationBranch
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	if typedInput.HostName != nil {
 		hostName := *typedInput.HostName
 		configuration.HostName = &hostName
 	}
 
-	// Set property ‘LastCommitId’:
+	// Set property "LastCommitId":
 	if typedInput.LastCommitId != nil {
 		lastCommitId := *typedInput.LastCommitId
 		configuration.LastCommitId = &lastCommitId
 	}
 
-	// Set property ‘ProjectName’:
+	// Set property "ProjectName":
 	if typedInput.ProjectName != nil {
 		projectName := *typedInput.ProjectName
 		configuration.ProjectName = &projectName
 	}
 
-	// Set property ‘RepositoryName’:
+	// Set property "RepositoryName":
 	if typedInput.RepositoryName != nil {
 		repositoryName := *typedInput.RepositoryName
 		configuration.RepositoryName = &repositoryName
 	}
 
-	// Set property ‘RootFolder’:
+	// Set property "RootFolder":
 	if typedInput.RootFolder != nil {
 		rootFolder := *typedInput.RootFolder
 		configuration.RootFolder = &rootFolder
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		configuration.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		configuration.Type = &typeVar
@@ -4123,55 +4123,55 @@ func (configuration *WorkspaceRepositoryConfiguration_STATUS) PopulateFromARM(ow
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceRepositoryConfiguration_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if typedInput.AccountName != nil {
 		accountName := *typedInput.AccountName
 		configuration.AccountName = &accountName
 	}
 
-	// Set property ‘CollaborationBranch’:
+	// Set property "CollaborationBranch":
 	if typedInput.CollaborationBranch != nil {
 		collaborationBranch := *typedInput.CollaborationBranch
 		configuration.CollaborationBranch = &collaborationBranch
 	}
 
-	// Set property ‘HostName’:
+	// Set property "HostName":
 	if typedInput.HostName != nil {
 		hostName := *typedInput.HostName
 		configuration.HostName = &hostName
 	}
 
-	// Set property ‘LastCommitId’:
+	// Set property "LastCommitId":
 	if typedInput.LastCommitId != nil {
 		lastCommitId := *typedInput.LastCommitId
 		configuration.LastCommitId = &lastCommitId
 	}
 
-	// Set property ‘ProjectName’:
+	// Set property "ProjectName":
 	if typedInput.ProjectName != nil {
 		projectName := *typedInput.ProjectName
 		configuration.ProjectName = &projectName
 	}
 
-	// Set property ‘RepositoryName’:
+	// Set property "RepositoryName":
 	if typedInput.RepositoryName != nil {
 		repositoryName := *typedInput.RepositoryName
 		configuration.RepositoryName = &repositoryName
 	}
 
-	// Set property ‘RootFolder’:
+	// Set property "RootFolder":
 	if typedInput.RootFolder != nil {
 		rootFolder := *typedInput.RootFolder
 		configuration.RootFolder = &rootFolder
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		configuration.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		configuration.Type = &typeVar
@@ -4276,7 +4276,7 @@ func (details *CustomerManagedKeyDetails) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &CustomerManagedKeyDetails_ARM{}
 
-	// Set property ‘KekIdentity’:
+	// Set property "KekIdentity":
 	if details.KekIdentity != nil {
 		kekIdentity_ARM, err := (*details.KekIdentity).ConvertToARM(resolved)
 		if err != nil {
@@ -4286,7 +4286,7 @@ func (details *CustomerManagedKeyDetails) ConvertToARM(resolved genruntime.Conve
 		result.KekIdentity = &kekIdentity
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if details.Key != nil {
 		key_ARM, err := (*details.Key).ConvertToARM(resolved)
 		if err != nil {
@@ -4310,7 +4310,7 @@ func (details *CustomerManagedKeyDetails) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CustomerManagedKeyDetails_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KekIdentity’:
+	// Set property "KekIdentity":
 	if typedInput.KekIdentity != nil {
 		var kekIdentity1 KekIdentityProperties
 		err := kekIdentity1.PopulateFromARM(owner, *typedInput.KekIdentity)
@@ -4321,7 +4321,7 @@ func (details *CustomerManagedKeyDetails) PopulateFromARM(owner genruntime.Arbit
 		details.KekIdentity = &kekIdentity
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		var key1 WorkspaceKeyDetails
 		err := key1.PopulateFromARM(owner, *typedInput.Key)
@@ -4464,7 +4464,7 @@ func (details *CustomerManagedKeyDetails_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CustomerManagedKeyDetails_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KekIdentity’:
+	// Set property "KekIdentity":
 	if typedInput.KekIdentity != nil {
 		var kekIdentity1 KekIdentityProperties_STATUS
 		err := kekIdentity1.PopulateFromARM(owner, *typedInput.KekIdentity)
@@ -4475,7 +4475,7 @@ func (details *CustomerManagedKeyDetails_STATUS) PopulateFromARM(owner genruntim
 		details.KekIdentity = &kekIdentity
 	}
 
-	// Set property ‘Key’:
+	// Set property "Key":
 	if typedInput.Key != nil {
 		var key1 WorkspaceKeyDetails_STATUS
 		err := key1.PopulateFromARM(owner, *typedInput.Key)
@@ -4486,7 +4486,7 @@ func (details *CustomerManagedKeyDetails_STATUS) PopulateFromARM(owner genruntim
 		details.Key = &key
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		details.Status = &status
@@ -4630,13 +4630,13 @@ func (identity *UserAssignedManagedIdentity_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedManagedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
@@ -4699,13 +4699,13 @@ func (properties *KekIdentityProperties) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &KekIdentityProperties_ARM{}
 
-	// Set property ‘UseSystemAssignedIdentity’:
+	// Set property "UseSystemAssignedIdentity":
 	if properties.UseSystemAssignedIdentity != nil {
 		useSystemAssignedIdentity := *(*properties.UseSystemAssignedIdentity).DeepCopy()
 		result.UseSystemAssignedIdentity = &useSystemAssignedIdentity
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if properties.UserAssignedIdentityReference != nil {
 		userAssignedIdentityReferenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.UserAssignedIdentityReference)
 		if err != nil {
@@ -4729,13 +4729,13 @@ func (properties *KekIdentityProperties) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KekIdentityProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UseSystemAssignedIdentity’:
+	// Set property "UseSystemAssignedIdentity":
 	if typedInput.UseSystemAssignedIdentity != nil {
 		useSystemAssignedIdentity := *(*typedInput.UseSystemAssignedIdentity).DeepCopy()
 		properties.UseSystemAssignedIdentity = &useSystemAssignedIdentity
 	}
 
-	// no assignment for property ‘UserAssignedIdentityReference’
+	// no assignment for property "UserAssignedIdentityReference"
 
 	// No error
 	return nil
@@ -4834,13 +4834,13 @@ func (properties *KekIdentityProperties_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KekIdentityProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘UseSystemAssignedIdentity’:
+	// Set property "UseSystemAssignedIdentity":
 	if typedInput.UseSystemAssignedIdentity != nil {
 		useSystemAssignedIdentity := *(*typedInput.UseSystemAssignedIdentity).DeepCopy()
 		properties.UseSystemAssignedIdentity = &useSystemAssignedIdentity
 	}
 
-	// Set property ‘UserAssignedIdentity’:
+	// Set property "UserAssignedIdentity":
 	if typedInput.UserAssignedIdentity != nil {
 		userAssignedIdentity := *typedInput.UserAssignedIdentity
 		properties.UserAssignedIdentity = &userAssignedIdentity
@@ -4913,13 +4913,13 @@ func (details *WorkspaceKeyDetails) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &WorkspaceKeyDetails_ARM{}
 
-	// Set property ‘KeyVaultUrl’:
+	// Set property "KeyVaultUrl":
 	if details.KeyVaultUrl != nil {
 		keyVaultUrl := *details.KeyVaultUrl
 		result.KeyVaultUrl = &keyVaultUrl
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if details.Name != nil {
 		name := *details.Name
 		result.Name = &name
@@ -4939,13 +4939,13 @@ func (details *WorkspaceKeyDetails) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceKeyDetails_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyVaultUrl’:
+	// Set property "KeyVaultUrl":
 	if typedInput.KeyVaultUrl != nil {
 		keyVaultUrl := *typedInput.KeyVaultUrl
 		details.KeyVaultUrl = &keyVaultUrl
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		details.Name = &name
@@ -5026,13 +5026,13 @@ func (details *WorkspaceKeyDetails_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected WorkspaceKeyDetails_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘KeyVaultUrl’:
+	// Set property "KeyVaultUrl":
 	if typedInput.KeyVaultUrl != nil {
 		keyVaultUrl := *typedInput.KeyVaultUrl
 		details.KeyVaultUrl = &keyVaultUrl
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		details.Name = &name

--- a/v2/api/synapse/v1api20210601/workspaces_big_data_pool_types_gen.go
+++ b/v2/api/synapse/v1api20210601/workspaces_big_data_pool_types_gen.go
@@ -386,16 +386,16 @@ func (pool *Workspaces_BigDataPool_Spec) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &Workspaces_BigDataPool_Spec_ARM{}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if pool.Location != nil {
 		location := *pool.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if pool.AutoPause != nil ||
 		pool.AutoScale != nil ||
 		pool.CustomLibraries != nil ||
@@ -502,7 +502,7 @@ func (pool *Workspaces_BigDataPool_Spec) ConvertToARM(resolved genruntime.Conver
 		result.Properties.SparkVersion = &sparkVersion
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if pool.Tags != nil {
 		result.Tags = make(map[string]string, len(pool.Tags))
 		for key, value := range pool.Tags {
@@ -524,7 +524,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspaces_BigDataPool_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoPause’:
+	// Set property "AutoPause":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoPause != nil {
@@ -538,7 +538,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘AutoScale’:
+	// Set property "AutoScale":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoScale != nil {
@@ -552,10 +552,10 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	pool.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘CustomLibraries’:
+	// Set property "CustomLibraries":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CustomLibraries {
@@ -568,7 +568,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘DefaultSparkLogFolder’:
+	// Set property "DefaultSparkLogFolder":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultSparkLogFolder != nil {
@@ -577,7 +577,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘DynamicExecutorAllocation’:
+	// Set property "DynamicExecutorAllocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DynamicExecutorAllocation != nil {
@@ -591,7 +591,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘IsAutotuneEnabled’:
+	// Set property "IsAutotuneEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAutotuneEnabled != nil {
@@ -600,7 +600,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘IsComputeIsolationEnabled’:
+	// Set property "IsComputeIsolationEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsComputeIsolationEnabled != nil {
@@ -609,7 +609,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘LibraryRequirements’:
+	// Set property "LibraryRequirements":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LibraryRequirements != nil {
@@ -623,13 +623,13 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		pool.Location = &location
 	}
 
-	// Set property ‘NodeCount’:
+	// Set property "NodeCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeCount != nil {
@@ -638,7 +638,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘NodeSize’:
+	// Set property "NodeSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeSize != nil {
@@ -647,7 +647,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘NodeSizeFamily’:
+	// Set property "NodeSizeFamily":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeSizeFamily != nil {
@@ -656,10 +656,10 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	pool.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -668,7 +668,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘SessionLevelPackagesEnabled’:
+	// Set property "SessionLevelPackagesEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SessionLevelPackagesEnabled != nil {
@@ -677,7 +677,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘SparkConfigProperties’:
+	// Set property "SparkConfigProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SparkConfigProperties != nil {
@@ -691,7 +691,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘SparkEventsFolder’:
+	// Set property "SparkEventsFolder":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SparkEventsFolder != nil {
@@ -700,7 +700,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘SparkVersion’:
+	// Set property "SparkVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SparkVersion != nil {
@@ -709,7 +709,7 @@ func (pool *Workspaces_BigDataPool_Spec) PopulateFromARM(owner genruntime.Arbitr
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		pool.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1393,7 +1393,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Workspaces_BigDataPool_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AutoPause’:
+	// Set property "AutoPause":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoPause != nil {
@@ -1407,7 +1407,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘AutoScale’:
+	// Set property "AutoScale":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AutoScale != nil {
@@ -1421,7 +1421,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘CacheSize’:
+	// Set property "CacheSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CacheSize != nil {
@@ -1430,9 +1430,9 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘CreationDate’:
+	// Set property "CreationDate":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CreationDate != nil {
@@ -1441,7 +1441,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘CustomLibraries’:
+	// Set property "CustomLibraries":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.CustomLibraries {
@@ -1454,7 +1454,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘DefaultSparkLogFolder’:
+	// Set property "DefaultSparkLogFolder":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultSparkLogFolder != nil {
@@ -1463,7 +1463,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘DynamicExecutorAllocation’:
+	// Set property "DynamicExecutorAllocation":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DynamicExecutorAllocation != nil {
@@ -1477,13 +1477,13 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		pool.Id = &id
 	}
 
-	// Set property ‘IsAutotuneEnabled’:
+	// Set property "IsAutotuneEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsAutotuneEnabled != nil {
@@ -1492,7 +1492,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘IsComputeIsolationEnabled’:
+	// Set property "IsComputeIsolationEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsComputeIsolationEnabled != nil {
@@ -1501,7 +1501,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘LastSucceededTimestamp’:
+	// Set property "LastSucceededTimestamp":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastSucceededTimestamp != nil {
@@ -1510,7 +1510,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘LibraryRequirements’:
+	// Set property "LibraryRequirements":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LibraryRequirements != nil {
@@ -1524,19 +1524,19 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		pool.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pool.Name = &name
 	}
 
-	// Set property ‘NodeCount’:
+	// Set property "NodeCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeCount != nil {
@@ -1545,7 +1545,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘NodeSize’:
+	// Set property "NodeSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeSize != nil {
@@ -1554,7 +1554,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘NodeSizeFamily’:
+	// Set property "NodeSizeFamily":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NodeSizeFamily != nil {
@@ -1563,7 +1563,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1572,7 +1572,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘SessionLevelPackagesEnabled’:
+	// Set property "SessionLevelPackagesEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SessionLevelPackagesEnabled != nil {
@@ -1581,7 +1581,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘SparkConfigProperties’:
+	// Set property "SparkConfigProperties":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SparkConfigProperties != nil {
@@ -1595,7 +1595,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘SparkEventsFolder’:
+	// Set property "SparkEventsFolder":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SparkEventsFolder != nil {
@@ -1604,7 +1604,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘SparkVersion’:
+	// Set property "SparkVersion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SparkVersion != nil {
@@ -1613,7 +1613,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		pool.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1621,7 +1621,7 @@ func (pool *Workspaces_BigDataPool_STATUS) PopulateFromARM(owner genruntime.Arbi
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		pool.Type = &typeVar
@@ -1992,13 +1992,13 @@ func (properties *AutoPauseProperties) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &AutoPauseProperties_ARM{}
 
-	// Set property ‘DelayInMinutes’:
+	// Set property "DelayInMinutes":
 	if properties.DelayInMinutes != nil {
 		delayInMinutes := *properties.DelayInMinutes
 		result.DelayInMinutes = &delayInMinutes
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if properties.Enabled != nil {
 		enabled := *properties.Enabled
 		result.Enabled = &enabled
@@ -2018,13 +2018,13 @@ func (properties *AutoPauseProperties) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoPauseProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DelayInMinutes’:
+	// Set property "DelayInMinutes":
 	if typedInput.DelayInMinutes != nil {
 		delayInMinutes := *typedInput.DelayInMinutes
 		properties.DelayInMinutes = &delayInMinutes
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
@@ -2120,13 +2120,13 @@ func (properties *AutoPauseProperties_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoPauseProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DelayInMinutes’:
+	// Set property "DelayInMinutes":
 	if typedInput.DelayInMinutes != nil {
 		delayInMinutes := *typedInput.DelayInMinutes
 		properties.DelayInMinutes = &delayInMinutes
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
@@ -2202,19 +2202,19 @@ func (properties *AutoScaleProperties) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &AutoScaleProperties_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if properties.Enabled != nil {
 		enabled := *properties.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if properties.MaxNodeCount != nil {
 		maxNodeCount := *properties.MaxNodeCount
 		result.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if properties.MinNodeCount != nil {
 		minNodeCount := *properties.MinNodeCount
 		result.MinNodeCount = &minNodeCount
@@ -2234,19 +2234,19 @@ func (properties *AutoScaleProperties) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoScaleProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
 	}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if typedInput.MaxNodeCount != nil {
 		maxNodeCount := *typedInput.MaxNodeCount
 		properties.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if typedInput.MinNodeCount != nil {
 		minNodeCount := *typedInput.MinNodeCount
 		properties.MinNodeCount = &minNodeCount
@@ -2354,19 +2354,19 @@ func (properties *AutoScaleProperties_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoScaleProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		properties.Enabled = &enabled
 	}
 
-	// Set property ‘MaxNodeCount’:
+	// Set property "MaxNodeCount":
 	if typedInput.MaxNodeCount != nil {
 		maxNodeCount := *typedInput.MaxNodeCount
 		properties.MaxNodeCount = &maxNodeCount
 	}
 
-	// Set property ‘MinNodeCount’:
+	// Set property "MinNodeCount":
 	if typedInput.MinNodeCount != nil {
 		minNodeCount := *typedInput.MinNodeCount
 		properties.MinNodeCount = &minNodeCount
@@ -2492,19 +2492,19 @@ func (allocation *DynamicExecutorAllocation) ConvertToARM(resolved genruntime.Co
 	}
 	result := &DynamicExecutorAllocation_ARM{}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if allocation.Enabled != nil {
 		enabled := *allocation.Enabled
 		result.Enabled = &enabled
 	}
 
-	// Set property ‘MaxExecutors’:
+	// Set property "MaxExecutors":
 	if allocation.MaxExecutors != nil {
 		maxExecutors := *allocation.MaxExecutors
 		result.MaxExecutors = &maxExecutors
 	}
 
-	// Set property ‘MinExecutors’:
+	// Set property "MinExecutors":
 	if allocation.MinExecutors != nil {
 		minExecutors := *allocation.MinExecutors
 		result.MinExecutors = &minExecutors
@@ -2524,19 +2524,19 @@ func (allocation *DynamicExecutorAllocation) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DynamicExecutorAllocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		allocation.Enabled = &enabled
 	}
 
-	// Set property ‘MaxExecutors’:
+	// Set property "MaxExecutors":
 	if typedInput.MaxExecutors != nil {
 		maxExecutors := *typedInput.MaxExecutors
 		allocation.MaxExecutors = &maxExecutors
 	}
 
-	// Set property ‘MinExecutors’:
+	// Set property "MinExecutors":
 	if typedInput.MinExecutors != nil {
 		minExecutors := *typedInput.MinExecutors
 		allocation.MinExecutors = &minExecutors
@@ -2644,19 +2644,19 @@ func (allocation *DynamicExecutorAllocation_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected DynamicExecutorAllocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	if typedInput.Enabled != nil {
 		enabled := *typedInput.Enabled
 		allocation.Enabled = &enabled
 	}
 
-	// Set property ‘MaxExecutors’:
+	// Set property "MaxExecutors":
 	if typedInput.MaxExecutors != nil {
 		maxExecutors := *typedInput.MaxExecutors
 		allocation.MaxExecutors = &maxExecutors
 	}
 
-	// Set property ‘MinExecutors’:
+	// Set property "MinExecutors":
 	if typedInput.MinExecutors != nil {
 		minExecutors := *typedInput.MinExecutors
 		allocation.MinExecutors = &minExecutors
@@ -2741,25 +2741,25 @@ func (info *LibraryInfo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &LibraryInfo_ARM{}
 
-	// Set property ‘ContainerName’:
+	// Set property "ContainerName":
 	if info.ContainerName != nil {
 		containerName := *info.ContainerName
 		result.ContainerName = &containerName
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if info.Name != nil {
 		name := *info.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if info.Path != nil {
 		path := *info.Path
 		result.Path = &path
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if info.Type != nil {
 		typeVar := *info.Type
 		result.Type = &typeVar
@@ -2779,25 +2779,25 @@ func (info *LibraryInfo) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LibraryInfo_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContainerName’:
+	// Set property "ContainerName":
 	if typedInput.ContainerName != nil {
 		containerName := *typedInput.ContainerName
 		info.ContainerName = &containerName
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		info.Name = &name
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		info.Path = &path
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		info.Type = &typeVar
@@ -2911,43 +2911,43 @@ func (info *LibraryInfo_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LibraryInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ContainerName’:
+	// Set property "ContainerName":
 	if typedInput.ContainerName != nil {
 		containerName := *typedInput.ContainerName
 		info.ContainerName = &containerName
 	}
 
-	// Set property ‘CreatorId’:
+	// Set property "CreatorId":
 	if typedInput.CreatorId != nil {
 		creatorId := *typedInput.CreatorId
 		info.CreatorId = &creatorId
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		info.Name = &name
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		info.Path = &path
 	}
 
-	// Set property ‘ProvisioningStatus’:
+	// Set property "ProvisioningStatus":
 	if typedInput.ProvisioningStatus != nil {
 		provisioningStatus := *typedInput.ProvisioningStatus
 		info.ProvisioningStatus = &provisioningStatus
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		info.Type = &typeVar
 	}
 
-	// Set property ‘UploadedTimestamp’:
+	// Set property "UploadedTimestamp":
 	if typedInput.UploadedTimestamp != nil {
 		uploadedTimestamp := *typedInput.UploadedTimestamp
 		info.UploadedTimestamp = &uploadedTimestamp
@@ -3040,13 +3040,13 @@ func (requirements *LibraryRequirements) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &LibraryRequirements_ARM{}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if requirements.Content != nil {
 		content := *requirements.Content
 		result.Content = &content
 	}
 
-	// Set property ‘Filename’:
+	// Set property "Filename":
 	if requirements.Filename != nil {
 		filename := *requirements.Filename
 		result.Filename = &filename
@@ -3066,13 +3066,13 @@ func (requirements *LibraryRequirements) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LibraryRequirements_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if typedInput.Content != nil {
 		content := *typedInput.Content
 		requirements.Content = &content
 	}
 
-	// Set property ‘Filename’:
+	// Set property "Filename":
 	if typedInput.Filename != nil {
 		filename := *typedInput.Filename
 		requirements.Filename = &filename
@@ -3156,19 +3156,19 @@ func (requirements *LibraryRequirements_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected LibraryRequirements_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if typedInput.Content != nil {
 		content := *typedInput.Content
 		requirements.Content = &content
 	}
 
-	// Set property ‘Filename’:
+	// Set property "Filename":
 	if typedInput.Filename != nil {
 		filename := *typedInput.Filename
 		requirements.Filename = &filename
 	}
 
-	// Set property ‘Time’:
+	// Set property "Time":
 	if typedInput.Time != nil {
 		time := *typedInput.Time
 		requirements.Time = &time
@@ -3240,19 +3240,19 @@ func (properties *SparkConfigProperties) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &SparkConfigProperties_ARM{}
 
-	// Set property ‘ConfigurationType’:
+	// Set property "ConfigurationType":
 	if properties.ConfigurationType != nil {
 		configurationType := *properties.ConfigurationType
 		result.ConfigurationType = &configurationType
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if properties.Content != nil {
 		content := *properties.Content
 		result.Content = &content
 	}
 
-	// Set property ‘Filename’:
+	// Set property "Filename":
 	if properties.Filename != nil {
 		filename := *properties.Filename
 		result.Filename = &filename
@@ -3272,19 +3272,19 @@ func (properties *SparkConfigProperties) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SparkConfigProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConfigurationType’:
+	// Set property "ConfigurationType":
 	if typedInput.ConfigurationType != nil {
 		configurationType := *typedInput.ConfigurationType
 		properties.ConfigurationType = &configurationType
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if typedInput.Content != nil {
 		content := *typedInput.Content
 		properties.Content = &content
 	}
 
-	// Set property ‘Filename’:
+	// Set property "Filename":
 	if typedInput.Filename != nil {
 		filename := *typedInput.Filename
 		properties.Filename = &filename
@@ -3395,25 +3395,25 @@ func (properties *SparkConfigProperties_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SparkConfigProperties_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConfigurationType’:
+	// Set property "ConfigurationType":
 	if typedInput.ConfigurationType != nil {
 		configurationType := *typedInput.ConfigurationType
 		properties.ConfigurationType = &configurationType
 	}
 
-	// Set property ‘Content’:
+	// Set property "Content":
 	if typedInput.Content != nil {
 		content := *typedInput.Content
 		properties.Content = &content
 	}
 
-	// Set property ‘Filename’:
+	// Set property "Filename":
 	if typedInput.Filename != nil {
 		filename := *typedInput.Filename
 		properties.Filename = &filename
 	}
 
-	// Set property ‘Time’:
+	// Set property "Time":
 	if typedInput.Time != nil {
 		time := *typedInput.Time
 		properties.Time = &time

--- a/v2/api/web/v1api20220301/server_farm_types_gen.go
+++ b/v2/api/web/v1api20220301/server_farm_types_gen.go
@@ -400,7 +400,7 @@ func (serverfarm *Serverfarm_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &Serverfarm_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if serverfarm.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*serverfarm.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -410,22 +410,22 @@ func (serverfarm *Serverfarm_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if serverfarm.Kind != nil {
 		kind := *serverfarm.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if serverfarm.Location != nil {
 		location := *serverfarm.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if serverfarm.ElasticScaleEnabled != nil ||
 		serverfarm.FreeOfferExpirationTime != nil ||
 		serverfarm.HostingEnvironmentProfile != nil ||
@@ -512,7 +512,7 @@ func (serverfarm *Serverfarm_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.ZoneRedundant = &zoneRedundant
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if serverfarm.Sku != nil {
 		sku_ARM, err := (*serverfarm.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -522,7 +522,7 @@ func (serverfarm *Serverfarm_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if serverfarm.Tags != nil {
 		result.Tags = make(map[string]string, len(serverfarm.Tags))
 		for key, value := range serverfarm.Tags {
@@ -544,10 +544,10 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Serverfarm_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	serverfarm.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘ElasticScaleEnabled’:
+	// Set property "ElasticScaleEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ElasticScaleEnabled != nil {
@@ -556,7 +556,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -567,7 +567,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		serverfarm.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FreeOfferExpirationTime’:
+	// Set property "FreeOfferExpirationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FreeOfferExpirationTime != nil {
@@ -576,7 +576,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HostingEnvironmentProfile’:
+	// Set property "HostingEnvironmentProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostingEnvironmentProfile != nil {
@@ -590,7 +590,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HyperV’:
+	// Set property "HyperV":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperV != nil {
@@ -599,7 +599,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘IsSpot’:
+	// Set property "IsSpot":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsSpot != nil {
@@ -608,7 +608,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘IsXenon’:
+	// Set property "IsXenon":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsXenon != nil {
@@ -617,13 +617,13 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		serverfarm.Kind = &kind
 	}
 
-	// Set property ‘KubeEnvironmentProfile’:
+	// Set property "KubeEnvironmentProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeEnvironmentProfile != nil {
@@ -637,13 +637,13 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		serverfarm.Location = &location
 	}
 
-	// Set property ‘MaximumElasticWorkerCount’:
+	// Set property "MaximumElasticWorkerCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaximumElasticWorkerCount != nil {
@@ -652,10 +652,10 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	serverfarm.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PerSiteScaling’:
+	// Set property "PerSiteScaling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PerSiteScaling != nil {
@@ -664,7 +664,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Reserved’:
+	// Set property "Reserved":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Reserved != nil {
@@ -673,7 +673,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 SkuDescription
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -684,7 +684,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		serverfarm.Sku = &sku
 	}
 
-	// Set property ‘SpotExpirationTime’:
+	// Set property "SpotExpirationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotExpirationTime != nil {
@@ -693,7 +693,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		serverfarm.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -701,7 +701,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TargetWorkerCount’:
+	// Set property "TargetWorkerCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetWorkerCount != nil {
@@ -710,7 +710,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TargetWorkerSizeId’:
+	// Set property "TargetWorkerSizeId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetWorkerSizeId != nil {
@@ -719,7 +719,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘WorkerTierName’:
+	// Set property "WorkerTierName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkerTierName != nil {
@@ -728,7 +728,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -1412,9 +1412,9 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Serverfarm_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ElasticScaleEnabled’:
+	// Set property "ElasticScaleEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ElasticScaleEnabled != nil {
@@ -1423,7 +1423,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1434,7 +1434,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		serverfarm.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FreeOfferExpirationTime’:
+	// Set property "FreeOfferExpirationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FreeOfferExpirationTime != nil {
@@ -1443,7 +1443,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘GeoRegion’:
+	// Set property "GeoRegion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GeoRegion != nil {
@@ -1452,7 +1452,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘HostingEnvironmentProfile’:
+	// Set property "HostingEnvironmentProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostingEnvironmentProfile != nil {
@@ -1466,7 +1466,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘HyperV’:
+	// Set property "HyperV":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperV != nil {
@@ -1475,13 +1475,13 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		serverfarm.Id = &id
 	}
 
-	// Set property ‘IsSpot’:
+	// Set property "IsSpot":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsSpot != nil {
@@ -1490,7 +1490,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘IsXenon’:
+	// Set property "IsXenon":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsXenon != nil {
@@ -1499,13 +1499,13 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		serverfarm.Kind = &kind
 	}
 
-	// Set property ‘KubeEnvironmentProfile’:
+	// Set property "KubeEnvironmentProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeEnvironmentProfile != nil {
@@ -1519,13 +1519,13 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		serverfarm.Location = &location
 	}
 
-	// Set property ‘MaximumElasticWorkerCount’:
+	// Set property "MaximumElasticWorkerCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaximumElasticWorkerCount != nil {
@@ -1534,7 +1534,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘MaximumNumberOfWorkers’:
+	// Set property "MaximumNumberOfWorkers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaximumNumberOfWorkers != nil {
@@ -1543,13 +1543,13 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		serverfarm.Name = &name
 	}
 
-	// Set property ‘NumberOfSites’:
+	// Set property "NumberOfSites":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfSites != nil {
@@ -1558,7 +1558,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NumberOfWorkers’:
+	// Set property "NumberOfWorkers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfWorkers != nil {
@@ -1567,7 +1567,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PerSiteScaling’:
+	// Set property "PerSiteScaling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PerSiteScaling != nil {
@@ -1576,7 +1576,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1585,7 +1585,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Reserved’:
+	// Set property "Reserved":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Reserved != nil {
@@ -1594,7 +1594,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGroup != nil {
@@ -1603,7 +1603,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 SkuDescription_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1614,7 +1614,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		serverfarm.Sku = &sku
 	}
 
-	// Set property ‘SpotExpirationTime’:
+	// Set property "SpotExpirationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotExpirationTime != nil {
@@ -1623,7 +1623,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -1632,7 +1632,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Subscription’:
+	// Set property "Subscription":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subscription != nil {
@@ -1641,7 +1641,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		serverfarm.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1649,7 +1649,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TargetWorkerCount’:
+	// Set property "TargetWorkerCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetWorkerCount != nil {
@@ -1658,7 +1658,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TargetWorkerSizeId’:
+	// Set property "TargetWorkerSizeId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetWorkerSizeId != nil {
@@ -1667,13 +1667,13 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		serverfarm.Type = &typeVar
 	}
 
-	// Set property ‘WorkerTierName’:
+	// Set property "WorkerTierName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkerTierName != nil {
@@ -1682,7 +1682,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -2087,7 +2087,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
@@ -2107,7 +2107,7 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
@@ -2179,13 +2179,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -2245,7 +2245,7 @@ func (profile *HostingEnvironmentProfile) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &HostingEnvironmentProfile_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if profile.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.Reference)
 		if err != nil {
@@ -2269,7 +2269,7 @@ func (profile *HostingEnvironmentProfile) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HostingEnvironmentProfile_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2355,19 +2355,19 @@ func (profile *HostingEnvironmentProfile_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HostingEnvironmentProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		profile.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
@@ -2433,7 +2433,7 @@ func (profile *KubeEnvironmentProfile) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &KubeEnvironmentProfile_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if profile.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.Reference)
 		if err != nil {
@@ -2457,7 +2457,7 @@ func (profile *KubeEnvironmentProfile) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubeEnvironmentProfile_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2543,19 +2543,19 @@ func (profile *KubeEnvironmentProfile_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubeEnvironmentProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		profile.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
@@ -2660,7 +2660,7 @@ func (description *SkuDescription) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &SkuDescription_ARM{}
 
-	// Set property ‘Capabilities’:
+	// Set property "Capabilities":
 	for _, item := range description.Capabilities {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2669,36 +2669,36 @@ func (description *SkuDescription) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Capabilities = append(result.Capabilities, *item_ARM.(*Capability_ARM))
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if description.Capacity != nil {
 		capacity := *description.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if description.Family != nil {
 		family := *description.Family
 		result.Family = &family
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	for _, item := range description.Locations {
 		result.Locations = append(result.Locations, item)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if description.Name != nil {
 		name := *description.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if description.Size != nil {
 		size := *description.Size
 		result.Size = &size
 	}
 
-	// Set property ‘SkuCapacity’:
+	// Set property "SkuCapacity":
 	if description.SkuCapacity != nil {
 		skuCapacity_ARM, err := (*description.SkuCapacity).ConvertToARM(resolved)
 		if err != nil {
@@ -2708,7 +2708,7 @@ func (description *SkuDescription) ConvertToARM(resolved genruntime.ConvertToARM
 		result.SkuCapacity = &skuCapacity
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if description.Tier != nil {
 		tier := *description.Tier
 		result.Tier = &tier
@@ -2728,7 +2728,7 @@ func (description *SkuDescription) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SkuDescription_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capabilities’:
+	// Set property "Capabilities":
 	for _, item := range typedInput.Capabilities {
 		var item1 Capability
 		err := item1.PopulateFromARM(owner, item)
@@ -2738,36 +2738,36 @@ func (description *SkuDescription) PopulateFromARM(owner genruntime.ArbitraryOwn
 		description.Capabilities = append(description.Capabilities, item1)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		description.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		description.Family = &family
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	for _, item := range typedInput.Locations {
 		description.Locations = append(description.Locations, item)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		description.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if typedInput.Size != nil {
 		size := *typedInput.Size
 		description.Size = &size
 	}
 
-	// Set property ‘SkuCapacity’:
+	// Set property "SkuCapacity":
 	if typedInput.SkuCapacity != nil {
 		var skuCapacity1 SkuCapacity
 		err := skuCapacity1.PopulateFromARM(owner, *typedInput.SkuCapacity)
@@ -2778,7 +2778,7 @@ func (description *SkuDescription) PopulateFromARM(owner genruntime.ArbitraryOwn
 		description.SkuCapacity = &skuCapacity
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		description.Tier = &tier
@@ -3003,7 +3003,7 @@ func (description *SkuDescription_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SkuDescription_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capabilities’:
+	// Set property "Capabilities":
 	for _, item := range typedInput.Capabilities {
 		var item1 Capability_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -3013,36 +3013,36 @@ func (description *SkuDescription_STATUS) PopulateFromARM(owner genruntime.Arbit
 		description.Capabilities = append(description.Capabilities, item1)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		description.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		description.Family = &family
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	for _, item := range typedInput.Locations {
 		description.Locations = append(description.Locations, item)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		description.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if typedInput.Size != nil {
 		size := *typedInput.Size
 		description.Size = &size
 	}
 
-	// Set property ‘SkuCapacity’:
+	// Set property "SkuCapacity":
 	if typedInput.SkuCapacity != nil {
 		var skuCapacity1 SkuCapacity_STATUS
 		err := skuCapacity1.PopulateFromARM(owner, *typedInput.SkuCapacity)
@@ -3053,7 +3053,7 @@ func (description *SkuDescription_STATUS) PopulateFromARM(owner genruntime.Arbit
 		description.SkuCapacity = &skuCapacity
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		description.Tier = &tier
@@ -3203,19 +3203,19 @@ func (capability *Capability) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Capability_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if capability.Name != nil {
 		name := *capability.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Reason’:
+	// Set property "Reason":
 	if capability.Reason != nil {
 		reason := *capability.Reason
 		result.Reason = &reason
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if capability.Value != nil {
 		value := *capability.Value
 		result.Value = &value
@@ -3235,19 +3235,19 @@ func (capability *Capability) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Capability_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		capability.Name = &name
 	}
 
-	// Set property ‘Reason’:
+	// Set property "Reason":
 	if typedInput.Reason != nil {
 		reason := *typedInput.Reason
 		capability.Reason = &reason
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		capability.Value = &value
@@ -3340,19 +3340,19 @@ func (capability *Capability_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Capability_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		capability.Name = &name
 	}
 
-	// Set property ‘Reason’:
+	// Set property "Reason":
 	if typedInput.Reason != nil {
 		reason := *typedInput.Reason
 		capability.Reason = &reason
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		capability.Value = &value
@@ -3430,31 +3430,31 @@ func (capacity *SkuCapacity) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SkuCapacity_ARM{}
 
-	// Set property ‘Default’:
+	// Set property "Default":
 	if capacity.Default != nil {
 		def := *capacity.Default
 		result.Default = &def
 	}
 
-	// Set property ‘ElasticMaximum’:
+	// Set property "ElasticMaximum":
 	if capacity.ElasticMaximum != nil {
 		elasticMaximum := *capacity.ElasticMaximum
 		result.ElasticMaximum = &elasticMaximum
 	}
 
-	// Set property ‘Maximum’:
+	// Set property "Maximum":
 	if capacity.Maximum != nil {
 		maximum := *capacity.Maximum
 		result.Maximum = &maximum
 	}
 
-	// Set property ‘Minimum’:
+	// Set property "Minimum":
 	if capacity.Minimum != nil {
 		minimum := *capacity.Minimum
 		result.Minimum = &minimum
 	}
 
-	// Set property ‘ScaleType’:
+	// Set property "ScaleType":
 	if capacity.ScaleType != nil {
 		scaleType := *capacity.ScaleType
 		result.ScaleType = &scaleType
@@ -3474,31 +3474,31 @@ func (capacity *SkuCapacity) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SkuCapacity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Default’:
+	// Set property "Default":
 	if typedInput.Default != nil {
 		def := *typedInput.Default
 		capacity.Default = &def
 	}
 
-	// Set property ‘ElasticMaximum’:
+	// Set property "ElasticMaximum":
 	if typedInput.ElasticMaximum != nil {
 		elasticMaximum := *typedInput.ElasticMaximum
 		capacity.ElasticMaximum = &elasticMaximum
 	}
 
-	// Set property ‘Maximum’:
+	// Set property "Maximum":
 	if typedInput.Maximum != nil {
 		maximum := *typedInput.Maximum
 		capacity.Maximum = &maximum
 	}
 
-	// Set property ‘Minimum’:
+	// Set property "Minimum":
 	if typedInput.Minimum != nil {
 		minimum := *typedInput.Minimum
 		capacity.Minimum = &minimum
 	}
 
-	// Set property ‘ScaleType’:
+	// Set property "ScaleType":
 	if typedInput.ScaleType != nil {
 		scaleType := *typedInput.ScaleType
 		capacity.ScaleType = &scaleType
@@ -3615,31 +3615,31 @@ func (capacity *SkuCapacity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SkuCapacity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Default’:
+	// Set property "Default":
 	if typedInput.Default != nil {
 		def := *typedInput.Default
 		capacity.Default = &def
 	}
 
-	// Set property ‘ElasticMaximum’:
+	// Set property "ElasticMaximum":
 	if typedInput.ElasticMaximum != nil {
 		elasticMaximum := *typedInput.ElasticMaximum
 		capacity.ElasticMaximum = &elasticMaximum
 	}
 
-	// Set property ‘Maximum’:
+	// Set property "Maximum":
 	if typedInput.Maximum != nil {
 		maximum := *typedInput.Maximum
 		capacity.Maximum = &maximum
 	}
 
-	// Set property ‘Minimum’:
+	// Set property "Minimum":
 	if typedInput.Minimum != nil {
 		minimum := *typedInput.Minimum
 		capacity.Minimum = &minimum
 	}
 
-	// Set property ‘ScaleType’:
+	// Set property "ScaleType":
 	if typedInput.ScaleType != nil {
 		scaleType := *typedInput.ScaleType
 		capacity.ScaleType = &scaleType

--- a/v2/api/web/v1api20220301/site_types_gen.go
+++ b/v2/api/web/v1api20220301/site_types_gen.go
@@ -444,7 +444,7 @@ func (site *Site_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 	}
 	result := &Site_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if site.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*site.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -454,7 +454,7 @@ func (site *Site_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if site.Identity != nil {
 		identity_ARM, err := (*site.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -464,22 +464,22 @@ func (site *Site_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Identity = &identity
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if site.Kind != nil {
 		kind := *site.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if site.Location != nil {
 		location := *site.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if site.ClientAffinityEnabled != nil ||
 		site.ClientCertEnabled != nil ||
 		site.ClientCertExclusionPaths != nil ||
@@ -641,7 +641,7 @@ func (site *Site_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.VnetRouteAllEnabled = &vnetRouteAllEnabled
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if site.Tags != nil {
 		result.Tags = make(map[string]string, len(site.Tags))
 		for key, value := range site.Tags {
@@ -663,10 +663,10 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Site_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	site.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘ClientAffinityEnabled’:
+	// Set property "ClientAffinityEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientAffinityEnabled != nil {
@@ -675,7 +675,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ClientCertEnabled’:
+	// Set property "ClientCertEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientCertEnabled != nil {
@@ -684,7 +684,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ClientCertExclusionPaths’:
+	// Set property "ClientCertExclusionPaths":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientCertExclusionPaths != nil {
@@ -693,7 +693,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ClientCertMode’:
+	// Set property "ClientCertMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientCertMode != nil {
@@ -702,7 +702,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘CloningInfo’:
+	// Set property "CloningInfo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CloningInfo != nil {
@@ -716,7 +716,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ContainerSize’:
+	// Set property "ContainerSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ContainerSize != nil {
@@ -725,7 +725,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘CustomDomainVerificationId’:
+	// Set property "CustomDomainVerificationId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomDomainVerificationId != nil {
@@ -734,7 +734,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘DailyMemoryTimeQuota’:
+	// Set property "DailyMemoryTimeQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DailyMemoryTimeQuota != nil {
@@ -743,7 +743,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Enabled != nil {
@@ -752,7 +752,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -763,7 +763,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		site.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostNameSslStates’:
+	// Set property "HostNameSslStates":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.HostNameSslStates {
@@ -776,7 +776,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘HostNamesDisabled’:
+	// Set property "HostNamesDisabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostNamesDisabled != nil {
@@ -785,7 +785,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘HostingEnvironmentProfile’:
+	// Set property "HostingEnvironmentProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostingEnvironmentProfile != nil {
@@ -799,7 +799,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘HttpsOnly’:
+	// Set property "HttpsOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpsOnly != nil {
@@ -808,7 +808,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘HyperV’:
+	// Set property "HyperV":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperV != nil {
@@ -817,7 +817,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedServiceIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -828,7 +828,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		site.Identity = &identity
 	}
 
-	// Set property ‘IsXenon’:
+	// Set property "IsXenon":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsXenon != nil {
@@ -837,7 +837,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘KeyVaultReferenceIdentity’:
+	// Set property "KeyVaultReferenceIdentity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVaultReferenceIdentity != nil {
@@ -846,22 +846,22 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		site.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		site.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	site.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -870,7 +870,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘RedundancyMode’:
+	// Set property "RedundancyMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedundancyMode != nil {
@@ -879,7 +879,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Reserved’:
+	// Set property "Reserved":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Reserved != nil {
@@ -888,7 +888,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ScmSiteAlsoStopped’:
+	// Set property "ScmSiteAlsoStopped":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScmSiteAlsoStopped != nil {
@@ -897,9 +897,9 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// no assignment for property ‘ServerFarmReference’
+	// no assignment for property "ServerFarmReference"
 
-	// Set property ‘SiteConfig’:
+	// Set property "SiteConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SiteConfig != nil {
@@ -913,7 +913,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘StorageAccountRequired’:
+	// Set property "StorageAccountRequired":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageAccountRequired != nil {
@@ -922,7 +922,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		site.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -930,9 +930,9 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// no assignment for property ‘VirtualNetworkSubnetReference’
+	// no assignment for property "VirtualNetworkSubnetReference"
 
-	// Set property ‘VnetContentShareEnabled’:
+	// Set property "VnetContentShareEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetContentShareEnabled != nil {
@@ -941,7 +941,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘VnetImagePullEnabled’:
+	// Set property "VnetImagePullEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetImagePullEnabled != nil {
@@ -950,7 +950,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘VnetRouteAllEnabled’:
+	// Set property "VnetRouteAllEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetRouteAllEnabled != nil {
@@ -2048,7 +2048,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Site_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityState’:
+	// Set property "AvailabilityState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityState != nil {
@@ -2057,7 +2057,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ClientAffinityEnabled’:
+	// Set property "ClientAffinityEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientAffinityEnabled != nil {
@@ -2066,7 +2066,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ClientCertEnabled’:
+	// Set property "ClientCertEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientCertEnabled != nil {
@@ -2075,7 +2075,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ClientCertExclusionPaths’:
+	// Set property "ClientCertExclusionPaths":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientCertExclusionPaths != nil {
@@ -2084,7 +2084,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ClientCertMode’:
+	// Set property "ClientCertMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientCertMode != nil {
@@ -2093,7 +2093,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘CloningInfo’:
+	// Set property "CloningInfo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CloningInfo != nil {
@@ -2107,9 +2107,9 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ContainerSize’:
+	// Set property "ContainerSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ContainerSize != nil {
@@ -2118,7 +2118,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘CustomDomainVerificationId’:
+	// Set property "CustomDomainVerificationId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomDomainVerificationId != nil {
@@ -2127,7 +2127,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DailyMemoryTimeQuota’:
+	// Set property "DailyMemoryTimeQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DailyMemoryTimeQuota != nil {
@@ -2136,7 +2136,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DefaultHostName’:
+	// Set property "DefaultHostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultHostName != nil {
@@ -2145,7 +2145,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Enabled != nil {
@@ -2154,7 +2154,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘EnabledHostNames’:
+	// Set property "EnabledHostNames":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EnabledHostNames {
@@ -2162,7 +2162,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -2173,7 +2173,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		site.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostNameSslStates’:
+	// Set property "HostNameSslStates":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.HostNameSslStates {
@@ -2186,7 +2186,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘HostNames’:
+	// Set property "HostNames":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.HostNames {
@@ -2194,7 +2194,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘HostNamesDisabled’:
+	// Set property "HostNamesDisabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostNamesDisabled != nil {
@@ -2203,7 +2203,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘HostingEnvironmentProfile’:
+	// Set property "HostingEnvironmentProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostingEnvironmentProfile != nil {
@@ -2217,7 +2217,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘HttpsOnly’:
+	// Set property "HttpsOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpsOnly != nil {
@@ -2226,7 +2226,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘HyperV’:
+	// Set property "HyperV":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperV != nil {
@@ -2235,13 +2235,13 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		site.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedServiceIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -2252,7 +2252,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		site.Identity = &identity
 	}
 
-	// Set property ‘InProgressOperationId’:
+	// Set property "InProgressOperationId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InProgressOperationId != nil {
@@ -2261,7 +2261,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘IsDefaultContainer’:
+	// Set property "IsDefaultContainer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsDefaultContainer != nil {
@@ -2270,7 +2270,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘IsXenon’:
+	// Set property "IsXenon":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsXenon != nil {
@@ -2279,7 +2279,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘KeyVaultReferenceIdentity’:
+	// Set property "KeyVaultReferenceIdentity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVaultReferenceIdentity != nil {
@@ -2288,13 +2288,13 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		site.Kind = &kind
 	}
 
-	// Set property ‘LastModifiedTimeUtc’:
+	// Set property "LastModifiedTimeUtc":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastModifiedTimeUtc != nil {
@@ -2303,13 +2303,13 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		site.Location = &location
 	}
 
-	// Set property ‘MaxNumberOfWorkers’:
+	// Set property "MaxNumberOfWorkers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxNumberOfWorkers != nil {
@@ -2318,13 +2318,13 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		site.Name = &name
 	}
 
-	// Set property ‘OutboundIpAddresses’:
+	// Set property "OutboundIpAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OutboundIpAddresses != nil {
@@ -2333,7 +2333,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘PossibleOutboundIpAddresses’:
+	// Set property "PossibleOutboundIpAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PossibleOutboundIpAddresses != nil {
@@ -2342,7 +2342,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -2351,7 +2351,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘RedundancyMode’:
+	// Set property "RedundancyMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedundancyMode != nil {
@@ -2360,7 +2360,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘RepositorySiteName’:
+	// Set property "RepositorySiteName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RepositorySiteName != nil {
@@ -2369,7 +2369,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Reserved’:
+	// Set property "Reserved":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Reserved != nil {
@@ -2378,7 +2378,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGroup != nil {
@@ -2387,7 +2387,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ScmSiteAlsoStopped’:
+	// Set property "ScmSiteAlsoStopped":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScmSiteAlsoStopped != nil {
@@ -2396,7 +2396,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ServerFarmId’:
+	// Set property "ServerFarmId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServerFarmId != nil {
@@ -2405,7 +2405,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘SiteConfig’:
+	// Set property "SiteConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SiteConfig != nil {
@@ -2419,7 +2419,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘SlotSwapStatus’:
+	// Set property "SlotSwapStatus":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SlotSwapStatus != nil {
@@ -2433,7 +2433,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -2442,7 +2442,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘StorageAccountRequired’:
+	// Set property "StorageAccountRequired":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageAccountRequired != nil {
@@ -2451,7 +2451,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘SuspendedTill’:
+	// Set property "SuspendedTill":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SuspendedTill != nil {
@@ -2460,7 +2460,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		site.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -2468,7 +2468,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘TargetSwapSlot’:
+	// Set property "TargetSwapSlot":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetSwapSlot != nil {
@@ -2477,7 +2477,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘TrafficManagerHostNames’:
+	// Set property "TrafficManagerHostNames":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TrafficManagerHostNames {
@@ -2485,13 +2485,13 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		site.Type = &typeVar
 	}
 
-	// Set property ‘UsageState’:
+	// Set property "UsageState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UsageState != nil {
@@ -2500,7 +2500,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘VirtualNetworkSubnetId’:
+	// Set property "VirtualNetworkSubnetId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetworkSubnetId != nil {
@@ -2509,7 +2509,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘VnetContentShareEnabled’:
+	// Set property "VnetContentShareEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetContentShareEnabled != nil {
@@ -2518,7 +2518,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘VnetImagePullEnabled’:
+	// Set property "VnetImagePullEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetImagePullEnabled != nil {
@@ -2527,7 +2527,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘VnetRouteAllEnabled’:
+	// Set property "VnetRouteAllEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetRouteAllEnabled != nil {
@@ -3262,7 +3262,7 @@ func (info *CloningInfo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &CloningInfo_ARM{}
 
-	// Set property ‘AppSettingsOverrides’:
+	// Set property "AppSettingsOverrides":
 	if info.AppSettingsOverrides != nil {
 		result.AppSettingsOverrides = make(map[string]string, len(info.AppSettingsOverrides))
 		for key, value := range info.AppSettingsOverrides {
@@ -3270,43 +3270,43 @@ func (info *CloningInfo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		}
 	}
 
-	// Set property ‘CloneCustomHostNames’:
+	// Set property "CloneCustomHostNames":
 	if info.CloneCustomHostNames != nil {
 		cloneCustomHostNames := *info.CloneCustomHostNames
 		result.CloneCustomHostNames = &cloneCustomHostNames
 	}
 
-	// Set property ‘CloneSourceControl’:
+	// Set property "CloneSourceControl":
 	if info.CloneSourceControl != nil {
 		cloneSourceControl := *info.CloneSourceControl
 		result.CloneSourceControl = &cloneSourceControl
 	}
 
-	// Set property ‘ConfigureLoadBalancing’:
+	// Set property "ConfigureLoadBalancing":
 	if info.ConfigureLoadBalancing != nil {
 		configureLoadBalancing := *info.ConfigureLoadBalancing
 		result.ConfigureLoadBalancing = &configureLoadBalancing
 	}
 
-	// Set property ‘CorrelationId’:
+	// Set property "CorrelationId":
 	if info.CorrelationId != nil {
 		correlationId := *info.CorrelationId
 		result.CorrelationId = &correlationId
 	}
 
-	// Set property ‘HostingEnvironment’:
+	// Set property "HostingEnvironment":
 	if info.HostingEnvironment != nil {
 		hostingEnvironment := *info.HostingEnvironment
 		result.HostingEnvironment = &hostingEnvironment
 	}
 
-	// Set property ‘Overwrite’:
+	// Set property "Overwrite":
 	if info.Overwrite != nil {
 		overwrite := *info.Overwrite
 		result.Overwrite = &overwrite
 	}
 
-	// Set property ‘SourceWebAppId’:
+	// Set property "SourceWebAppId":
 	if info.SourceWebAppReference != nil {
 		sourceWebAppReferenceARMID, err := resolved.ResolvedReferences.Lookup(*info.SourceWebAppReference)
 		if err != nil {
@@ -3316,13 +3316,13 @@ func (info *CloningInfo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.SourceWebAppId = &sourceWebAppReference
 	}
 
-	// Set property ‘SourceWebAppLocation’:
+	// Set property "SourceWebAppLocation":
 	if info.SourceWebAppLocation != nil {
 		sourceWebAppLocation := *info.SourceWebAppLocation
 		result.SourceWebAppLocation = &sourceWebAppLocation
 	}
 
-	// Set property ‘TrafficManagerProfileId’:
+	// Set property "TrafficManagerProfileId":
 	if info.TrafficManagerProfileReference != nil {
 		trafficManagerProfileReferenceARMID, err := resolved.ResolvedReferences.Lookup(*info.TrafficManagerProfileReference)
 		if err != nil {
@@ -3332,7 +3332,7 @@ func (info *CloningInfo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.TrafficManagerProfileId = &trafficManagerProfileReference
 	}
 
-	// Set property ‘TrafficManagerProfileName’:
+	// Set property "TrafficManagerProfileName":
 	if info.TrafficManagerProfileName != nil {
 		trafficManagerProfileName := *info.TrafficManagerProfileName
 		result.TrafficManagerProfileName = &trafficManagerProfileName
@@ -3352,7 +3352,7 @@ func (info *CloningInfo) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CloningInfo_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AppSettingsOverrides’:
+	// Set property "AppSettingsOverrides":
 	if typedInput.AppSettingsOverrides != nil {
 		info.AppSettingsOverrides = make(map[string]string, len(typedInput.AppSettingsOverrides))
 		for key, value := range typedInput.AppSettingsOverrides {
@@ -3360,57 +3360,57 @@ func (info *CloningInfo) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘CloneCustomHostNames’:
+	// Set property "CloneCustomHostNames":
 	if typedInput.CloneCustomHostNames != nil {
 		cloneCustomHostNames := *typedInput.CloneCustomHostNames
 		info.CloneCustomHostNames = &cloneCustomHostNames
 	}
 
-	// Set property ‘CloneSourceControl’:
+	// Set property "CloneSourceControl":
 	if typedInput.CloneSourceControl != nil {
 		cloneSourceControl := *typedInput.CloneSourceControl
 		info.CloneSourceControl = &cloneSourceControl
 	}
 
-	// Set property ‘ConfigureLoadBalancing’:
+	// Set property "ConfigureLoadBalancing":
 	if typedInput.ConfigureLoadBalancing != nil {
 		configureLoadBalancing := *typedInput.ConfigureLoadBalancing
 		info.ConfigureLoadBalancing = &configureLoadBalancing
 	}
 
-	// Set property ‘CorrelationId’:
+	// Set property "CorrelationId":
 	if typedInput.CorrelationId != nil {
 		correlationId := *typedInput.CorrelationId
 		info.CorrelationId = &correlationId
 	}
 
-	// Set property ‘HostingEnvironment’:
+	// Set property "HostingEnvironment":
 	if typedInput.HostingEnvironment != nil {
 		hostingEnvironment := *typedInput.HostingEnvironment
 		info.HostingEnvironment = &hostingEnvironment
 	}
 
-	// Set property ‘Overwrite’:
+	// Set property "Overwrite":
 	if typedInput.Overwrite != nil {
 		overwrite := *typedInput.Overwrite
 		info.Overwrite = &overwrite
 	}
 
-	// Set property ‘SourceWebAppLocation’:
+	// Set property "SourceWebAppLocation":
 	if typedInput.SourceWebAppLocation != nil {
 		sourceWebAppLocation := *typedInput.SourceWebAppLocation
 		info.SourceWebAppLocation = &sourceWebAppLocation
 	}
 
-	// no assignment for property ‘SourceWebAppReference’
+	// no assignment for property "SourceWebAppReference"
 
-	// Set property ‘TrafficManagerProfileName’:
+	// Set property "TrafficManagerProfileName":
 	if typedInput.TrafficManagerProfileName != nil {
 		trafficManagerProfileName := *typedInput.TrafficManagerProfileName
 		info.TrafficManagerProfileName = &trafficManagerProfileName
 	}
 
-	// no assignment for property ‘TrafficManagerProfileReference’
+	// no assignment for property "TrafficManagerProfileReference"
 
 	// No error
 	return nil
@@ -3710,7 +3710,7 @@ func (info *CloningInfo_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CloningInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AppSettingsOverrides’:
+	// Set property "AppSettingsOverrides":
 	if typedInput.AppSettingsOverrides != nil {
 		info.AppSettingsOverrides = make(map[string]string, len(typedInput.AppSettingsOverrides))
 		for key, value := range typedInput.AppSettingsOverrides {
@@ -3718,61 +3718,61 @@ func (info *CloningInfo_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘CloneCustomHostNames’:
+	// Set property "CloneCustomHostNames":
 	if typedInput.CloneCustomHostNames != nil {
 		cloneCustomHostNames := *typedInput.CloneCustomHostNames
 		info.CloneCustomHostNames = &cloneCustomHostNames
 	}
 
-	// Set property ‘CloneSourceControl’:
+	// Set property "CloneSourceControl":
 	if typedInput.CloneSourceControl != nil {
 		cloneSourceControl := *typedInput.CloneSourceControl
 		info.CloneSourceControl = &cloneSourceControl
 	}
 
-	// Set property ‘ConfigureLoadBalancing’:
+	// Set property "ConfigureLoadBalancing":
 	if typedInput.ConfigureLoadBalancing != nil {
 		configureLoadBalancing := *typedInput.ConfigureLoadBalancing
 		info.ConfigureLoadBalancing = &configureLoadBalancing
 	}
 
-	// Set property ‘CorrelationId’:
+	// Set property "CorrelationId":
 	if typedInput.CorrelationId != nil {
 		correlationId := *typedInput.CorrelationId
 		info.CorrelationId = &correlationId
 	}
 
-	// Set property ‘HostingEnvironment’:
+	// Set property "HostingEnvironment":
 	if typedInput.HostingEnvironment != nil {
 		hostingEnvironment := *typedInput.HostingEnvironment
 		info.HostingEnvironment = &hostingEnvironment
 	}
 
-	// Set property ‘Overwrite’:
+	// Set property "Overwrite":
 	if typedInput.Overwrite != nil {
 		overwrite := *typedInput.Overwrite
 		info.Overwrite = &overwrite
 	}
 
-	// Set property ‘SourceWebAppId’:
+	// Set property "SourceWebAppId":
 	if typedInput.SourceWebAppId != nil {
 		sourceWebAppId := *typedInput.SourceWebAppId
 		info.SourceWebAppId = &sourceWebAppId
 	}
 
-	// Set property ‘SourceWebAppLocation’:
+	// Set property "SourceWebAppLocation":
 	if typedInput.SourceWebAppLocation != nil {
 		sourceWebAppLocation := *typedInput.SourceWebAppLocation
 		info.SourceWebAppLocation = &sourceWebAppLocation
 	}
 
-	// Set property ‘TrafficManagerProfileId’:
+	// Set property "TrafficManagerProfileId":
 	if typedInput.TrafficManagerProfileId != nil {
 		trafficManagerProfileId := *typedInput.TrafficManagerProfileId
 		info.TrafficManagerProfileId = &trafficManagerProfileId
 	}
 
-	// Set property ‘TrafficManagerProfileName’:
+	// Set property "TrafficManagerProfileName":
 	if typedInput.TrafficManagerProfileName != nil {
 		trafficManagerProfileName := *typedInput.TrafficManagerProfileName
 		info.TrafficManagerProfileName = &trafficManagerProfileName
@@ -3941,37 +3941,37 @@ func (state *HostNameSslState) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &HostNameSslState_ARM{}
 
-	// Set property ‘HostType’:
+	// Set property "HostType":
 	if state.HostType != nil {
 		hostType := *state.HostType
 		result.HostType = &hostType
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if state.Name != nil {
 		name := *state.Name
 		result.Name = &name
 	}
 
-	// Set property ‘SslState’:
+	// Set property "SslState":
 	if state.SslState != nil {
 		sslState := *state.SslState
 		result.SslState = &sslState
 	}
 
-	// Set property ‘Thumbprint’:
+	// Set property "Thumbprint":
 	if state.Thumbprint != nil {
 		thumbprint := *state.Thumbprint
 		result.Thumbprint = &thumbprint
 	}
 
-	// Set property ‘ToUpdate’:
+	// Set property "ToUpdate":
 	if state.ToUpdate != nil {
 		toUpdate := *state.ToUpdate
 		result.ToUpdate = &toUpdate
 	}
 
-	// Set property ‘VirtualIP’:
+	// Set property "VirtualIP":
 	if state.VirtualIP != nil {
 		virtualIP := *state.VirtualIP
 		result.VirtualIP = &virtualIP
@@ -3991,37 +3991,37 @@ func (state *HostNameSslState) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HostNameSslState_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HostType’:
+	// Set property "HostType":
 	if typedInput.HostType != nil {
 		hostType := *typedInput.HostType
 		state.HostType = &hostType
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		state.Name = &name
 	}
 
-	// Set property ‘SslState’:
+	// Set property "SslState":
 	if typedInput.SslState != nil {
 		sslState := *typedInput.SslState
 		state.SslState = &sslState
 	}
 
-	// Set property ‘Thumbprint’:
+	// Set property "Thumbprint":
 	if typedInput.Thumbprint != nil {
 		thumbprint := *typedInput.Thumbprint
 		state.Thumbprint = &thumbprint
 	}
 
-	// Set property ‘ToUpdate’:
+	// Set property "ToUpdate":
 	if typedInput.ToUpdate != nil {
 		toUpdate := *typedInput.ToUpdate
 		state.ToUpdate = &toUpdate
 	}
 
-	// Set property ‘VirtualIP’:
+	// Set property "VirtualIP":
 	if typedInput.VirtualIP != nil {
 		virtualIP := *typedInput.VirtualIP
 		state.VirtualIP = &virtualIP
@@ -4195,37 +4195,37 @@ func (state *HostNameSslState_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HostNameSslState_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HostType’:
+	// Set property "HostType":
 	if typedInput.HostType != nil {
 		hostType := *typedInput.HostType
 		state.HostType = &hostType
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		state.Name = &name
 	}
 
-	// Set property ‘SslState’:
+	// Set property "SslState":
 	if typedInput.SslState != nil {
 		sslState := *typedInput.SslState
 		state.SslState = &sslState
 	}
 
-	// Set property ‘Thumbprint’:
+	// Set property "Thumbprint":
 	if typedInput.Thumbprint != nil {
 		thumbprint := *typedInput.Thumbprint
 		state.Thumbprint = &thumbprint
 	}
 
-	// Set property ‘ToUpdate’:
+	// Set property "ToUpdate":
 	if typedInput.ToUpdate != nil {
 		toUpdate := *typedInput.ToUpdate
 		state.ToUpdate = &toUpdate
 	}
 
-	// Set property ‘VirtualIP’:
+	// Set property "VirtualIP":
 	if typedInput.VirtualIP != nil {
 		virtualIP := *typedInput.VirtualIP
 		state.VirtualIP = &virtualIP
@@ -4344,13 +4344,13 @@ func (identity *ManagedServiceIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ManagedServiceIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -4375,13 +4375,13 @@ func (identity *ManagedServiceIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedServiceIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -4520,25 +4520,25 @@ func (identity *ManagedServiceIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedServiceIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -4921,25 +4921,25 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &SiteConfig_ARM{}
 
-	// Set property ‘AcrUseManagedIdentityCreds’:
+	// Set property "AcrUseManagedIdentityCreds":
 	if config.AcrUseManagedIdentityCreds != nil {
 		acrUseManagedIdentityCreds := *config.AcrUseManagedIdentityCreds
 		result.AcrUseManagedIdentityCreds = &acrUseManagedIdentityCreds
 	}
 
-	// Set property ‘AcrUserManagedIdentityID’:
+	// Set property "AcrUserManagedIdentityID":
 	if config.AcrUserManagedIdentityID != nil {
 		acrUserManagedIdentityID := *config.AcrUserManagedIdentityID
 		result.AcrUserManagedIdentityID = &acrUserManagedIdentityID
 	}
 
-	// Set property ‘AlwaysOn’:
+	// Set property "AlwaysOn":
 	if config.AlwaysOn != nil {
 		alwaysOn := *config.AlwaysOn
 		result.AlwaysOn = &alwaysOn
 	}
 
-	// Set property ‘ApiDefinition’:
+	// Set property "ApiDefinition":
 	if config.ApiDefinition != nil {
 		apiDefinition_ARM, err := (*config.ApiDefinition).ConvertToARM(resolved)
 		if err != nil {
@@ -4949,7 +4949,7 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.ApiDefinition = &apiDefinition
 	}
 
-	// Set property ‘ApiManagementConfig’:
+	// Set property "ApiManagementConfig":
 	if config.ApiManagementConfig != nil {
 		apiManagementConfig_ARM, err := (*config.ApiManagementConfig).ConvertToARM(resolved)
 		if err != nil {
@@ -4959,13 +4959,13 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.ApiManagementConfig = &apiManagementConfig
 	}
 
-	// Set property ‘AppCommandLine’:
+	// Set property "AppCommandLine":
 	if config.AppCommandLine != nil {
 		appCommandLine := *config.AppCommandLine
 		result.AppCommandLine = &appCommandLine
 	}
 
-	// Set property ‘AppSettings’:
+	// Set property "AppSettings":
 	for _, item := range config.AppSettings {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4974,13 +4974,13 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.AppSettings = append(result.AppSettings, *item_ARM.(*NameValuePair_ARM))
 	}
 
-	// Set property ‘AutoHealEnabled’:
+	// Set property "AutoHealEnabled":
 	if config.AutoHealEnabled != nil {
 		autoHealEnabled := *config.AutoHealEnabled
 		result.AutoHealEnabled = &autoHealEnabled
 	}
 
-	// Set property ‘AutoHealRules’:
+	// Set property "AutoHealRules":
 	if config.AutoHealRules != nil {
 		autoHealRules_ARM, err := (*config.AutoHealRules).ConvertToARM(resolved)
 		if err != nil {
@@ -4990,13 +4990,13 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.AutoHealRules = &autoHealRules
 	}
 
-	// Set property ‘AutoSwapSlotName’:
+	// Set property "AutoSwapSlotName":
 	if config.AutoSwapSlotName != nil {
 		autoSwapSlotName := *config.AutoSwapSlotName
 		result.AutoSwapSlotName = &autoSwapSlotName
 	}
 
-	// Set property ‘AzureStorageAccounts’:
+	// Set property "AzureStorageAccounts":
 	if config.AzureStorageAccounts != nil {
 		result.AzureStorageAccounts = make(map[string]AzureStorageInfoValue_ARM, len(config.AzureStorageAccounts))
 		for key, value := range config.AzureStorageAccounts {
@@ -5008,7 +5008,7 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		}
 	}
 
-	// Set property ‘ConnectionStrings’:
+	// Set property "ConnectionStrings":
 	for _, item := range config.ConnectionStrings {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5017,7 +5017,7 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.ConnectionStrings = append(result.ConnectionStrings, *item_ARM.(*ConnStringInfo_ARM))
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	if config.Cors != nil {
 		cors_ARM, err := (*config.Cors).ConvertToARM(resolved)
 		if err != nil {
@@ -5027,24 +5027,24 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Cors = &cors
 	}
 
-	// Set property ‘DefaultDocuments’:
+	// Set property "DefaultDocuments":
 	for _, item := range config.DefaultDocuments {
 		result.DefaultDocuments = append(result.DefaultDocuments, item)
 	}
 
-	// Set property ‘DetailedErrorLoggingEnabled’:
+	// Set property "DetailedErrorLoggingEnabled":
 	if config.DetailedErrorLoggingEnabled != nil {
 		detailedErrorLoggingEnabled := *config.DetailedErrorLoggingEnabled
 		result.DetailedErrorLoggingEnabled = &detailedErrorLoggingEnabled
 	}
 
-	// Set property ‘DocumentRoot’:
+	// Set property "DocumentRoot":
 	if config.DocumentRoot != nil {
 		documentRoot := *config.DocumentRoot
 		result.DocumentRoot = &documentRoot
 	}
 
-	// Set property ‘Experiments’:
+	// Set property "Experiments":
 	if config.Experiments != nil {
 		experiments_ARM, err := (*config.Experiments).ConvertToARM(resolved)
 		if err != nil {
@@ -5054,25 +5054,25 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Experiments = &experiments
 	}
 
-	// Set property ‘FtpsState’:
+	// Set property "FtpsState":
 	if config.FtpsState != nil {
 		ftpsState := *config.FtpsState
 		result.FtpsState = &ftpsState
 	}
 
-	// Set property ‘FunctionAppScaleLimit’:
+	// Set property "FunctionAppScaleLimit":
 	if config.FunctionAppScaleLimit != nil {
 		functionAppScaleLimit := *config.FunctionAppScaleLimit
 		result.FunctionAppScaleLimit = &functionAppScaleLimit
 	}
 
-	// Set property ‘FunctionsRuntimeScaleMonitoringEnabled’:
+	// Set property "FunctionsRuntimeScaleMonitoringEnabled":
 	if config.FunctionsRuntimeScaleMonitoringEnabled != nil {
 		functionsRuntimeScaleMonitoringEnabled := *config.FunctionsRuntimeScaleMonitoringEnabled
 		result.FunctionsRuntimeScaleMonitoringEnabled = &functionsRuntimeScaleMonitoringEnabled
 	}
 
-	// Set property ‘HandlerMappings’:
+	// Set property "HandlerMappings":
 	for _, item := range config.HandlerMappings {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5081,25 +5081,25 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.HandlerMappings = append(result.HandlerMappings, *item_ARM.(*HandlerMapping_ARM))
 	}
 
-	// Set property ‘HealthCheckPath’:
+	// Set property "HealthCheckPath":
 	if config.HealthCheckPath != nil {
 		healthCheckPath := *config.HealthCheckPath
 		result.HealthCheckPath = &healthCheckPath
 	}
 
-	// Set property ‘Http20Enabled’:
+	// Set property "Http20Enabled":
 	if config.Http20Enabled != nil {
 		http20Enabled := *config.Http20Enabled
 		result.Http20Enabled = &http20Enabled
 	}
 
-	// Set property ‘HttpLoggingEnabled’:
+	// Set property "HttpLoggingEnabled":
 	if config.HttpLoggingEnabled != nil {
 		httpLoggingEnabled := *config.HttpLoggingEnabled
 		result.HttpLoggingEnabled = &httpLoggingEnabled
 	}
 
-	// Set property ‘IpSecurityRestrictions’:
+	// Set property "IpSecurityRestrictions":
 	for _, item := range config.IpSecurityRestrictions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5108,31 +5108,31 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.IpSecurityRestrictions = append(result.IpSecurityRestrictions, *item_ARM.(*IpSecurityRestriction_ARM))
 	}
 
-	// Set property ‘JavaContainer’:
+	// Set property "JavaContainer":
 	if config.JavaContainer != nil {
 		javaContainer := *config.JavaContainer
 		result.JavaContainer = &javaContainer
 	}
 
-	// Set property ‘JavaContainerVersion’:
+	// Set property "JavaContainerVersion":
 	if config.JavaContainerVersion != nil {
 		javaContainerVersion := *config.JavaContainerVersion
 		result.JavaContainerVersion = &javaContainerVersion
 	}
 
-	// Set property ‘JavaVersion’:
+	// Set property "JavaVersion":
 	if config.JavaVersion != nil {
 		javaVersion := *config.JavaVersion
 		result.JavaVersion = &javaVersion
 	}
 
-	// Set property ‘KeyVaultReferenceIdentity’:
+	// Set property "KeyVaultReferenceIdentity":
 	if config.KeyVaultReferenceIdentity != nil {
 		keyVaultReferenceIdentity := *config.KeyVaultReferenceIdentity
 		result.KeyVaultReferenceIdentity = &keyVaultReferenceIdentity
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if config.Limits != nil {
 		limits_ARM, err := (*config.Limits).ConvertToARM(resolved)
 		if err != nil {
@@ -5142,103 +5142,103 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Limits = &limits
 	}
 
-	// Set property ‘LinuxFxVersion’:
+	// Set property "LinuxFxVersion":
 	if config.LinuxFxVersion != nil {
 		linuxFxVersion := *config.LinuxFxVersion
 		result.LinuxFxVersion = &linuxFxVersion
 	}
 
-	// Set property ‘LoadBalancing’:
+	// Set property "LoadBalancing":
 	if config.LoadBalancing != nil {
 		loadBalancing := *config.LoadBalancing
 		result.LoadBalancing = &loadBalancing
 	}
 
-	// Set property ‘LocalMySqlEnabled’:
+	// Set property "LocalMySqlEnabled":
 	if config.LocalMySqlEnabled != nil {
 		localMySqlEnabled := *config.LocalMySqlEnabled
 		result.LocalMySqlEnabled = &localMySqlEnabled
 	}
 
-	// Set property ‘LogsDirectorySizeLimit’:
+	// Set property "LogsDirectorySizeLimit":
 	if config.LogsDirectorySizeLimit != nil {
 		logsDirectorySizeLimit := *config.LogsDirectorySizeLimit
 		result.LogsDirectorySizeLimit = &logsDirectorySizeLimit
 	}
 
-	// Set property ‘ManagedPipelineMode’:
+	// Set property "ManagedPipelineMode":
 	if config.ManagedPipelineMode != nil {
 		managedPipelineMode := *config.ManagedPipelineMode
 		result.ManagedPipelineMode = &managedPipelineMode
 	}
 
-	// Set property ‘ManagedServiceIdentityId’:
+	// Set property "ManagedServiceIdentityId":
 	if config.ManagedServiceIdentityId != nil {
 		managedServiceIdentityId := *config.ManagedServiceIdentityId
 		result.ManagedServiceIdentityId = &managedServiceIdentityId
 	}
 
-	// Set property ‘MinTlsVersion’:
+	// Set property "MinTlsVersion":
 	if config.MinTlsVersion != nil {
 		minTlsVersion := *config.MinTlsVersion
 		result.MinTlsVersion = &minTlsVersion
 	}
 
-	// Set property ‘MinimumElasticInstanceCount’:
+	// Set property "MinimumElasticInstanceCount":
 	if config.MinimumElasticInstanceCount != nil {
 		minimumElasticInstanceCount := *config.MinimumElasticInstanceCount
 		result.MinimumElasticInstanceCount = &minimumElasticInstanceCount
 	}
 
-	// Set property ‘NetFrameworkVersion’:
+	// Set property "NetFrameworkVersion":
 	if config.NetFrameworkVersion != nil {
 		netFrameworkVersion := *config.NetFrameworkVersion
 		result.NetFrameworkVersion = &netFrameworkVersion
 	}
 
-	// Set property ‘NodeVersion’:
+	// Set property "NodeVersion":
 	if config.NodeVersion != nil {
 		nodeVersion := *config.NodeVersion
 		result.NodeVersion = &nodeVersion
 	}
 
-	// Set property ‘NumberOfWorkers’:
+	// Set property "NumberOfWorkers":
 	if config.NumberOfWorkers != nil {
 		numberOfWorkers := *config.NumberOfWorkers
 		result.NumberOfWorkers = &numberOfWorkers
 	}
 
-	// Set property ‘PhpVersion’:
+	// Set property "PhpVersion":
 	if config.PhpVersion != nil {
 		phpVersion := *config.PhpVersion
 		result.PhpVersion = &phpVersion
 	}
 
-	// Set property ‘PowerShellVersion’:
+	// Set property "PowerShellVersion":
 	if config.PowerShellVersion != nil {
 		powerShellVersion := *config.PowerShellVersion
 		result.PowerShellVersion = &powerShellVersion
 	}
 
-	// Set property ‘PreWarmedInstanceCount’:
+	// Set property "PreWarmedInstanceCount":
 	if config.PreWarmedInstanceCount != nil {
 		preWarmedInstanceCount := *config.PreWarmedInstanceCount
 		result.PreWarmedInstanceCount = &preWarmedInstanceCount
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if config.PublicNetworkAccess != nil {
 		publicNetworkAccess := *config.PublicNetworkAccess
 		result.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘PublishingUsername’:
+	// Set property "PublishingUsername":
 	if config.PublishingUsername != nil {
 		publishingUsername := *config.PublishingUsername
 		result.PublishingUsername = &publishingUsername
 	}
 
-	// Set property ‘Push’:
+	// Set property "Push":
 	if config.Push != nil {
 		push_ARM, err := (*config.Push).ConvertToARM(resolved)
 		if err != nil {
@@ -5248,37 +5248,37 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Push = &push
 	}
 
-	// Set property ‘PythonVersion’:
+	// Set property "PythonVersion":
 	if config.PythonVersion != nil {
 		pythonVersion := *config.PythonVersion
 		result.PythonVersion = &pythonVersion
 	}
 
-	// Set property ‘RemoteDebuggingEnabled’:
+	// Set property "RemoteDebuggingEnabled":
 	if config.RemoteDebuggingEnabled != nil {
 		remoteDebuggingEnabled := *config.RemoteDebuggingEnabled
 		result.RemoteDebuggingEnabled = &remoteDebuggingEnabled
 	}
 
-	// Set property ‘RemoteDebuggingVersion’:
+	// Set property "RemoteDebuggingVersion":
 	if config.RemoteDebuggingVersion != nil {
 		remoteDebuggingVersion := *config.RemoteDebuggingVersion
 		result.RemoteDebuggingVersion = &remoteDebuggingVersion
 	}
 
-	// Set property ‘RequestTracingEnabled’:
+	// Set property "RequestTracingEnabled":
 	if config.RequestTracingEnabled != nil {
 		requestTracingEnabled := *config.RequestTracingEnabled
 		result.RequestTracingEnabled = &requestTracingEnabled
 	}
 
-	// Set property ‘RequestTracingExpirationTime’:
+	// Set property "RequestTracingExpirationTime":
 	if config.RequestTracingExpirationTime != nil {
 		requestTracingExpirationTime := *config.RequestTracingExpirationTime
 		result.RequestTracingExpirationTime = &requestTracingExpirationTime
 	}
 
-	// Set property ‘ScmIpSecurityRestrictions’:
+	// Set property "ScmIpSecurityRestrictions":
 	for _, item := range config.ScmIpSecurityRestrictions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5287,37 +5287,37 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.ScmIpSecurityRestrictions = append(result.ScmIpSecurityRestrictions, *item_ARM.(*IpSecurityRestriction_ARM))
 	}
 
-	// Set property ‘ScmIpSecurityRestrictionsUseMain’:
+	// Set property "ScmIpSecurityRestrictionsUseMain":
 	if config.ScmIpSecurityRestrictionsUseMain != nil {
 		scmIpSecurityRestrictionsUseMain := *config.ScmIpSecurityRestrictionsUseMain
 		result.ScmIpSecurityRestrictionsUseMain = &scmIpSecurityRestrictionsUseMain
 	}
 
-	// Set property ‘ScmMinTlsVersion’:
+	// Set property "ScmMinTlsVersion":
 	if config.ScmMinTlsVersion != nil {
 		scmMinTlsVersion := *config.ScmMinTlsVersion
 		result.ScmMinTlsVersion = &scmMinTlsVersion
 	}
 
-	// Set property ‘ScmType’:
+	// Set property "ScmType":
 	if config.ScmType != nil {
 		scmType := *config.ScmType
 		result.ScmType = &scmType
 	}
 
-	// Set property ‘TracingOptions’:
+	// Set property "TracingOptions":
 	if config.TracingOptions != nil {
 		tracingOptions := *config.TracingOptions
 		result.TracingOptions = &tracingOptions
 	}
 
-	// Set property ‘Use32BitWorkerProcess’:
+	// Set property "Use32BitWorkerProcess":
 	if config.Use32BitWorkerProcess != nil {
 		use32BitWorkerProcess := *config.Use32BitWorkerProcess
 		result.Use32BitWorkerProcess = &use32BitWorkerProcess
 	}
 
-	// Set property ‘VirtualApplications’:
+	// Set property "VirtualApplications":
 	for _, item := range config.VirtualApplications {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -5326,43 +5326,43 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.VirtualApplications = append(result.VirtualApplications, *item_ARM.(*VirtualApplication_ARM))
 	}
 
-	// Set property ‘VnetName’:
+	// Set property "VnetName":
 	if config.VnetName != nil {
 		vnetName := *config.VnetName
 		result.VnetName = &vnetName
 	}
 
-	// Set property ‘VnetPrivatePortsCount’:
+	// Set property "VnetPrivatePortsCount":
 	if config.VnetPrivatePortsCount != nil {
 		vnetPrivatePortsCount := *config.VnetPrivatePortsCount
 		result.VnetPrivatePortsCount = &vnetPrivatePortsCount
 	}
 
-	// Set property ‘VnetRouteAllEnabled’:
+	// Set property "VnetRouteAllEnabled":
 	if config.VnetRouteAllEnabled != nil {
 		vnetRouteAllEnabled := *config.VnetRouteAllEnabled
 		result.VnetRouteAllEnabled = &vnetRouteAllEnabled
 	}
 
-	// Set property ‘WebSocketsEnabled’:
+	// Set property "WebSocketsEnabled":
 	if config.WebSocketsEnabled != nil {
 		webSocketsEnabled := *config.WebSocketsEnabled
 		result.WebSocketsEnabled = &webSocketsEnabled
 	}
 
-	// Set property ‘WebsiteTimeZone’:
+	// Set property "WebsiteTimeZone":
 	if config.WebsiteTimeZone != nil {
 		websiteTimeZone := *config.WebsiteTimeZone
 		result.WebsiteTimeZone = &websiteTimeZone
 	}
 
-	// Set property ‘WindowsFxVersion’:
+	// Set property "WindowsFxVersion":
 	if config.WindowsFxVersion != nil {
 		windowsFxVersion := *config.WindowsFxVersion
 		result.WindowsFxVersion = &windowsFxVersion
 	}
 
-	// Set property ‘XManagedServiceIdentityId’:
+	// Set property "XManagedServiceIdentityId":
 	if config.XManagedServiceIdentityId != nil {
 		xManagedServiceIdentityId := *config.XManagedServiceIdentityId
 		result.XManagedServiceIdentityId = &xManagedServiceIdentityId
@@ -5382,25 +5382,25 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SiteConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AcrUseManagedIdentityCreds’:
+	// Set property "AcrUseManagedIdentityCreds":
 	if typedInput.AcrUseManagedIdentityCreds != nil {
 		acrUseManagedIdentityCreds := *typedInput.AcrUseManagedIdentityCreds
 		config.AcrUseManagedIdentityCreds = &acrUseManagedIdentityCreds
 	}
 
-	// Set property ‘AcrUserManagedIdentityID’:
+	// Set property "AcrUserManagedIdentityID":
 	if typedInput.AcrUserManagedIdentityID != nil {
 		acrUserManagedIdentityID := *typedInput.AcrUserManagedIdentityID
 		config.AcrUserManagedIdentityID = &acrUserManagedIdentityID
 	}
 
-	// Set property ‘AlwaysOn’:
+	// Set property "AlwaysOn":
 	if typedInput.AlwaysOn != nil {
 		alwaysOn := *typedInput.AlwaysOn
 		config.AlwaysOn = &alwaysOn
 	}
 
-	// Set property ‘ApiDefinition’:
+	// Set property "ApiDefinition":
 	if typedInput.ApiDefinition != nil {
 		var apiDefinition1 ApiDefinitionInfo
 		err := apiDefinition1.PopulateFromARM(owner, *typedInput.ApiDefinition)
@@ -5411,7 +5411,7 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.ApiDefinition = &apiDefinition
 	}
 
-	// Set property ‘ApiManagementConfig’:
+	// Set property "ApiManagementConfig":
 	if typedInput.ApiManagementConfig != nil {
 		var apiManagementConfig1 ApiManagementConfig
 		err := apiManagementConfig1.PopulateFromARM(owner, *typedInput.ApiManagementConfig)
@@ -5422,13 +5422,13 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.ApiManagementConfig = &apiManagementConfig
 	}
 
-	// Set property ‘AppCommandLine’:
+	// Set property "AppCommandLine":
 	if typedInput.AppCommandLine != nil {
 		appCommandLine := *typedInput.AppCommandLine
 		config.AppCommandLine = &appCommandLine
 	}
 
-	// Set property ‘AppSettings’:
+	// Set property "AppSettings":
 	for _, item := range typedInput.AppSettings {
 		var item1 NameValuePair
 		err := item1.PopulateFromARM(owner, item)
@@ -5438,13 +5438,13 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.AppSettings = append(config.AppSettings, item1)
 	}
 
-	// Set property ‘AutoHealEnabled’:
+	// Set property "AutoHealEnabled":
 	if typedInput.AutoHealEnabled != nil {
 		autoHealEnabled := *typedInput.AutoHealEnabled
 		config.AutoHealEnabled = &autoHealEnabled
 	}
 
-	// Set property ‘AutoHealRules’:
+	// Set property "AutoHealRules":
 	if typedInput.AutoHealRules != nil {
 		var autoHealRules1 AutoHealRules
 		err := autoHealRules1.PopulateFromARM(owner, *typedInput.AutoHealRules)
@@ -5455,13 +5455,13 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.AutoHealRules = &autoHealRules
 	}
 
-	// Set property ‘AutoSwapSlotName’:
+	// Set property "AutoSwapSlotName":
 	if typedInput.AutoSwapSlotName != nil {
 		autoSwapSlotName := *typedInput.AutoSwapSlotName
 		config.AutoSwapSlotName = &autoSwapSlotName
 	}
 
-	// Set property ‘AzureStorageAccounts’:
+	// Set property "AzureStorageAccounts":
 	if typedInput.AzureStorageAccounts != nil {
 		config.AzureStorageAccounts = make(map[string]AzureStorageInfoValue, len(typedInput.AzureStorageAccounts))
 		for key, value := range typedInput.AzureStorageAccounts {
@@ -5474,7 +5474,7 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘ConnectionStrings’:
+	// Set property "ConnectionStrings":
 	for _, item := range typedInput.ConnectionStrings {
 		var item1 ConnStringInfo
 		err := item1.PopulateFromARM(owner, item)
@@ -5484,7 +5484,7 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.ConnectionStrings = append(config.ConnectionStrings, item1)
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	if typedInput.Cors != nil {
 		var cors1 CorsSettings
 		err := cors1.PopulateFromARM(owner, *typedInput.Cors)
@@ -5495,24 +5495,24 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.Cors = &cors
 	}
 
-	// Set property ‘DefaultDocuments’:
+	// Set property "DefaultDocuments":
 	for _, item := range typedInput.DefaultDocuments {
 		config.DefaultDocuments = append(config.DefaultDocuments, item)
 	}
 
-	// Set property ‘DetailedErrorLoggingEnabled’:
+	// Set property "DetailedErrorLoggingEnabled":
 	if typedInput.DetailedErrorLoggingEnabled != nil {
 		detailedErrorLoggingEnabled := *typedInput.DetailedErrorLoggingEnabled
 		config.DetailedErrorLoggingEnabled = &detailedErrorLoggingEnabled
 	}
 
-	// Set property ‘DocumentRoot’:
+	// Set property "DocumentRoot":
 	if typedInput.DocumentRoot != nil {
 		documentRoot := *typedInput.DocumentRoot
 		config.DocumentRoot = &documentRoot
 	}
 
-	// Set property ‘Experiments’:
+	// Set property "Experiments":
 	if typedInput.Experiments != nil {
 		var experiments1 Experiments
 		err := experiments1.PopulateFromARM(owner, *typedInput.Experiments)
@@ -5523,25 +5523,25 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.Experiments = &experiments
 	}
 
-	// Set property ‘FtpsState’:
+	// Set property "FtpsState":
 	if typedInput.FtpsState != nil {
 		ftpsState := *typedInput.FtpsState
 		config.FtpsState = &ftpsState
 	}
 
-	// Set property ‘FunctionAppScaleLimit’:
+	// Set property "FunctionAppScaleLimit":
 	if typedInput.FunctionAppScaleLimit != nil {
 		functionAppScaleLimit := *typedInput.FunctionAppScaleLimit
 		config.FunctionAppScaleLimit = &functionAppScaleLimit
 	}
 
-	// Set property ‘FunctionsRuntimeScaleMonitoringEnabled’:
+	// Set property "FunctionsRuntimeScaleMonitoringEnabled":
 	if typedInput.FunctionsRuntimeScaleMonitoringEnabled != nil {
 		functionsRuntimeScaleMonitoringEnabled := *typedInput.FunctionsRuntimeScaleMonitoringEnabled
 		config.FunctionsRuntimeScaleMonitoringEnabled = &functionsRuntimeScaleMonitoringEnabled
 	}
 
-	// Set property ‘HandlerMappings’:
+	// Set property "HandlerMappings":
 	for _, item := range typedInput.HandlerMappings {
 		var item1 HandlerMapping
 		err := item1.PopulateFromARM(owner, item)
@@ -5551,25 +5551,25 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.HandlerMappings = append(config.HandlerMappings, item1)
 	}
 
-	// Set property ‘HealthCheckPath’:
+	// Set property "HealthCheckPath":
 	if typedInput.HealthCheckPath != nil {
 		healthCheckPath := *typedInput.HealthCheckPath
 		config.HealthCheckPath = &healthCheckPath
 	}
 
-	// Set property ‘Http20Enabled’:
+	// Set property "Http20Enabled":
 	if typedInput.Http20Enabled != nil {
 		http20Enabled := *typedInput.Http20Enabled
 		config.Http20Enabled = &http20Enabled
 	}
 
-	// Set property ‘HttpLoggingEnabled’:
+	// Set property "HttpLoggingEnabled":
 	if typedInput.HttpLoggingEnabled != nil {
 		httpLoggingEnabled := *typedInput.HttpLoggingEnabled
 		config.HttpLoggingEnabled = &httpLoggingEnabled
 	}
 
-	// Set property ‘IpSecurityRestrictions’:
+	// Set property "IpSecurityRestrictions":
 	for _, item := range typedInput.IpSecurityRestrictions {
 		var item1 IpSecurityRestriction
 		err := item1.PopulateFromARM(owner, item)
@@ -5579,31 +5579,31 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.IpSecurityRestrictions = append(config.IpSecurityRestrictions, item1)
 	}
 
-	// Set property ‘JavaContainer’:
+	// Set property "JavaContainer":
 	if typedInput.JavaContainer != nil {
 		javaContainer := *typedInput.JavaContainer
 		config.JavaContainer = &javaContainer
 	}
 
-	// Set property ‘JavaContainerVersion’:
+	// Set property "JavaContainerVersion":
 	if typedInput.JavaContainerVersion != nil {
 		javaContainerVersion := *typedInput.JavaContainerVersion
 		config.JavaContainerVersion = &javaContainerVersion
 	}
 
-	// Set property ‘JavaVersion’:
+	// Set property "JavaVersion":
 	if typedInput.JavaVersion != nil {
 		javaVersion := *typedInput.JavaVersion
 		config.JavaVersion = &javaVersion
 	}
 
-	// Set property ‘KeyVaultReferenceIdentity’:
+	// Set property "KeyVaultReferenceIdentity":
 	if typedInput.KeyVaultReferenceIdentity != nil {
 		keyVaultReferenceIdentity := *typedInput.KeyVaultReferenceIdentity
 		config.KeyVaultReferenceIdentity = &keyVaultReferenceIdentity
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if typedInput.Limits != nil {
 		var limits1 SiteLimits
 		err := limits1.PopulateFromARM(owner, *typedInput.Limits)
@@ -5614,103 +5614,103 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.Limits = &limits
 	}
 
-	// Set property ‘LinuxFxVersion’:
+	// Set property "LinuxFxVersion":
 	if typedInput.LinuxFxVersion != nil {
 		linuxFxVersion := *typedInput.LinuxFxVersion
 		config.LinuxFxVersion = &linuxFxVersion
 	}
 
-	// Set property ‘LoadBalancing’:
+	// Set property "LoadBalancing":
 	if typedInput.LoadBalancing != nil {
 		loadBalancing := *typedInput.LoadBalancing
 		config.LoadBalancing = &loadBalancing
 	}
 
-	// Set property ‘LocalMySqlEnabled’:
+	// Set property "LocalMySqlEnabled":
 	if typedInput.LocalMySqlEnabled != nil {
 		localMySqlEnabled := *typedInput.LocalMySqlEnabled
 		config.LocalMySqlEnabled = &localMySqlEnabled
 	}
 
-	// Set property ‘LogsDirectorySizeLimit’:
+	// Set property "LogsDirectorySizeLimit":
 	if typedInput.LogsDirectorySizeLimit != nil {
 		logsDirectorySizeLimit := *typedInput.LogsDirectorySizeLimit
 		config.LogsDirectorySizeLimit = &logsDirectorySizeLimit
 	}
 
-	// Set property ‘ManagedPipelineMode’:
+	// Set property "ManagedPipelineMode":
 	if typedInput.ManagedPipelineMode != nil {
 		managedPipelineMode := *typedInput.ManagedPipelineMode
 		config.ManagedPipelineMode = &managedPipelineMode
 	}
 
-	// Set property ‘ManagedServiceIdentityId’:
+	// Set property "ManagedServiceIdentityId":
 	if typedInput.ManagedServiceIdentityId != nil {
 		managedServiceIdentityId := *typedInput.ManagedServiceIdentityId
 		config.ManagedServiceIdentityId = &managedServiceIdentityId
 	}
 
-	// Set property ‘MinTlsVersion’:
+	// Set property "MinTlsVersion":
 	if typedInput.MinTlsVersion != nil {
 		minTlsVersion := *typedInput.MinTlsVersion
 		config.MinTlsVersion = &minTlsVersion
 	}
 
-	// Set property ‘MinimumElasticInstanceCount’:
+	// Set property "MinimumElasticInstanceCount":
 	if typedInput.MinimumElasticInstanceCount != nil {
 		minimumElasticInstanceCount := *typedInput.MinimumElasticInstanceCount
 		config.MinimumElasticInstanceCount = &minimumElasticInstanceCount
 	}
 
-	// Set property ‘NetFrameworkVersion’:
+	// Set property "NetFrameworkVersion":
 	if typedInput.NetFrameworkVersion != nil {
 		netFrameworkVersion := *typedInput.NetFrameworkVersion
 		config.NetFrameworkVersion = &netFrameworkVersion
 	}
 
-	// Set property ‘NodeVersion’:
+	// Set property "NodeVersion":
 	if typedInput.NodeVersion != nil {
 		nodeVersion := *typedInput.NodeVersion
 		config.NodeVersion = &nodeVersion
 	}
 
-	// Set property ‘NumberOfWorkers’:
+	// Set property "NumberOfWorkers":
 	if typedInput.NumberOfWorkers != nil {
 		numberOfWorkers := *typedInput.NumberOfWorkers
 		config.NumberOfWorkers = &numberOfWorkers
 	}
 
-	// Set property ‘PhpVersion’:
+	// Set property "PhpVersion":
 	if typedInput.PhpVersion != nil {
 		phpVersion := *typedInput.PhpVersion
 		config.PhpVersion = &phpVersion
 	}
 
-	// Set property ‘PowerShellVersion’:
+	// Set property "PowerShellVersion":
 	if typedInput.PowerShellVersion != nil {
 		powerShellVersion := *typedInput.PowerShellVersion
 		config.PowerShellVersion = &powerShellVersion
 	}
 
-	// Set property ‘PreWarmedInstanceCount’:
+	// Set property "PreWarmedInstanceCount":
 	if typedInput.PreWarmedInstanceCount != nil {
 		preWarmedInstanceCount := *typedInput.PreWarmedInstanceCount
 		config.PreWarmedInstanceCount = &preWarmedInstanceCount
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		config.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘PublishingUsername’:
+	// Set property "PublishingUsername":
 	if typedInput.PublishingUsername != nil {
 		publishingUsername := *typedInput.PublishingUsername
 		config.PublishingUsername = &publishingUsername
 	}
 
-	// Set property ‘Push’:
+	// Set property "Push":
 	if typedInput.Push != nil {
 		var push1 PushSettings
 		err := push1.PopulateFromARM(owner, *typedInput.Push)
@@ -5721,37 +5721,37 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.Push = &push
 	}
 
-	// Set property ‘PythonVersion’:
+	// Set property "PythonVersion":
 	if typedInput.PythonVersion != nil {
 		pythonVersion := *typedInput.PythonVersion
 		config.PythonVersion = &pythonVersion
 	}
 
-	// Set property ‘RemoteDebuggingEnabled’:
+	// Set property "RemoteDebuggingEnabled":
 	if typedInput.RemoteDebuggingEnabled != nil {
 		remoteDebuggingEnabled := *typedInput.RemoteDebuggingEnabled
 		config.RemoteDebuggingEnabled = &remoteDebuggingEnabled
 	}
 
-	// Set property ‘RemoteDebuggingVersion’:
+	// Set property "RemoteDebuggingVersion":
 	if typedInput.RemoteDebuggingVersion != nil {
 		remoteDebuggingVersion := *typedInput.RemoteDebuggingVersion
 		config.RemoteDebuggingVersion = &remoteDebuggingVersion
 	}
 
-	// Set property ‘RequestTracingEnabled’:
+	// Set property "RequestTracingEnabled":
 	if typedInput.RequestTracingEnabled != nil {
 		requestTracingEnabled := *typedInput.RequestTracingEnabled
 		config.RequestTracingEnabled = &requestTracingEnabled
 	}
 
-	// Set property ‘RequestTracingExpirationTime’:
+	// Set property "RequestTracingExpirationTime":
 	if typedInput.RequestTracingExpirationTime != nil {
 		requestTracingExpirationTime := *typedInput.RequestTracingExpirationTime
 		config.RequestTracingExpirationTime = &requestTracingExpirationTime
 	}
 
-	// Set property ‘ScmIpSecurityRestrictions’:
+	// Set property "ScmIpSecurityRestrictions":
 	for _, item := range typedInput.ScmIpSecurityRestrictions {
 		var item1 IpSecurityRestriction
 		err := item1.PopulateFromARM(owner, item)
@@ -5761,37 +5761,37 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.ScmIpSecurityRestrictions = append(config.ScmIpSecurityRestrictions, item1)
 	}
 
-	// Set property ‘ScmIpSecurityRestrictionsUseMain’:
+	// Set property "ScmIpSecurityRestrictionsUseMain":
 	if typedInput.ScmIpSecurityRestrictionsUseMain != nil {
 		scmIpSecurityRestrictionsUseMain := *typedInput.ScmIpSecurityRestrictionsUseMain
 		config.ScmIpSecurityRestrictionsUseMain = &scmIpSecurityRestrictionsUseMain
 	}
 
-	// Set property ‘ScmMinTlsVersion’:
+	// Set property "ScmMinTlsVersion":
 	if typedInput.ScmMinTlsVersion != nil {
 		scmMinTlsVersion := *typedInput.ScmMinTlsVersion
 		config.ScmMinTlsVersion = &scmMinTlsVersion
 	}
 
-	// Set property ‘ScmType’:
+	// Set property "ScmType":
 	if typedInput.ScmType != nil {
 		scmType := *typedInput.ScmType
 		config.ScmType = &scmType
 	}
 
-	// Set property ‘TracingOptions’:
+	// Set property "TracingOptions":
 	if typedInput.TracingOptions != nil {
 		tracingOptions := *typedInput.TracingOptions
 		config.TracingOptions = &tracingOptions
 	}
 
-	// Set property ‘Use32BitWorkerProcess’:
+	// Set property "Use32BitWorkerProcess":
 	if typedInput.Use32BitWorkerProcess != nil {
 		use32BitWorkerProcess := *typedInput.Use32BitWorkerProcess
 		config.Use32BitWorkerProcess = &use32BitWorkerProcess
 	}
 
-	// Set property ‘VirtualApplications’:
+	// Set property "VirtualApplications":
 	for _, item := range typedInput.VirtualApplications {
 		var item1 VirtualApplication
 		err := item1.PopulateFromARM(owner, item)
@@ -5801,43 +5801,43 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.VirtualApplications = append(config.VirtualApplications, item1)
 	}
 
-	// Set property ‘VnetName’:
+	// Set property "VnetName":
 	if typedInput.VnetName != nil {
 		vnetName := *typedInput.VnetName
 		config.VnetName = &vnetName
 	}
 
-	// Set property ‘VnetPrivatePortsCount’:
+	// Set property "VnetPrivatePortsCount":
 	if typedInput.VnetPrivatePortsCount != nil {
 		vnetPrivatePortsCount := *typedInput.VnetPrivatePortsCount
 		config.VnetPrivatePortsCount = &vnetPrivatePortsCount
 	}
 
-	// Set property ‘VnetRouteAllEnabled’:
+	// Set property "VnetRouteAllEnabled":
 	if typedInput.VnetRouteAllEnabled != nil {
 		vnetRouteAllEnabled := *typedInput.VnetRouteAllEnabled
 		config.VnetRouteAllEnabled = &vnetRouteAllEnabled
 	}
 
-	// Set property ‘WebSocketsEnabled’:
+	// Set property "WebSocketsEnabled":
 	if typedInput.WebSocketsEnabled != nil {
 		webSocketsEnabled := *typedInput.WebSocketsEnabled
 		config.WebSocketsEnabled = &webSocketsEnabled
 	}
 
-	// Set property ‘WebsiteTimeZone’:
+	// Set property "WebsiteTimeZone":
 	if typedInput.WebsiteTimeZone != nil {
 		websiteTimeZone := *typedInput.WebsiteTimeZone
 		config.WebsiteTimeZone = &websiteTimeZone
 	}
 
-	// Set property ‘WindowsFxVersion’:
+	// Set property "WindowsFxVersion":
 	if typedInput.WindowsFxVersion != nil {
 		windowsFxVersion := *typedInput.WindowsFxVersion
 		config.WindowsFxVersion = &windowsFxVersion
 	}
 
-	// Set property ‘XManagedServiceIdentityId’:
+	// Set property "XManagedServiceIdentityId":
 	if typedInput.XManagedServiceIdentityId != nil {
 		xManagedServiceIdentityId := *typedInput.XManagedServiceIdentityId
 		config.XManagedServiceIdentityId = &xManagedServiceIdentityId
@@ -7549,25 +7549,25 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SiteConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AcrUseManagedIdentityCreds’:
+	// Set property "AcrUseManagedIdentityCreds":
 	if typedInput.AcrUseManagedIdentityCreds != nil {
 		acrUseManagedIdentityCreds := *typedInput.AcrUseManagedIdentityCreds
 		config.AcrUseManagedIdentityCreds = &acrUseManagedIdentityCreds
 	}
 
-	// Set property ‘AcrUserManagedIdentityID’:
+	// Set property "AcrUserManagedIdentityID":
 	if typedInput.AcrUserManagedIdentityID != nil {
 		acrUserManagedIdentityID := *typedInput.AcrUserManagedIdentityID
 		config.AcrUserManagedIdentityID = &acrUserManagedIdentityID
 	}
 
-	// Set property ‘AlwaysOn’:
+	// Set property "AlwaysOn":
 	if typedInput.AlwaysOn != nil {
 		alwaysOn := *typedInput.AlwaysOn
 		config.AlwaysOn = &alwaysOn
 	}
 
-	// Set property ‘ApiDefinition’:
+	// Set property "ApiDefinition":
 	if typedInput.ApiDefinition != nil {
 		var apiDefinition1 ApiDefinitionInfo_STATUS
 		err := apiDefinition1.PopulateFromARM(owner, *typedInput.ApiDefinition)
@@ -7578,7 +7578,7 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.ApiDefinition = &apiDefinition
 	}
 
-	// Set property ‘ApiManagementConfig’:
+	// Set property "ApiManagementConfig":
 	if typedInput.ApiManagementConfig != nil {
 		var apiManagementConfig1 ApiManagementConfig_STATUS
 		err := apiManagementConfig1.PopulateFromARM(owner, *typedInput.ApiManagementConfig)
@@ -7589,13 +7589,13 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.ApiManagementConfig = &apiManagementConfig
 	}
 
-	// Set property ‘AppCommandLine’:
+	// Set property "AppCommandLine":
 	if typedInput.AppCommandLine != nil {
 		appCommandLine := *typedInput.AppCommandLine
 		config.AppCommandLine = &appCommandLine
 	}
 
-	// Set property ‘AppSettings’:
+	// Set property "AppSettings":
 	for _, item := range typedInput.AppSettings {
 		var item1 NameValuePair_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7605,13 +7605,13 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.AppSettings = append(config.AppSettings, item1)
 	}
 
-	// Set property ‘AutoHealEnabled’:
+	// Set property "AutoHealEnabled":
 	if typedInput.AutoHealEnabled != nil {
 		autoHealEnabled := *typedInput.AutoHealEnabled
 		config.AutoHealEnabled = &autoHealEnabled
 	}
 
-	// Set property ‘AutoHealRules’:
+	// Set property "AutoHealRules":
 	if typedInput.AutoHealRules != nil {
 		var autoHealRules1 AutoHealRules_STATUS
 		err := autoHealRules1.PopulateFromARM(owner, *typedInput.AutoHealRules)
@@ -7622,13 +7622,13 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.AutoHealRules = &autoHealRules
 	}
 
-	// Set property ‘AutoSwapSlotName’:
+	// Set property "AutoSwapSlotName":
 	if typedInput.AutoSwapSlotName != nil {
 		autoSwapSlotName := *typedInput.AutoSwapSlotName
 		config.AutoSwapSlotName = &autoSwapSlotName
 	}
 
-	// Set property ‘AzureStorageAccounts’:
+	// Set property "AzureStorageAccounts":
 	if typedInput.AzureStorageAccounts != nil {
 		config.AzureStorageAccounts = make(map[string]AzureStorageInfoValue_STATUS, len(typedInput.AzureStorageAccounts))
 		for key, value := range typedInput.AzureStorageAccounts {
@@ -7641,7 +7641,7 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ConnectionStrings’:
+	// Set property "ConnectionStrings":
 	for _, item := range typedInput.ConnectionStrings {
 		var item1 ConnStringInfo_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7651,7 +7651,7 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.ConnectionStrings = append(config.ConnectionStrings, item1)
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	if typedInput.Cors != nil {
 		var cors1 CorsSettings_STATUS
 		err := cors1.PopulateFromARM(owner, *typedInput.Cors)
@@ -7662,24 +7662,24 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.Cors = &cors
 	}
 
-	// Set property ‘DefaultDocuments’:
+	// Set property "DefaultDocuments":
 	for _, item := range typedInput.DefaultDocuments {
 		config.DefaultDocuments = append(config.DefaultDocuments, item)
 	}
 
-	// Set property ‘DetailedErrorLoggingEnabled’:
+	// Set property "DetailedErrorLoggingEnabled":
 	if typedInput.DetailedErrorLoggingEnabled != nil {
 		detailedErrorLoggingEnabled := *typedInput.DetailedErrorLoggingEnabled
 		config.DetailedErrorLoggingEnabled = &detailedErrorLoggingEnabled
 	}
 
-	// Set property ‘DocumentRoot’:
+	// Set property "DocumentRoot":
 	if typedInput.DocumentRoot != nil {
 		documentRoot := *typedInput.DocumentRoot
 		config.DocumentRoot = &documentRoot
 	}
 
-	// Set property ‘Experiments’:
+	// Set property "Experiments":
 	if typedInput.Experiments != nil {
 		var experiments1 Experiments_STATUS
 		err := experiments1.PopulateFromARM(owner, *typedInput.Experiments)
@@ -7690,25 +7690,25 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.Experiments = &experiments
 	}
 
-	// Set property ‘FtpsState’:
+	// Set property "FtpsState":
 	if typedInput.FtpsState != nil {
 		ftpsState := *typedInput.FtpsState
 		config.FtpsState = &ftpsState
 	}
 
-	// Set property ‘FunctionAppScaleLimit’:
+	// Set property "FunctionAppScaleLimit":
 	if typedInput.FunctionAppScaleLimit != nil {
 		functionAppScaleLimit := *typedInput.FunctionAppScaleLimit
 		config.FunctionAppScaleLimit = &functionAppScaleLimit
 	}
 
-	// Set property ‘FunctionsRuntimeScaleMonitoringEnabled’:
+	// Set property "FunctionsRuntimeScaleMonitoringEnabled":
 	if typedInput.FunctionsRuntimeScaleMonitoringEnabled != nil {
 		functionsRuntimeScaleMonitoringEnabled := *typedInput.FunctionsRuntimeScaleMonitoringEnabled
 		config.FunctionsRuntimeScaleMonitoringEnabled = &functionsRuntimeScaleMonitoringEnabled
 	}
 
-	// Set property ‘HandlerMappings’:
+	// Set property "HandlerMappings":
 	for _, item := range typedInput.HandlerMappings {
 		var item1 HandlerMapping_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7718,25 +7718,25 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.HandlerMappings = append(config.HandlerMappings, item1)
 	}
 
-	// Set property ‘HealthCheckPath’:
+	// Set property "HealthCheckPath":
 	if typedInput.HealthCheckPath != nil {
 		healthCheckPath := *typedInput.HealthCheckPath
 		config.HealthCheckPath = &healthCheckPath
 	}
 
-	// Set property ‘Http20Enabled’:
+	// Set property "Http20Enabled":
 	if typedInput.Http20Enabled != nil {
 		http20Enabled := *typedInput.Http20Enabled
 		config.Http20Enabled = &http20Enabled
 	}
 
-	// Set property ‘HttpLoggingEnabled’:
+	// Set property "HttpLoggingEnabled":
 	if typedInput.HttpLoggingEnabled != nil {
 		httpLoggingEnabled := *typedInput.HttpLoggingEnabled
 		config.HttpLoggingEnabled = &httpLoggingEnabled
 	}
 
-	// Set property ‘IpSecurityRestrictions’:
+	// Set property "IpSecurityRestrictions":
 	for _, item := range typedInput.IpSecurityRestrictions {
 		var item1 IpSecurityRestriction_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7746,31 +7746,31 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.IpSecurityRestrictions = append(config.IpSecurityRestrictions, item1)
 	}
 
-	// Set property ‘JavaContainer’:
+	// Set property "JavaContainer":
 	if typedInput.JavaContainer != nil {
 		javaContainer := *typedInput.JavaContainer
 		config.JavaContainer = &javaContainer
 	}
 
-	// Set property ‘JavaContainerVersion’:
+	// Set property "JavaContainerVersion":
 	if typedInput.JavaContainerVersion != nil {
 		javaContainerVersion := *typedInput.JavaContainerVersion
 		config.JavaContainerVersion = &javaContainerVersion
 	}
 
-	// Set property ‘JavaVersion’:
+	// Set property "JavaVersion":
 	if typedInput.JavaVersion != nil {
 		javaVersion := *typedInput.JavaVersion
 		config.JavaVersion = &javaVersion
 	}
 
-	// Set property ‘KeyVaultReferenceIdentity’:
+	// Set property "KeyVaultReferenceIdentity":
 	if typedInput.KeyVaultReferenceIdentity != nil {
 		keyVaultReferenceIdentity := *typedInput.KeyVaultReferenceIdentity
 		config.KeyVaultReferenceIdentity = &keyVaultReferenceIdentity
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if typedInput.Limits != nil {
 		var limits1 SiteLimits_STATUS
 		err := limits1.PopulateFromARM(owner, *typedInput.Limits)
@@ -7781,31 +7781,31 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.Limits = &limits
 	}
 
-	// Set property ‘LinuxFxVersion’:
+	// Set property "LinuxFxVersion":
 	if typedInput.LinuxFxVersion != nil {
 		linuxFxVersion := *typedInput.LinuxFxVersion
 		config.LinuxFxVersion = &linuxFxVersion
 	}
 
-	// Set property ‘LoadBalancing’:
+	// Set property "LoadBalancing":
 	if typedInput.LoadBalancing != nil {
 		loadBalancing := *typedInput.LoadBalancing
 		config.LoadBalancing = &loadBalancing
 	}
 
-	// Set property ‘LocalMySqlEnabled’:
+	// Set property "LocalMySqlEnabled":
 	if typedInput.LocalMySqlEnabled != nil {
 		localMySqlEnabled := *typedInput.LocalMySqlEnabled
 		config.LocalMySqlEnabled = &localMySqlEnabled
 	}
 
-	// Set property ‘LogsDirectorySizeLimit’:
+	// Set property "LogsDirectorySizeLimit":
 	if typedInput.LogsDirectorySizeLimit != nil {
 		logsDirectorySizeLimit := *typedInput.LogsDirectorySizeLimit
 		config.LogsDirectorySizeLimit = &logsDirectorySizeLimit
 	}
 
-	// Set property ‘MachineKey’:
+	// Set property "MachineKey":
 	if typedInput.MachineKey != nil {
 		var machineKey1 SiteMachineKey_STATUS
 		err := machineKey1.PopulateFromARM(owner, *typedInput.MachineKey)
@@ -7816,79 +7816,79 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.MachineKey = &machineKey
 	}
 
-	// Set property ‘ManagedPipelineMode’:
+	// Set property "ManagedPipelineMode":
 	if typedInput.ManagedPipelineMode != nil {
 		managedPipelineMode := *typedInput.ManagedPipelineMode
 		config.ManagedPipelineMode = &managedPipelineMode
 	}
 
-	// Set property ‘ManagedServiceIdentityId’:
+	// Set property "ManagedServiceIdentityId":
 	if typedInput.ManagedServiceIdentityId != nil {
 		managedServiceIdentityId := *typedInput.ManagedServiceIdentityId
 		config.ManagedServiceIdentityId = &managedServiceIdentityId
 	}
 
-	// Set property ‘MinTlsVersion’:
+	// Set property "MinTlsVersion":
 	if typedInput.MinTlsVersion != nil {
 		minTlsVersion := *typedInput.MinTlsVersion
 		config.MinTlsVersion = &minTlsVersion
 	}
 
-	// Set property ‘MinimumElasticInstanceCount’:
+	// Set property "MinimumElasticInstanceCount":
 	if typedInput.MinimumElasticInstanceCount != nil {
 		minimumElasticInstanceCount := *typedInput.MinimumElasticInstanceCount
 		config.MinimumElasticInstanceCount = &minimumElasticInstanceCount
 	}
 
-	// Set property ‘NetFrameworkVersion’:
+	// Set property "NetFrameworkVersion":
 	if typedInput.NetFrameworkVersion != nil {
 		netFrameworkVersion := *typedInput.NetFrameworkVersion
 		config.NetFrameworkVersion = &netFrameworkVersion
 	}
 
-	// Set property ‘NodeVersion’:
+	// Set property "NodeVersion":
 	if typedInput.NodeVersion != nil {
 		nodeVersion := *typedInput.NodeVersion
 		config.NodeVersion = &nodeVersion
 	}
 
-	// Set property ‘NumberOfWorkers’:
+	// Set property "NumberOfWorkers":
 	if typedInput.NumberOfWorkers != nil {
 		numberOfWorkers := *typedInput.NumberOfWorkers
 		config.NumberOfWorkers = &numberOfWorkers
 	}
 
-	// Set property ‘PhpVersion’:
+	// Set property "PhpVersion":
 	if typedInput.PhpVersion != nil {
 		phpVersion := *typedInput.PhpVersion
 		config.PhpVersion = &phpVersion
 	}
 
-	// Set property ‘PowerShellVersion’:
+	// Set property "PowerShellVersion":
 	if typedInput.PowerShellVersion != nil {
 		powerShellVersion := *typedInput.PowerShellVersion
 		config.PowerShellVersion = &powerShellVersion
 	}
 
-	// Set property ‘PreWarmedInstanceCount’:
+	// Set property "PreWarmedInstanceCount":
 	if typedInput.PreWarmedInstanceCount != nil {
 		preWarmedInstanceCount := *typedInput.PreWarmedInstanceCount
 		config.PreWarmedInstanceCount = &preWarmedInstanceCount
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		config.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘PublishingUsername’:
+	// Set property "PublishingUsername":
 	if typedInput.PublishingUsername != nil {
 		publishingUsername := *typedInput.PublishingUsername
 		config.PublishingUsername = &publishingUsername
 	}
 
-	// Set property ‘Push’:
+	// Set property "Push":
 	if typedInput.Push != nil {
 		var push1 PushSettings_STATUS
 		err := push1.PopulateFromARM(owner, *typedInput.Push)
@@ -7899,37 +7899,37 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.Push = &push
 	}
 
-	// Set property ‘PythonVersion’:
+	// Set property "PythonVersion":
 	if typedInput.PythonVersion != nil {
 		pythonVersion := *typedInput.PythonVersion
 		config.PythonVersion = &pythonVersion
 	}
 
-	// Set property ‘RemoteDebuggingEnabled’:
+	// Set property "RemoteDebuggingEnabled":
 	if typedInput.RemoteDebuggingEnabled != nil {
 		remoteDebuggingEnabled := *typedInput.RemoteDebuggingEnabled
 		config.RemoteDebuggingEnabled = &remoteDebuggingEnabled
 	}
 
-	// Set property ‘RemoteDebuggingVersion’:
+	// Set property "RemoteDebuggingVersion":
 	if typedInput.RemoteDebuggingVersion != nil {
 		remoteDebuggingVersion := *typedInput.RemoteDebuggingVersion
 		config.RemoteDebuggingVersion = &remoteDebuggingVersion
 	}
 
-	// Set property ‘RequestTracingEnabled’:
+	// Set property "RequestTracingEnabled":
 	if typedInput.RequestTracingEnabled != nil {
 		requestTracingEnabled := *typedInput.RequestTracingEnabled
 		config.RequestTracingEnabled = &requestTracingEnabled
 	}
 
-	// Set property ‘RequestTracingExpirationTime’:
+	// Set property "RequestTracingExpirationTime":
 	if typedInput.RequestTracingExpirationTime != nil {
 		requestTracingExpirationTime := *typedInput.RequestTracingExpirationTime
 		config.RequestTracingExpirationTime = &requestTracingExpirationTime
 	}
 
-	// Set property ‘ScmIpSecurityRestrictions’:
+	// Set property "ScmIpSecurityRestrictions":
 	for _, item := range typedInput.ScmIpSecurityRestrictions {
 		var item1 IpSecurityRestriction_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7939,37 +7939,37 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.ScmIpSecurityRestrictions = append(config.ScmIpSecurityRestrictions, item1)
 	}
 
-	// Set property ‘ScmIpSecurityRestrictionsUseMain’:
+	// Set property "ScmIpSecurityRestrictionsUseMain":
 	if typedInput.ScmIpSecurityRestrictionsUseMain != nil {
 		scmIpSecurityRestrictionsUseMain := *typedInput.ScmIpSecurityRestrictionsUseMain
 		config.ScmIpSecurityRestrictionsUseMain = &scmIpSecurityRestrictionsUseMain
 	}
 
-	// Set property ‘ScmMinTlsVersion’:
+	// Set property "ScmMinTlsVersion":
 	if typedInput.ScmMinTlsVersion != nil {
 		scmMinTlsVersion := *typedInput.ScmMinTlsVersion
 		config.ScmMinTlsVersion = &scmMinTlsVersion
 	}
 
-	// Set property ‘ScmType’:
+	// Set property "ScmType":
 	if typedInput.ScmType != nil {
 		scmType := *typedInput.ScmType
 		config.ScmType = &scmType
 	}
 
-	// Set property ‘TracingOptions’:
+	// Set property "TracingOptions":
 	if typedInput.TracingOptions != nil {
 		tracingOptions := *typedInput.TracingOptions
 		config.TracingOptions = &tracingOptions
 	}
 
-	// Set property ‘Use32BitWorkerProcess’:
+	// Set property "Use32BitWorkerProcess":
 	if typedInput.Use32BitWorkerProcess != nil {
 		use32BitWorkerProcess := *typedInput.Use32BitWorkerProcess
 		config.Use32BitWorkerProcess = &use32BitWorkerProcess
 	}
 
-	// Set property ‘VirtualApplications’:
+	// Set property "VirtualApplications":
 	for _, item := range typedInput.VirtualApplications {
 		var item1 VirtualApplication_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -7979,43 +7979,43 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.VirtualApplications = append(config.VirtualApplications, item1)
 	}
 
-	// Set property ‘VnetName’:
+	// Set property "VnetName":
 	if typedInput.VnetName != nil {
 		vnetName := *typedInput.VnetName
 		config.VnetName = &vnetName
 	}
 
-	// Set property ‘VnetPrivatePortsCount’:
+	// Set property "VnetPrivatePortsCount":
 	if typedInput.VnetPrivatePortsCount != nil {
 		vnetPrivatePortsCount := *typedInput.VnetPrivatePortsCount
 		config.VnetPrivatePortsCount = &vnetPrivatePortsCount
 	}
 
-	// Set property ‘VnetRouteAllEnabled’:
+	// Set property "VnetRouteAllEnabled":
 	if typedInput.VnetRouteAllEnabled != nil {
 		vnetRouteAllEnabled := *typedInput.VnetRouteAllEnabled
 		config.VnetRouteAllEnabled = &vnetRouteAllEnabled
 	}
 
-	// Set property ‘WebSocketsEnabled’:
+	// Set property "WebSocketsEnabled":
 	if typedInput.WebSocketsEnabled != nil {
 		webSocketsEnabled := *typedInput.WebSocketsEnabled
 		config.WebSocketsEnabled = &webSocketsEnabled
 	}
 
-	// Set property ‘WebsiteTimeZone’:
+	// Set property "WebsiteTimeZone":
 	if typedInput.WebsiteTimeZone != nil {
 		websiteTimeZone := *typedInput.WebsiteTimeZone
 		config.WebsiteTimeZone = &websiteTimeZone
 	}
 
-	// Set property ‘WindowsFxVersion’:
+	// Set property "WindowsFxVersion":
 	if typedInput.WindowsFxVersion != nil {
 		windowsFxVersion := *typedInput.WindowsFxVersion
 		config.WindowsFxVersion = &windowsFxVersion
 	}
 
-	// Set property ‘XManagedServiceIdentityId’:
+	// Set property "XManagedServiceIdentityId":
 	if typedInput.XManagedServiceIdentityId != nil {
 		xManagedServiceIdentityId := *typedInput.XManagedServiceIdentityId
 		config.XManagedServiceIdentityId = &xManagedServiceIdentityId
@@ -9030,19 +9030,19 @@ func (status *SlotSwapStatus_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SlotSwapStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DestinationSlotName’:
+	// Set property "DestinationSlotName":
 	if typedInput.DestinationSlotName != nil {
 		destinationSlotName := *typedInput.DestinationSlotName
 		status.DestinationSlotName = &destinationSlotName
 	}
 
-	// Set property ‘SourceSlotName’:
+	// Set property "SourceSlotName":
 	if typedInput.SourceSlotName != nil {
 		sourceSlotName := *typedInput.SourceSlotName
 		status.SourceSlotName = &sourceSlotName
 	}
 
-	// Set property ‘TimestampUtc’:
+	// Set property "TimestampUtc":
 	if typedInput.TimestampUtc != nil {
 		timestampUtc := *typedInput.TimestampUtc
 		status.TimestampUtc = &timestampUtc
@@ -9108,7 +9108,7 @@ func (info *ApiDefinitionInfo) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &ApiDefinitionInfo_ARM{}
 
-	// Set property ‘Url’:
+	// Set property "Url":
 	if info.Url != nil {
 		url := *info.Url
 		result.Url = &url
@@ -9128,7 +9128,7 @@ func (info *ApiDefinitionInfo) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiDefinitionInfo_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Url’:
+	// Set property "Url":
 	if typedInput.Url != nil {
 		url := *typedInput.Url
 		info.Url = &url
@@ -9197,7 +9197,7 @@ func (info *ApiDefinitionInfo_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiDefinitionInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Url’:
+	// Set property "Url":
 	if typedInput.Url != nil {
 		url := *typedInput.Url
 		info.Url = &url
@@ -9251,7 +9251,7 @@ func (config *ApiManagementConfig) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &ApiManagementConfig_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if config.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*config.Reference)
 		if err != nil {
@@ -9275,7 +9275,7 @@ func (config *ApiManagementConfig) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiManagementConfig_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -9355,7 +9355,7 @@ func (config *ApiManagementConfig_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiManagementConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		config.Id = &id
@@ -9412,7 +9412,7 @@ func (rules *AutoHealRules) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &AutoHealRules_ARM{}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if rules.Actions != nil {
 		actions_ARM, err := (*rules.Actions).ConvertToARM(resolved)
 		if err != nil {
@@ -9422,7 +9422,7 @@ func (rules *AutoHealRules) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		result.Actions = &actions
 	}
 
-	// Set property ‘Triggers’:
+	// Set property "Triggers":
 	if rules.Triggers != nil {
 		triggers_ARM, err := (*rules.Triggers).ConvertToARM(resolved)
 		if err != nil {
@@ -9446,7 +9446,7 @@ func (rules *AutoHealRules) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealRules_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if typedInput.Actions != nil {
 		var actions1 AutoHealActions
 		err := actions1.PopulateFromARM(owner, *typedInput.Actions)
@@ -9457,7 +9457,7 @@ func (rules *AutoHealRules) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		rules.Actions = &actions
 	}
 
-	// Set property ‘Triggers’:
+	// Set property "Triggers":
 	if typedInput.Triggers != nil {
 		var triggers1 AutoHealTriggers
 		err := triggers1.PopulateFromARM(owner, *typedInput.Triggers)
@@ -9597,7 +9597,7 @@ func (rules *AutoHealRules_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealRules_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if typedInput.Actions != nil {
 		var actions1 AutoHealActions_STATUS
 		err := actions1.PopulateFromARM(owner, *typedInput.Actions)
@@ -9608,7 +9608,7 @@ func (rules *AutoHealRules_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		rules.Actions = &actions
 	}
 
-	// Set property ‘Triggers’:
+	// Set property "Triggers":
 	if typedInput.Triggers != nil {
 		var triggers1 AutoHealTriggers_STATUS
 		err := triggers1.PopulateFromARM(owner, *typedInput.Triggers)
@@ -9721,7 +9721,7 @@ func (value *AzureStorageInfoValue) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &AzureStorageInfoValue_ARM{}
 
-	// Set property ‘AccessKey’:
+	// Set property "AccessKey":
 	if value.AccessKey != nil {
 		accessKeySecret, err := resolved.ResolvedSecrets.Lookup(*value.AccessKey)
 		if err != nil {
@@ -9731,25 +9731,25 @@ func (value *AzureStorageInfoValue) ConvertToARM(resolved genruntime.ConvertToAR
 		result.AccessKey = &accessKey
 	}
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if value.AccountName != nil {
 		accountName := *value.AccountName
 		result.AccountName = &accountName
 	}
 
-	// Set property ‘MountPath’:
+	// Set property "MountPath":
 	if value.MountPath != nil {
 		mountPath := *value.MountPath
 		result.MountPath = &mountPath
 	}
 
-	// Set property ‘ShareName’:
+	// Set property "ShareName":
 	if value.ShareName != nil {
 		shareName := *value.ShareName
 		result.ShareName = &shareName
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if value.Type != nil {
 		typeVar := *value.Type
 		result.Type = &typeVar
@@ -9769,27 +9769,27 @@ func (value *AzureStorageInfoValue) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureStorageInfoValue_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘AccessKey’
+	// no assignment for property "AccessKey"
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if typedInput.AccountName != nil {
 		accountName := *typedInput.AccountName
 		value.AccountName = &accountName
 	}
 
-	// Set property ‘MountPath’:
+	// Set property "MountPath":
 	if typedInput.MountPath != nil {
 		mountPath := *typedInput.MountPath
 		value.MountPath = &mountPath
 	}
 
-	// Set property ‘ShareName’:
+	// Set property "ShareName":
 	if typedInput.ShareName != nil {
 		shareName := *typedInput.ShareName
 		value.ShareName = &shareName
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		value.Type = &typeVar
@@ -9928,31 +9928,31 @@ func (value *AzureStorageInfoValue_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureStorageInfoValue_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if typedInput.AccountName != nil {
 		accountName := *typedInput.AccountName
 		value.AccountName = &accountName
 	}
 
-	// Set property ‘MountPath’:
+	// Set property "MountPath":
 	if typedInput.MountPath != nil {
 		mountPath := *typedInput.MountPath
 		value.MountPath = &mountPath
 	}
 
-	// Set property ‘ShareName’:
+	// Set property "ShareName":
 	if typedInput.ShareName != nil {
 		shareName := *typedInput.ShareName
 		value.ShareName = &shareName
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		value.State = &state
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		value.Type = &typeVar
@@ -10056,19 +10056,19 @@ func (info *ConnStringInfo) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &ConnStringInfo_ARM{}
 
-	// Set property ‘ConnectionString’:
+	// Set property "ConnectionString":
 	if info.ConnectionString != nil {
 		connectionString := *info.ConnectionString
 		result.ConnectionString = &connectionString
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if info.Name != nil {
 		name := *info.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if info.Type != nil {
 		typeVar := *info.Type
 		result.Type = &typeVar
@@ -10088,19 +10088,19 @@ func (info *ConnStringInfo) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConnStringInfo_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConnectionString’:
+	// Set property "ConnectionString":
 	if typedInput.ConnectionString != nil {
 		connectionString := *typedInput.ConnectionString
 		info.ConnectionString = &connectionString
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		info.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		info.Type = &typeVar
@@ -10208,19 +10208,19 @@ func (info *ConnStringInfo_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConnStringInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConnectionString’:
+	// Set property "ConnectionString":
 	if typedInput.ConnectionString != nil {
 		connectionString := *typedInput.ConnectionString
 		info.ConnectionString = &connectionString
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		info.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		info.Type = &typeVar
@@ -10302,12 +10302,12 @@ func (settings *CorsSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &CorsSettings_ARM{}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range settings.AllowedOrigins {
 		result.AllowedOrigins = append(result.AllowedOrigins, item)
 	}
 
-	// Set property ‘SupportCredentials’:
+	// Set property "SupportCredentials":
 	if settings.SupportCredentials != nil {
 		supportCredentials := *settings.SupportCredentials
 		result.SupportCredentials = &supportCredentials
@@ -10327,12 +10327,12 @@ func (settings *CorsSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		settings.AllowedOrigins = append(settings.AllowedOrigins, item)
 	}
 
-	// Set property ‘SupportCredentials’:
+	// Set property "SupportCredentials":
 	if typedInput.SupportCredentials != nil {
 		supportCredentials := *typedInput.SupportCredentials
 		settings.SupportCredentials = &supportCredentials
@@ -10431,12 +10431,12 @@ func (settings *CorsSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		settings.AllowedOrigins = append(settings.AllowedOrigins, item)
 	}
 
-	// Set property ‘SupportCredentials’:
+	// Set property "SupportCredentials":
 	if typedInput.SupportCredentials != nil {
 		supportCredentials := *typedInput.SupportCredentials
 		settings.SupportCredentials = &supportCredentials
@@ -10506,7 +10506,7 @@ func (experiments *Experiments) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &Experiments_ARM{}
 
-	// Set property ‘RampUpRules’:
+	// Set property "RampUpRules":
 	for _, item := range experiments.RampUpRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -10529,7 +10529,7 @@ func (experiments *Experiments) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Experiments_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RampUpRules’:
+	// Set property "RampUpRules":
 	for _, item := range typedInput.RampUpRules {
 		var item1 RampUpRule
 		err := item1.PopulateFromARM(owner, item)
@@ -10647,7 +10647,7 @@ func (experiments *Experiments_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Experiments_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RampUpRules’:
+	// Set property "RampUpRules":
 	for _, item := range typedInput.RampUpRules {
 		var item1 RampUpRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -10743,19 +10743,19 @@ func (mapping *HandlerMapping) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &HandlerMapping_ARM{}
 
-	// Set property ‘Arguments’:
+	// Set property "Arguments":
 	if mapping.Arguments != nil {
 		arguments := *mapping.Arguments
 		result.Arguments = &arguments
 	}
 
-	// Set property ‘Extension’:
+	// Set property "Extension":
 	if mapping.Extension != nil {
 		extension := *mapping.Extension
 		result.Extension = &extension
 	}
 
-	// Set property ‘ScriptProcessor’:
+	// Set property "ScriptProcessor":
 	if mapping.ScriptProcessor != nil {
 		scriptProcessor := *mapping.ScriptProcessor
 		result.ScriptProcessor = &scriptProcessor
@@ -10775,19 +10775,19 @@ func (mapping *HandlerMapping) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HandlerMapping_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Arguments’:
+	// Set property "Arguments":
 	if typedInput.Arguments != nil {
 		arguments := *typedInput.Arguments
 		mapping.Arguments = &arguments
 	}
 
-	// Set property ‘Extension’:
+	// Set property "Extension":
 	if typedInput.Extension != nil {
 		extension := *typedInput.Extension
 		mapping.Extension = &extension
 	}
 
-	// Set property ‘ScriptProcessor’:
+	// Set property "ScriptProcessor":
 	if typedInput.ScriptProcessor != nil {
 		scriptProcessor := *typedInput.ScriptProcessor
 		mapping.ScriptProcessor = &scriptProcessor
@@ -10882,19 +10882,19 @@ func (mapping *HandlerMapping_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HandlerMapping_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Arguments’:
+	// Set property "Arguments":
 	if typedInput.Arguments != nil {
 		arguments := *typedInput.Arguments
 		mapping.Arguments = &arguments
 	}
 
-	// Set property ‘Extension’:
+	// Set property "Extension":
 	if typedInput.Extension != nil {
 		extension := *typedInput.Extension
 		mapping.Extension = &extension
 	}
 
-	// Set property ‘ScriptProcessor’:
+	// Set property "ScriptProcessor":
 	if typedInput.ScriptProcessor != nil {
 		scriptProcessor := *typedInput.ScriptProcessor
 		mapping.ScriptProcessor = &scriptProcessor
@@ -11039,19 +11039,19 @@ func (restriction *IpSecurityRestriction) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &IpSecurityRestriction_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if restriction.Action != nil {
 		action := *restriction.Action
 		result.Action = &action
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if restriction.Description != nil {
 		description := *restriction.Description
 		result.Description = &description
 	}
 
-	// Set property ‘Headers’:
+	// Set property "Headers":
 	if restriction.Headers != nil {
 		result.Headers = make(map[string][]string, len(restriction.Headers))
 		for key, value := range restriction.Headers {
@@ -11063,43 +11063,43 @@ func (restriction *IpSecurityRestriction) ConvertToARM(resolved genruntime.Conve
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	if restriction.IpAddress != nil {
 		ipAddress := *restriction.IpAddress
 		result.IpAddress = &ipAddress
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if restriction.Name != nil {
 		name := *restriction.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if restriction.Priority != nil {
 		priority := *restriction.Priority
 		result.Priority = &priority
 	}
 
-	// Set property ‘SubnetMask’:
+	// Set property "SubnetMask":
 	if restriction.SubnetMask != nil {
 		subnetMask := *restriction.SubnetMask
 		result.SubnetMask = &subnetMask
 	}
 
-	// Set property ‘SubnetTrafficTag’:
+	// Set property "SubnetTrafficTag":
 	if restriction.SubnetTrafficTag != nil {
 		subnetTrafficTag := *restriction.SubnetTrafficTag
 		result.SubnetTrafficTag = &subnetTrafficTag
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if restriction.Tag != nil {
 		tag := *restriction.Tag
 		result.Tag = &tag
 	}
 
-	// Set property ‘VnetSubnetResourceId’:
+	// Set property "VnetSubnetResourceId":
 	if restriction.VnetSubnetResourceReference != nil {
 		vnetSubnetResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*restriction.VnetSubnetResourceReference)
 		if err != nil {
@@ -11109,7 +11109,7 @@ func (restriction *IpSecurityRestriction) ConvertToARM(resolved genruntime.Conve
 		result.VnetSubnetResourceId = &vnetSubnetResourceReference
 	}
 
-	// Set property ‘VnetTrafficTag’:
+	// Set property "VnetTrafficTag":
 	if restriction.VnetTrafficTag != nil {
 		vnetTrafficTag := *restriction.VnetTrafficTag
 		result.VnetTrafficTag = &vnetTrafficTag
@@ -11129,19 +11129,19 @@ func (restriction *IpSecurityRestriction) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpSecurityRestriction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		restriction.Action = &action
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		restriction.Description = &description
 	}
 
-	// Set property ‘Headers’:
+	// Set property "Headers":
 	if typedInput.Headers != nil {
 		restriction.Headers = make(map[string][]string, len(typedInput.Headers))
 		for key, value := range typedInput.Headers {
@@ -11153,45 +11153,45 @@ func (restriction *IpSecurityRestriction) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	if typedInput.IpAddress != nil {
 		ipAddress := *typedInput.IpAddress
 		restriction.IpAddress = &ipAddress
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		restriction.Name = &name
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		restriction.Priority = &priority
 	}
 
-	// Set property ‘SubnetMask’:
+	// Set property "SubnetMask":
 	if typedInput.SubnetMask != nil {
 		subnetMask := *typedInput.SubnetMask
 		restriction.SubnetMask = &subnetMask
 	}
 
-	// Set property ‘SubnetTrafficTag’:
+	// Set property "SubnetTrafficTag":
 	if typedInput.SubnetTrafficTag != nil {
 		subnetTrafficTag := *typedInput.SubnetTrafficTag
 		restriction.SubnetTrafficTag = &subnetTrafficTag
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		restriction.Tag = &tag
 	}
 
-	// no assignment for property ‘VnetSubnetResourceReference’
+	// no assignment for property "VnetSubnetResourceReference"
 
-	// Set property ‘VnetTrafficTag’:
+	// Set property "VnetTrafficTag":
 	if typedInput.VnetTrafficTag != nil {
 		vnetTrafficTag := *typedInput.VnetTrafficTag
 		restriction.VnetTrafficTag = &vnetTrafficTag
@@ -11457,19 +11457,19 @@ func (restriction *IpSecurityRestriction_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpSecurityRestriction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		restriction.Action = &action
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		restriction.Description = &description
 	}
 
-	// Set property ‘Headers’:
+	// Set property "Headers":
 	if typedInput.Headers != nil {
 		restriction.Headers = make(map[string][]string, len(typedInput.Headers))
 		for key, value := range typedInput.Headers {
@@ -11481,49 +11481,49 @@ func (restriction *IpSecurityRestriction_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	if typedInput.IpAddress != nil {
 		ipAddress := *typedInput.IpAddress
 		restriction.IpAddress = &ipAddress
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		restriction.Name = &name
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		restriction.Priority = &priority
 	}
 
-	// Set property ‘SubnetMask’:
+	// Set property "SubnetMask":
 	if typedInput.SubnetMask != nil {
 		subnetMask := *typedInput.SubnetMask
 		restriction.SubnetMask = &subnetMask
 	}
 
-	// Set property ‘SubnetTrafficTag’:
+	// Set property "SubnetTrafficTag":
 	if typedInput.SubnetTrafficTag != nil {
 		subnetTrafficTag := *typedInput.SubnetTrafficTag
 		restriction.SubnetTrafficTag = &subnetTrafficTag
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		restriction.Tag = &tag
 	}
 
-	// Set property ‘VnetSubnetResourceId’:
+	// Set property "VnetSubnetResourceId":
 	if typedInput.VnetSubnetResourceId != nil {
 		vnetSubnetResourceId := *typedInput.VnetSubnetResourceId
 		restriction.VnetSubnetResourceId = &vnetSubnetResourceId
 	}
 
-	// Set property ‘VnetTrafficTag’:
+	// Set property "VnetTrafficTag":
 	if typedInput.VnetTrafficTag != nil {
 		vnetTrafficTag := *typedInput.VnetTrafficTag
 		restriction.VnetTrafficTag = &vnetTrafficTag
@@ -11670,13 +11670,13 @@ func (pair *NameValuePair) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &NameValuePair_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if pair.Name != nil {
 		name := *pair.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if pair.Value != nil {
 		value := *pair.Value
 		result.Value = &value
@@ -11696,13 +11696,13 @@ func (pair *NameValuePair) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NameValuePair_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pair.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		pair.Value = &value
@@ -11783,13 +11783,13 @@ func (pair *NameValuePair_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NameValuePair_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pair.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		pair.Value = &value
@@ -11868,13 +11868,13 @@ func (settings *PushSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &PushSettings_ARM{}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if settings.Kind != nil {
 		kind := *settings.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if settings.DynamicTagsJson != nil ||
 		settings.IsPushEnabled != nil ||
 		settings.TagWhitelistJson != nil ||
@@ -11912,7 +11912,7 @@ func (settings *PushSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PushSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DynamicTagsJson’:
+	// Set property "DynamicTagsJson":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DynamicTagsJson != nil {
@@ -11921,7 +11921,7 @@ func (settings *PushSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘IsPushEnabled’:
+	// Set property "IsPushEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsPushEnabled != nil {
@@ -11930,13 +11930,13 @@ func (settings *PushSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		settings.Kind = &kind
 	}
 
-	// Set property ‘TagWhitelistJson’:
+	// Set property "TagWhitelistJson":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TagWhitelistJson != nil {
@@ -11945,7 +11945,7 @@ func (settings *PushSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘TagsRequiringAuth’:
+	// Set property "TagsRequiringAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TagsRequiringAuth != nil {
@@ -12095,7 +12095,7 @@ func (settings *PushSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PushSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DynamicTagsJson’:
+	// Set property "DynamicTagsJson":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DynamicTagsJson != nil {
@@ -12104,13 +12104,13 @@ func (settings *PushSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		settings.Id = &id
 	}
 
-	// Set property ‘IsPushEnabled’:
+	// Set property "IsPushEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsPushEnabled != nil {
@@ -12119,19 +12119,19 @@ func (settings *PushSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		settings.Kind = &kind
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		settings.Name = &name
 	}
 
-	// Set property ‘TagWhitelistJson’:
+	// Set property "TagWhitelistJson":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TagWhitelistJson != nil {
@@ -12140,7 +12140,7 @@ func (settings *PushSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TagsRequiringAuth’:
+	// Set property "TagsRequiringAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TagsRequiringAuth != nil {
@@ -12149,7 +12149,7 @@ func (settings *PushSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		settings.Type = &typeVar
@@ -12389,19 +12389,19 @@ func (limits *SiteLimits) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &SiteLimits_ARM{}
 
-	// Set property ‘MaxDiskSizeInMb’:
+	// Set property "MaxDiskSizeInMb":
 	if limits.MaxDiskSizeInMb != nil {
 		maxDiskSizeInMb := *limits.MaxDiskSizeInMb
 		result.MaxDiskSizeInMb = &maxDiskSizeInMb
 	}
 
-	// Set property ‘MaxMemoryInMb’:
+	// Set property "MaxMemoryInMb":
 	if limits.MaxMemoryInMb != nil {
 		maxMemoryInMb := *limits.MaxMemoryInMb
 		result.MaxMemoryInMb = &maxMemoryInMb
 	}
 
-	// Set property ‘MaxPercentageCpu’:
+	// Set property "MaxPercentageCpu":
 	if limits.MaxPercentageCpu != nil {
 		maxPercentageCpu := *limits.MaxPercentageCpu
 		result.MaxPercentageCpu = &maxPercentageCpu
@@ -12421,19 +12421,19 @@ func (limits *SiteLimits) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SiteLimits_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxDiskSizeInMb’:
+	// Set property "MaxDiskSizeInMb":
 	if typedInput.MaxDiskSizeInMb != nil {
 		maxDiskSizeInMb := *typedInput.MaxDiskSizeInMb
 		limits.MaxDiskSizeInMb = &maxDiskSizeInMb
 	}
 
-	// Set property ‘MaxMemoryInMb’:
+	// Set property "MaxMemoryInMb":
 	if typedInput.MaxMemoryInMb != nil {
 		maxMemoryInMb := *typedInput.MaxMemoryInMb
 		limits.MaxMemoryInMb = &maxMemoryInMb
 	}
 
-	// Set property ‘MaxPercentageCpu’:
+	// Set property "MaxPercentageCpu":
 	if typedInput.MaxPercentageCpu != nil {
 		maxPercentageCpu := *typedInput.MaxPercentageCpu
 		limits.MaxPercentageCpu = &maxPercentageCpu
@@ -12541,19 +12541,19 @@ func (limits *SiteLimits_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SiteLimits_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxDiskSizeInMb’:
+	// Set property "MaxDiskSizeInMb":
 	if typedInput.MaxDiskSizeInMb != nil {
 		maxDiskSizeInMb := *typedInput.MaxDiskSizeInMb
 		limits.MaxDiskSizeInMb = &maxDiskSizeInMb
 	}
 
-	// Set property ‘MaxMemoryInMb’:
+	// Set property "MaxMemoryInMb":
 	if typedInput.MaxMemoryInMb != nil {
 		maxMemoryInMb := *typedInput.MaxMemoryInMb
 		limits.MaxMemoryInMb = &maxMemoryInMb
 	}
 
-	// Set property ‘MaxPercentageCpu’:
+	// Set property "MaxPercentageCpu":
 	if typedInput.MaxPercentageCpu != nil {
 		maxPercentageCpu := *typedInput.MaxPercentageCpu
 		limits.MaxPercentageCpu = &maxPercentageCpu
@@ -12643,25 +12643,25 @@ func (machineKey *SiteMachineKey_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SiteMachineKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Decryption’:
+	// Set property "Decryption":
 	if typedInput.Decryption != nil {
 		decryption := *typedInput.Decryption
 		machineKey.Decryption = &decryption
 	}
 
-	// Set property ‘DecryptionKey’:
+	// Set property "DecryptionKey":
 	if typedInput.DecryptionKey != nil {
 		decryptionKey := *typedInput.DecryptionKey
 		machineKey.DecryptionKey = &decryptionKey
 	}
 
-	// Set property ‘Validation’:
+	// Set property "Validation":
 	if typedInput.Validation != nil {
 		validation := *typedInput.Validation
 		machineKey.Validation = &validation
 	}
 
-	// Set property ‘ValidationKey’:
+	// Set property "ValidationKey":
 	if typedInput.ValidationKey != nil {
 		validationKey := *typedInput.ValidationKey
 		machineKey.ValidationKey = &validationKey
@@ -12741,13 +12741,13 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
@@ -12850,19 +12850,19 @@ func (application *VirtualApplication) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &VirtualApplication_ARM{}
 
-	// Set property ‘PhysicalPath’:
+	// Set property "PhysicalPath":
 	if application.PhysicalPath != nil {
 		physicalPath := *application.PhysicalPath
 		result.PhysicalPath = &physicalPath
 	}
 
-	// Set property ‘PreloadEnabled’:
+	// Set property "PreloadEnabled":
 	if application.PreloadEnabled != nil {
 		preloadEnabled := *application.PreloadEnabled
 		result.PreloadEnabled = &preloadEnabled
 	}
 
-	// Set property ‘VirtualDirectories’:
+	// Set property "VirtualDirectories":
 	for _, item := range application.VirtualDirectories {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -12871,7 +12871,7 @@ func (application *VirtualApplication) ConvertToARM(resolved genruntime.ConvertT
 		result.VirtualDirectories = append(result.VirtualDirectories, *item_ARM.(*VirtualDirectory_ARM))
 	}
 
-	// Set property ‘VirtualPath’:
+	// Set property "VirtualPath":
 	if application.VirtualPath != nil {
 		virtualPath := *application.VirtualPath
 		result.VirtualPath = &virtualPath
@@ -12891,19 +12891,19 @@ func (application *VirtualApplication) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualApplication_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PhysicalPath’:
+	// Set property "PhysicalPath":
 	if typedInput.PhysicalPath != nil {
 		physicalPath := *typedInput.PhysicalPath
 		application.PhysicalPath = &physicalPath
 	}
 
-	// Set property ‘PreloadEnabled’:
+	// Set property "PreloadEnabled":
 	if typedInput.PreloadEnabled != nil {
 		preloadEnabled := *typedInput.PreloadEnabled
 		application.PreloadEnabled = &preloadEnabled
 	}
 
-	// Set property ‘VirtualDirectories’:
+	// Set property "VirtualDirectories":
 	for _, item := range typedInput.VirtualDirectories {
 		var item1 VirtualDirectory
 		err := item1.PopulateFromARM(owner, item)
@@ -12913,7 +12913,7 @@ func (application *VirtualApplication) PopulateFromARM(owner genruntime.Arbitrar
 		application.VirtualDirectories = append(application.VirtualDirectories, item1)
 	}
 
-	// Set property ‘VirtualPath’:
+	// Set property "VirtualPath":
 	if typedInput.VirtualPath != nil {
 		virtualPath := *typedInput.VirtualPath
 		application.VirtualPath = &virtualPath
@@ -13078,19 +13078,19 @@ func (application *VirtualApplication_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualApplication_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PhysicalPath’:
+	// Set property "PhysicalPath":
 	if typedInput.PhysicalPath != nil {
 		physicalPath := *typedInput.PhysicalPath
 		application.PhysicalPath = &physicalPath
 	}
 
-	// Set property ‘PreloadEnabled’:
+	// Set property "PreloadEnabled":
 	if typedInput.PreloadEnabled != nil {
 		preloadEnabled := *typedInput.PreloadEnabled
 		application.PreloadEnabled = &preloadEnabled
 	}
 
-	// Set property ‘VirtualDirectories’:
+	// Set property "VirtualDirectories":
 	for _, item := range typedInput.VirtualDirectories {
 		var item1 VirtualDirectory_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -13100,7 +13100,7 @@ func (application *VirtualApplication_STATUS) PopulateFromARM(owner genruntime.A
 		application.VirtualDirectories = append(application.VirtualDirectories, item1)
 	}
 
-	// Set property ‘VirtualPath’:
+	// Set property "VirtualPath":
 	if typedInput.VirtualPath != nil {
 		virtualPath := *typedInput.VirtualPath
 		application.VirtualPath = &virtualPath
@@ -13219,13 +13219,13 @@ func (actions *AutoHealActions) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &AutoHealActions_ARM{}
 
-	// Set property ‘ActionType’:
+	// Set property "ActionType":
 	if actions.ActionType != nil {
 		actionType := *actions.ActionType
 		result.ActionType = &actionType
 	}
 
-	// Set property ‘CustomAction’:
+	// Set property "CustomAction":
 	if actions.CustomAction != nil {
 		customAction_ARM, err := (*actions.CustomAction).ConvertToARM(resolved)
 		if err != nil {
@@ -13235,7 +13235,7 @@ func (actions *AutoHealActions) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.CustomAction = &customAction
 	}
 
-	// Set property ‘MinProcessExecutionTime’:
+	// Set property "MinProcessExecutionTime":
 	if actions.MinProcessExecutionTime != nil {
 		minProcessExecutionTime := *actions.MinProcessExecutionTime
 		result.MinProcessExecutionTime = &minProcessExecutionTime
@@ -13255,13 +13255,13 @@ func (actions *AutoHealActions) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealActions_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionType’:
+	// Set property "ActionType":
 	if typedInput.ActionType != nil {
 		actionType := *typedInput.ActionType
 		actions.ActionType = &actionType
 	}
 
-	// Set property ‘CustomAction’:
+	// Set property "CustomAction":
 	if typedInput.CustomAction != nil {
 		var customAction1 AutoHealCustomAction
 		err := customAction1.PopulateFromARM(owner, *typedInput.CustomAction)
@@ -13272,7 +13272,7 @@ func (actions *AutoHealActions) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		actions.CustomAction = &customAction
 	}
 
-	// Set property ‘MinProcessExecutionTime’:
+	// Set property "MinProcessExecutionTime":
 	if typedInput.MinProcessExecutionTime != nil {
 		minProcessExecutionTime := *typedInput.MinProcessExecutionTime
 		actions.MinProcessExecutionTime = &minProcessExecutionTime
@@ -13408,13 +13408,13 @@ func (actions *AutoHealActions_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealActions_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionType’:
+	// Set property "ActionType":
 	if typedInput.ActionType != nil {
 		actionType := *typedInput.ActionType
 		actions.ActionType = &actionType
 	}
 
-	// Set property ‘CustomAction’:
+	// Set property "CustomAction":
 	if typedInput.CustomAction != nil {
 		var customAction1 AutoHealCustomAction_STATUS
 		err := customAction1.PopulateFromARM(owner, *typedInput.CustomAction)
@@ -13425,7 +13425,7 @@ func (actions *AutoHealActions_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		actions.CustomAction = &customAction
 	}
 
-	// Set property ‘MinProcessExecutionTime’:
+	// Set property "MinProcessExecutionTime":
 	if typedInput.MinProcessExecutionTime != nil {
 		minProcessExecutionTime := *typedInput.MinProcessExecutionTime
 		actions.MinProcessExecutionTime = &minProcessExecutionTime
@@ -13534,13 +13534,13 @@ func (triggers *AutoHealTriggers) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &AutoHealTriggers_ARM{}
 
-	// Set property ‘PrivateBytesInKB’:
+	// Set property "PrivateBytesInKB":
 	if triggers.PrivateBytesInKB != nil {
 		privateBytesInKB := *triggers.PrivateBytesInKB
 		result.PrivateBytesInKB = &privateBytesInKB
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if triggers.Requests != nil {
 		requests_ARM, err := (*triggers.Requests).ConvertToARM(resolved)
 		if err != nil {
@@ -13550,7 +13550,7 @@ func (triggers *AutoHealTriggers) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Requests = &requests
 	}
 
-	// Set property ‘SlowRequests’:
+	// Set property "SlowRequests":
 	if triggers.SlowRequests != nil {
 		slowRequests_ARM, err := (*triggers.SlowRequests).ConvertToARM(resolved)
 		if err != nil {
@@ -13560,7 +13560,7 @@ func (triggers *AutoHealTriggers) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.SlowRequests = &slowRequests
 	}
 
-	// Set property ‘SlowRequestsWithPath’:
+	// Set property "SlowRequestsWithPath":
 	for _, item := range triggers.SlowRequestsWithPath {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -13569,7 +13569,7 @@ func (triggers *AutoHealTriggers) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.SlowRequestsWithPath = append(result.SlowRequestsWithPath, *item_ARM.(*SlowRequestsBasedTrigger_ARM))
 	}
 
-	// Set property ‘StatusCodes’:
+	// Set property "StatusCodes":
 	for _, item := range triggers.StatusCodes {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -13578,7 +13578,7 @@ func (triggers *AutoHealTriggers) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.StatusCodes = append(result.StatusCodes, *item_ARM.(*StatusCodesBasedTrigger_ARM))
 	}
 
-	// Set property ‘StatusCodesRange’:
+	// Set property "StatusCodesRange":
 	for _, item := range triggers.StatusCodesRange {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -13601,13 +13601,13 @@ func (triggers *AutoHealTriggers) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealTriggers_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrivateBytesInKB’:
+	// Set property "PrivateBytesInKB":
 	if typedInput.PrivateBytesInKB != nil {
 		privateBytesInKB := *typedInput.PrivateBytesInKB
 		triggers.PrivateBytesInKB = &privateBytesInKB
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if typedInput.Requests != nil {
 		var requests1 RequestsBasedTrigger
 		err := requests1.PopulateFromARM(owner, *typedInput.Requests)
@@ -13618,7 +13618,7 @@ func (triggers *AutoHealTriggers) PopulateFromARM(owner genruntime.ArbitraryOwne
 		triggers.Requests = &requests
 	}
 
-	// Set property ‘SlowRequests’:
+	// Set property "SlowRequests":
 	if typedInput.SlowRequests != nil {
 		var slowRequests1 SlowRequestsBasedTrigger
 		err := slowRequests1.PopulateFromARM(owner, *typedInput.SlowRequests)
@@ -13629,7 +13629,7 @@ func (triggers *AutoHealTriggers) PopulateFromARM(owner genruntime.ArbitraryOwne
 		triggers.SlowRequests = &slowRequests
 	}
 
-	// Set property ‘SlowRequestsWithPath’:
+	// Set property "SlowRequestsWithPath":
 	for _, item := range typedInput.SlowRequestsWithPath {
 		var item1 SlowRequestsBasedTrigger
 		err := item1.PopulateFromARM(owner, item)
@@ -13639,7 +13639,7 @@ func (triggers *AutoHealTriggers) PopulateFromARM(owner genruntime.ArbitraryOwne
 		triggers.SlowRequestsWithPath = append(triggers.SlowRequestsWithPath, item1)
 	}
 
-	// Set property ‘StatusCodes’:
+	// Set property "StatusCodes":
 	for _, item := range typedInput.StatusCodes {
 		var item1 StatusCodesBasedTrigger
 		err := item1.PopulateFromARM(owner, item)
@@ -13649,7 +13649,7 @@ func (triggers *AutoHealTriggers) PopulateFromARM(owner genruntime.ArbitraryOwne
 		triggers.StatusCodes = append(triggers.StatusCodes, item1)
 	}
 
-	// Set property ‘StatusCodesRange’:
+	// Set property "StatusCodesRange":
 	for _, item := range typedInput.StatusCodesRange {
 		var item1 StatusCodesRangeBasedTrigger
 		err := item1.PopulateFromARM(owner, item)
@@ -13971,13 +13971,13 @@ func (triggers *AutoHealTriggers_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealTriggers_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrivateBytesInKB’:
+	// Set property "PrivateBytesInKB":
 	if typedInput.PrivateBytesInKB != nil {
 		privateBytesInKB := *typedInput.PrivateBytesInKB
 		triggers.PrivateBytesInKB = &privateBytesInKB
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if typedInput.Requests != nil {
 		var requests1 RequestsBasedTrigger_STATUS
 		err := requests1.PopulateFromARM(owner, *typedInput.Requests)
@@ -13988,7 +13988,7 @@ func (triggers *AutoHealTriggers_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		triggers.Requests = &requests
 	}
 
-	// Set property ‘SlowRequests’:
+	// Set property "SlowRequests":
 	if typedInput.SlowRequests != nil {
 		var slowRequests1 SlowRequestsBasedTrigger_STATUS
 		err := slowRequests1.PopulateFromARM(owner, *typedInput.SlowRequests)
@@ -13999,7 +13999,7 @@ func (triggers *AutoHealTriggers_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		triggers.SlowRequests = &slowRequests
 	}
 
-	// Set property ‘SlowRequestsWithPath’:
+	// Set property "SlowRequestsWithPath":
 	for _, item := range typedInput.SlowRequestsWithPath {
 		var item1 SlowRequestsBasedTrigger_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -14009,7 +14009,7 @@ func (triggers *AutoHealTriggers_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		triggers.SlowRequestsWithPath = append(triggers.SlowRequestsWithPath, item1)
 	}
 
-	// Set property ‘StatusCodes’:
+	// Set property "StatusCodes":
 	for _, item := range typedInput.StatusCodes {
 		var item1 StatusCodesBasedTrigger_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -14019,7 +14019,7 @@ func (triggers *AutoHealTriggers_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		triggers.StatusCodes = append(triggers.StatusCodes, item1)
 	}
 
-	// Set property ‘StatusCodesRange’:
+	// Set property "StatusCodesRange":
 	for _, item := range typedInput.StatusCodesRange {
 		var item1 StatusCodesRangeBasedTrigger_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -14337,49 +14337,49 @@ func (rule *RampUpRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &RampUpRule_ARM{}
 
-	// Set property ‘ActionHostName’:
+	// Set property "ActionHostName":
 	if rule.ActionHostName != nil {
 		actionHostName := *rule.ActionHostName
 		result.ActionHostName = &actionHostName
 	}
 
-	// Set property ‘ChangeDecisionCallbackUrl’:
+	// Set property "ChangeDecisionCallbackUrl":
 	if rule.ChangeDecisionCallbackUrl != nil {
 		changeDecisionCallbackUrl := *rule.ChangeDecisionCallbackUrl
 		result.ChangeDecisionCallbackUrl = &changeDecisionCallbackUrl
 	}
 
-	// Set property ‘ChangeIntervalInMinutes’:
+	// Set property "ChangeIntervalInMinutes":
 	if rule.ChangeIntervalInMinutes != nil {
 		changeIntervalInMinutes := *rule.ChangeIntervalInMinutes
 		result.ChangeIntervalInMinutes = &changeIntervalInMinutes
 	}
 
-	// Set property ‘ChangeStep’:
+	// Set property "ChangeStep":
 	if rule.ChangeStep != nil {
 		changeStep := *rule.ChangeStep
 		result.ChangeStep = &changeStep
 	}
 
-	// Set property ‘MaxReroutePercentage’:
+	// Set property "MaxReroutePercentage":
 	if rule.MaxReroutePercentage != nil {
 		maxReroutePercentage := *rule.MaxReroutePercentage
 		result.MaxReroutePercentage = &maxReroutePercentage
 	}
 
-	// Set property ‘MinReroutePercentage’:
+	// Set property "MinReroutePercentage":
 	if rule.MinReroutePercentage != nil {
 		minReroutePercentage := *rule.MinReroutePercentage
 		result.MinReroutePercentage = &minReroutePercentage
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if rule.Name != nil {
 		name := *rule.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ReroutePercentage’:
+	// Set property "ReroutePercentage":
 	if rule.ReroutePercentage != nil {
 		reroutePercentage := *rule.ReroutePercentage
 		result.ReroutePercentage = &reroutePercentage
@@ -14399,49 +14399,49 @@ func (rule *RampUpRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RampUpRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionHostName’:
+	// Set property "ActionHostName":
 	if typedInput.ActionHostName != nil {
 		actionHostName := *typedInput.ActionHostName
 		rule.ActionHostName = &actionHostName
 	}
 
-	// Set property ‘ChangeDecisionCallbackUrl’:
+	// Set property "ChangeDecisionCallbackUrl":
 	if typedInput.ChangeDecisionCallbackUrl != nil {
 		changeDecisionCallbackUrl := *typedInput.ChangeDecisionCallbackUrl
 		rule.ChangeDecisionCallbackUrl = &changeDecisionCallbackUrl
 	}
 
-	// Set property ‘ChangeIntervalInMinutes’:
+	// Set property "ChangeIntervalInMinutes":
 	if typedInput.ChangeIntervalInMinutes != nil {
 		changeIntervalInMinutes := *typedInput.ChangeIntervalInMinutes
 		rule.ChangeIntervalInMinutes = &changeIntervalInMinutes
 	}
 
-	// Set property ‘ChangeStep’:
+	// Set property "ChangeStep":
 	if typedInput.ChangeStep != nil {
 		changeStep := *typedInput.ChangeStep
 		rule.ChangeStep = &changeStep
 	}
 
-	// Set property ‘MaxReroutePercentage’:
+	// Set property "MaxReroutePercentage":
 	if typedInput.MaxReroutePercentage != nil {
 		maxReroutePercentage := *typedInput.MaxReroutePercentage
 		rule.MaxReroutePercentage = &maxReroutePercentage
 	}
 
-	// Set property ‘MinReroutePercentage’:
+	// Set property "MinReroutePercentage":
 	if typedInput.MinReroutePercentage != nil {
 		minReroutePercentage := *typedInput.MinReroutePercentage
 		rule.MinReroutePercentage = &minReroutePercentage
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘ReroutePercentage’:
+	// Set property "ReroutePercentage":
 	if typedInput.ReroutePercentage != nil {
 		reroutePercentage := *typedInput.ReroutePercentage
 		rule.ReroutePercentage = &reroutePercentage
@@ -14663,49 +14663,49 @@ func (rule *RampUpRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RampUpRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionHostName’:
+	// Set property "ActionHostName":
 	if typedInput.ActionHostName != nil {
 		actionHostName := *typedInput.ActionHostName
 		rule.ActionHostName = &actionHostName
 	}
 
-	// Set property ‘ChangeDecisionCallbackUrl’:
+	// Set property "ChangeDecisionCallbackUrl":
 	if typedInput.ChangeDecisionCallbackUrl != nil {
 		changeDecisionCallbackUrl := *typedInput.ChangeDecisionCallbackUrl
 		rule.ChangeDecisionCallbackUrl = &changeDecisionCallbackUrl
 	}
 
-	// Set property ‘ChangeIntervalInMinutes’:
+	// Set property "ChangeIntervalInMinutes":
 	if typedInput.ChangeIntervalInMinutes != nil {
 		changeIntervalInMinutes := *typedInput.ChangeIntervalInMinutes
 		rule.ChangeIntervalInMinutes = &changeIntervalInMinutes
 	}
 
-	// Set property ‘ChangeStep’:
+	// Set property "ChangeStep":
 	if typedInput.ChangeStep != nil {
 		changeStep := *typedInput.ChangeStep
 		rule.ChangeStep = &changeStep
 	}
 
-	// Set property ‘MaxReroutePercentage’:
+	// Set property "MaxReroutePercentage":
 	if typedInput.MaxReroutePercentage != nil {
 		maxReroutePercentage := *typedInput.MaxReroutePercentage
 		rule.MaxReroutePercentage = &maxReroutePercentage
 	}
 
-	// Set property ‘MinReroutePercentage’:
+	// Set property "MinReroutePercentage":
 	if typedInput.MinReroutePercentage != nil {
 		minReroutePercentage := *typedInput.MinReroutePercentage
 		rule.MinReroutePercentage = &minReroutePercentage
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘ReroutePercentage’:
+	// Set property "ReroutePercentage":
 	if typedInput.ReroutePercentage != nil {
 		reroutePercentage := *typedInput.ReroutePercentage
 		rule.ReroutePercentage = &reroutePercentage
@@ -14844,13 +14844,13 @@ func (directory *VirtualDirectory) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &VirtualDirectory_ARM{}
 
-	// Set property ‘PhysicalPath’:
+	// Set property "PhysicalPath":
 	if directory.PhysicalPath != nil {
 		physicalPath := *directory.PhysicalPath
 		result.PhysicalPath = &physicalPath
 	}
 
-	// Set property ‘VirtualPath’:
+	// Set property "VirtualPath":
 	if directory.VirtualPath != nil {
 		virtualPath := *directory.VirtualPath
 		result.VirtualPath = &virtualPath
@@ -14870,13 +14870,13 @@ func (directory *VirtualDirectory) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualDirectory_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PhysicalPath’:
+	// Set property "PhysicalPath":
 	if typedInput.PhysicalPath != nil {
 		physicalPath := *typedInput.PhysicalPath
 		directory.PhysicalPath = &physicalPath
 	}
 
-	// Set property ‘VirtualPath’:
+	// Set property "VirtualPath":
 	if typedInput.VirtualPath != nil {
 		virtualPath := *typedInput.VirtualPath
 		directory.VirtualPath = &virtualPath
@@ -14957,13 +14957,13 @@ func (directory *VirtualDirectory_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualDirectory_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PhysicalPath’:
+	// Set property "PhysicalPath":
 	if typedInput.PhysicalPath != nil {
 		physicalPath := *typedInput.PhysicalPath
 		directory.PhysicalPath = &physicalPath
 	}
 
-	// Set property ‘VirtualPath’:
+	// Set property "VirtualPath":
 	if typedInput.VirtualPath != nil {
 		virtualPath := *typedInput.VirtualPath
 		directory.VirtualPath = &virtualPath
@@ -15044,13 +15044,13 @@ func (action *AutoHealCustomAction) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &AutoHealCustomAction_ARM{}
 
-	// Set property ‘Exe’:
+	// Set property "Exe":
 	if action.Exe != nil {
 		exe := *action.Exe
 		result.Exe = &exe
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters := *action.Parameters
 		result.Parameters = &parameters
@@ -15070,13 +15070,13 @@ func (action *AutoHealCustomAction) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealCustomAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Exe’:
+	// Set property "Exe":
 	if typedInput.Exe != nil {
 		exe := *typedInput.Exe
 		action.Exe = &exe
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		parameters := *typedInput.Parameters
 		action.Parameters = &parameters
@@ -15158,13 +15158,13 @@ func (action *AutoHealCustomAction_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealCustomAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Exe’:
+	// Set property "Exe":
 	if typedInput.Exe != nil {
 		exe := *typedInput.Exe
 		action.Exe = &exe
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		parameters := *typedInput.Parameters
 		action.Parameters = &parameters
@@ -15227,13 +15227,13 @@ func (trigger *RequestsBasedTrigger) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &RequestsBasedTrigger_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if trigger.Count != nil {
 		count := *trigger.Count
 		result.Count = &count
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if trigger.TimeInterval != nil {
 		timeInterval := *trigger.TimeInterval
 		result.TimeInterval = &timeInterval
@@ -15253,13 +15253,13 @@ func (trigger *RequestsBasedTrigger) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestsBasedTrigger_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
@@ -15340,13 +15340,13 @@ func (trigger *RequestsBasedTrigger_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestsBasedTrigger_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
@@ -15415,25 +15415,25 @@ func (trigger *SlowRequestsBasedTrigger) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &SlowRequestsBasedTrigger_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if trigger.Count != nil {
 		count := *trigger.Count
 		result.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if trigger.Path != nil {
 		path := *trigger.Path
 		result.Path = &path
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if trigger.TimeInterval != nil {
 		timeInterval := *trigger.TimeInterval
 		result.TimeInterval = &timeInterval
 	}
 
-	// Set property ‘TimeTaken’:
+	// Set property "TimeTaken":
 	if trigger.TimeTaken != nil {
 		timeTaken := *trigger.TimeTaken
 		result.TimeTaken = &timeTaken
@@ -15453,25 +15453,25 @@ func (trigger *SlowRequestsBasedTrigger) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SlowRequestsBasedTrigger_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		trigger.Path = &path
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
 	}
 
-	// Set property ‘TimeTaken’:
+	// Set property "TimeTaken":
 	if typedInput.TimeTaken != nil {
 		timeTaken := *typedInput.TimeTaken
 		trigger.TimeTaken = &timeTaken
@@ -15576,25 +15576,25 @@ func (trigger *SlowRequestsBasedTrigger_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SlowRequestsBasedTrigger_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		trigger.Path = &path
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
 	}
 
-	// Set property ‘TimeTaken’:
+	// Set property "TimeTaken":
 	if typedInput.TimeTaken != nil {
 		timeTaken := *typedInput.TimeTaken
 		trigger.TimeTaken = &timeTaken
@@ -15681,37 +15681,37 @@ func (trigger *StatusCodesBasedTrigger) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &StatusCodesBasedTrigger_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if trigger.Count != nil {
 		count := *trigger.Count
 		result.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if trigger.Path != nil {
 		path := *trigger.Path
 		result.Path = &path
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if trigger.Status != nil {
 		status := *trigger.Status
 		result.Status = &status
 	}
 
-	// Set property ‘SubStatus’:
+	// Set property "SubStatus":
 	if trigger.SubStatus != nil {
 		subStatus := *trigger.SubStatus
 		result.SubStatus = &subStatus
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if trigger.TimeInterval != nil {
 		timeInterval := *trigger.TimeInterval
 		result.TimeInterval = &timeInterval
 	}
 
-	// Set property ‘Win32Status’:
+	// Set property "Win32Status":
 	if trigger.Win32Status != nil {
 		win32Status := *trigger.Win32Status
 		result.Win32Status = &win32Status
@@ -15731,37 +15731,37 @@ func (trigger *StatusCodesBasedTrigger) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StatusCodesBasedTrigger_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		trigger.Path = &path
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		trigger.Status = &status
 	}
 
-	// Set property ‘SubStatus’:
+	// Set property "SubStatus":
 	if typedInput.SubStatus != nil {
 		subStatus := *typedInput.SubStatus
 		trigger.SubStatus = &subStatus
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
 	}
 
-	// Set property ‘Win32Status’:
+	// Set property "Win32Status":
 	if typedInput.Win32Status != nil {
 		win32Status := *typedInput.Win32Status
 		trigger.Win32Status = &win32Status
@@ -15890,37 +15890,37 @@ func (trigger *StatusCodesBasedTrigger_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StatusCodesBasedTrigger_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		trigger.Path = &path
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		trigger.Status = &status
 	}
 
-	// Set property ‘SubStatus’:
+	// Set property "SubStatus":
 	if typedInput.SubStatus != nil {
 		subStatus := *typedInput.SubStatus
 		trigger.SubStatus = &subStatus
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
 	}
 
-	// Set property ‘Win32Status’:
+	// Set property "Win32Status":
 	if typedInput.Win32Status != nil {
 		win32Status := *typedInput.Win32Status
 		trigger.Win32Status = &win32Status
@@ -16011,25 +16011,25 @@ func (trigger *StatusCodesRangeBasedTrigger) ConvertToARM(resolved genruntime.Co
 	}
 	result := &StatusCodesRangeBasedTrigger_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if trigger.Count != nil {
 		count := *trigger.Count
 		result.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if trigger.Path != nil {
 		path := *trigger.Path
 		result.Path = &path
 	}
 
-	// Set property ‘StatusCodes’:
+	// Set property "StatusCodes":
 	if trigger.StatusCodes != nil {
 		statusCodes := *trigger.StatusCodes
 		result.StatusCodes = &statusCodes
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if trigger.TimeInterval != nil {
 		timeInterval := *trigger.TimeInterval
 		result.TimeInterval = &timeInterval
@@ -16049,25 +16049,25 @@ func (trigger *StatusCodesRangeBasedTrigger) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StatusCodesRangeBasedTrigger_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		trigger.Path = &path
 	}
 
-	// Set property ‘StatusCodes’:
+	// Set property "StatusCodes":
 	if typedInput.StatusCodes != nil {
 		statusCodes := *typedInput.StatusCodes
 		trigger.StatusCodes = &statusCodes
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
@@ -16170,25 +16170,25 @@ func (trigger *StatusCodesRangeBasedTrigger_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StatusCodesRangeBasedTrigger_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		trigger.Path = &path
 	}
 
-	// Set property ‘StatusCodes’:
+	// Set property "StatusCodes":
 	if typedInput.StatusCodes != nil {
 		statusCodes := *typedInput.StatusCodes
 		trigger.StatusCodes = &statusCodes
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval

--- a/v2/api/web/v1beta20220301/server_farm_types_gen.go
+++ b/v2/api/web/v1beta20220301/server_farm_types_gen.go
@@ -358,7 +358,7 @@ func (serverfarm *Serverfarm_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &Serverfarm_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if serverfarm.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*serverfarm.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -368,22 +368,22 @@ func (serverfarm *Serverfarm_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if serverfarm.Kind != nil {
 		kind := *serverfarm.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if serverfarm.Location != nil {
 		location := *serverfarm.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if serverfarm.ElasticScaleEnabled != nil ||
 		serverfarm.FreeOfferExpirationTime != nil ||
 		serverfarm.HostingEnvironmentProfile != nil ||
@@ -470,7 +470,7 @@ func (serverfarm *Serverfarm_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties.ZoneRedundant = &zoneRedundant
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if serverfarm.Sku != nil {
 		sku_ARM, err := (*serverfarm.Sku).ConvertToARM(resolved)
 		if err != nil {
@@ -480,7 +480,7 @@ func (serverfarm *Serverfarm_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Sku = &sku
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if serverfarm.Tags != nil {
 		result.Tags = make(map[string]string, len(serverfarm.Tags))
 		for key, value := range serverfarm.Tags {
@@ -502,10 +502,10 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Serverfarm_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	serverfarm.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘ElasticScaleEnabled’:
+	// Set property "ElasticScaleEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ElasticScaleEnabled != nil {
@@ -514,7 +514,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -525,7 +525,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		serverfarm.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FreeOfferExpirationTime’:
+	// Set property "FreeOfferExpirationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FreeOfferExpirationTime != nil {
@@ -534,7 +534,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HostingEnvironmentProfile’:
+	// Set property "HostingEnvironmentProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostingEnvironmentProfile != nil {
@@ -548,7 +548,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘HyperV’:
+	// Set property "HyperV":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperV != nil {
@@ -557,7 +557,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘IsSpot’:
+	// Set property "IsSpot":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsSpot != nil {
@@ -566,7 +566,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘IsXenon’:
+	// Set property "IsXenon":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsXenon != nil {
@@ -575,13 +575,13 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		serverfarm.Kind = &kind
 	}
 
-	// Set property ‘KubeEnvironmentProfile’:
+	// Set property "KubeEnvironmentProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeEnvironmentProfile != nil {
@@ -595,13 +595,13 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		serverfarm.Location = &location
 	}
 
-	// Set property ‘MaximumElasticWorkerCount’:
+	// Set property "MaximumElasticWorkerCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaximumElasticWorkerCount != nil {
@@ -610,10 +610,10 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	serverfarm.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PerSiteScaling’:
+	// Set property "PerSiteScaling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PerSiteScaling != nil {
@@ -622,7 +622,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Reserved’:
+	// Set property "Reserved":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Reserved != nil {
@@ -631,7 +631,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 SkuDescription
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -642,7 +642,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		serverfarm.Sku = &sku
 	}
 
-	// Set property ‘SpotExpirationTime’:
+	// Set property "SpotExpirationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotExpirationTime != nil {
@@ -651,7 +651,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		serverfarm.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -659,7 +659,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TargetWorkerCount’:
+	// Set property "TargetWorkerCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetWorkerCount != nil {
@@ -668,7 +668,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘TargetWorkerSizeId’:
+	// Set property "TargetWorkerSizeId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetWorkerSizeId != nil {
@@ -677,7 +677,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘WorkerTierName’:
+	// Set property "WorkerTierName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkerTierName != nil {
@@ -686,7 +686,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -1168,9 +1168,9 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Serverfarm_STATUS_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ElasticScaleEnabled’:
+	// Set property "ElasticScaleEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ElasticScaleEnabled != nil {
@@ -1179,7 +1179,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1190,7 +1190,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		serverfarm.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘FreeOfferExpirationTime’:
+	// Set property "FreeOfferExpirationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FreeOfferExpirationTime != nil {
@@ -1199,7 +1199,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘GeoRegion’:
+	// Set property "GeoRegion":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.GeoRegion != nil {
@@ -1208,7 +1208,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘HostingEnvironmentProfile’:
+	// Set property "HostingEnvironmentProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostingEnvironmentProfile != nil {
@@ -1222,7 +1222,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘HyperV’:
+	// Set property "HyperV":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperV != nil {
@@ -1231,13 +1231,13 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		serverfarm.Id = &id
 	}
 
-	// Set property ‘IsSpot’:
+	// Set property "IsSpot":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsSpot != nil {
@@ -1246,7 +1246,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘IsXenon’:
+	// Set property "IsXenon":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsXenon != nil {
@@ -1255,13 +1255,13 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		serverfarm.Kind = &kind
 	}
 
-	// Set property ‘KubeEnvironmentProfile’:
+	// Set property "KubeEnvironmentProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KubeEnvironmentProfile != nil {
@@ -1275,13 +1275,13 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		serverfarm.Location = &location
 	}
 
-	// Set property ‘MaximumElasticWorkerCount’:
+	// Set property "MaximumElasticWorkerCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaximumElasticWorkerCount != nil {
@@ -1290,7 +1290,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘MaximumNumberOfWorkers’:
+	// Set property "MaximumNumberOfWorkers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaximumNumberOfWorkers != nil {
@@ -1299,13 +1299,13 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		serverfarm.Name = &name
 	}
 
-	// Set property ‘NumberOfSites’:
+	// Set property "NumberOfSites":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfSites != nil {
@@ -1314,7 +1314,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘NumberOfWorkers’:
+	// Set property "NumberOfWorkers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.NumberOfWorkers != nil {
@@ -1323,7 +1323,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘PerSiteScaling’:
+	// Set property "PerSiteScaling":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PerSiteScaling != nil {
@@ -1332,7 +1332,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ProvisioningState’:
+	// Set property "ProvisioningState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ProvisioningState != nil {
@@ -1341,7 +1341,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Reserved’:
+	// Set property "Reserved":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Reserved != nil {
@@ -1350,7 +1350,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGroup != nil {
@@ -1359,7 +1359,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Sku’:
+	// Set property "Sku":
 	if typedInput.Sku != nil {
 		var sku1 SkuDescription_STATUS
 		err := sku1.PopulateFromARM(owner, *typedInput.Sku)
@@ -1370,7 +1370,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		serverfarm.Sku = &sku
 	}
 
-	// Set property ‘SpotExpirationTime’:
+	// Set property "SpotExpirationTime":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SpotExpirationTime != nil {
@@ -1379,7 +1379,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Status != nil {
@@ -1388,7 +1388,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Subscription’:
+	// Set property "Subscription":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Subscription != nil {
@@ -1397,7 +1397,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		serverfarm.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -1405,7 +1405,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TargetWorkerCount’:
+	// Set property "TargetWorkerCount":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetWorkerCount != nil {
@@ -1414,7 +1414,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TargetWorkerSizeId’:
+	// Set property "TargetWorkerSizeId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetWorkerSizeId != nil {
@@ -1423,13 +1423,13 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		serverfarm.Type = &typeVar
 	}
 
-	// Set property ‘WorkerTierName’:
+	// Set property "WorkerTierName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.WorkerTierName != nil {
@@ -1438,7 +1438,7 @@ func (serverfarm *Serverfarm_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘ZoneRedundant’:
+	// Set property "ZoneRedundant":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ZoneRedundant != nil {
@@ -1842,7 +1842,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &ExtendedLocation_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if location.Name != nil {
 		name := *location.Name
 		result.Name = &name
@@ -1862,7 +1862,7 @@ func (location *ExtendedLocation) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
@@ -1921,13 +1921,13 @@ func (location *ExtendedLocation_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ExtendedLocation_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		location.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		location.Type = &typeVar
@@ -1986,7 +1986,7 @@ func (profile *HostingEnvironmentProfile) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &HostingEnvironmentProfile_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if profile.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.Reference)
 		if err != nil {
@@ -2010,7 +2010,7 @@ func (profile *HostingEnvironmentProfile) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HostingEnvironmentProfile_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2076,19 +2076,19 @@ func (profile *HostingEnvironmentProfile_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HostingEnvironmentProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		profile.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
@@ -2153,7 +2153,7 @@ func (profile *KubeEnvironmentProfile) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &KubeEnvironmentProfile_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if profile.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*profile.Reference)
 		if err != nil {
@@ -2177,7 +2177,7 @@ func (profile *KubeEnvironmentProfile) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubeEnvironmentProfile_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -2243,19 +2243,19 @@ func (profile *KubeEnvironmentProfile_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected KubeEnvironmentProfile_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		profile.Id = &id
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		profile.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		profile.Type = &typeVar
@@ -2348,7 +2348,7 @@ func (description *SkuDescription) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &SkuDescription_ARM{}
 
-	// Set property ‘Capabilities’:
+	// Set property "Capabilities":
 	for _, item := range description.Capabilities {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -2357,36 +2357,36 @@ func (description *SkuDescription) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Capabilities = append(result.Capabilities, *item_ARM.(*Capability_ARM))
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if description.Capacity != nil {
 		capacity := *description.Capacity
 		result.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if description.Family != nil {
 		family := *description.Family
 		result.Family = &family
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	for _, item := range description.Locations {
 		result.Locations = append(result.Locations, item)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if description.Name != nil {
 		name := *description.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if description.Size != nil {
 		size := *description.Size
 		result.Size = &size
 	}
 
-	// Set property ‘SkuCapacity’:
+	// Set property "SkuCapacity":
 	if description.SkuCapacity != nil {
 		skuCapacity_ARM, err := (*description.SkuCapacity).ConvertToARM(resolved)
 		if err != nil {
@@ -2396,7 +2396,7 @@ func (description *SkuDescription) ConvertToARM(resolved genruntime.ConvertToARM
 		result.SkuCapacity = &skuCapacity
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if description.Tier != nil {
 		tier := *description.Tier
 		result.Tier = &tier
@@ -2416,7 +2416,7 @@ func (description *SkuDescription) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SkuDescription_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capabilities’:
+	// Set property "Capabilities":
 	for _, item := range typedInput.Capabilities {
 		var item1 Capability
 		err := item1.PopulateFromARM(owner, item)
@@ -2426,36 +2426,36 @@ func (description *SkuDescription) PopulateFromARM(owner genruntime.ArbitraryOwn
 		description.Capabilities = append(description.Capabilities, item1)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		description.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		description.Family = &family
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	for _, item := range typedInput.Locations {
 		description.Locations = append(description.Locations, item)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		description.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if typedInput.Size != nil {
 		size := *typedInput.Size
 		description.Size = &size
 	}
 
-	// Set property ‘SkuCapacity’:
+	// Set property "SkuCapacity":
 	if typedInput.SkuCapacity != nil {
 		var skuCapacity1 SkuCapacity
 		err := skuCapacity1.PopulateFromARM(owner, *typedInput.SkuCapacity)
@@ -2466,7 +2466,7 @@ func (description *SkuDescription) PopulateFromARM(owner genruntime.ArbitraryOwn
 		description.SkuCapacity = &skuCapacity
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		description.Tier = &tier
@@ -2621,7 +2621,7 @@ func (description *SkuDescription_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SkuDescription_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Capabilities’:
+	// Set property "Capabilities":
 	for _, item := range typedInput.Capabilities {
 		var item1 Capability_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -2631,36 +2631,36 @@ func (description *SkuDescription_STATUS) PopulateFromARM(owner genruntime.Arbit
 		description.Capabilities = append(description.Capabilities, item1)
 	}
 
-	// Set property ‘Capacity’:
+	// Set property "Capacity":
 	if typedInput.Capacity != nil {
 		capacity := *typedInput.Capacity
 		description.Capacity = &capacity
 	}
 
-	// Set property ‘Family’:
+	// Set property "Family":
 	if typedInput.Family != nil {
 		family := *typedInput.Family
 		description.Family = &family
 	}
 
-	// Set property ‘Locations’:
+	// Set property "Locations":
 	for _, item := range typedInput.Locations {
 		description.Locations = append(description.Locations, item)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		description.Name = &name
 	}
 
-	// Set property ‘Size’:
+	// Set property "Size":
 	if typedInput.Size != nil {
 		size := *typedInput.Size
 		description.Size = &size
 	}
 
-	// Set property ‘SkuCapacity’:
+	// Set property "SkuCapacity":
 	if typedInput.SkuCapacity != nil {
 		var skuCapacity1 SkuCapacity_STATUS
 		err := skuCapacity1.PopulateFromARM(owner, *typedInput.SkuCapacity)
@@ -2671,7 +2671,7 @@ func (description *SkuDescription_STATUS) PopulateFromARM(owner genruntime.Arbit
 		description.SkuCapacity = &skuCapacity
 	}
 
-	// Set property ‘Tier’:
+	// Set property "Tier":
 	if typedInput.Tier != nil {
 		tier := *typedInput.Tier
 		description.Tier = &tier
@@ -2816,19 +2816,19 @@ func (capability *Capability) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &Capability_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if capability.Name != nil {
 		name := *capability.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Reason’:
+	// Set property "Reason":
 	if capability.Reason != nil {
 		reason := *capability.Reason
 		result.Reason = &reason
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if capability.Value != nil {
 		value := *capability.Value
 		result.Value = &value
@@ -2848,19 +2848,19 @@ func (capability *Capability) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Capability_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		capability.Name = &name
 	}
 
-	// Set property ‘Reason’:
+	// Set property "Reason":
 	if typedInput.Reason != nil {
 		reason := *typedInput.Reason
 		capability.Reason = &reason
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		capability.Value = &value
@@ -2932,19 +2932,19 @@ func (capability *Capability_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Capability_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		capability.Name = &name
 	}
 
-	// Set property ‘Reason’:
+	// Set property "Reason":
 	if typedInput.Reason != nil {
 		reason := *typedInput.Reason
 		capability.Reason = &reason
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		capability.Value = &value
@@ -3013,31 +3013,31 @@ func (capacity *SkuCapacity) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	}
 	result := &SkuCapacity_ARM{}
 
-	// Set property ‘Default’:
+	// Set property "Default":
 	if capacity.Default != nil {
 		def := *capacity.Default
 		result.Default = &def
 	}
 
-	// Set property ‘ElasticMaximum’:
+	// Set property "ElasticMaximum":
 	if capacity.ElasticMaximum != nil {
 		elasticMaximum := *capacity.ElasticMaximum
 		result.ElasticMaximum = &elasticMaximum
 	}
 
-	// Set property ‘Maximum’:
+	// Set property "Maximum":
 	if capacity.Maximum != nil {
 		maximum := *capacity.Maximum
 		result.Maximum = &maximum
 	}
 
-	// Set property ‘Minimum’:
+	// Set property "Minimum":
 	if capacity.Minimum != nil {
 		minimum := *capacity.Minimum
 		result.Minimum = &minimum
 	}
 
-	// Set property ‘ScaleType’:
+	// Set property "ScaleType":
 	if capacity.ScaleType != nil {
 		scaleType := *capacity.ScaleType
 		result.ScaleType = &scaleType
@@ -3057,31 +3057,31 @@ func (capacity *SkuCapacity) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SkuCapacity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Default’:
+	// Set property "Default":
 	if typedInput.Default != nil {
 		def := *typedInput.Default
 		capacity.Default = &def
 	}
 
-	// Set property ‘ElasticMaximum’:
+	// Set property "ElasticMaximum":
 	if typedInput.ElasticMaximum != nil {
 		elasticMaximum := *typedInput.ElasticMaximum
 		capacity.ElasticMaximum = &elasticMaximum
 	}
 
-	// Set property ‘Maximum’:
+	// Set property "Maximum":
 	if typedInput.Maximum != nil {
 		maximum := *typedInput.Maximum
 		capacity.Maximum = &maximum
 	}
 
-	// Set property ‘Minimum’:
+	// Set property "Minimum":
 	if typedInput.Minimum != nil {
 		minimum := *typedInput.Minimum
 		capacity.Minimum = &minimum
 	}
 
-	// Set property ‘ScaleType’:
+	// Set property "ScaleType":
 	if typedInput.ScaleType != nil {
 		scaleType := *typedInput.ScaleType
 		capacity.ScaleType = &scaleType
@@ -3167,31 +3167,31 @@ func (capacity *SkuCapacity_STATUS) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SkuCapacity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Default’:
+	// Set property "Default":
 	if typedInput.Default != nil {
 		def := *typedInput.Default
 		capacity.Default = &def
 	}
 
-	// Set property ‘ElasticMaximum’:
+	// Set property "ElasticMaximum":
 	if typedInput.ElasticMaximum != nil {
 		elasticMaximum := *typedInput.ElasticMaximum
 		capacity.ElasticMaximum = &elasticMaximum
 	}
 
-	// Set property ‘Maximum’:
+	// Set property "Maximum":
 	if typedInput.Maximum != nil {
 		maximum := *typedInput.Maximum
 		capacity.Maximum = &maximum
 	}
 
-	// Set property ‘Minimum’:
+	// Set property "Minimum":
 	if typedInput.Minimum != nil {
 		minimum := *typedInput.Minimum
 		capacity.Minimum = &minimum
 	}
 
-	// Set property ‘ScaleType’:
+	// Set property "ScaleType":
 	if typedInput.ScaleType != nil {
 		scaleType := *typedInput.ScaleType
 		capacity.ScaleType = &scaleType

--- a/v2/api/web/v1beta20220301/site_types_gen.go
+++ b/v2/api/web/v1beta20220301/site_types_gen.go
@@ -364,7 +364,7 @@ func (site *Site_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 	}
 	result := &Site_Spec_ARM{}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if site.ExtendedLocation != nil {
 		extendedLocation_ARM, err := (*site.ExtendedLocation).ConvertToARM(resolved)
 		if err != nil {
@@ -374,7 +374,7 @@ func (site *Site_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if site.Identity != nil {
 		identity_ARM, err := (*site.Identity).ConvertToARM(resolved)
 		if err != nil {
@@ -384,22 +384,22 @@ func (site *Site_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Identity = &identity
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if site.Kind != nil {
 		kind := *site.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if site.Location != nil {
 		location := *site.Location
 		result.Location = &location
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if site.ClientAffinityEnabled != nil ||
 		site.ClientCertEnabled != nil ||
 		site.ClientCertExclusionPaths != nil ||
@@ -561,7 +561,7 @@ func (site *Site_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDeta
 		result.Properties.VnetRouteAllEnabled = &vnetRouteAllEnabled
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if site.Tags != nil {
 		result.Tags = make(map[string]string, len(site.Tags))
 		for key, value := range site.Tags {
@@ -583,10 +583,10 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Site_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	site.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘ClientAffinityEnabled’:
+	// Set property "ClientAffinityEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientAffinityEnabled != nil {
@@ -595,7 +595,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ClientCertEnabled’:
+	// Set property "ClientCertEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientCertEnabled != nil {
@@ -604,7 +604,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ClientCertExclusionPaths’:
+	// Set property "ClientCertExclusionPaths":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientCertExclusionPaths != nil {
@@ -613,7 +613,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ClientCertMode’:
+	// Set property "ClientCertMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientCertMode != nil {
@@ -622,7 +622,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘CloningInfo’:
+	// Set property "CloningInfo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CloningInfo != nil {
@@ -636,7 +636,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ContainerSize’:
+	// Set property "ContainerSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ContainerSize != nil {
@@ -645,7 +645,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘CustomDomainVerificationId’:
+	// Set property "CustomDomainVerificationId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomDomainVerificationId != nil {
@@ -654,7 +654,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘DailyMemoryTimeQuota’:
+	// Set property "DailyMemoryTimeQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DailyMemoryTimeQuota != nil {
@@ -663,7 +663,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Enabled != nil {
@@ -672,7 +672,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -683,7 +683,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		site.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostNameSslStates’:
+	// Set property "HostNameSslStates":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.HostNameSslStates {
@@ -696,7 +696,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘HostNamesDisabled’:
+	// Set property "HostNamesDisabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostNamesDisabled != nil {
@@ -705,7 +705,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘HostingEnvironmentProfile’:
+	// Set property "HostingEnvironmentProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostingEnvironmentProfile != nil {
@@ -719,7 +719,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘HttpsOnly’:
+	// Set property "HttpsOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpsOnly != nil {
@@ -728,7 +728,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘HyperV’:
+	// Set property "HyperV":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperV != nil {
@@ -737,7 +737,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedServiceIdentity
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -748,7 +748,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		site.Identity = &identity
 	}
 
-	// Set property ‘IsXenon’:
+	// Set property "IsXenon":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsXenon != nil {
@@ -757,7 +757,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘KeyVaultReferenceIdentity’:
+	// Set property "KeyVaultReferenceIdentity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVaultReferenceIdentity != nil {
@@ -766,22 +766,22 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		site.Kind = &kind
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		site.Location = &location
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	site.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -790,7 +790,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘RedundancyMode’:
+	// Set property "RedundancyMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedundancyMode != nil {
@@ -799,7 +799,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Reserved’:
+	// Set property "Reserved":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Reserved != nil {
@@ -808,7 +808,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘ScmSiteAlsoStopped’:
+	// Set property "ScmSiteAlsoStopped":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScmSiteAlsoStopped != nil {
@@ -817,9 +817,9 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// no assignment for property ‘ServerFarmReference’
+	// no assignment for property "ServerFarmReference"
 
-	// Set property ‘SiteConfig’:
+	// Set property "SiteConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SiteConfig != nil {
@@ -833,7 +833,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘StorageAccountRequired’:
+	// Set property "StorageAccountRequired":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageAccountRequired != nil {
@@ -842,7 +842,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		site.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -850,9 +850,9 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// no assignment for property ‘VirtualNetworkSubnetReference’
+	// no assignment for property "VirtualNetworkSubnetReference"
 
-	// Set property ‘VnetContentShareEnabled’:
+	// Set property "VnetContentShareEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetContentShareEnabled != nil {
@@ -861,7 +861,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘VnetImagePullEnabled’:
+	// Set property "VnetImagePullEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetImagePullEnabled != nil {
@@ -870,7 +870,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 		}
 	}
 
-	// Set property ‘VnetRouteAllEnabled’:
+	// Set property "VnetRouteAllEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetRouteAllEnabled != nil {
@@ -1595,7 +1595,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Site_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AvailabilityState’:
+	// Set property "AvailabilityState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.AvailabilityState != nil {
@@ -1604,7 +1604,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ClientAffinityEnabled’:
+	// Set property "ClientAffinityEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientAffinityEnabled != nil {
@@ -1613,7 +1613,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ClientCertEnabled’:
+	// Set property "ClientCertEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientCertEnabled != nil {
@@ -1622,7 +1622,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ClientCertExclusionPaths’:
+	// Set property "ClientCertExclusionPaths":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientCertExclusionPaths != nil {
@@ -1631,7 +1631,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ClientCertMode’:
+	// Set property "ClientCertMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ClientCertMode != nil {
@@ -1640,7 +1640,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘CloningInfo’:
+	// Set property "CloningInfo":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CloningInfo != nil {
@@ -1654,9 +1654,9 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// no assignment for property ‘Conditions’
+	// no assignment for property "Conditions"
 
-	// Set property ‘ContainerSize’:
+	// Set property "ContainerSize":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ContainerSize != nil {
@@ -1665,7 +1665,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘CustomDomainVerificationId’:
+	// Set property "CustomDomainVerificationId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.CustomDomainVerificationId != nil {
@@ -1674,7 +1674,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DailyMemoryTimeQuota’:
+	// Set property "DailyMemoryTimeQuota":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DailyMemoryTimeQuota != nil {
@@ -1683,7 +1683,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘DefaultHostName’:
+	// Set property "DefaultHostName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DefaultHostName != nil {
@@ -1692,7 +1692,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Enabled’:
+	// Set property "Enabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Enabled != nil {
@@ -1701,7 +1701,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘EnabledHostNames’:
+	// Set property "EnabledHostNames":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.EnabledHostNames {
@@ -1709,7 +1709,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ExtendedLocation’:
+	// Set property "ExtendedLocation":
 	if typedInput.ExtendedLocation != nil {
 		var extendedLocation1 ExtendedLocation_STATUS
 		err := extendedLocation1.PopulateFromARM(owner, *typedInput.ExtendedLocation)
@@ -1720,7 +1720,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		site.ExtendedLocation = &extendedLocation
 	}
 
-	// Set property ‘HostNameSslStates’:
+	// Set property "HostNameSslStates":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.HostNameSslStates {
@@ -1733,7 +1733,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘HostNames’:
+	// Set property "HostNames":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.HostNames {
@@ -1741,7 +1741,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘HostNamesDisabled’:
+	// Set property "HostNamesDisabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostNamesDisabled != nil {
@@ -1750,7 +1750,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘HostingEnvironmentProfile’:
+	// Set property "HostingEnvironmentProfile":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HostingEnvironmentProfile != nil {
@@ -1764,7 +1764,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘HttpsOnly’:
+	// Set property "HttpsOnly":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HttpsOnly != nil {
@@ -1773,7 +1773,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘HyperV’:
+	// Set property "HyperV":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.HyperV != nil {
@@ -1782,13 +1782,13 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		site.Id = &id
 	}
 
-	// Set property ‘Identity’:
+	// Set property "Identity":
 	if typedInput.Identity != nil {
 		var identity1 ManagedServiceIdentity_STATUS
 		err := identity1.PopulateFromARM(owner, *typedInput.Identity)
@@ -1799,7 +1799,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		site.Identity = &identity
 	}
 
-	// Set property ‘InProgressOperationId’:
+	// Set property "InProgressOperationId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.InProgressOperationId != nil {
@@ -1808,7 +1808,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘IsDefaultContainer’:
+	// Set property "IsDefaultContainer":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsDefaultContainer != nil {
@@ -1817,7 +1817,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘IsXenon’:
+	// Set property "IsXenon":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsXenon != nil {
@@ -1826,7 +1826,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘KeyVaultReferenceIdentity’:
+	// Set property "KeyVaultReferenceIdentity":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.KeyVaultReferenceIdentity != nil {
@@ -1835,13 +1835,13 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		site.Kind = &kind
 	}
 
-	// Set property ‘LastModifiedTimeUtc’:
+	// Set property "LastModifiedTimeUtc":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.LastModifiedTimeUtc != nil {
@@ -1850,13 +1850,13 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Location’:
+	// Set property "Location":
 	if typedInput.Location != nil {
 		location := *typedInput.Location
 		site.Location = &location
 	}
 
-	// Set property ‘MaxNumberOfWorkers’:
+	// Set property "MaxNumberOfWorkers":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.MaxNumberOfWorkers != nil {
@@ -1865,13 +1865,13 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		site.Name = &name
 	}
 
-	// Set property ‘OutboundIpAddresses’:
+	// Set property "OutboundIpAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OutboundIpAddresses != nil {
@@ -1880,7 +1880,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘PossibleOutboundIpAddresses’:
+	// Set property "PossibleOutboundIpAddresses":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PossibleOutboundIpAddresses != nil {
@@ -1889,7 +1889,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.PublicNetworkAccess != nil {
@@ -1898,7 +1898,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘RedundancyMode’:
+	// Set property "RedundancyMode":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RedundancyMode != nil {
@@ -1907,7 +1907,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘RepositorySiteName’:
+	// Set property "RepositorySiteName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.RepositorySiteName != nil {
@@ -1916,7 +1916,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Reserved’:
+	// Set property "Reserved":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.Reserved != nil {
@@ -1925,7 +1925,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ResourceGroup’:
+	// Set property "ResourceGroup":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ResourceGroup != nil {
@@ -1934,7 +1934,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ScmSiteAlsoStopped’:
+	// Set property "ScmSiteAlsoStopped":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ScmSiteAlsoStopped != nil {
@@ -1943,7 +1943,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘ServerFarmId’:
+	// Set property "ServerFarmId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.ServerFarmId != nil {
@@ -1952,7 +1952,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘SiteConfig’:
+	// Set property "SiteConfig":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SiteConfig != nil {
@@ -1966,7 +1966,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘SlotSwapStatus’:
+	// Set property "SlotSwapStatus":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SlotSwapStatus != nil {
@@ -1980,7 +1980,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.State != nil {
@@ -1989,7 +1989,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘StorageAccountRequired’:
+	// Set property "StorageAccountRequired":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.StorageAccountRequired != nil {
@@ -1998,7 +1998,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘SuspendedTill’:
+	// Set property "SuspendedTill":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.SuspendedTill != nil {
@@ -2007,7 +2007,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Tags’:
+	// Set property "Tags":
 	if typedInput.Tags != nil {
 		site.Tags = make(map[string]string, len(typedInput.Tags))
 		for key, value := range typedInput.Tags {
@@ -2015,7 +2015,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘TargetSwapSlot’:
+	// Set property "TargetSwapSlot":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TargetSwapSlot != nil {
@@ -2024,7 +2024,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘TrafficManagerHostNames’:
+	// Set property "TrafficManagerHostNames":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		for _, item := range typedInput.Properties.TrafficManagerHostNames {
@@ -2032,13 +2032,13 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		site.Type = &typeVar
 	}
 
-	// Set property ‘UsageState’:
+	// Set property "UsageState":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.UsageState != nil {
@@ -2047,7 +2047,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘VirtualNetworkSubnetId’:
+	// Set property "VirtualNetworkSubnetId":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VirtualNetworkSubnetId != nil {
@@ -2056,7 +2056,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘VnetContentShareEnabled’:
+	// Set property "VnetContentShareEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetContentShareEnabled != nil {
@@ -2065,7 +2065,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘VnetImagePullEnabled’:
+	// Set property "VnetImagePullEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetImagePullEnabled != nil {
@@ -2074,7 +2074,7 @@ func (site *Site_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘VnetRouteAllEnabled’:
+	// Set property "VnetRouteAllEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.VnetRouteAllEnabled != nil {
@@ -2780,7 +2780,7 @@ func (info *CloningInfo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	}
 	result := &CloningInfo_ARM{}
 
-	// Set property ‘AppSettingsOverrides’:
+	// Set property "AppSettingsOverrides":
 	if info.AppSettingsOverrides != nil {
 		result.AppSettingsOverrides = make(map[string]string, len(info.AppSettingsOverrides))
 		for key, value := range info.AppSettingsOverrides {
@@ -2788,43 +2788,43 @@ func (info *CloningInfo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		}
 	}
 
-	// Set property ‘CloneCustomHostNames’:
+	// Set property "CloneCustomHostNames":
 	if info.CloneCustomHostNames != nil {
 		cloneCustomHostNames := *info.CloneCustomHostNames
 		result.CloneCustomHostNames = &cloneCustomHostNames
 	}
 
-	// Set property ‘CloneSourceControl’:
+	// Set property "CloneSourceControl":
 	if info.CloneSourceControl != nil {
 		cloneSourceControl := *info.CloneSourceControl
 		result.CloneSourceControl = &cloneSourceControl
 	}
 
-	// Set property ‘ConfigureLoadBalancing’:
+	// Set property "ConfigureLoadBalancing":
 	if info.ConfigureLoadBalancing != nil {
 		configureLoadBalancing := *info.ConfigureLoadBalancing
 		result.ConfigureLoadBalancing = &configureLoadBalancing
 	}
 
-	// Set property ‘CorrelationId’:
+	// Set property "CorrelationId":
 	if info.CorrelationId != nil {
 		correlationId := *info.CorrelationId
 		result.CorrelationId = &correlationId
 	}
 
-	// Set property ‘HostingEnvironment’:
+	// Set property "HostingEnvironment":
 	if info.HostingEnvironment != nil {
 		hostingEnvironment := *info.HostingEnvironment
 		result.HostingEnvironment = &hostingEnvironment
 	}
 
-	// Set property ‘Overwrite’:
+	// Set property "Overwrite":
 	if info.Overwrite != nil {
 		overwrite := *info.Overwrite
 		result.Overwrite = &overwrite
 	}
 
-	// Set property ‘SourceWebAppId’:
+	// Set property "SourceWebAppId":
 	if info.SourceWebAppReference != nil {
 		sourceWebAppReferenceARMID, err := resolved.ResolvedReferences.Lookup(*info.SourceWebAppReference)
 		if err != nil {
@@ -2834,13 +2834,13 @@ func (info *CloningInfo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.SourceWebAppId = &sourceWebAppReference
 	}
 
-	// Set property ‘SourceWebAppLocation’:
+	// Set property "SourceWebAppLocation":
 	if info.SourceWebAppLocation != nil {
 		sourceWebAppLocation := *info.SourceWebAppLocation
 		result.SourceWebAppLocation = &sourceWebAppLocation
 	}
 
-	// Set property ‘TrafficManagerProfileId’:
+	// Set property "TrafficManagerProfileId":
 	if info.TrafficManagerProfileReference != nil {
 		trafficManagerProfileReferenceARMID, err := resolved.ResolvedReferences.Lookup(*info.TrafficManagerProfileReference)
 		if err != nil {
@@ -2850,7 +2850,7 @@ func (info *CloningInfo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		result.TrafficManagerProfileId = &trafficManagerProfileReference
 	}
 
-	// Set property ‘TrafficManagerProfileName’:
+	// Set property "TrafficManagerProfileName":
 	if info.TrafficManagerProfileName != nil {
 		trafficManagerProfileName := *info.TrafficManagerProfileName
 		result.TrafficManagerProfileName = &trafficManagerProfileName
@@ -2870,7 +2870,7 @@ func (info *CloningInfo) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CloningInfo_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AppSettingsOverrides’:
+	// Set property "AppSettingsOverrides":
 	if typedInput.AppSettingsOverrides != nil {
 		info.AppSettingsOverrides = make(map[string]string, len(typedInput.AppSettingsOverrides))
 		for key, value := range typedInput.AppSettingsOverrides {
@@ -2878,57 +2878,57 @@ func (info *CloningInfo) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 		}
 	}
 
-	// Set property ‘CloneCustomHostNames’:
+	// Set property "CloneCustomHostNames":
 	if typedInput.CloneCustomHostNames != nil {
 		cloneCustomHostNames := *typedInput.CloneCustomHostNames
 		info.CloneCustomHostNames = &cloneCustomHostNames
 	}
 
-	// Set property ‘CloneSourceControl’:
+	// Set property "CloneSourceControl":
 	if typedInput.CloneSourceControl != nil {
 		cloneSourceControl := *typedInput.CloneSourceControl
 		info.CloneSourceControl = &cloneSourceControl
 	}
 
-	// Set property ‘ConfigureLoadBalancing’:
+	// Set property "ConfigureLoadBalancing":
 	if typedInput.ConfigureLoadBalancing != nil {
 		configureLoadBalancing := *typedInput.ConfigureLoadBalancing
 		info.ConfigureLoadBalancing = &configureLoadBalancing
 	}
 
-	// Set property ‘CorrelationId’:
+	// Set property "CorrelationId":
 	if typedInput.CorrelationId != nil {
 		correlationId := *typedInput.CorrelationId
 		info.CorrelationId = &correlationId
 	}
 
-	// Set property ‘HostingEnvironment’:
+	// Set property "HostingEnvironment":
 	if typedInput.HostingEnvironment != nil {
 		hostingEnvironment := *typedInput.HostingEnvironment
 		info.HostingEnvironment = &hostingEnvironment
 	}
 
-	// Set property ‘Overwrite’:
+	// Set property "Overwrite":
 	if typedInput.Overwrite != nil {
 		overwrite := *typedInput.Overwrite
 		info.Overwrite = &overwrite
 	}
 
-	// Set property ‘SourceWebAppLocation’:
+	// Set property "SourceWebAppLocation":
 	if typedInput.SourceWebAppLocation != nil {
 		sourceWebAppLocation := *typedInput.SourceWebAppLocation
 		info.SourceWebAppLocation = &sourceWebAppLocation
 	}
 
-	// no assignment for property ‘SourceWebAppReference’
+	// no assignment for property "SourceWebAppReference"
 
-	// Set property ‘TrafficManagerProfileName’:
+	// Set property "TrafficManagerProfileName":
 	if typedInput.TrafficManagerProfileName != nil {
 		trafficManagerProfileName := *typedInput.TrafficManagerProfileName
 		info.TrafficManagerProfileName = &trafficManagerProfileName
 	}
 
-	// no assignment for property ‘TrafficManagerProfileReference’
+	// no assignment for property "TrafficManagerProfileReference"
 
 	// No error
 	return nil
@@ -3122,7 +3122,7 @@ func (info *CloningInfo_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CloningInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AppSettingsOverrides’:
+	// Set property "AppSettingsOverrides":
 	if typedInput.AppSettingsOverrides != nil {
 		info.AppSettingsOverrides = make(map[string]string, len(typedInput.AppSettingsOverrides))
 		for key, value := range typedInput.AppSettingsOverrides {
@@ -3130,61 +3130,61 @@ func (info *CloningInfo_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		}
 	}
 
-	// Set property ‘CloneCustomHostNames’:
+	// Set property "CloneCustomHostNames":
 	if typedInput.CloneCustomHostNames != nil {
 		cloneCustomHostNames := *typedInput.CloneCustomHostNames
 		info.CloneCustomHostNames = &cloneCustomHostNames
 	}
 
-	// Set property ‘CloneSourceControl’:
+	// Set property "CloneSourceControl":
 	if typedInput.CloneSourceControl != nil {
 		cloneSourceControl := *typedInput.CloneSourceControl
 		info.CloneSourceControl = &cloneSourceControl
 	}
 
-	// Set property ‘ConfigureLoadBalancing’:
+	// Set property "ConfigureLoadBalancing":
 	if typedInput.ConfigureLoadBalancing != nil {
 		configureLoadBalancing := *typedInput.ConfigureLoadBalancing
 		info.ConfigureLoadBalancing = &configureLoadBalancing
 	}
 
-	// Set property ‘CorrelationId’:
+	// Set property "CorrelationId":
 	if typedInput.CorrelationId != nil {
 		correlationId := *typedInput.CorrelationId
 		info.CorrelationId = &correlationId
 	}
 
-	// Set property ‘HostingEnvironment’:
+	// Set property "HostingEnvironment":
 	if typedInput.HostingEnvironment != nil {
 		hostingEnvironment := *typedInput.HostingEnvironment
 		info.HostingEnvironment = &hostingEnvironment
 	}
 
-	// Set property ‘Overwrite’:
+	// Set property "Overwrite":
 	if typedInput.Overwrite != nil {
 		overwrite := *typedInput.Overwrite
 		info.Overwrite = &overwrite
 	}
 
-	// Set property ‘SourceWebAppId’:
+	// Set property "SourceWebAppId":
 	if typedInput.SourceWebAppId != nil {
 		sourceWebAppId := *typedInput.SourceWebAppId
 		info.SourceWebAppId = &sourceWebAppId
 	}
 
-	// Set property ‘SourceWebAppLocation’:
+	// Set property "SourceWebAppLocation":
 	if typedInput.SourceWebAppLocation != nil {
 		sourceWebAppLocation := *typedInput.SourceWebAppLocation
 		info.SourceWebAppLocation = &sourceWebAppLocation
 	}
 
-	// Set property ‘TrafficManagerProfileId’:
+	// Set property "TrafficManagerProfileId":
 	if typedInput.TrafficManagerProfileId != nil {
 		trafficManagerProfileId := *typedInput.TrafficManagerProfileId
 		info.TrafficManagerProfileId = &trafficManagerProfileId
 	}
 
-	// Set property ‘TrafficManagerProfileName’:
+	// Set property "TrafficManagerProfileName":
 	if typedInput.TrafficManagerProfileName != nil {
 		trafficManagerProfileName := *typedInput.TrafficManagerProfileName
 		info.TrafficManagerProfileName = &trafficManagerProfileName
@@ -3342,37 +3342,37 @@ func (state *HostNameSslState) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &HostNameSslState_ARM{}
 
-	// Set property ‘HostType’:
+	// Set property "HostType":
 	if state.HostType != nil {
 		hostType := *state.HostType
 		result.HostType = &hostType
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if state.Name != nil {
 		name := *state.Name
 		result.Name = &name
 	}
 
-	// Set property ‘SslState’:
+	// Set property "SslState":
 	if state.SslState != nil {
 		sslState := *state.SslState
 		result.SslState = &sslState
 	}
 
-	// Set property ‘Thumbprint’:
+	// Set property "Thumbprint":
 	if state.Thumbprint != nil {
 		thumbprint := *state.Thumbprint
 		result.Thumbprint = &thumbprint
 	}
 
-	// Set property ‘ToUpdate’:
+	// Set property "ToUpdate":
 	if state.ToUpdate != nil {
 		toUpdate := *state.ToUpdate
 		result.ToUpdate = &toUpdate
 	}
 
-	// Set property ‘VirtualIP’:
+	// Set property "VirtualIP":
 	if state.VirtualIP != nil {
 		virtualIP := *state.VirtualIP
 		result.VirtualIP = &virtualIP
@@ -3392,37 +3392,37 @@ func (state *HostNameSslState) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HostNameSslState_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HostType’:
+	// Set property "HostType":
 	if typedInput.HostType != nil {
 		hostType := *typedInput.HostType
 		state.HostType = &hostType
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		state.Name = &name
 	}
 
-	// Set property ‘SslState’:
+	// Set property "SslState":
 	if typedInput.SslState != nil {
 		sslState := *typedInput.SslState
 		state.SslState = &sslState
 	}
 
-	// Set property ‘Thumbprint’:
+	// Set property "Thumbprint":
 	if typedInput.Thumbprint != nil {
 		thumbprint := *typedInput.Thumbprint
 		state.Thumbprint = &thumbprint
 	}
 
-	// Set property ‘ToUpdate’:
+	// Set property "ToUpdate":
 	if typedInput.ToUpdate != nil {
 		toUpdate := *typedInput.ToUpdate
 		state.ToUpdate = &toUpdate
 	}
 
-	// Set property ‘VirtualIP’:
+	// Set property "VirtualIP":
 	if typedInput.VirtualIP != nil {
 		virtualIP := *typedInput.VirtualIP
 		state.VirtualIP = &virtualIP
@@ -3545,37 +3545,37 @@ func (state *HostNameSslState_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HostNameSslState_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘HostType’:
+	// Set property "HostType":
 	if typedInput.HostType != nil {
 		hostType := *typedInput.HostType
 		state.HostType = &hostType
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		state.Name = &name
 	}
 
-	// Set property ‘SslState’:
+	// Set property "SslState":
 	if typedInput.SslState != nil {
 		sslState := *typedInput.SslState
 		state.SslState = &sslState
 	}
 
-	// Set property ‘Thumbprint’:
+	// Set property "Thumbprint":
 	if typedInput.Thumbprint != nil {
 		thumbprint := *typedInput.Thumbprint
 		state.Thumbprint = &thumbprint
 	}
 
-	// Set property ‘ToUpdate’:
+	// Set property "ToUpdate":
 	if typedInput.ToUpdate != nil {
 		toUpdate := *typedInput.ToUpdate
 		state.ToUpdate = &toUpdate
 	}
 
-	// Set property ‘VirtualIP’:
+	// Set property "VirtualIP":
 	if typedInput.VirtualIP != nil {
 		virtualIP := *typedInput.VirtualIP
 		state.VirtualIP = &virtualIP
@@ -3689,13 +3689,13 @@ func (identity *ManagedServiceIdentity) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &ManagedServiceIdentity_ARM{}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if identity.Type != nil {
 		typeVar := *identity.Type
 		result.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	result.UserAssignedIdentities = make(map[string]UserAssignedIdentityDetails_ARM, len(identity.UserAssignedIdentities))
 	for _, ident := range identity.UserAssignedIdentities {
 		identARMID, err := resolved.ResolvedReferences.Lookup(ident.Reference)
@@ -3720,13 +3720,13 @@ func (identity *ManagedServiceIdentity) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedServiceIdentity_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// no assignment for property ‘UserAssignedIdentities’
+	// no assignment for property "UserAssignedIdentities"
 
 	// No error
 	return nil
@@ -3829,25 +3829,25 @@ func (identity *ManagedServiceIdentity_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ManagedServiceIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
 	}
 
-	// Set property ‘TenantId’:
+	// Set property "TenantId":
 	if typedInput.TenantId != nil {
 		tenantId := *typedInput.TenantId
 		identity.TenantId = &tenantId
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		identity.Type = &typeVar
 	}
 
-	// Set property ‘UserAssignedIdentities’:
+	// Set property "UserAssignedIdentities":
 	if typedInput.UserAssignedIdentities != nil {
 		identity.UserAssignedIdentities = make(map[string]UserAssignedIdentity_STATUS, len(typedInput.UserAssignedIdentities))
 		for key, value := range typedInput.UserAssignedIdentities {
@@ -4100,25 +4100,25 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &SiteConfig_ARM{}
 
-	// Set property ‘AcrUseManagedIdentityCreds’:
+	// Set property "AcrUseManagedIdentityCreds":
 	if config.AcrUseManagedIdentityCreds != nil {
 		acrUseManagedIdentityCreds := *config.AcrUseManagedIdentityCreds
 		result.AcrUseManagedIdentityCreds = &acrUseManagedIdentityCreds
 	}
 
-	// Set property ‘AcrUserManagedIdentityID’:
+	// Set property "AcrUserManagedIdentityID":
 	if config.AcrUserManagedIdentityID != nil {
 		acrUserManagedIdentityID := *config.AcrUserManagedIdentityID
 		result.AcrUserManagedIdentityID = &acrUserManagedIdentityID
 	}
 
-	// Set property ‘AlwaysOn’:
+	// Set property "AlwaysOn":
 	if config.AlwaysOn != nil {
 		alwaysOn := *config.AlwaysOn
 		result.AlwaysOn = &alwaysOn
 	}
 
-	// Set property ‘ApiDefinition’:
+	// Set property "ApiDefinition":
 	if config.ApiDefinition != nil {
 		apiDefinition_ARM, err := (*config.ApiDefinition).ConvertToARM(resolved)
 		if err != nil {
@@ -4128,7 +4128,7 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.ApiDefinition = &apiDefinition
 	}
 
-	// Set property ‘ApiManagementConfig’:
+	// Set property "ApiManagementConfig":
 	if config.ApiManagementConfig != nil {
 		apiManagementConfig_ARM, err := (*config.ApiManagementConfig).ConvertToARM(resolved)
 		if err != nil {
@@ -4138,13 +4138,13 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.ApiManagementConfig = &apiManagementConfig
 	}
 
-	// Set property ‘AppCommandLine’:
+	// Set property "AppCommandLine":
 	if config.AppCommandLine != nil {
 		appCommandLine := *config.AppCommandLine
 		result.AppCommandLine = &appCommandLine
 	}
 
-	// Set property ‘AppSettings’:
+	// Set property "AppSettings":
 	for _, item := range config.AppSettings {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4153,13 +4153,13 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.AppSettings = append(result.AppSettings, *item_ARM.(*NameValuePair_ARM))
 	}
 
-	// Set property ‘AutoHealEnabled’:
+	// Set property "AutoHealEnabled":
 	if config.AutoHealEnabled != nil {
 		autoHealEnabled := *config.AutoHealEnabled
 		result.AutoHealEnabled = &autoHealEnabled
 	}
 
-	// Set property ‘AutoHealRules’:
+	// Set property "AutoHealRules":
 	if config.AutoHealRules != nil {
 		autoHealRules_ARM, err := (*config.AutoHealRules).ConvertToARM(resolved)
 		if err != nil {
@@ -4169,13 +4169,13 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.AutoHealRules = &autoHealRules
 	}
 
-	// Set property ‘AutoSwapSlotName’:
+	// Set property "AutoSwapSlotName":
 	if config.AutoSwapSlotName != nil {
 		autoSwapSlotName := *config.AutoSwapSlotName
 		result.AutoSwapSlotName = &autoSwapSlotName
 	}
 
-	// Set property ‘AzureStorageAccounts’:
+	// Set property "AzureStorageAccounts":
 	if config.AzureStorageAccounts != nil {
 		result.AzureStorageAccounts = make(map[string]AzureStorageInfoValue_ARM, len(config.AzureStorageAccounts))
 		for key, value := range config.AzureStorageAccounts {
@@ -4187,7 +4187,7 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		}
 	}
 
-	// Set property ‘ConnectionStrings’:
+	// Set property "ConnectionStrings":
 	for _, item := range config.ConnectionStrings {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4196,7 +4196,7 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.ConnectionStrings = append(result.ConnectionStrings, *item_ARM.(*ConnStringInfo_ARM))
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	if config.Cors != nil {
 		cors_ARM, err := (*config.Cors).ConvertToARM(resolved)
 		if err != nil {
@@ -4206,24 +4206,24 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Cors = &cors
 	}
 
-	// Set property ‘DefaultDocuments’:
+	// Set property "DefaultDocuments":
 	for _, item := range config.DefaultDocuments {
 		result.DefaultDocuments = append(result.DefaultDocuments, item)
 	}
 
-	// Set property ‘DetailedErrorLoggingEnabled’:
+	// Set property "DetailedErrorLoggingEnabled":
 	if config.DetailedErrorLoggingEnabled != nil {
 		detailedErrorLoggingEnabled := *config.DetailedErrorLoggingEnabled
 		result.DetailedErrorLoggingEnabled = &detailedErrorLoggingEnabled
 	}
 
-	// Set property ‘DocumentRoot’:
+	// Set property "DocumentRoot":
 	if config.DocumentRoot != nil {
 		documentRoot := *config.DocumentRoot
 		result.DocumentRoot = &documentRoot
 	}
 
-	// Set property ‘Experiments’:
+	// Set property "Experiments":
 	if config.Experiments != nil {
 		experiments_ARM, err := (*config.Experiments).ConvertToARM(resolved)
 		if err != nil {
@@ -4233,25 +4233,25 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Experiments = &experiments
 	}
 
-	// Set property ‘FtpsState’:
+	// Set property "FtpsState":
 	if config.FtpsState != nil {
 		ftpsState := *config.FtpsState
 		result.FtpsState = &ftpsState
 	}
 
-	// Set property ‘FunctionAppScaleLimit’:
+	// Set property "FunctionAppScaleLimit":
 	if config.FunctionAppScaleLimit != nil {
 		functionAppScaleLimit := *config.FunctionAppScaleLimit
 		result.FunctionAppScaleLimit = &functionAppScaleLimit
 	}
 
-	// Set property ‘FunctionsRuntimeScaleMonitoringEnabled’:
+	// Set property "FunctionsRuntimeScaleMonitoringEnabled":
 	if config.FunctionsRuntimeScaleMonitoringEnabled != nil {
 		functionsRuntimeScaleMonitoringEnabled := *config.FunctionsRuntimeScaleMonitoringEnabled
 		result.FunctionsRuntimeScaleMonitoringEnabled = &functionsRuntimeScaleMonitoringEnabled
 	}
 
-	// Set property ‘HandlerMappings’:
+	// Set property "HandlerMappings":
 	for _, item := range config.HandlerMappings {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4260,25 +4260,25 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.HandlerMappings = append(result.HandlerMappings, *item_ARM.(*HandlerMapping_ARM))
 	}
 
-	// Set property ‘HealthCheckPath’:
+	// Set property "HealthCheckPath":
 	if config.HealthCheckPath != nil {
 		healthCheckPath := *config.HealthCheckPath
 		result.HealthCheckPath = &healthCheckPath
 	}
 
-	// Set property ‘Http20Enabled’:
+	// Set property "Http20Enabled":
 	if config.Http20Enabled != nil {
 		http20Enabled := *config.Http20Enabled
 		result.Http20Enabled = &http20Enabled
 	}
 
-	// Set property ‘HttpLoggingEnabled’:
+	// Set property "HttpLoggingEnabled":
 	if config.HttpLoggingEnabled != nil {
 		httpLoggingEnabled := *config.HttpLoggingEnabled
 		result.HttpLoggingEnabled = &httpLoggingEnabled
 	}
 
-	// Set property ‘IpSecurityRestrictions’:
+	// Set property "IpSecurityRestrictions":
 	for _, item := range config.IpSecurityRestrictions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4287,31 +4287,31 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.IpSecurityRestrictions = append(result.IpSecurityRestrictions, *item_ARM.(*IpSecurityRestriction_ARM))
 	}
 
-	// Set property ‘JavaContainer’:
+	// Set property "JavaContainer":
 	if config.JavaContainer != nil {
 		javaContainer := *config.JavaContainer
 		result.JavaContainer = &javaContainer
 	}
 
-	// Set property ‘JavaContainerVersion’:
+	// Set property "JavaContainerVersion":
 	if config.JavaContainerVersion != nil {
 		javaContainerVersion := *config.JavaContainerVersion
 		result.JavaContainerVersion = &javaContainerVersion
 	}
 
-	// Set property ‘JavaVersion’:
+	// Set property "JavaVersion":
 	if config.JavaVersion != nil {
 		javaVersion := *config.JavaVersion
 		result.JavaVersion = &javaVersion
 	}
 
-	// Set property ‘KeyVaultReferenceIdentity’:
+	// Set property "KeyVaultReferenceIdentity":
 	if config.KeyVaultReferenceIdentity != nil {
 		keyVaultReferenceIdentity := *config.KeyVaultReferenceIdentity
 		result.KeyVaultReferenceIdentity = &keyVaultReferenceIdentity
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if config.Limits != nil {
 		limits_ARM, err := (*config.Limits).ConvertToARM(resolved)
 		if err != nil {
@@ -4321,103 +4321,103 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Limits = &limits
 	}
 
-	// Set property ‘LinuxFxVersion’:
+	// Set property "LinuxFxVersion":
 	if config.LinuxFxVersion != nil {
 		linuxFxVersion := *config.LinuxFxVersion
 		result.LinuxFxVersion = &linuxFxVersion
 	}
 
-	// Set property ‘LoadBalancing’:
+	// Set property "LoadBalancing":
 	if config.LoadBalancing != nil {
 		loadBalancing := *config.LoadBalancing
 		result.LoadBalancing = &loadBalancing
 	}
 
-	// Set property ‘LocalMySqlEnabled’:
+	// Set property "LocalMySqlEnabled":
 	if config.LocalMySqlEnabled != nil {
 		localMySqlEnabled := *config.LocalMySqlEnabled
 		result.LocalMySqlEnabled = &localMySqlEnabled
 	}
 
-	// Set property ‘LogsDirectorySizeLimit’:
+	// Set property "LogsDirectorySizeLimit":
 	if config.LogsDirectorySizeLimit != nil {
 		logsDirectorySizeLimit := *config.LogsDirectorySizeLimit
 		result.LogsDirectorySizeLimit = &logsDirectorySizeLimit
 	}
 
-	// Set property ‘ManagedPipelineMode’:
+	// Set property "ManagedPipelineMode":
 	if config.ManagedPipelineMode != nil {
 		managedPipelineMode := *config.ManagedPipelineMode
 		result.ManagedPipelineMode = &managedPipelineMode
 	}
 
-	// Set property ‘ManagedServiceIdentityId’:
+	// Set property "ManagedServiceIdentityId":
 	if config.ManagedServiceIdentityId != nil {
 		managedServiceIdentityId := *config.ManagedServiceIdentityId
 		result.ManagedServiceIdentityId = &managedServiceIdentityId
 	}
 
-	// Set property ‘MinTlsVersion’:
+	// Set property "MinTlsVersion":
 	if config.MinTlsVersion != nil {
 		minTlsVersion := *config.MinTlsVersion
 		result.MinTlsVersion = &minTlsVersion
 	}
 
-	// Set property ‘MinimumElasticInstanceCount’:
+	// Set property "MinimumElasticInstanceCount":
 	if config.MinimumElasticInstanceCount != nil {
 		minimumElasticInstanceCount := *config.MinimumElasticInstanceCount
 		result.MinimumElasticInstanceCount = &minimumElasticInstanceCount
 	}
 
-	// Set property ‘NetFrameworkVersion’:
+	// Set property "NetFrameworkVersion":
 	if config.NetFrameworkVersion != nil {
 		netFrameworkVersion := *config.NetFrameworkVersion
 		result.NetFrameworkVersion = &netFrameworkVersion
 	}
 
-	// Set property ‘NodeVersion’:
+	// Set property "NodeVersion":
 	if config.NodeVersion != nil {
 		nodeVersion := *config.NodeVersion
 		result.NodeVersion = &nodeVersion
 	}
 
-	// Set property ‘NumberOfWorkers’:
+	// Set property "NumberOfWorkers":
 	if config.NumberOfWorkers != nil {
 		numberOfWorkers := *config.NumberOfWorkers
 		result.NumberOfWorkers = &numberOfWorkers
 	}
 
-	// Set property ‘PhpVersion’:
+	// Set property "PhpVersion":
 	if config.PhpVersion != nil {
 		phpVersion := *config.PhpVersion
 		result.PhpVersion = &phpVersion
 	}
 
-	// Set property ‘PowerShellVersion’:
+	// Set property "PowerShellVersion":
 	if config.PowerShellVersion != nil {
 		powerShellVersion := *config.PowerShellVersion
 		result.PowerShellVersion = &powerShellVersion
 	}
 
-	// Set property ‘PreWarmedInstanceCount’:
+	// Set property "PreWarmedInstanceCount":
 	if config.PreWarmedInstanceCount != nil {
 		preWarmedInstanceCount := *config.PreWarmedInstanceCount
 		result.PreWarmedInstanceCount = &preWarmedInstanceCount
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if config.PublicNetworkAccess != nil {
 		publicNetworkAccess := *config.PublicNetworkAccess
 		result.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘PublishingUsername’:
+	// Set property "PublishingUsername":
 	if config.PublishingUsername != nil {
 		publishingUsername := *config.PublishingUsername
 		result.PublishingUsername = &publishingUsername
 	}
 
-	// Set property ‘Push’:
+	// Set property "Push":
 	if config.Push != nil {
 		push_ARM, err := (*config.Push).ConvertToARM(resolved)
 		if err != nil {
@@ -4427,37 +4427,37 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.Push = &push
 	}
 
-	// Set property ‘PythonVersion’:
+	// Set property "PythonVersion":
 	if config.PythonVersion != nil {
 		pythonVersion := *config.PythonVersion
 		result.PythonVersion = &pythonVersion
 	}
 
-	// Set property ‘RemoteDebuggingEnabled’:
+	// Set property "RemoteDebuggingEnabled":
 	if config.RemoteDebuggingEnabled != nil {
 		remoteDebuggingEnabled := *config.RemoteDebuggingEnabled
 		result.RemoteDebuggingEnabled = &remoteDebuggingEnabled
 	}
 
-	// Set property ‘RemoteDebuggingVersion’:
+	// Set property "RemoteDebuggingVersion":
 	if config.RemoteDebuggingVersion != nil {
 		remoteDebuggingVersion := *config.RemoteDebuggingVersion
 		result.RemoteDebuggingVersion = &remoteDebuggingVersion
 	}
 
-	// Set property ‘RequestTracingEnabled’:
+	// Set property "RequestTracingEnabled":
 	if config.RequestTracingEnabled != nil {
 		requestTracingEnabled := *config.RequestTracingEnabled
 		result.RequestTracingEnabled = &requestTracingEnabled
 	}
 
-	// Set property ‘RequestTracingExpirationTime’:
+	// Set property "RequestTracingExpirationTime":
 	if config.RequestTracingExpirationTime != nil {
 		requestTracingExpirationTime := *config.RequestTracingExpirationTime
 		result.RequestTracingExpirationTime = &requestTracingExpirationTime
 	}
 
-	// Set property ‘ScmIpSecurityRestrictions’:
+	// Set property "ScmIpSecurityRestrictions":
 	for _, item := range config.ScmIpSecurityRestrictions {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4466,37 +4466,37 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.ScmIpSecurityRestrictions = append(result.ScmIpSecurityRestrictions, *item_ARM.(*IpSecurityRestriction_ARM))
 	}
 
-	// Set property ‘ScmIpSecurityRestrictionsUseMain’:
+	// Set property "ScmIpSecurityRestrictionsUseMain":
 	if config.ScmIpSecurityRestrictionsUseMain != nil {
 		scmIpSecurityRestrictionsUseMain := *config.ScmIpSecurityRestrictionsUseMain
 		result.ScmIpSecurityRestrictionsUseMain = &scmIpSecurityRestrictionsUseMain
 	}
 
-	// Set property ‘ScmMinTlsVersion’:
+	// Set property "ScmMinTlsVersion":
 	if config.ScmMinTlsVersion != nil {
 		scmMinTlsVersion := *config.ScmMinTlsVersion
 		result.ScmMinTlsVersion = &scmMinTlsVersion
 	}
 
-	// Set property ‘ScmType’:
+	// Set property "ScmType":
 	if config.ScmType != nil {
 		scmType := *config.ScmType
 		result.ScmType = &scmType
 	}
 
-	// Set property ‘TracingOptions’:
+	// Set property "TracingOptions":
 	if config.TracingOptions != nil {
 		tracingOptions := *config.TracingOptions
 		result.TracingOptions = &tracingOptions
 	}
 
-	// Set property ‘Use32BitWorkerProcess’:
+	// Set property "Use32BitWorkerProcess":
 	if config.Use32BitWorkerProcess != nil {
 		use32BitWorkerProcess := *config.Use32BitWorkerProcess
 		result.Use32BitWorkerProcess = &use32BitWorkerProcess
 	}
 
-	// Set property ‘VirtualApplications’:
+	// Set property "VirtualApplications":
 	for _, item := range config.VirtualApplications {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -4505,43 +4505,43 @@ func (config *SiteConfig) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		result.VirtualApplications = append(result.VirtualApplications, *item_ARM.(*VirtualApplication_ARM))
 	}
 
-	// Set property ‘VnetName’:
+	// Set property "VnetName":
 	if config.VnetName != nil {
 		vnetName := *config.VnetName
 		result.VnetName = &vnetName
 	}
 
-	// Set property ‘VnetPrivatePortsCount’:
+	// Set property "VnetPrivatePortsCount":
 	if config.VnetPrivatePortsCount != nil {
 		vnetPrivatePortsCount := *config.VnetPrivatePortsCount
 		result.VnetPrivatePortsCount = &vnetPrivatePortsCount
 	}
 
-	// Set property ‘VnetRouteAllEnabled’:
+	// Set property "VnetRouteAllEnabled":
 	if config.VnetRouteAllEnabled != nil {
 		vnetRouteAllEnabled := *config.VnetRouteAllEnabled
 		result.VnetRouteAllEnabled = &vnetRouteAllEnabled
 	}
 
-	// Set property ‘WebSocketsEnabled’:
+	// Set property "WebSocketsEnabled":
 	if config.WebSocketsEnabled != nil {
 		webSocketsEnabled := *config.WebSocketsEnabled
 		result.WebSocketsEnabled = &webSocketsEnabled
 	}
 
-	// Set property ‘WebsiteTimeZone’:
+	// Set property "WebsiteTimeZone":
 	if config.WebsiteTimeZone != nil {
 		websiteTimeZone := *config.WebsiteTimeZone
 		result.WebsiteTimeZone = &websiteTimeZone
 	}
 
-	// Set property ‘WindowsFxVersion’:
+	// Set property "WindowsFxVersion":
 	if config.WindowsFxVersion != nil {
 		windowsFxVersion := *config.WindowsFxVersion
 		result.WindowsFxVersion = &windowsFxVersion
 	}
 
-	// Set property ‘XManagedServiceIdentityId’:
+	// Set property "XManagedServiceIdentityId":
 	if config.XManagedServiceIdentityId != nil {
 		xManagedServiceIdentityId := *config.XManagedServiceIdentityId
 		result.XManagedServiceIdentityId = &xManagedServiceIdentityId
@@ -4561,25 +4561,25 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SiteConfig_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AcrUseManagedIdentityCreds’:
+	// Set property "AcrUseManagedIdentityCreds":
 	if typedInput.AcrUseManagedIdentityCreds != nil {
 		acrUseManagedIdentityCreds := *typedInput.AcrUseManagedIdentityCreds
 		config.AcrUseManagedIdentityCreds = &acrUseManagedIdentityCreds
 	}
 
-	// Set property ‘AcrUserManagedIdentityID’:
+	// Set property "AcrUserManagedIdentityID":
 	if typedInput.AcrUserManagedIdentityID != nil {
 		acrUserManagedIdentityID := *typedInput.AcrUserManagedIdentityID
 		config.AcrUserManagedIdentityID = &acrUserManagedIdentityID
 	}
 
-	// Set property ‘AlwaysOn’:
+	// Set property "AlwaysOn":
 	if typedInput.AlwaysOn != nil {
 		alwaysOn := *typedInput.AlwaysOn
 		config.AlwaysOn = &alwaysOn
 	}
 
-	// Set property ‘ApiDefinition’:
+	// Set property "ApiDefinition":
 	if typedInput.ApiDefinition != nil {
 		var apiDefinition1 ApiDefinitionInfo
 		err := apiDefinition1.PopulateFromARM(owner, *typedInput.ApiDefinition)
@@ -4590,7 +4590,7 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.ApiDefinition = &apiDefinition
 	}
 
-	// Set property ‘ApiManagementConfig’:
+	// Set property "ApiManagementConfig":
 	if typedInput.ApiManagementConfig != nil {
 		var apiManagementConfig1 ApiManagementConfig
 		err := apiManagementConfig1.PopulateFromARM(owner, *typedInput.ApiManagementConfig)
@@ -4601,13 +4601,13 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.ApiManagementConfig = &apiManagementConfig
 	}
 
-	// Set property ‘AppCommandLine’:
+	// Set property "AppCommandLine":
 	if typedInput.AppCommandLine != nil {
 		appCommandLine := *typedInput.AppCommandLine
 		config.AppCommandLine = &appCommandLine
 	}
 
-	// Set property ‘AppSettings’:
+	// Set property "AppSettings":
 	for _, item := range typedInput.AppSettings {
 		var item1 NameValuePair
 		err := item1.PopulateFromARM(owner, item)
@@ -4617,13 +4617,13 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.AppSettings = append(config.AppSettings, item1)
 	}
 
-	// Set property ‘AutoHealEnabled’:
+	// Set property "AutoHealEnabled":
 	if typedInput.AutoHealEnabled != nil {
 		autoHealEnabled := *typedInput.AutoHealEnabled
 		config.AutoHealEnabled = &autoHealEnabled
 	}
 
-	// Set property ‘AutoHealRules’:
+	// Set property "AutoHealRules":
 	if typedInput.AutoHealRules != nil {
 		var autoHealRules1 AutoHealRules
 		err := autoHealRules1.PopulateFromARM(owner, *typedInput.AutoHealRules)
@@ -4634,13 +4634,13 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.AutoHealRules = &autoHealRules
 	}
 
-	// Set property ‘AutoSwapSlotName’:
+	// Set property "AutoSwapSlotName":
 	if typedInput.AutoSwapSlotName != nil {
 		autoSwapSlotName := *typedInput.AutoSwapSlotName
 		config.AutoSwapSlotName = &autoSwapSlotName
 	}
 
-	// Set property ‘AzureStorageAccounts’:
+	// Set property "AzureStorageAccounts":
 	if typedInput.AzureStorageAccounts != nil {
 		config.AzureStorageAccounts = make(map[string]AzureStorageInfoValue, len(typedInput.AzureStorageAccounts))
 		for key, value := range typedInput.AzureStorageAccounts {
@@ -4653,7 +4653,7 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		}
 	}
 
-	// Set property ‘ConnectionStrings’:
+	// Set property "ConnectionStrings":
 	for _, item := range typedInput.ConnectionStrings {
 		var item1 ConnStringInfo
 		err := item1.PopulateFromARM(owner, item)
@@ -4663,7 +4663,7 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.ConnectionStrings = append(config.ConnectionStrings, item1)
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	if typedInput.Cors != nil {
 		var cors1 CorsSettings
 		err := cors1.PopulateFromARM(owner, *typedInput.Cors)
@@ -4674,24 +4674,24 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.Cors = &cors
 	}
 
-	// Set property ‘DefaultDocuments’:
+	// Set property "DefaultDocuments":
 	for _, item := range typedInput.DefaultDocuments {
 		config.DefaultDocuments = append(config.DefaultDocuments, item)
 	}
 
-	// Set property ‘DetailedErrorLoggingEnabled’:
+	// Set property "DetailedErrorLoggingEnabled":
 	if typedInput.DetailedErrorLoggingEnabled != nil {
 		detailedErrorLoggingEnabled := *typedInput.DetailedErrorLoggingEnabled
 		config.DetailedErrorLoggingEnabled = &detailedErrorLoggingEnabled
 	}
 
-	// Set property ‘DocumentRoot’:
+	// Set property "DocumentRoot":
 	if typedInput.DocumentRoot != nil {
 		documentRoot := *typedInput.DocumentRoot
 		config.DocumentRoot = &documentRoot
 	}
 
-	// Set property ‘Experiments’:
+	// Set property "Experiments":
 	if typedInput.Experiments != nil {
 		var experiments1 Experiments
 		err := experiments1.PopulateFromARM(owner, *typedInput.Experiments)
@@ -4702,25 +4702,25 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.Experiments = &experiments
 	}
 
-	// Set property ‘FtpsState’:
+	// Set property "FtpsState":
 	if typedInput.FtpsState != nil {
 		ftpsState := *typedInput.FtpsState
 		config.FtpsState = &ftpsState
 	}
 
-	// Set property ‘FunctionAppScaleLimit’:
+	// Set property "FunctionAppScaleLimit":
 	if typedInput.FunctionAppScaleLimit != nil {
 		functionAppScaleLimit := *typedInput.FunctionAppScaleLimit
 		config.FunctionAppScaleLimit = &functionAppScaleLimit
 	}
 
-	// Set property ‘FunctionsRuntimeScaleMonitoringEnabled’:
+	// Set property "FunctionsRuntimeScaleMonitoringEnabled":
 	if typedInput.FunctionsRuntimeScaleMonitoringEnabled != nil {
 		functionsRuntimeScaleMonitoringEnabled := *typedInput.FunctionsRuntimeScaleMonitoringEnabled
 		config.FunctionsRuntimeScaleMonitoringEnabled = &functionsRuntimeScaleMonitoringEnabled
 	}
 
-	// Set property ‘HandlerMappings’:
+	// Set property "HandlerMappings":
 	for _, item := range typedInput.HandlerMappings {
 		var item1 HandlerMapping
 		err := item1.PopulateFromARM(owner, item)
@@ -4730,25 +4730,25 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.HandlerMappings = append(config.HandlerMappings, item1)
 	}
 
-	// Set property ‘HealthCheckPath’:
+	// Set property "HealthCheckPath":
 	if typedInput.HealthCheckPath != nil {
 		healthCheckPath := *typedInput.HealthCheckPath
 		config.HealthCheckPath = &healthCheckPath
 	}
 
-	// Set property ‘Http20Enabled’:
+	// Set property "Http20Enabled":
 	if typedInput.Http20Enabled != nil {
 		http20Enabled := *typedInput.Http20Enabled
 		config.Http20Enabled = &http20Enabled
 	}
 
-	// Set property ‘HttpLoggingEnabled’:
+	// Set property "HttpLoggingEnabled":
 	if typedInput.HttpLoggingEnabled != nil {
 		httpLoggingEnabled := *typedInput.HttpLoggingEnabled
 		config.HttpLoggingEnabled = &httpLoggingEnabled
 	}
 
-	// Set property ‘IpSecurityRestrictions’:
+	// Set property "IpSecurityRestrictions":
 	for _, item := range typedInput.IpSecurityRestrictions {
 		var item1 IpSecurityRestriction
 		err := item1.PopulateFromARM(owner, item)
@@ -4758,31 +4758,31 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.IpSecurityRestrictions = append(config.IpSecurityRestrictions, item1)
 	}
 
-	// Set property ‘JavaContainer’:
+	// Set property "JavaContainer":
 	if typedInput.JavaContainer != nil {
 		javaContainer := *typedInput.JavaContainer
 		config.JavaContainer = &javaContainer
 	}
 
-	// Set property ‘JavaContainerVersion’:
+	// Set property "JavaContainerVersion":
 	if typedInput.JavaContainerVersion != nil {
 		javaContainerVersion := *typedInput.JavaContainerVersion
 		config.JavaContainerVersion = &javaContainerVersion
 	}
 
-	// Set property ‘JavaVersion’:
+	// Set property "JavaVersion":
 	if typedInput.JavaVersion != nil {
 		javaVersion := *typedInput.JavaVersion
 		config.JavaVersion = &javaVersion
 	}
 
-	// Set property ‘KeyVaultReferenceIdentity’:
+	// Set property "KeyVaultReferenceIdentity":
 	if typedInput.KeyVaultReferenceIdentity != nil {
 		keyVaultReferenceIdentity := *typedInput.KeyVaultReferenceIdentity
 		config.KeyVaultReferenceIdentity = &keyVaultReferenceIdentity
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if typedInput.Limits != nil {
 		var limits1 SiteLimits
 		err := limits1.PopulateFromARM(owner, *typedInput.Limits)
@@ -4793,103 +4793,103 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.Limits = &limits
 	}
 
-	// Set property ‘LinuxFxVersion’:
+	// Set property "LinuxFxVersion":
 	if typedInput.LinuxFxVersion != nil {
 		linuxFxVersion := *typedInput.LinuxFxVersion
 		config.LinuxFxVersion = &linuxFxVersion
 	}
 
-	// Set property ‘LoadBalancing’:
+	// Set property "LoadBalancing":
 	if typedInput.LoadBalancing != nil {
 		loadBalancing := *typedInput.LoadBalancing
 		config.LoadBalancing = &loadBalancing
 	}
 
-	// Set property ‘LocalMySqlEnabled’:
+	// Set property "LocalMySqlEnabled":
 	if typedInput.LocalMySqlEnabled != nil {
 		localMySqlEnabled := *typedInput.LocalMySqlEnabled
 		config.LocalMySqlEnabled = &localMySqlEnabled
 	}
 
-	// Set property ‘LogsDirectorySizeLimit’:
+	// Set property "LogsDirectorySizeLimit":
 	if typedInput.LogsDirectorySizeLimit != nil {
 		logsDirectorySizeLimit := *typedInput.LogsDirectorySizeLimit
 		config.LogsDirectorySizeLimit = &logsDirectorySizeLimit
 	}
 
-	// Set property ‘ManagedPipelineMode’:
+	// Set property "ManagedPipelineMode":
 	if typedInput.ManagedPipelineMode != nil {
 		managedPipelineMode := *typedInput.ManagedPipelineMode
 		config.ManagedPipelineMode = &managedPipelineMode
 	}
 
-	// Set property ‘ManagedServiceIdentityId’:
+	// Set property "ManagedServiceIdentityId":
 	if typedInput.ManagedServiceIdentityId != nil {
 		managedServiceIdentityId := *typedInput.ManagedServiceIdentityId
 		config.ManagedServiceIdentityId = &managedServiceIdentityId
 	}
 
-	// Set property ‘MinTlsVersion’:
+	// Set property "MinTlsVersion":
 	if typedInput.MinTlsVersion != nil {
 		minTlsVersion := *typedInput.MinTlsVersion
 		config.MinTlsVersion = &minTlsVersion
 	}
 
-	// Set property ‘MinimumElasticInstanceCount’:
+	// Set property "MinimumElasticInstanceCount":
 	if typedInput.MinimumElasticInstanceCount != nil {
 		minimumElasticInstanceCount := *typedInput.MinimumElasticInstanceCount
 		config.MinimumElasticInstanceCount = &minimumElasticInstanceCount
 	}
 
-	// Set property ‘NetFrameworkVersion’:
+	// Set property "NetFrameworkVersion":
 	if typedInput.NetFrameworkVersion != nil {
 		netFrameworkVersion := *typedInput.NetFrameworkVersion
 		config.NetFrameworkVersion = &netFrameworkVersion
 	}
 
-	// Set property ‘NodeVersion’:
+	// Set property "NodeVersion":
 	if typedInput.NodeVersion != nil {
 		nodeVersion := *typedInput.NodeVersion
 		config.NodeVersion = &nodeVersion
 	}
 
-	// Set property ‘NumberOfWorkers’:
+	// Set property "NumberOfWorkers":
 	if typedInput.NumberOfWorkers != nil {
 		numberOfWorkers := *typedInput.NumberOfWorkers
 		config.NumberOfWorkers = &numberOfWorkers
 	}
 
-	// Set property ‘PhpVersion’:
+	// Set property "PhpVersion":
 	if typedInput.PhpVersion != nil {
 		phpVersion := *typedInput.PhpVersion
 		config.PhpVersion = &phpVersion
 	}
 
-	// Set property ‘PowerShellVersion’:
+	// Set property "PowerShellVersion":
 	if typedInput.PowerShellVersion != nil {
 		powerShellVersion := *typedInput.PowerShellVersion
 		config.PowerShellVersion = &powerShellVersion
 	}
 
-	// Set property ‘PreWarmedInstanceCount’:
+	// Set property "PreWarmedInstanceCount":
 	if typedInput.PreWarmedInstanceCount != nil {
 		preWarmedInstanceCount := *typedInput.PreWarmedInstanceCount
 		config.PreWarmedInstanceCount = &preWarmedInstanceCount
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		config.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘PublishingUsername’:
+	// Set property "PublishingUsername":
 	if typedInput.PublishingUsername != nil {
 		publishingUsername := *typedInput.PublishingUsername
 		config.PublishingUsername = &publishingUsername
 	}
 
-	// Set property ‘Push’:
+	// Set property "Push":
 	if typedInput.Push != nil {
 		var push1 PushSettings
 		err := push1.PopulateFromARM(owner, *typedInput.Push)
@@ -4900,37 +4900,37 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.Push = &push
 	}
 
-	// Set property ‘PythonVersion’:
+	// Set property "PythonVersion":
 	if typedInput.PythonVersion != nil {
 		pythonVersion := *typedInput.PythonVersion
 		config.PythonVersion = &pythonVersion
 	}
 
-	// Set property ‘RemoteDebuggingEnabled’:
+	// Set property "RemoteDebuggingEnabled":
 	if typedInput.RemoteDebuggingEnabled != nil {
 		remoteDebuggingEnabled := *typedInput.RemoteDebuggingEnabled
 		config.RemoteDebuggingEnabled = &remoteDebuggingEnabled
 	}
 
-	// Set property ‘RemoteDebuggingVersion’:
+	// Set property "RemoteDebuggingVersion":
 	if typedInput.RemoteDebuggingVersion != nil {
 		remoteDebuggingVersion := *typedInput.RemoteDebuggingVersion
 		config.RemoteDebuggingVersion = &remoteDebuggingVersion
 	}
 
-	// Set property ‘RequestTracingEnabled’:
+	// Set property "RequestTracingEnabled":
 	if typedInput.RequestTracingEnabled != nil {
 		requestTracingEnabled := *typedInput.RequestTracingEnabled
 		config.RequestTracingEnabled = &requestTracingEnabled
 	}
 
-	// Set property ‘RequestTracingExpirationTime’:
+	// Set property "RequestTracingExpirationTime":
 	if typedInput.RequestTracingExpirationTime != nil {
 		requestTracingExpirationTime := *typedInput.RequestTracingExpirationTime
 		config.RequestTracingExpirationTime = &requestTracingExpirationTime
 	}
 
-	// Set property ‘ScmIpSecurityRestrictions’:
+	// Set property "ScmIpSecurityRestrictions":
 	for _, item := range typedInput.ScmIpSecurityRestrictions {
 		var item1 IpSecurityRestriction
 		err := item1.PopulateFromARM(owner, item)
@@ -4940,37 +4940,37 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.ScmIpSecurityRestrictions = append(config.ScmIpSecurityRestrictions, item1)
 	}
 
-	// Set property ‘ScmIpSecurityRestrictionsUseMain’:
+	// Set property "ScmIpSecurityRestrictionsUseMain":
 	if typedInput.ScmIpSecurityRestrictionsUseMain != nil {
 		scmIpSecurityRestrictionsUseMain := *typedInput.ScmIpSecurityRestrictionsUseMain
 		config.ScmIpSecurityRestrictionsUseMain = &scmIpSecurityRestrictionsUseMain
 	}
 
-	// Set property ‘ScmMinTlsVersion’:
+	// Set property "ScmMinTlsVersion":
 	if typedInput.ScmMinTlsVersion != nil {
 		scmMinTlsVersion := *typedInput.ScmMinTlsVersion
 		config.ScmMinTlsVersion = &scmMinTlsVersion
 	}
 
-	// Set property ‘ScmType’:
+	// Set property "ScmType":
 	if typedInput.ScmType != nil {
 		scmType := *typedInput.ScmType
 		config.ScmType = &scmType
 	}
 
-	// Set property ‘TracingOptions’:
+	// Set property "TracingOptions":
 	if typedInput.TracingOptions != nil {
 		tracingOptions := *typedInput.TracingOptions
 		config.TracingOptions = &tracingOptions
 	}
 
-	// Set property ‘Use32BitWorkerProcess’:
+	// Set property "Use32BitWorkerProcess":
 	if typedInput.Use32BitWorkerProcess != nil {
 		use32BitWorkerProcess := *typedInput.Use32BitWorkerProcess
 		config.Use32BitWorkerProcess = &use32BitWorkerProcess
 	}
 
-	// Set property ‘VirtualApplications’:
+	// Set property "VirtualApplications":
 	for _, item := range typedInput.VirtualApplications {
 		var item1 VirtualApplication
 		err := item1.PopulateFromARM(owner, item)
@@ -4980,43 +4980,43 @@ func (config *SiteConfig) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		config.VirtualApplications = append(config.VirtualApplications, item1)
 	}
 
-	// Set property ‘VnetName’:
+	// Set property "VnetName":
 	if typedInput.VnetName != nil {
 		vnetName := *typedInput.VnetName
 		config.VnetName = &vnetName
 	}
 
-	// Set property ‘VnetPrivatePortsCount’:
+	// Set property "VnetPrivatePortsCount":
 	if typedInput.VnetPrivatePortsCount != nil {
 		vnetPrivatePortsCount := *typedInput.VnetPrivatePortsCount
 		config.VnetPrivatePortsCount = &vnetPrivatePortsCount
 	}
 
-	// Set property ‘VnetRouteAllEnabled’:
+	// Set property "VnetRouteAllEnabled":
 	if typedInput.VnetRouteAllEnabled != nil {
 		vnetRouteAllEnabled := *typedInput.VnetRouteAllEnabled
 		config.VnetRouteAllEnabled = &vnetRouteAllEnabled
 	}
 
-	// Set property ‘WebSocketsEnabled’:
+	// Set property "WebSocketsEnabled":
 	if typedInput.WebSocketsEnabled != nil {
 		webSocketsEnabled := *typedInput.WebSocketsEnabled
 		config.WebSocketsEnabled = &webSocketsEnabled
 	}
 
-	// Set property ‘WebsiteTimeZone’:
+	// Set property "WebsiteTimeZone":
 	if typedInput.WebsiteTimeZone != nil {
 		websiteTimeZone := *typedInput.WebsiteTimeZone
 		config.WebsiteTimeZone = &websiteTimeZone
 	}
 
-	// Set property ‘WindowsFxVersion’:
+	// Set property "WindowsFxVersion":
 	if typedInput.WindowsFxVersion != nil {
 		windowsFxVersion := *typedInput.WindowsFxVersion
 		config.WindowsFxVersion = &windowsFxVersion
 	}
 
-	// Set property ‘XManagedServiceIdentityId’:
+	// Set property "XManagedServiceIdentityId":
 	if typedInput.XManagedServiceIdentityId != nil {
 		xManagedServiceIdentityId := *typedInput.XManagedServiceIdentityId
 		config.XManagedServiceIdentityId = &xManagedServiceIdentityId
@@ -6096,25 +6096,25 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SiteConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AcrUseManagedIdentityCreds’:
+	// Set property "AcrUseManagedIdentityCreds":
 	if typedInput.AcrUseManagedIdentityCreds != nil {
 		acrUseManagedIdentityCreds := *typedInput.AcrUseManagedIdentityCreds
 		config.AcrUseManagedIdentityCreds = &acrUseManagedIdentityCreds
 	}
 
-	// Set property ‘AcrUserManagedIdentityID’:
+	// Set property "AcrUserManagedIdentityID":
 	if typedInput.AcrUserManagedIdentityID != nil {
 		acrUserManagedIdentityID := *typedInput.AcrUserManagedIdentityID
 		config.AcrUserManagedIdentityID = &acrUserManagedIdentityID
 	}
 
-	// Set property ‘AlwaysOn’:
+	// Set property "AlwaysOn":
 	if typedInput.AlwaysOn != nil {
 		alwaysOn := *typedInput.AlwaysOn
 		config.AlwaysOn = &alwaysOn
 	}
 
-	// Set property ‘ApiDefinition’:
+	// Set property "ApiDefinition":
 	if typedInput.ApiDefinition != nil {
 		var apiDefinition1 ApiDefinitionInfo_STATUS
 		err := apiDefinition1.PopulateFromARM(owner, *typedInput.ApiDefinition)
@@ -6125,7 +6125,7 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.ApiDefinition = &apiDefinition
 	}
 
-	// Set property ‘ApiManagementConfig’:
+	// Set property "ApiManagementConfig":
 	if typedInput.ApiManagementConfig != nil {
 		var apiManagementConfig1 ApiManagementConfig_STATUS
 		err := apiManagementConfig1.PopulateFromARM(owner, *typedInput.ApiManagementConfig)
@@ -6136,13 +6136,13 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.ApiManagementConfig = &apiManagementConfig
 	}
 
-	// Set property ‘AppCommandLine’:
+	// Set property "AppCommandLine":
 	if typedInput.AppCommandLine != nil {
 		appCommandLine := *typedInput.AppCommandLine
 		config.AppCommandLine = &appCommandLine
 	}
 
-	// Set property ‘AppSettings’:
+	// Set property "AppSettings":
 	for _, item := range typedInput.AppSettings {
 		var item1 NameValuePair_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6152,13 +6152,13 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.AppSettings = append(config.AppSettings, item1)
 	}
 
-	// Set property ‘AutoHealEnabled’:
+	// Set property "AutoHealEnabled":
 	if typedInput.AutoHealEnabled != nil {
 		autoHealEnabled := *typedInput.AutoHealEnabled
 		config.AutoHealEnabled = &autoHealEnabled
 	}
 
-	// Set property ‘AutoHealRules’:
+	// Set property "AutoHealRules":
 	if typedInput.AutoHealRules != nil {
 		var autoHealRules1 AutoHealRules_STATUS
 		err := autoHealRules1.PopulateFromARM(owner, *typedInput.AutoHealRules)
@@ -6169,13 +6169,13 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.AutoHealRules = &autoHealRules
 	}
 
-	// Set property ‘AutoSwapSlotName’:
+	// Set property "AutoSwapSlotName":
 	if typedInput.AutoSwapSlotName != nil {
 		autoSwapSlotName := *typedInput.AutoSwapSlotName
 		config.AutoSwapSlotName = &autoSwapSlotName
 	}
 
-	// Set property ‘AzureStorageAccounts’:
+	// Set property "AzureStorageAccounts":
 	if typedInput.AzureStorageAccounts != nil {
 		config.AzureStorageAccounts = make(map[string]AzureStorageInfoValue_STATUS, len(typedInput.AzureStorageAccounts))
 		for key, value := range typedInput.AzureStorageAccounts {
@@ -6188,7 +6188,7 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		}
 	}
 
-	// Set property ‘ConnectionStrings’:
+	// Set property "ConnectionStrings":
 	for _, item := range typedInput.ConnectionStrings {
 		var item1 ConnStringInfo_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6198,7 +6198,7 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.ConnectionStrings = append(config.ConnectionStrings, item1)
 	}
 
-	// Set property ‘Cors’:
+	// Set property "Cors":
 	if typedInput.Cors != nil {
 		var cors1 CorsSettings_STATUS
 		err := cors1.PopulateFromARM(owner, *typedInput.Cors)
@@ -6209,24 +6209,24 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.Cors = &cors
 	}
 
-	// Set property ‘DefaultDocuments’:
+	// Set property "DefaultDocuments":
 	for _, item := range typedInput.DefaultDocuments {
 		config.DefaultDocuments = append(config.DefaultDocuments, item)
 	}
 
-	// Set property ‘DetailedErrorLoggingEnabled’:
+	// Set property "DetailedErrorLoggingEnabled":
 	if typedInput.DetailedErrorLoggingEnabled != nil {
 		detailedErrorLoggingEnabled := *typedInput.DetailedErrorLoggingEnabled
 		config.DetailedErrorLoggingEnabled = &detailedErrorLoggingEnabled
 	}
 
-	// Set property ‘DocumentRoot’:
+	// Set property "DocumentRoot":
 	if typedInput.DocumentRoot != nil {
 		documentRoot := *typedInput.DocumentRoot
 		config.DocumentRoot = &documentRoot
 	}
 
-	// Set property ‘Experiments’:
+	// Set property "Experiments":
 	if typedInput.Experiments != nil {
 		var experiments1 Experiments_STATUS
 		err := experiments1.PopulateFromARM(owner, *typedInput.Experiments)
@@ -6237,25 +6237,25 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.Experiments = &experiments
 	}
 
-	// Set property ‘FtpsState’:
+	// Set property "FtpsState":
 	if typedInput.FtpsState != nil {
 		ftpsState := *typedInput.FtpsState
 		config.FtpsState = &ftpsState
 	}
 
-	// Set property ‘FunctionAppScaleLimit’:
+	// Set property "FunctionAppScaleLimit":
 	if typedInput.FunctionAppScaleLimit != nil {
 		functionAppScaleLimit := *typedInput.FunctionAppScaleLimit
 		config.FunctionAppScaleLimit = &functionAppScaleLimit
 	}
 
-	// Set property ‘FunctionsRuntimeScaleMonitoringEnabled’:
+	// Set property "FunctionsRuntimeScaleMonitoringEnabled":
 	if typedInput.FunctionsRuntimeScaleMonitoringEnabled != nil {
 		functionsRuntimeScaleMonitoringEnabled := *typedInput.FunctionsRuntimeScaleMonitoringEnabled
 		config.FunctionsRuntimeScaleMonitoringEnabled = &functionsRuntimeScaleMonitoringEnabled
 	}
 
-	// Set property ‘HandlerMappings’:
+	// Set property "HandlerMappings":
 	for _, item := range typedInput.HandlerMappings {
 		var item1 HandlerMapping_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6265,25 +6265,25 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.HandlerMappings = append(config.HandlerMappings, item1)
 	}
 
-	// Set property ‘HealthCheckPath’:
+	// Set property "HealthCheckPath":
 	if typedInput.HealthCheckPath != nil {
 		healthCheckPath := *typedInput.HealthCheckPath
 		config.HealthCheckPath = &healthCheckPath
 	}
 
-	// Set property ‘Http20Enabled’:
+	// Set property "Http20Enabled":
 	if typedInput.Http20Enabled != nil {
 		http20Enabled := *typedInput.Http20Enabled
 		config.Http20Enabled = &http20Enabled
 	}
 
-	// Set property ‘HttpLoggingEnabled’:
+	// Set property "HttpLoggingEnabled":
 	if typedInput.HttpLoggingEnabled != nil {
 		httpLoggingEnabled := *typedInput.HttpLoggingEnabled
 		config.HttpLoggingEnabled = &httpLoggingEnabled
 	}
 
-	// Set property ‘IpSecurityRestrictions’:
+	// Set property "IpSecurityRestrictions":
 	for _, item := range typedInput.IpSecurityRestrictions {
 		var item1 IpSecurityRestriction_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6293,31 +6293,31 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.IpSecurityRestrictions = append(config.IpSecurityRestrictions, item1)
 	}
 
-	// Set property ‘JavaContainer’:
+	// Set property "JavaContainer":
 	if typedInput.JavaContainer != nil {
 		javaContainer := *typedInput.JavaContainer
 		config.JavaContainer = &javaContainer
 	}
 
-	// Set property ‘JavaContainerVersion’:
+	// Set property "JavaContainerVersion":
 	if typedInput.JavaContainerVersion != nil {
 		javaContainerVersion := *typedInput.JavaContainerVersion
 		config.JavaContainerVersion = &javaContainerVersion
 	}
 
-	// Set property ‘JavaVersion’:
+	// Set property "JavaVersion":
 	if typedInput.JavaVersion != nil {
 		javaVersion := *typedInput.JavaVersion
 		config.JavaVersion = &javaVersion
 	}
 
-	// Set property ‘KeyVaultReferenceIdentity’:
+	// Set property "KeyVaultReferenceIdentity":
 	if typedInput.KeyVaultReferenceIdentity != nil {
 		keyVaultReferenceIdentity := *typedInput.KeyVaultReferenceIdentity
 		config.KeyVaultReferenceIdentity = &keyVaultReferenceIdentity
 	}
 
-	// Set property ‘Limits’:
+	// Set property "Limits":
 	if typedInput.Limits != nil {
 		var limits1 SiteLimits_STATUS
 		err := limits1.PopulateFromARM(owner, *typedInput.Limits)
@@ -6328,31 +6328,31 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.Limits = &limits
 	}
 
-	// Set property ‘LinuxFxVersion’:
+	// Set property "LinuxFxVersion":
 	if typedInput.LinuxFxVersion != nil {
 		linuxFxVersion := *typedInput.LinuxFxVersion
 		config.LinuxFxVersion = &linuxFxVersion
 	}
 
-	// Set property ‘LoadBalancing’:
+	// Set property "LoadBalancing":
 	if typedInput.LoadBalancing != nil {
 		loadBalancing := *typedInput.LoadBalancing
 		config.LoadBalancing = &loadBalancing
 	}
 
-	// Set property ‘LocalMySqlEnabled’:
+	// Set property "LocalMySqlEnabled":
 	if typedInput.LocalMySqlEnabled != nil {
 		localMySqlEnabled := *typedInput.LocalMySqlEnabled
 		config.LocalMySqlEnabled = &localMySqlEnabled
 	}
 
-	// Set property ‘LogsDirectorySizeLimit’:
+	// Set property "LogsDirectorySizeLimit":
 	if typedInput.LogsDirectorySizeLimit != nil {
 		logsDirectorySizeLimit := *typedInput.LogsDirectorySizeLimit
 		config.LogsDirectorySizeLimit = &logsDirectorySizeLimit
 	}
 
-	// Set property ‘MachineKey’:
+	// Set property "MachineKey":
 	if typedInput.MachineKey != nil {
 		var machineKey1 SiteMachineKey_STATUS
 		err := machineKey1.PopulateFromARM(owner, *typedInput.MachineKey)
@@ -6363,79 +6363,79 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.MachineKey = &machineKey
 	}
 
-	// Set property ‘ManagedPipelineMode’:
+	// Set property "ManagedPipelineMode":
 	if typedInput.ManagedPipelineMode != nil {
 		managedPipelineMode := *typedInput.ManagedPipelineMode
 		config.ManagedPipelineMode = &managedPipelineMode
 	}
 
-	// Set property ‘ManagedServiceIdentityId’:
+	// Set property "ManagedServiceIdentityId":
 	if typedInput.ManagedServiceIdentityId != nil {
 		managedServiceIdentityId := *typedInput.ManagedServiceIdentityId
 		config.ManagedServiceIdentityId = &managedServiceIdentityId
 	}
 
-	// Set property ‘MinTlsVersion’:
+	// Set property "MinTlsVersion":
 	if typedInput.MinTlsVersion != nil {
 		minTlsVersion := *typedInput.MinTlsVersion
 		config.MinTlsVersion = &minTlsVersion
 	}
 
-	// Set property ‘MinimumElasticInstanceCount’:
+	// Set property "MinimumElasticInstanceCount":
 	if typedInput.MinimumElasticInstanceCount != nil {
 		minimumElasticInstanceCount := *typedInput.MinimumElasticInstanceCount
 		config.MinimumElasticInstanceCount = &minimumElasticInstanceCount
 	}
 
-	// Set property ‘NetFrameworkVersion’:
+	// Set property "NetFrameworkVersion":
 	if typedInput.NetFrameworkVersion != nil {
 		netFrameworkVersion := *typedInput.NetFrameworkVersion
 		config.NetFrameworkVersion = &netFrameworkVersion
 	}
 
-	// Set property ‘NodeVersion’:
+	// Set property "NodeVersion":
 	if typedInput.NodeVersion != nil {
 		nodeVersion := *typedInput.NodeVersion
 		config.NodeVersion = &nodeVersion
 	}
 
-	// Set property ‘NumberOfWorkers’:
+	// Set property "NumberOfWorkers":
 	if typedInput.NumberOfWorkers != nil {
 		numberOfWorkers := *typedInput.NumberOfWorkers
 		config.NumberOfWorkers = &numberOfWorkers
 	}
 
-	// Set property ‘PhpVersion’:
+	// Set property "PhpVersion":
 	if typedInput.PhpVersion != nil {
 		phpVersion := *typedInput.PhpVersion
 		config.PhpVersion = &phpVersion
 	}
 
-	// Set property ‘PowerShellVersion’:
+	// Set property "PowerShellVersion":
 	if typedInput.PowerShellVersion != nil {
 		powerShellVersion := *typedInput.PowerShellVersion
 		config.PowerShellVersion = &powerShellVersion
 	}
 
-	// Set property ‘PreWarmedInstanceCount’:
+	// Set property "PreWarmedInstanceCount":
 	if typedInput.PreWarmedInstanceCount != nil {
 		preWarmedInstanceCount := *typedInput.PreWarmedInstanceCount
 		config.PreWarmedInstanceCount = &preWarmedInstanceCount
 	}
 
-	// Set property ‘PublicNetworkAccess’:
+	// Set property "PublicNetworkAccess":
 	if typedInput.PublicNetworkAccess != nil {
 		publicNetworkAccess := *typedInput.PublicNetworkAccess
 		config.PublicNetworkAccess = &publicNetworkAccess
 	}
 
-	// Set property ‘PublishingUsername’:
+	// Set property "PublishingUsername":
 	if typedInput.PublishingUsername != nil {
 		publishingUsername := *typedInput.PublishingUsername
 		config.PublishingUsername = &publishingUsername
 	}
 
-	// Set property ‘Push’:
+	// Set property "Push":
 	if typedInput.Push != nil {
 		var push1 PushSettings_STATUS
 		err := push1.PopulateFromARM(owner, *typedInput.Push)
@@ -6446,37 +6446,37 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.Push = &push
 	}
 
-	// Set property ‘PythonVersion’:
+	// Set property "PythonVersion":
 	if typedInput.PythonVersion != nil {
 		pythonVersion := *typedInput.PythonVersion
 		config.PythonVersion = &pythonVersion
 	}
 
-	// Set property ‘RemoteDebuggingEnabled’:
+	// Set property "RemoteDebuggingEnabled":
 	if typedInput.RemoteDebuggingEnabled != nil {
 		remoteDebuggingEnabled := *typedInput.RemoteDebuggingEnabled
 		config.RemoteDebuggingEnabled = &remoteDebuggingEnabled
 	}
 
-	// Set property ‘RemoteDebuggingVersion’:
+	// Set property "RemoteDebuggingVersion":
 	if typedInput.RemoteDebuggingVersion != nil {
 		remoteDebuggingVersion := *typedInput.RemoteDebuggingVersion
 		config.RemoteDebuggingVersion = &remoteDebuggingVersion
 	}
 
-	// Set property ‘RequestTracingEnabled’:
+	// Set property "RequestTracingEnabled":
 	if typedInput.RequestTracingEnabled != nil {
 		requestTracingEnabled := *typedInput.RequestTracingEnabled
 		config.RequestTracingEnabled = &requestTracingEnabled
 	}
 
-	// Set property ‘RequestTracingExpirationTime’:
+	// Set property "RequestTracingExpirationTime":
 	if typedInput.RequestTracingExpirationTime != nil {
 		requestTracingExpirationTime := *typedInput.RequestTracingExpirationTime
 		config.RequestTracingExpirationTime = &requestTracingExpirationTime
 	}
 
-	// Set property ‘ScmIpSecurityRestrictions’:
+	// Set property "ScmIpSecurityRestrictions":
 	for _, item := range typedInput.ScmIpSecurityRestrictions {
 		var item1 IpSecurityRestriction_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6486,37 +6486,37 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.ScmIpSecurityRestrictions = append(config.ScmIpSecurityRestrictions, item1)
 	}
 
-	// Set property ‘ScmIpSecurityRestrictionsUseMain’:
+	// Set property "ScmIpSecurityRestrictionsUseMain":
 	if typedInput.ScmIpSecurityRestrictionsUseMain != nil {
 		scmIpSecurityRestrictionsUseMain := *typedInput.ScmIpSecurityRestrictionsUseMain
 		config.ScmIpSecurityRestrictionsUseMain = &scmIpSecurityRestrictionsUseMain
 	}
 
-	// Set property ‘ScmMinTlsVersion’:
+	// Set property "ScmMinTlsVersion":
 	if typedInput.ScmMinTlsVersion != nil {
 		scmMinTlsVersion := *typedInput.ScmMinTlsVersion
 		config.ScmMinTlsVersion = &scmMinTlsVersion
 	}
 
-	// Set property ‘ScmType’:
+	// Set property "ScmType":
 	if typedInput.ScmType != nil {
 		scmType := *typedInput.ScmType
 		config.ScmType = &scmType
 	}
 
-	// Set property ‘TracingOptions’:
+	// Set property "TracingOptions":
 	if typedInput.TracingOptions != nil {
 		tracingOptions := *typedInput.TracingOptions
 		config.TracingOptions = &tracingOptions
 	}
 
-	// Set property ‘Use32BitWorkerProcess’:
+	// Set property "Use32BitWorkerProcess":
 	if typedInput.Use32BitWorkerProcess != nil {
 		use32BitWorkerProcess := *typedInput.Use32BitWorkerProcess
 		config.Use32BitWorkerProcess = &use32BitWorkerProcess
 	}
 
-	// Set property ‘VirtualApplications’:
+	// Set property "VirtualApplications":
 	for _, item := range typedInput.VirtualApplications {
 		var item1 VirtualApplication_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -6526,43 +6526,43 @@ func (config *SiteConfig_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		config.VirtualApplications = append(config.VirtualApplications, item1)
 	}
 
-	// Set property ‘VnetName’:
+	// Set property "VnetName":
 	if typedInput.VnetName != nil {
 		vnetName := *typedInput.VnetName
 		config.VnetName = &vnetName
 	}
 
-	// Set property ‘VnetPrivatePortsCount’:
+	// Set property "VnetPrivatePortsCount":
 	if typedInput.VnetPrivatePortsCount != nil {
 		vnetPrivatePortsCount := *typedInput.VnetPrivatePortsCount
 		config.VnetPrivatePortsCount = &vnetPrivatePortsCount
 	}
 
-	// Set property ‘VnetRouteAllEnabled’:
+	// Set property "VnetRouteAllEnabled":
 	if typedInput.VnetRouteAllEnabled != nil {
 		vnetRouteAllEnabled := *typedInput.VnetRouteAllEnabled
 		config.VnetRouteAllEnabled = &vnetRouteAllEnabled
 	}
 
-	// Set property ‘WebSocketsEnabled’:
+	// Set property "WebSocketsEnabled":
 	if typedInput.WebSocketsEnabled != nil {
 		webSocketsEnabled := *typedInput.WebSocketsEnabled
 		config.WebSocketsEnabled = &webSocketsEnabled
 	}
 
-	// Set property ‘WebsiteTimeZone’:
+	// Set property "WebsiteTimeZone":
 	if typedInput.WebsiteTimeZone != nil {
 		websiteTimeZone := *typedInput.WebsiteTimeZone
 		config.WebsiteTimeZone = &websiteTimeZone
 	}
 
-	// Set property ‘WindowsFxVersion’:
+	// Set property "WindowsFxVersion":
 	if typedInput.WindowsFxVersion != nil {
 		windowsFxVersion := *typedInput.WindowsFxVersion
 		config.WindowsFxVersion = &windowsFxVersion
 	}
 
-	// Set property ‘XManagedServiceIdentityId’:
+	// Set property "XManagedServiceIdentityId":
 	if typedInput.XManagedServiceIdentityId != nil {
 		xManagedServiceIdentityId := *typedInput.XManagedServiceIdentityId
 		config.XManagedServiceIdentityId = &xManagedServiceIdentityId
@@ -7572,19 +7572,19 @@ func (status *SlotSwapStatus_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SlotSwapStatus_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DestinationSlotName’:
+	// Set property "DestinationSlotName":
 	if typedInput.DestinationSlotName != nil {
 		destinationSlotName := *typedInput.DestinationSlotName
 		status.DestinationSlotName = &destinationSlotName
 	}
 
-	// Set property ‘SourceSlotName’:
+	// Set property "SourceSlotName":
 	if typedInput.SourceSlotName != nil {
 		sourceSlotName := *typedInput.SourceSlotName
 		status.SourceSlotName = &sourceSlotName
 	}
 
-	// Set property ‘TimestampUtc’:
+	// Set property "TimestampUtc":
 	if typedInput.TimestampUtc != nil {
 		timestampUtc := *typedInput.TimestampUtc
 		status.TimestampUtc = &timestampUtc
@@ -7649,7 +7649,7 @@ func (info *ApiDefinitionInfo) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &ApiDefinitionInfo_ARM{}
 
-	// Set property ‘Url’:
+	// Set property "Url":
 	if info.Url != nil {
 		url := *info.Url
 		result.Url = &url
@@ -7669,7 +7669,7 @@ func (info *ApiDefinitionInfo) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiDefinitionInfo_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Url’:
+	// Set property "Url":
 	if typedInput.Url != nil {
 		url := *typedInput.Url
 		info.Url = &url
@@ -7727,7 +7727,7 @@ func (info *ApiDefinitionInfo_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiDefinitionInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Url’:
+	// Set property "Url":
 	if typedInput.Url != nil {
 		url := *typedInput.Url
 		info.Url = &url
@@ -7780,7 +7780,7 @@ func (config *ApiManagementConfig) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &ApiManagementConfig_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if config.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*config.Reference)
 		if err != nil {
@@ -7804,7 +7804,7 @@ func (config *ApiManagementConfig) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiManagementConfig_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
 	// No error
 	return nil
@@ -7868,7 +7868,7 @@ func (config *ApiManagementConfig_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ApiManagementConfig_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		config.Id = &id
@@ -7922,7 +7922,7 @@ func (rules *AutoHealRules) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &AutoHealRules_ARM{}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if rules.Actions != nil {
 		actions_ARM, err := (*rules.Actions).ConvertToARM(resolved)
 		if err != nil {
@@ -7932,7 +7932,7 @@ func (rules *AutoHealRules) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		result.Actions = &actions
 	}
 
-	// Set property ‘Triggers’:
+	// Set property "Triggers":
 	if rules.Triggers != nil {
 		triggers_ARM, err := (*rules.Triggers).ConvertToARM(resolved)
 		if err != nil {
@@ -7956,7 +7956,7 @@ func (rules *AutoHealRules) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealRules_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if typedInput.Actions != nil {
 		var actions1 AutoHealActions
 		err := actions1.PopulateFromARM(owner, *typedInput.Actions)
@@ -7967,7 +7967,7 @@ func (rules *AutoHealRules) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		rules.Actions = &actions
 	}
 
-	// Set property ‘Triggers’:
+	// Set property "Triggers":
 	if typedInput.Triggers != nil {
 		var triggers1 AutoHealTriggers
 		err := triggers1.PopulateFromARM(owner, *typedInput.Triggers)
@@ -8073,7 +8073,7 @@ func (rules *AutoHealRules_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealRules_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Actions’:
+	// Set property "Actions":
 	if typedInput.Actions != nil {
 		var actions1 AutoHealActions_STATUS
 		err := actions1.PopulateFromARM(owner, *typedInput.Actions)
@@ -8084,7 +8084,7 @@ func (rules *AutoHealRules_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		rules.Actions = &actions
 	}
 
-	// Set property ‘Triggers’:
+	// Set property "Triggers":
 	if typedInput.Triggers != nil {
 		var triggers1 AutoHealTriggers_STATUS
 		err := triggers1.PopulateFromARM(owner, *typedInput.Triggers)
@@ -8188,7 +8188,7 @@ func (value *AzureStorageInfoValue) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &AzureStorageInfoValue_ARM{}
 
-	// Set property ‘AccessKey’:
+	// Set property "AccessKey":
 	if value.AccessKey != nil {
 		accessKeySecret, err := resolved.ResolvedSecrets.Lookup(*value.AccessKey)
 		if err != nil {
@@ -8198,25 +8198,25 @@ func (value *AzureStorageInfoValue) ConvertToARM(resolved genruntime.ConvertToAR
 		result.AccessKey = &accessKey
 	}
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if value.AccountName != nil {
 		accountName := *value.AccountName
 		result.AccountName = &accountName
 	}
 
-	// Set property ‘MountPath’:
+	// Set property "MountPath":
 	if value.MountPath != nil {
 		mountPath := *value.MountPath
 		result.MountPath = &mountPath
 	}
 
-	// Set property ‘ShareName’:
+	// Set property "ShareName":
 	if value.ShareName != nil {
 		shareName := *value.ShareName
 		result.ShareName = &shareName
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if value.Type != nil {
 		typeVar := *value.Type
 		result.Type = &typeVar
@@ -8236,27 +8236,27 @@ func (value *AzureStorageInfoValue) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureStorageInfoValue_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘AccessKey’
+	// no assignment for property "AccessKey"
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if typedInput.AccountName != nil {
 		accountName := *typedInput.AccountName
 		value.AccountName = &accountName
 	}
 
-	// Set property ‘MountPath’:
+	// Set property "MountPath":
 	if typedInput.MountPath != nil {
 		mountPath := *typedInput.MountPath
 		value.MountPath = &mountPath
 	}
 
-	// Set property ‘ShareName’:
+	// Set property "ShareName":
 	if typedInput.ShareName != nil {
 		shareName := *typedInput.ShareName
 		value.ShareName = &shareName
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		value.Type = &typeVar
@@ -8362,31 +8362,31 @@ func (value *AzureStorageInfoValue_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AzureStorageInfoValue_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AccountName’:
+	// Set property "AccountName":
 	if typedInput.AccountName != nil {
 		accountName := *typedInput.AccountName
 		value.AccountName = &accountName
 	}
 
-	// Set property ‘MountPath’:
+	// Set property "MountPath":
 	if typedInput.MountPath != nil {
 		mountPath := *typedInput.MountPath
 		value.MountPath = &mountPath
 	}
 
-	// Set property ‘ShareName’:
+	// Set property "ShareName":
 	if typedInput.ShareName != nil {
 		shareName := *typedInput.ShareName
 		value.ShareName = &shareName
 	}
 
-	// Set property ‘State’:
+	// Set property "State":
 	if typedInput.State != nil {
 		state := *typedInput.State
 		value.State = &state
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		value.Type = &typeVar
@@ -8485,19 +8485,19 @@ func (info *ConnStringInfo) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 	result := &ConnStringInfo_ARM{}
 
-	// Set property ‘ConnectionString’:
+	// Set property "ConnectionString":
 	if info.ConnectionString != nil {
 		connectionString := *info.ConnectionString
 		result.ConnectionString = &connectionString
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if info.Name != nil {
 		name := *info.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if info.Type != nil {
 		typeVar := *info.Type
 		result.Type = &typeVar
@@ -8517,19 +8517,19 @@ func (info *ConnStringInfo) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConnStringInfo_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConnectionString’:
+	// Set property "ConnectionString":
 	if typedInput.ConnectionString != nil {
 		connectionString := *typedInput.ConnectionString
 		info.ConnectionString = &connectionString
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		info.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		info.Type = &typeVar
@@ -8611,19 +8611,19 @@ func (info *ConnStringInfo_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected ConnStringInfo_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ConnectionString’:
+	// Set property "ConnectionString":
 	if typedInput.ConnectionString != nil {
 		connectionString := *typedInput.ConnectionString
 		info.ConnectionString = &connectionString
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		info.Name = &name
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		info.Type = &typeVar
@@ -8699,12 +8699,12 @@ func (settings *CorsSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &CorsSettings_ARM{}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range settings.AllowedOrigins {
 		result.AllowedOrigins = append(result.AllowedOrigins, item)
 	}
 
-	// Set property ‘SupportCredentials’:
+	// Set property "SupportCredentials":
 	if settings.SupportCredentials != nil {
 		supportCredentials := *settings.SupportCredentials
 		result.SupportCredentials = &supportCredentials
@@ -8724,12 +8724,12 @@ func (settings *CorsSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		settings.AllowedOrigins = append(settings.AllowedOrigins, item)
 	}
 
-	// Set property ‘SupportCredentials’:
+	// Set property "SupportCredentials":
 	if typedInput.SupportCredentials != nil {
 		supportCredentials := *typedInput.SupportCredentials
 		settings.SupportCredentials = &supportCredentials
@@ -8804,12 +8804,12 @@ func (settings *CorsSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CorsSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AllowedOrigins’:
+	// Set property "AllowedOrigins":
 	for _, item := range typedInput.AllowedOrigins {
 		settings.AllowedOrigins = append(settings.AllowedOrigins, item)
 	}
 
-	// Set property ‘SupportCredentials’:
+	// Set property "SupportCredentials":
 	if typedInput.SupportCredentials != nil {
 		supportCredentials := *typedInput.SupportCredentials
 		settings.SupportCredentials = &supportCredentials
@@ -8878,7 +8878,7 @@ func (experiments *Experiments) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &Experiments_ARM{}
 
-	// Set property ‘RampUpRules’:
+	// Set property "RampUpRules":
 	for _, item := range experiments.RampUpRules {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -8901,7 +8901,7 @@ func (experiments *Experiments) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Experiments_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RampUpRules’:
+	// Set property "RampUpRules":
 	for _, item := range typedInput.RampUpRules {
 		var item1 RampUpRule
 		err := item1.PopulateFromARM(owner, item)
@@ -8993,7 +8993,7 @@ func (experiments *Experiments_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Experiments_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘RampUpRules’:
+	// Set property "RampUpRules":
 	for _, item := range typedInput.RampUpRules {
 		var item1 RampUpRule_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -9082,19 +9082,19 @@ func (mapping *HandlerMapping) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 	result := &HandlerMapping_ARM{}
 
-	// Set property ‘Arguments’:
+	// Set property "Arguments":
 	if mapping.Arguments != nil {
 		arguments := *mapping.Arguments
 		result.Arguments = &arguments
 	}
 
-	// Set property ‘Extension’:
+	// Set property "Extension":
 	if mapping.Extension != nil {
 		extension := *mapping.Extension
 		result.Extension = &extension
 	}
 
-	// Set property ‘ScriptProcessor’:
+	// Set property "ScriptProcessor":
 	if mapping.ScriptProcessor != nil {
 		scriptProcessor := *mapping.ScriptProcessor
 		result.ScriptProcessor = &scriptProcessor
@@ -9114,19 +9114,19 @@ func (mapping *HandlerMapping) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HandlerMapping_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Arguments’:
+	// Set property "Arguments":
 	if typedInput.Arguments != nil {
 		arguments := *typedInput.Arguments
 		mapping.Arguments = &arguments
 	}
 
-	// Set property ‘Extension’:
+	// Set property "Extension":
 	if typedInput.Extension != nil {
 		extension := *typedInput.Extension
 		mapping.Extension = &extension
 	}
 
-	// Set property ‘ScriptProcessor’:
+	// Set property "ScriptProcessor":
 	if typedInput.ScriptProcessor != nil {
 		scriptProcessor := *typedInput.ScriptProcessor
 		mapping.ScriptProcessor = &scriptProcessor
@@ -9198,19 +9198,19 @@ func (mapping *HandlerMapping_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected HandlerMapping_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Arguments’:
+	// Set property "Arguments":
 	if typedInput.Arguments != nil {
 		arguments := *typedInput.Arguments
 		mapping.Arguments = &arguments
 	}
 
-	// Set property ‘Extension’:
+	// Set property "Extension":
 	if typedInput.Extension != nil {
 		extension := *typedInput.Extension
 		mapping.Extension = &extension
 	}
 
-	// Set property ‘ScriptProcessor’:
+	// Set property "ScriptProcessor":
 	if typedInput.ScriptProcessor != nil {
 		scriptProcessor := *typedInput.ScriptProcessor
 		mapping.ScriptProcessor = &scriptProcessor
@@ -9321,19 +9321,19 @@ func (restriction *IpSecurityRestriction) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &IpSecurityRestriction_ARM{}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if restriction.Action != nil {
 		action := *restriction.Action
 		result.Action = &action
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if restriction.Description != nil {
 		description := *restriction.Description
 		result.Description = &description
 	}
 
-	// Set property ‘Headers’:
+	// Set property "Headers":
 	if restriction.Headers != nil {
 		result.Headers = make(map[string][]string, len(restriction.Headers))
 		for key, value := range restriction.Headers {
@@ -9345,43 +9345,43 @@ func (restriction *IpSecurityRestriction) ConvertToARM(resolved genruntime.Conve
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	if restriction.IpAddress != nil {
 		ipAddress := *restriction.IpAddress
 		result.IpAddress = &ipAddress
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if restriction.Name != nil {
 		name := *restriction.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if restriction.Priority != nil {
 		priority := *restriction.Priority
 		result.Priority = &priority
 	}
 
-	// Set property ‘SubnetMask’:
+	// Set property "SubnetMask":
 	if restriction.SubnetMask != nil {
 		subnetMask := *restriction.SubnetMask
 		result.SubnetMask = &subnetMask
 	}
 
-	// Set property ‘SubnetTrafficTag’:
+	// Set property "SubnetTrafficTag":
 	if restriction.SubnetTrafficTag != nil {
 		subnetTrafficTag := *restriction.SubnetTrafficTag
 		result.SubnetTrafficTag = &subnetTrafficTag
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if restriction.Tag != nil {
 		tag := *restriction.Tag
 		result.Tag = &tag
 	}
 
-	// Set property ‘VnetSubnetResourceId’:
+	// Set property "VnetSubnetResourceId":
 	if restriction.VnetSubnetResourceReference != nil {
 		vnetSubnetResourceReferenceARMID, err := resolved.ResolvedReferences.Lookup(*restriction.VnetSubnetResourceReference)
 		if err != nil {
@@ -9391,7 +9391,7 @@ func (restriction *IpSecurityRestriction) ConvertToARM(resolved genruntime.Conve
 		result.VnetSubnetResourceId = &vnetSubnetResourceReference
 	}
 
-	// Set property ‘VnetTrafficTag’:
+	// Set property "VnetTrafficTag":
 	if restriction.VnetTrafficTag != nil {
 		vnetTrafficTag := *restriction.VnetTrafficTag
 		result.VnetTrafficTag = &vnetTrafficTag
@@ -9411,19 +9411,19 @@ func (restriction *IpSecurityRestriction) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpSecurityRestriction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		restriction.Action = &action
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		restriction.Description = &description
 	}
 
-	// Set property ‘Headers’:
+	// Set property "Headers":
 	if typedInput.Headers != nil {
 		restriction.Headers = make(map[string][]string, len(typedInput.Headers))
 		for key, value := range typedInput.Headers {
@@ -9435,45 +9435,45 @@ func (restriction *IpSecurityRestriction) PopulateFromARM(owner genruntime.Arbit
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	if typedInput.IpAddress != nil {
 		ipAddress := *typedInput.IpAddress
 		restriction.IpAddress = &ipAddress
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		restriction.Name = &name
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		restriction.Priority = &priority
 	}
 
-	// Set property ‘SubnetMask’:
+	// Set property "SubnetMask":
 	if typedInput.SubnetMask != nil {
 		subnetMask := *typedInput.SubnetMask
 		restriction.SubnetMask = &subnetMask
 	}
 
-	// Set property ‘SubnetTrafficTag’:
+	// Set property "SubnetTrafficTag":
 	if typedInput.SubnetTrafficTag != nil {
 		subnetTrafficTag := *typedInput.SubnetTrafficTag
 		restriction.SubnetTrafficTag = &subnetTrafficTag
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		restriction.Tag = &tag
 	}
 
-	// no assignment for property ‘VnetSubnetResourceReference’
+	// no assignment for property "VnetSubnetResourceReference"
 
-	// Set property ‘VnetTrafficTag’:
+	// Set property "VnetTrafficTag":
 	if typedInput.VnetTrafficTag != nil {
 		vnetTrafficTag := *typedInput.VnetTrafficTag
 		restriction.VnetTrafficTag = &vnetTrafficTag
@@ -9641,19 +9641,19 @@ func (restriction *IpSecurityRestriction_STATUS) PopulateFromARM(owner genruntim
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected IpSecurityRestriction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Action’:
+	// Set property "Action":
 	if typedInput.Action != nil {
 		action := *typedInput.Action
 		restriction.Action = &action
 	}
 
-	// Set property ‘Description’:
+	// Set property "Description":
 	if typedInput.Description != nil {
 		description := *typedInput.Description
 		restriction.Description = &description
 	}
 
-	// Set property ‘Headers’:
+	// Set property "Headers":
 	if typedInput.Headers != nil {
 		restriction.Headers = make(map[string][]string, len(typedInput.Headers))
 		for key, value := range typedInput.Headers {
@@ -9665,49 +9665,49 @@ func (restriction *IpSecurityRestriction_STATUS) PopulateFromARM(owner genruntim
 		}
 	}
 
-	// Set property ‘IpAddress’:
+	// Set property "IpAddress":
 	if typedInput.IpAddress != nil {
 		ipAddress := *typedInput.IpAddress
 		restriction.IpAddress = &ipAddress
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		restriction.Name = &name
 	}
 
-	// Set property ‘Priority’:
+	// Set property "Priority":
 	if typedInput.Priority != nil {
 		priority := *typedInput.Priority
 		restriction.Priority = &priority
 	}
 
-	// Set property ‘SubnetMask’:
+	// Set property "SubnetMask":
 	if typedInput.SubnetMask != nil {
 		subnetMask := *typedInput.SubnetMask
 		restriction.SubnetMask = &subnetMask
 	}
 
-	// Set property ‘SubnetTrafficTag’:
+	// Set property "SubnetTrafficTag":
 	if typedInput.SubnetTrafficTag != nil {
 		subnetTrafficTag := *typedInput.SubnetTrafficTag
 		restriction.SubnetTrafficTag = &subnetTrafficTag
 	}
 
-	// Set property ‘Tag’:
+	// Set property "Tag":
 	if typedInput.Tag != nil {
 		tag := *typedInput.Tag
 		restriction.Tag = &tag
 	}
 
-	// Set property ‘VnetSubnetResourceId’:
+	// Set property "VnetSubnetResourceId":
 	if typedInput.VnetSubnetResourceId != nil {
 		vnetSubnetResourceId := *typedInput.VnetSubnetResourceId
 		restriction.VnetSubnetResourceId = &vnetSubnetResourceId
 	}
 
-	// Set property ‘VnetTrafficTag’:
+	// Set property "VnetTrafficTag":
 	if typedInput.VnetTrafficTag != nil {
 		vnetTrafficTag := *typedInput.VnetTrafficTag
 		restriction.VnetTrafficTag = &vnetTrafficTag
@@ -9851,13 +9851,13 @@ func (pair *NameValuePair) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &NameValuePair_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if pair.Name != nil {
 		name := *pair.Name
 		result.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if pair.Value != nil {
 		value := *pair.Value
 		result.Value = &value
@@ -9877,13 +9877,13 @@ func (pair *NameValuePair) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NameValuePair_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pair.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		pair.Value = &value
@@ -9948,13 +9948,13 @@ func (pair *NameValuePair_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected NameValuePair_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		pair.Name = &name
 	}
 
-	// Set property ‘Value’:
+	// Set property "Value":
 	if typedInput.Value != nil {
 		value := *typedInput.Value
 		pair.Value = &value
@@ -10019,13 +10019,13 @@ func (settings *PushSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 	result := &PushSettings_ARM{}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if settings.Kind != nil {
 		kind := *settings.Kind
 		result.Kind = &kind
 	}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if settings.DynamicTagsJson != nil ||
 		settings.IsPushEnabled != nil ||
 		settings.TagWhitelistJson != nil ||
@@ -10063,7 +10063,7 @@ func (settings *PushSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PushSettings_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DynamicTagsJson’:
+	// Set property "DynamicTagsJson":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DynamicTagsJson != nil {
@@ -10072,7 +10072,7 @@ func (settings *PushSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘IsPushEnabled’:
+	// Set property "IsPushEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsPushEnabled != nil {
@@ -10081,13 +10081,13 @@ func (settings *PushSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		settings.Kind = &kind
 	}
 
-	// Set property ‘TagWhitelistJson’:
+	// Set property "TagWhitelistJson":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TagWhitelistJson != nil {
@@ -10096,7 +10096,7 @@ func (settings *PushSettings) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 		}
 	}
 
-	// Set property ‘TagsRequiringAuth’:
+	// Set property "TagsRequiringAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TagsRequiringAuth != nil {
@@ -10198,7 +10198,7 @@ func (settings *PushSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PushSettings_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘DynamicTagsJson’:
+	// Set property "DynamicTagsJson":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.DynamicTagsJson != nil {
@@ -10207,13 +10207,13 @@ func (settings *PushSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if typedInput.Id != nil {
 		id := *typedInput.Id
 		settings.Id = &id
 	}
 
-	// Set property ‘IsPushEnabled’:
+	// Set property "IsPushEnabled":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.IsPushEnabled != nil {
@@ -10222,19 +10222,19 @@ func (settings *PushSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Kind’:
+	// Set property "Kind":
 	if typedInput.Kind != nil {
 		kind := *typedInput.Kind
 		settings.Kind = &kind
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		settings.Name = &name
 	}
 
-	// Set property ‘TagWhitelistJson’:
+	// Set property "TagWhitelistJson":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TagWhitelistJson != nil {
@@ -10243,7 +10243,7 @@ func (settings *PushSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘TagsRequiringAuth’:
+	// Set property "TagsRequiringAuth":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.TagsRequiringAuth != nil {
@@ -10252,7 +10252,7 @@ func (settings *PushSettings_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 		}
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	if typedInput.Type != nil {
 		typeVar := *typedInput.Type
 		settings.Type = &typeVar
@@ -10500,19 +10500,19 @@ func (limits *SiteLimits) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 	result := &SiteLimits_ARM{}
 
-	// Set property ‘MaxDiskSizeInMb’:
+	// Set property "MaxDiskSizeInMb":
 	if limits.MaxDiskSizeInMb != nil {
 		maxDiskSizeInMb := *limits.MaxDiskSizeInMb
 		result.MaxDiskSizeInMb = &maxDiskSizeInMb
 	}
 
-	// Set property ‘MaxMemoryInMb’:
+	// Set property "MaxMemoryInMb":
 	if limits.MaxMemoryInMb != nil {
 		maxMemoryInMb := *limits.MaxMemoryInMb
 		result.MaxMemoryInMb = &maxMemoryInMb
 	}
 
-	// Set property ‘MaxPercentageCpu’:
+	// Set property "MaxPercentageCpu":
 	if limits.MaxPercentageCpu != nil {
 		maxPercentageCpu := *limits.MaxPercentageCpu
 		result.MaxPercentageCpu = &maxPercentageCpu
@@ -10532,19 +10532,19 @@ func (limits *SiteLimits) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SiteLimits_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxDiskSizeInMb’:
+	// Set property "MaxDiskSizeInMb":
 	if typedInput.MaxDiskSizeInMb != nil {
 		maxDiskSizeInMb := *typedInput.MaxDiskSizeInMb
 		limits.MaxDiskSizeInMb = &maxDiskSizeInMb
 	}
 
-	// Set property ‘MaxMemoryInMb’:
+	// Set property "MaxMemoryInMb":
 	if typedInput.MaxMemoryInMb != nil {
 		maxMemoryInMb := *typedInput.MaxMemoryInMb
 		limits.MaxMemoryInMb = &maxMemoryInMb
 	}
 
-	// Set property ‘MaxPercentageCpu’:
+	// Set property "MaxPercentageCpu":
 	if typedInput.MaxPercentageCpu != nil {
 		maxPercentageCpu := *typedInput.MaxPercentageCpu
 		limits.MaxPercentageCpu = &maxPercentageCpu
@@ -10626,19 +10626,19 @@ func (limits *SiteLimits_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SiteLimits_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘MaxDiskSizeInMb’:
+	// Set property "MaxDiskSizeInMb":
 	if typedInput.MaxDiskSizeInMb != nil {
 		maxDiskSizeInMb := *typedInput.MaxDiskSizeInMb
 		limits.MaxDiskSizeInMb = &maxDiskSizeInMb
 	}
 
-	// Set property ‘MaxMemoryInMb’:
+	// Set property "MaxMemoryInMb":
 	if typedInput.MaxMemoryInMb != nil {
 		maxMemoryInMb := *typedInput.MaxMemoryInMb
 		limits.MaxMemoryInMb = &maxMemoryInMb
 	}
 
-	// Set property ‘MaxPercentageCpu’:
+	// Set property "MaxPercentageCpu":
 	if typedInput.MaxPercentageCpu != nil {
 		maxPercentageCpu := *typedInput.MaxPercentageCpu
 		limits.MaxPercentageCpu = &maxPercentageCpu
@@ -10721,25 +10721,25 @@ func (machineKey *SiteMachineKey_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SiteMachineKey_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Decryption’:
+	// Set property "Decryption":
 	if typedInput.Decryption != nil {
 		decryption := *typedInput.Decryption
 		machineKey.Decryption = &decryption
 	}
 
-	// Set property ‘DecryptionKey’:
+	// Set property "DecryptionKey":
 	if typedInput.DecryptionKey != nil {
 		decryptionKey := *typedInput.DecryptionKey
 		machineKey.DecryptionKey = &decryptionKey
 	}
 
-	// Set property ‘Validation’:
+	// Set property "Validation":
 	if typedInput.Validation != nil {
 		validation := *typedInput.Validation
 		machineKey.Validation = &validation
 	}
 
-	// Set property ‘ValidationKey’:
+	// Set property "ValidationKey":
 	if typedInput.ValidationKey != nil {
 		validationKey := *typedInput.ValidationKey
 		machineKey.ValidationKey = &validationKey
@@ -10816,13 +10816,13 @@ func (identity *UserAssignedIdentity_STATUS) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected UserAssignedIdentity_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ClientId’:
+	// Set property "ClientId":
 	if typedInput.ClientId != nil {
 		clientId := *typedInput.ClientId
 		identity.ClientId = &clientId
 	}
 
-	// Set property ‘PrincipalId’:
+	// Set property "PrincipalId":
 	if typedInput.PrincipalId != nil {
 		principalId := *typedInput.PrincipalId
 		identity.PrincipalId = &principalId
@@ -10918,19 +10918,19 @@ func (application *VirtualApplication) ConvertToARM(resolved genruntime.ConvertT
 	}
 	result := &VirtualApplication_ARM{}
 
-	// Set property ‘PhysicalPath’:
+	// Set property "PhysicalPath":
 	if application.PhysicalPath != nil {
 		physicalPath := *application.PhysicalPath
 		result.PhysicalPath = &physicalPath
 	}
 
-	// Set property ‘PreloadEnabled’:
+	// Set property "PreloadEnabled":
 	if application.PreloadEnabled != nil {
 		preloadEnabled := *application.PreloadEnabled
 		result.PreloadEnabled = &preloadEnabled
 	}
 
-	// Set property ‘VirtualDirectories’:
+	// Set property "VirtualDirectories":
 	for _, item := range application.VirtualDirectories {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -10939,7 +10939,7 @@ func (application *VirtualApplication) ConvertToARM(resolved genruntime.ConvertT
 		result.VirtualDirectories = append(result.VirtualDirectories, *item_ARM.(*VirtualDirectory_ARM))
 	}
 
-	// Set property ‘VirtualPath’:
+	// Set property "VirtualPath":
 	if application.VirtualPath != nil {
 		virtualPath := *application.VirtualPath
 		result.VirtualPath = &virtualPath
@@ -10959,19 +10959,19 @@ func (application *VirtualApplication) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualApplication_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PhysicalPath’:
+	// Set property "PhysicalPath":
 	if typedInput.PhysicalPath != nil {
 		physicalPath := *typedInput.PhysicalPath
 		application.PhysicalPath = &physicalPath
 	}
 
-	// Set property ‘PreloadEnabled’:
+	// Set property "PreloadEnabled":
 	if typedInput.PreloadEnabled != nil {
 		preloadEnabled := *typedInput.PreloadEnabled
 		application.PreloadEnabled = &preloadEnabled
 	}
 
-	// Set property ‘VirtualDirectories’:
+	// Set property "VirtualDirectories":
 	for _, item := range typedInput.VirtualDirectories {
 		var item1 VirtualDirectory
 		err := item1.PopulateFromARM(owner, item)
@@ -10981,7 +10981,7 @@ func (application *VirtualApplication) PopulateFromARM(owner genruntime.Arbitrar
 		application.VirtualDirectories = append(application.VirtualDirectories, item1)
 	}
 
-	// Set property ‘VirtualPath’:
+	// Set property "VirtualPath":
 	if typedInput.VirtualPath != nil {
 		virtualPath := *typedInput.VirtualPath
 		application.VirtualPath = &virtualPath
@@ -11100,19 +11100,19 @@ func (application *VirtualApplication_STATUS) PopulateFromARM(owner genruntime.A
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualApplication_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PhysicalPath’:
+	// Set property "PhysicalPath":
 	if typedInput.PhysicalPath != nil {
 		physicalPath := *typedInput.PhysicalPath
 		application.PhysicalPath = &physicalPath
 	}
 
-	// Set property ‘PreloadEnabled’:
+	// Set property "PreloadEnabled":
 	if typedInput.PreloadEnabled != nil {
 		preloadEnabled := *typedInput.PreloadEnabled
 		application.PreloadEnabled = &preloadEnabled
 	}
 
-	// Set property ‘VirtualDirectories’:
+	// Set property "VirtualDirectories":
 	for _, item := range typedInput.VirtualDirectories {
 		var item1 VirtualDirectory_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11122,7 +11122,7 @@ func (application *VirtualApplication_STATUS) PopulateFromARM(owner genruntime.A
 		application.VirtualDirectories = append(application.VirtualDirectories, item1)
 	}
 
-	// Set property ‘VirtualPath’:
+	// Set property "VirtualPath":
 	if typedInput.VirtualPath != nil {
 		virtualPath := *typedInput.VirtualPath
 		application.VirtualPath = &virtualPath
@@ -11235,13 +11235,13 @@ func (actions *AutoHealActions) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &AutoHealActions_ARM{}
 
-	// Set property ‘ActionType’:
+	// Set property "ActionType":
 	if actions.ActionType != nil {
 		actionType := *actions.ActionType
 		result.ActionType = &actionType
 	}
 
-	// Set property ‘CustomAction’:
+	// Set property "CustomAction":
 	if actions.CustomAction != nil {
 		customAction_ARM, err := (*actions.CustomAction).ConvertToARM(resolved)
 		if err != nil {
@@ -11251,7 +11251,7 @@ func (actions *AutoHealActions) ConvertToARM(resolved genruntime.ConvertToARMRes
 		result.CustomAction = &customAction
 	}
 
-	// Set property ‘MinProcessExecutionTime’:
+	// Set property "MinProcessExecutionTime":
 	if actions.MinProcessExecutionTime != nil {
 		minProcessExecutionTime := *actions.MinProcessExecutionTime
 		result.MinProcessExecutionTime = &minProcessExecutionTime
@@ -11271,13 +11271,13 @@ func (actions *AutoHealActions) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealActions_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionType’:
+	// Set property "ActionType":
 	if typedInput.ActionType != nil {
 		actionType := *typedInput.ActionType
 		actions.ActionType = &actionType
 	}
 
-	// Set property ‘CustomAction’:
+	// Set property "CustomAction":
 	if typedInput.CustomAction != nil {
 		var customAction1 AutoHealCustomAction
 		err := customAction1.PopulateFromARM(owner, *typedInput.CustomAction)
@@ -11288,7 +11288,7 @@ func (actions *AutoHealActions) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		actions.CustomAction = &customAction
 	}
 
-	// Set property ‘MinProcessExecutionTime’:
+	// Set property "MinProcessExecutionTime":
 	if typedInput.MinProcessExecutionTime != nil {
 		minProcessExecutionTime := *typedInput.MinProcessExecutionTime
 		actions.MinProcessExecutionTime = &minProcessExecutionTime
@@ -11388,13 +11388,13 @@ func (actions *AutoHealActions_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealActions_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionType’:
+	// Set property "ActionType":
 	if typedInput.ActionType != nil {
 		actionType := *typedInput.ActionType
 		actions.ActionType = &actionType
 	}
 
-	// Set property ‘CustomAction’:
+	// Set property "CustomAction":
 	if typedInput.CustomAction != nil {
 		var customAction1 AutoHealCustomAction_STATUS
 		err := customAction1.PopulateFromARM(owner, *typedInput.CustomAction)
@@ -11405,7 +11405,7 @@ func (actions *AutoHealActions_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 		actions.CustomAction = &customAction
 	}
 
-	// Set property ‘MinProcessExecutionTime’:
+	// Set property "MinProcessExecutionTime":
 	if typedInput.MinProcessExecutionTime != nil {
 		minProcessExecutionTime := *typedInput.MinProcessExecutionTime
 		actions.MinProcessExecutionTime = &minProcessExecutionTime
@@ -11503,13 +11503,13 @@ func (triggers *AutoHealTriggers) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &AutoHealTriggers_ARM{}
 
-	// Set property ‘PrivateBytesInKB’:
+	// Set property "PrivateBytesInKB":
 	if triggers.PrivateBytesInKB != nil {
 		privateBytesInKB := *triggers.PrivateBytesInKB
 		result.PrivateBytesInKB = &privateBytesInKB
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if triggers.Requests != nil {
 		requests_ARM, err := (*triggers.Requests).ConvertToARM(resolved)
 		if err != nil {
@@ -11519,7 +11519,7 @@ func (triggers *AutoHealTriggers) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.Requests = &requests
 	}
 
-	// Set property ‘SlowRequests’:
+	// Set property "SlowRequests":
 	if triggers.SlowRequests != nil {
 		slowRequests_ARM, err := (*triggers.SlowRequests).ConvertToARM(resolved)
 		if err != nil {
@@ -11529,7 +11529,7 @@ func (triggers *AutoHealTriggers) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.SlowRequests = &slowRequests
 	}
 
-	// Set property ‘SlowRequestsWithPath’:
+	// Set property "SlowRequestsWithPath":
 	for _, item := range triggers.SlowRequestsWithPath {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -11538,7 +11538,7 @@ func (triggers *AutoHealTriggers) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.SlowRequestsWithPath = append(result.SlowRequestsWithPath, *item_ARM.(*SlowRequestsBasedTrigger_ARM))
 	}
 
-	// Set property ‘StatusCodes’:
+	// Set property "StatusCodes":
 	for _, item := range triggers.StatusCodes {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -11547,7 +11547,7 @@ func (triggers *AutoHealTriggers) ConvertToARM(resolved genruntime.ConvertToARMR
 		result.StatusCodes = append(result.StatusCodes, *item_ARM.(*StatusCodesBasedTrigger_ARM))
 	}
 
-	// Set property ‘StatusCodesRange’:
+	// Set property "StatusCodesRange":
 	for _, item := range triggers.StatusCodesRange {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -11570,13 +11570,13 @@ func (triggers *AutoHealTriggers) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealTriggers_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrivateBytesInKB’:
+	// Set property "PrivateBytesInKB":
 	if typedInput.PrivateBytesInKB != nil {
 		privateBytesInKB := *typedInput.PrivateBytesInKB
 		triggers.PrivateBytesInKB = &privateBytesInKB
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if typedInput.Requests != nil {
 		var requests1 RequestsBasedTrigger
 		err := requests1.PopulateFromARM(owner, *typedInput.Requests)
@@ -11587,7 +11587,7 @@ func (triggers *AutoHealTriggers) PopulateFromARM(owner genruntime.ArbitraryOwne
 		triggers.Requests = &requests
 	}
 
-	// Set property ‘SlowRequests’:
+	// Set property "SlowRequests":
 	if typedInput.SlowRequests != nil {
 		var slowRequests1 SlowRequestsBasedTrigger
 		err := slowRequests1.PopulateFromARM(owner, *typedInput.SlowRequests)
@@ -11598,7 +11598,7 @@ func (triggers *AutoHealTriggers) PopulateFromARM(owner genruntime.ArbitraryOwne
 		triggers.SlowRequests = &slowRequests
 	}
 
-	// Set property ‘SlowRequestsWithPath’:
+	// Set property "SlowRequestsWithPath":
 	for _, item := range typedInput.SlowRequestsWithPath {
 		var item1 SlowRequestsBasedTrigger
 		err := item1.PopulateFromARM(owner, item)
@@ -11608,7 +11608,7 @@ func (triggers *AutoHealTriggers) PopulateFromARM(owner genruntime.ArbitraryOwne
 		triggers.SlowRequestsWithPath = append(triggers.SlowRequestsWithPath, item1)
 	}
 
-	// Set property ‘StatusCodes’:
+	// Set property "StatusCodes":
 	for _, item := range typedInput.StatusCodes {
 		var item1 StatusCodesBasedTrigger
 		err := item1.PopulateFromARM(owner, item)
@@ -11618,7 +11618,7 @@ func (triggers *AutoHealTriggers) PopulateFromARM(owner genruntime.ArbitraryOwne
 		triggers.StatusCodes = append(triggers.StatusCodes, item1)
 	}
 
-	// Set property ‘StatusCodesRange’:
+	// Set property "StatusCodesRange":
 	for _, item := range typedInput.StatusCodesRange {
 		var item1 StatusCodesRangeBasedTrigger
 		err := item1.PopulateFromARM(owner, item)
@@ -11841,13 +11841,13 @@ func (triggers *AutoHealTriggers_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealTriggers_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PrivateBytesInKB’:
+	// Set property "PrivateBytesInKB":
 	if typedInput.PrivateBytesInKB != nil {
 		privateBytesInKB := *typedInput.PrivateBytesInKB
 		triggers.PrivateBytesInKB = &privateBytesInKB
 	}
 
-	// Set property ‘Requests’:
+	// Set property "Requests":
 	if typedInput.Requests != nil {
 		var requests1 RequestsBasedTrigger_STATUS
 		err := requests1.PopulateFromARM(owner, *typedInput.Requests)
@@ -11858,7 +11858,7 @@ func (triggers *AutoHealTriggers_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		triggers.Requests = &requests
 	}
 
-	// Set property ‘SlowRequests’:
+	// Set property "SlowRequests":
 	if typedInput.SlowRequests != nil {
 		var slowRequests1 SlowRequestsBasedTrigger_STATUS
 		err := slowRequests1.PopulateFromARM(owner, *typedInput.SlowRequests)
@@ -11869,7 +11869,7 @@ func (triggers *AutoHealTriggers_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		triggers.SlowRequests = &slowRequests
 	}
 
-	// Set property ‘SlowRequestsWithPath’:
+	// Set property "SlowRequestsWithPath":
 	for _, item := range typedInput.SlowRequestsWithPath {
 		var item1 SlowRequestsBasedTrigger_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11879,7 +11879,7 @@ func (triggers *AutoHealTriggers_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		triggers.SlowRequestsWithPath = append(triggers.SlowRequestsWithPath, item1)
 	}
 
-	// Set property ‘StatusCodes’:
+	// Set property "StatusCodes":
 	for _, item := range typedInput.StatusCodes {
 		var item1 StatusCodesBasedTrigger_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -11889,7 +11889,7 @@ func (triggers *AutoHealTriggers_STATUS) PopulateFromARM(owner genruntime.Arbitr
 		triggers.StatusCodes = append(triggers.StatusCodes, item1)
 	}
 
-	// Set property ‘StatusCodesRange’:
+	// Set property "StatusCodesRange":
 	for _, item := range typedInput.StatusCodesRange {
 		var item1 StatusCodesRangeBasedTrigger_STATUS
 		err := item1.PopulateFromARM(owner, item)
@@ -12190,49 +12190,49 @@ func (rule *RampUpRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	}
 	result := &RampUpRule_ARM{}
 
-	// Set property ‘ActionHostName’:
+	// Set property "ActionHostName":
 	if rule.ActionHostName != nil {
 		actionHostName := *rule.ActionHostName
 		result.ActionHostName = &actionHostName
 	}
 
-	// Set property ‘ChangeDecisionCallbackUrl’:
+	// Set property "ChangeDecisionCallbackUrl":
 	if rule.ChangeDecisionCallbackUrl != nil {
 		changeDecisionCallbackUrl := *rule.ChangeDecisionCallbackUrl
 		result.ChangeDecisionCallbackUrl = &changeDecisionCallbackUrl
 	}
 
-	// Set property ‘ChangeIntervalInMinutes’:
+	// Set property "ChangeIntervalInMinutes":
 	if rule.ChangeIntervalInMinutes != nil {
 		changeIntervalInMinutes := *rule.ChangeIntervalInMinutes
 		result.ChangeIntervalInMinutes = &changeIntervalInMinutes
 	}
 
-	// Set property ‘ChangeStep’:
+	// Set property "ChangeStep":
 	if rule.ChangeStep != nil {
 		changeStep := *rule.ChangeStep
 		result.ChangeStep = &changeStep
 	}
 
-	// Set property ‘MaxReroutePercentage’:
+	// Set property "MaxReroutePercentage":
 	if rule.MaxReroutePercentage != nil {
 		maxReroutePercentage := *rule.MaxReroutePercentage
 		result.MaxReroutePercentage = &maxReroutePercentage
 	}
 
-	// Set property ‘MinReroutePercentage’:
+	// Set property "MinReroutePercentage":
 	if rule.MinReroutePercentage != nil {
 		minReroutePercentage := *rule.MinReroutePercentage
 		result.MinReroutePercentage = &minReroutePercentage
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if rule.Name != nil {
 		name := *rule.Name
 		result.Name = &name
 	}
 
-	// Set property ‘ReroutePercentage’:
+	// Set property "ReroutePercentage":
 	if rule.ReroutePercentage != nil {
 		reroutePercentage := *rule.ReroutePercentage
 		result.ReroutePercentage = &reroutePercentage
@@ -12252,49 +12252,49 @@ func (rule *RampUpRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RampUpRule_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionHostName’:
+	// Set property "ActionHostName":
 	if typedInput.ActionHostName != nil {
 		actionHostName := *typedInput.ActionHostName
 		rule.ActionHostName = &actionHostName
 	}
 
-	// Set property ‘ChangeDecisionCallbackUrl’:
+	// Set property "ChangeDecisionCallbackUrl":
 	if typedInput.ChangeDecisionCallbackUrl != nil {
 		changeDecisionCallbackUrl := *typedInput.ChangeDecisionCallbackUrl
 		rule.ChangeDecisionCallbackUrl = &changeDecisionCallbackUrl
 	}
 
-	// Set property ‘ChangeIntervalInMinutes’:
+	// Set property "ChangeIntervalInMinutes":
 	if typedInput.ChangeIntervalInMinutes != nil {
 		changeIntervalInMinutes := *typedInput.ChangeIntervalInMinutes
 		rule.ChangeIntervalInMinutes = &changeIntervalInMinutes
 	}
 
-	// Set property ‘ChangeStep’:
+	// Set property "ChangeStep":
 	if typedInput.ChangeStep != nil {
 		changeStep := *typedInput.ChangeStep
 		rule.ChangeStep = &changeStep
 	}
 
-	// Set property ‘MaxReroutePercentage’:
+	// Set property "MaxReroutePercentage":
 	if typedInput.MaxReroutePercentage != nil {
 		maxReroutePercentage := *typedInput.MaxReroutePercentage
 		rule.MaxReroutePercentage = &maxReroutePercentage
 	}
 
-	// Set property ‘MinReroutePercentage’:
+	// Set property "MinReroutePercentage":
 	if typedInput.MinReroutePercentage != nil {
 		minReroutePercentage := *typedInput.MinReroutePercentage
 		rule.MinReroutePercentage = &minReroutePercentage
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘ReroutePercentage’:
+	// Set property "ReroutePercentage":
 	if typedInput.ReroutePercentage != nil {
 		reroutePercentage := *typedInput.ReroutePercentage
 		rule.ReroutePercentage = &reroutePercentage
@@ -12441,49 +12441,49 @@ func (rule *RampUpRule_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RampUpRule_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘ActionHostName’:
+	// Set property "ActionHostName":
 	if typedInput.ActionHostName != nil {
 		actionHostName := *typedInput.ActionHostName
 		rule.ActionHostName = &actionHostName
 	}
 
-	// Set property ‘ChangeDecisionCallbackUrl’:
+	// Set property "ChangeDecisionCallbackUrl":
 	if typedInput.ChangeDecisionCallbackUrl != nil {
 		changeDecisionCallbackUrl := *typedInput.ChangeDecisionCallbackUrl
 		rule.ChangeDecisionCallbackUrl = &changeDecisionCallbackUrl
 	}
 
-	// Set property ‘ChangeIntervalInMinutes’:
+	// Set property "ChangeIntervalInMinutes":
 	if typedInput.ChangeIntervalInMinutes != nil {
 		changeIntervalInMinutes := *typedInput.ChangeIntervalInMinutes
 		rule.ChangeIntervalInMinutes = &changeIntervalInMinutes
 	}
 
-	// Set property ‘ChangeStep’:
+	// Set property "ChangeStep":
 	if typedInput.ChangeStep != nil {
 		changeStep := *typedInput.ChangeStep
 		rule.ChangeStep = &changeStep
 	}
 
-	// Set property ‘MaxReroutePercentage’:
+	// Set property "MaxReroutePercentage":
 	if typedInput.MaxReroutePercentage != nil {
 		maxReroutePercentage := *typedInput.MaxReroutePercentage
 		rule.MaxReroutePercentage = &maxReroutePercentage
 	}
 
-	// Set property ‘MinReroutePercentage’:
+	// Set property "MinReroutePercentage":
 	if typedInput.MinReroutePercentage != nil {
 		minReroutePercentage := *typedInput.MinReroutePercentage
 		rule.MinReroutePercentage = &minReroutePercentage
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		rule.Name = &name
 	}
 
-	// Set property ‘ReroutePercentage’:
+	// Set property "ReroutePercentage":
 	if typedInput.ReroutePercentage != nil {
 		reroutePercentage := *typedInput.ReroutePercentage
 		rule.ReroutePercentage = &reroutePercentage
@@ -12619,13 +12619,13 @@ func (directory *VirtualDirectory) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &VirtualDirectory_ARM{}
 
-	// Set property ‘PhysicalPath’:
+	// Set property "PhysicalPath":
 	if directory.PhysicalPath != nil {
 		physicalPath := *directory.PhysicalPath
 		result.PhysicalPath = &physicalPath
 	}
 
-	// Set property ‘VirtualPath’:
+	// Set property "VirtualPath":
 	if directory.VirtualPath != nil {
 		virtualPath := *directory.VirtualPath
 		result.VirtualPath = &virtualPath
@@ -12645,13 +12645,13 @@ func (directory *VirtualDirectory) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualDirectory_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PhysicalPath’:
+	// Set property "PhysicalPath":
 	if typedInput.PhysicalPath != nil {
 		physicalPath := *typedInput.PhysicalPath
 		directory.PhysicalPath = &physicalPath
 	}
 
-	// Set property ‘VirtualPath’:
+	// Set property "VirtualPath":
 	if typedInput.VirtualPath != nil {
 		virtualPath := *typedInput.VirtualPath
 		directory.VirtualPath = &virtualPath
@@ -12716,13 +12716,13 @@ func (directory *VirtualDirectory_STATUS) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected VirtualDirectory_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘PhysicalPath’:
+	// Set property "PhysicalPath":
 	if typedInput.PhysicalPath != nil {
 		physicalPath := *typedInput.PhysicalPath
 		directory.PhysicalPath = &physicalPath
 	}
 
-	// Set property ‘VirtualPath’:
+	// Set property "VirtualPath":
 	if typedInput.VirtualPath != nil {
 		virtualPath := *typedInput.VirtualPath
 		directory.VirtualPath = &virtualPath
@@ -12801,13 +12801,13 @@ func (action *AutoHealCustomAction) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &AutoHealCustomAction_ARM{}
 
-	// Set property ‘Exe’:
+	// Set property "Exe":
 	if action.Exe != nil {
 		exe := *action.Exe
 		result.Exe = &exe
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if action.Parameters != nil {
 		parameters := *action.Parameters
 		result.Parameters = &parameters
@@ -12827,13 +12827,13 @@ func (action *AutoHealCustomAction) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealCustomAction_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Exe’:
+	// Set property "Exe":
 	if typedInput.Exe != nil {
 		exe := *typedInput.Exe
 		action.Exe = &exe
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		parameters := *typedInput.Parameters
 		action.Parameters = &parameters
@@ -12898,13 +12898,13 @@ func (action *AutoHealCustomAction_STATUS) PopulateFromARM(owner genruntime.Arbi
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AutoHealCustomAction_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Exe’:
+	// Set property "Exe":
 	if typedInput.Exe != nil {
 		exe := *typedInput.Exe
 		action.Exe = &exe
 	}
 
-	// Set property ‘Parameters’:
+	// Set property "Parameters":
 	if typedInput.Parameters != nil {
 		parameters := *typedInput.Parameters
 		action.Parameters = &parameters
@@ -12964,13 +12964,13 @@ func (trigger *RequestsBasedTrigger) ConvertToARM(resolved genruntime.ConvertToA
 	}
 	result := &RequestsBasedTrigger_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if trigger.Count != nil {
 		count := *trigger.Count
 		result.Count = &count
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if trigger.TimeInterval != nil {
 		timeInterval := *trigger.TimeInterval
 		result.TimeInterval = &timeInterval
@@ -12990,13 +12990,13 @@ func (trigger *RequestsBasedTrigger) PopulateFromARM(owner genruntime.ArbitraryO
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestsBasedTrigger_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
@@ -13061,13 +13061,13 @@ func (trigger *RequestsBasedTrigger_STATUS) PopulateFromARM(owner genruntime.Arb
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected RequestsBasedTrigger_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
@@ -13129,25 +13129,25 @@ func (trigger *SlowRequestsBasedTrigger) ConvertToARM(resolved genruntime.Conver
 	}
 	result := &SlowRequestsBasedTrigger_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if trigger.Count != nil {
 		count := *trigger.Count
 		result.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if trigger.Path != nil {
 		path := *trigger.Path
 		result.Path = &path
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if trigger.TimeInterval != nil {
 		timeInterval := *trigger.TimeInterval
 		result.TimeInterval = &timeInterval
 	}
 
-	// Set property ‘TimeTaken’:
+	// Set property "TimeTaken":
 	if trigger.TimeTaken != nil {
 		timeTaken := *trigger.TimeTaken
 		result.TimeTaken = &timeTaken
@@ -13167,25 +13167,25 @@ func (trigger *SlowRequestsBasedTrigger) PopulateFromARM(owner genruntime.Arbitr
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SlowRequestsBasedTrigger_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		trigger.Path = &path
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
 	}
 
-	// Set property ‘TimeTaken’:
+	// Set property "TimeTaken":
 	if typedInput.TimeTaken != nil {
 		timeTaken := *typedInput.TimeTaken
 		trigger.TimeTaken = &timeTaken
@@ -13264,25 +13264,25 @@ func (trigger *SlowRequestsBasedTrigger_STATUS) PopulateFromARM(owner genruntime
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected SlowRequestsBasedTrigger_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		trigger.Path = &path
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
 	}
 
-	// Set property ‘TimeTaken’:
+	// Set property "TimeTaken":
 	if typedInput.TimeTaken != nil {
 		timeTaken := *typedInput.TimeTaken
 		trigger.TimeTaken = &timeTaken
@@ -13358,37 +13358,37 @@ func (trigger *StatusCodesBasedTrigger) ConvertToARM(resolved genruntime.Convert
 	}
 	result := &StatusCodesBasedTrigger_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if trigger.Count != nil {
 		count := *trigger.Count
 		result.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if trigger.Path != nil {
 		path := *trigger.Path
 		result.Path = &path
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if trigger.Status != nil {
 		status := *trigger.Status
 		result.Status = &status
 	}
 
-	// Set property ‘SubStatus’:
+	// Set property "SubStatus":
 	if trigger.SubStatus != nil {
 		subStatus := *trigger.SubStatus
 		result.SubStatus = &subStatus
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if trigger.TimeInterval != nil {
 		timeInterval := *trigger.TimeInterval
 		result.TimeInterval = &timeInterval
 	}
 
-	// Set property ‘Win32Status’:
+	// Set property "Win32Status":
 	if trigger.Win32Status != nil {
 		win32Status := *trigger.Win32Status
 		result.Win32Status = &win32Status
@@ -13408,37 +13408,37 @@ func (trigger *StatusCodesBasedTrigger) PopulateFromARM(owner genruntime.Arbitra
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StatusCodesBasedTrigger_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		trigger.Path = &path
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		trigger.Status = &status
 	}
 
-	// Set property ‘SubStatus’:
+	// Set property "SubStatus":
 	if typedInput.SubStatus != nil {
 		subStatus := *typedInput.SubStatus
 		trigger.SubStatus = &subStatus
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
 	}
 
-	// Set property ‘Win32Status’:
+	// Set property "Win32Status":
 	if typedInput.Win32Status != nil {
 		win32Status := *typedInput.Win32Status
 		trigger.Win32Status = &win32Status
@@ -13531,37 +13531,37 @@ func (trigger *StatusCodesBasedTrigger_STATUS) PopulateFromARM(owner genruntime.
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StatusCodesBasedTrigger_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		trigger.Path = &path
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	if typedInput.Status != nil {
 		status := *typedInput.Status
 		trigger.Status = &status
 	}
 
-	// Set property ‘SubStatus’:
+	// Set property "SubStatus":
 	if typedInput.SubStatus != nil {
 		subStatus := *typedInput.SubStatus
 		trigger.SubStatus = &subStatus
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
 	}
 
-	// Set property ‘Win32Status’:
+	// Set property "Win32Status":
 	if typedInput.Win32Status != nil {
 		win32Status := *typedInput.Win32Status
 		trigger.Win32Status = &win32Status
@@ -13647,25 +13647,25 @@ func (trigger *StatusCodesRangeBasedTrigger) ConvertToARM(resolved genruntime.Co
 	}
 	result := &StatusCodesRangeBasedTrigger_ARM{}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if trigger.Count != nil {
 		count := *trigger.Count
 		result.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if trigger.Path != nil {
 		path := *trigger.Path
 		result.Path = &path
 	}
 
-	// Set property ‘StatusCodes’:
+	// Set property "StatusCodes":
 	if trigger.StatusCodes != nil {
 		statusCodes := *trigger.StatusCodes
 		result.StatusCodes = &statusCodes
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if trigger.TimeInterval != nil {
 		timeInterval := *trigger.TimeInterval
 		result.TimeInterval = &timeInterval
@@ -13685,25 +13685,25 @@ func (trigger *StatusCodesRangeBasedTrigger) PopulateFromARM(owner genruntime.Ar
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StatusCodesRangeBasedTrigger_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		trigger.Path = &path
 	}
 
-	// Set property ‘StatusCodes’:
+	// Set property "StatusCodes":
 	if typedInput.StatusCodes != nil {
 		statusCodes := *typedInput.StatusCodes
 		trigger.StatusCodes = &statusCodes
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval
@@ -13782,25 +13782,25 @@ func (trigger *StatusCodesRangeBasedTrigger_STATUS) PopulateFromARM(owner genrun
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected StatusCodesRangeBasedTrigger_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Count’:
+	// Set property "Count":
 	if typedInput.Count != nil {
 		count := *typedInput.Count
 		trigger.Count = &count
 	}
 
-	// Set property ‘Path’:
+	// Set property "Path":
 	if typedInput.Path != nil {
 		path := *typedInput.Path
 		trigger.Path = &path
 	}
 
-	// Set property ‘StatusCodes’:
+	// Set property "StatusCodes":
 	if typedInput.StatusCodes != nil {
 		statusCodes := *typedInput.StatusCodes
 		trigger.StatusCodes = &statusCodes
 	}
 
-	// Set property ‘TimeInterval’:
+	// Set property "TimeInterval":
 	if typedInput.TimeInterval != nil {
 		timeInterval := *typedInput.TimeInterval
 		trigger.TimeInterval = &timeInterval

--- a/v2/tools/generator/internal/armconversion/arm_conversion_function.go
+++ b/v2/tools/generator/internal/armconversion/arm_conversion_function.go
@@ -65,24 +65,42 @@ func (c *ARMConversionFunction) References() astmodel.TypeNameSet {
 }
 
 // AsFunc returns the function as a Go AST
-func (c *ConvertToARMFunction) AsFunc(codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName) *dst.FuncDecl {
+func (c *ConvertToARMFunction) AsFunc(
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+) *dst.FuncDecl {
 	builder := newConvertToARMFunctionBuilder(
 		&c.ARMConversionFunction,
 		codeGenerationContext,
 		receiver,
 		c.Name())
 
-	return builder.functionDeclaration()
+	decl, err := builder.functionDeclaration()
+	if err != nil {
+		// TODO: This will become an error return when we refactor the conversion functions for issue #2971
+		panic(err)
+	}
+
+	return decl
 }
 
-func (c *PopulateFromARMFunction) AsFunc(codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName) *dst.FuncDecl {
+func (c *PopulateFromARMFunction) AsFunc(
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+) *dst.FuncDecl {
 	builder := newConvertFromARMFunctionBuilder(
 		&c.ARMConversionFunction,
 		codeGenerationContext,
 		receiver,
 		c.Name())
 
-	return builder.functionDeclaration()
+	decl, err := builder.functionDeclaration()
+	if err != nil {
+		// TODO: This will become an error return when we refactor the conversion functions for issue #2971
+		panic(err)
+	}
+
+	return decl
 }
 
 // Equals determines if this function is equal to the passed in function

--- a/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
@@ -56,11 +56,12 @@ func newConvertFromARMFunctionBuilder(
 	result.locals.Add(result.receiverIdent)
 
 	// It's a bit awkward that there are two levels of "handler" here, but they serve different purposes:
-	// The top level propertyConversionHandlers is about determining which properties are involved: given a property on the destination type it
-	// determines which property (if any) on the source type will be converted to the destination.
+	// The top level propertyConversionHandlers is about determining which properties are involved: given a property on
+	// the destination type it determines which property (if any) on the source type will be converted to the
+	// destination.
 	// The "inner" handler (typeConversionBuilder) is about determining how to convert between two types: given a
-	// source type and a destination type, figure out how to make the assignment work. It has no knowledge of broader object structure
-	// or other properties.
+	// source type and a destination type, figure out how to make the assignment work. It has no knowledge of broader
+	// object structure or other properties.
 	result.typeConversionBuilder.AddConversionHandlers(result.convertComplexTypeNameProperty)
 	result.propertyConversionHandlers = []propertyConversionHandler{
 		// Handlers for specific properties come first
@@ -378,7 +379,7 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 
 	allDefs := builder.codeGenerationContext.GetAllReachableDefinitions()
 
-	// the from shape here must be:
+	// the 'from' shape here must be:
 	// 1. maybe a typename, pointing to…
 	// 2. maybe optional, wrapping …
 	// 3. maybe a typename, pointing to…

--- a/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
@@ -556,11 +556,7 @@ func (builder *convertFromARMBuilder) convertComplexTypeNameProperty(
 	newVariable := astbuilder.NewVariable(propertyLocalVar, destinationType.Name())
 	if !destinationType.PackageReference.Equals(builder.codeGenerationContext.CurrentPackage()) {
 		// struct name has to be qualified
-		packageName, err := builder.codeGenerationContext.GetImportedPackageName(destinationType.PackageReference)
-		if err != nil {
-			panic(err)
-		}
-
+		packageName := builder.codeGenerationContext.MustGetImportedPackageName(destinationType.PackageReference)
 		newVariable = astbuilder.NewVariableQualified(
 			propertyLocalVar,
 			packageName,

--- a/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
@@ -423,7 +423,7 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 
 	// we were unable to generate an inner conversion, so we cannot generate the overall conversion
 	if len(stmts) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	if generateNilCheck {
@@ -442,7 +442,7 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 		},
 	}
 
-	return append(result, stmts...)
+	return append(result, stmts...), nil
 }
 
 func (builder *convertFromARMBuilder) propertiesWithSameNameHandler(
@@ -486,17 +486,17 @@ func (builder *convertFromARMBuilder) convertComplexTypeNameProperty(
 ) ([]dst.Stmt, error) {
 	destinationType, ok := params.DestinationType.(astmodel.TypeName)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	sourceType, ok := params.SourceType.(astmodel.TypeName)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	// This is for handling type names that aren't equal
 	if astmodel.TypeEquals(sourceType, destinationType) {
-		return nil
+		return nil, nil
 	}
 
 	propertyLocalVar := builder.typeConversionBuilder.CreateLocal(params.Locals, "", params.NameHint)
@@ -544,5 +544,5 @@ func (builder *convertFromARMBuilder) convertComplexTypeNameProperty(
 			params.AssignmentHandler(params.GetDestination(), dst.NewIdent(propertyLocalVar)))
 	}
 
-	return results
+	return results, nil
 }

--- a/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
@@ -337,7 +337,10 @@ func (builder *convertFromARMBuilder) flattenedPropertyHandler(
 	panic(fmt.Sprintf("couldn’t find source ARM property ‘%s’ that k8s property ‘%s’ was flattened from", toProp.FlattenedFrom()[0], toProp.PropertyName()))
 }
 
-func (builder *convertFromARMBuilder) buildFlattenedAssignment(toProp *astmodel.PropertyDefinition, fromProp *astmodel.PropertyDefinition) []dst.Stmt {
+func (builder *convertFromARMBuilder) buildFlattenedAssignment(
+	toProp *astmodel.PropertyDefinition,
+	fromProp *astmodel.PropertyDefinition,
+) ([]dst.Stmt, error) {
 	if len(toProp.FlattenedFrom()) > 2 {
 		// this doesn't appear to happen anywhere in the JSON schemas currently
 
@@ -477,7 +480,10 @@ func (builder *convertFromARMBuilder) propertiesWithSameNameHandler(
 //		return err
 //	}
 //	<destination> = <nameHint>
-func (builder *convertFromARMBuilder) convertComplexTypeNameProperty(_ *astmodel.ConversionFunctionBuilder, params astmodel.ConversionParameters) []dst.Stmt {
+func (builder *convertFromARMBuilder) convertComplexTypeNameProperty(
+	_ *astmodel.ConversionFunctionBuilder,
+	params astmodel.ConversionParameters,
+) ([]dst.Stmt, error) {
 	destinationType, ok := params.DestinationType.(astmodel.TypeName)
 	if !ok {
 		return nil

--- a/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
@@ -10,9 +10,8 @@ import (
 	"go/token"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -197,7 +196,7 @@ func (builder *convertFromARMBuilder) userAssignedIdentitiesPropertyHandler(
 	}
 
 	// TODO: For now we are not assigning these, as we don't know how to rebuild the reference
-	return handledWithNOP, nil
+	return handledWithNoOp, nil
 }
 
 func (builder *convertFromARMBuilder) referencePropertyHandler(
@@ -211,7 +210,7 @@ func (builder *convertFromARMBuilder) referencePropertyHandler(
 	// TODO: For now, we are NOT assigning to these. _Status types don't have them and it's unclear what
 	// TODO: the fromARM functions do for us on Spec types. We may need them for diffing though. If so we will
 	// TODO: need to revisit this and actually assign something
-	return handledWithNOP, nil
+	return handledWithNoOp, nil
 }
 
 func (builder *convertFromARMBuilder) secretPropertyHandler(
@@ -228,7 +227,7 @@ func (builder *convertFromARMBuilder) secretPropertyHandler(
 	// TODO: For now, we are NOT assigning to these. _Status types don't have them and it's unclear what
 	// TODO: the fromARM functions do for us on Spec types. We may need them for diffing though. If so we will
 	// TODO: need to revisit this and actually assign something
-	return handledWithNOP, nil
+	return handledWithNoOp, nil
 }
 
 func (builder *convertFromARMBuilder) configMapPropertyHandler(
@@ -245,7 +244,7 @@ func (builder *convertFromARMBuilder) configMapPropertyHandler(
 	// TODO: For now, we are NOT assigning to these. _Status types don't have them and it's unclear what
 	// TODO: the fromARM functions do for us on Spec types. We may need them for diffing though. If so we will
 	// TODO: need to revisit this and actually assign something
-	return handledWithNOP, nil
+	return handledWithNoOp, nil
 }
 
 func (builder *convertFromARMBuilder) ownerPropertyHandler(
@@ -308,7 +307,7 @@ func (builder *convertFromARMBuilder) conditionsPropertyHandler(
 		return notHandled, nil
 	}
 
-	return handledWithNOP, nil
+	return handledWithNoOp, nil
 }
 
 // operatorSpecPropertyHandler generates conversions for the "OperatorSpec" property.
@@ -323,7 +322,7 @@ func (builder *convertFromARMBuilder) operatorSpecPropertyHandler(
 		return notHandled, nil
 	}
 
-	return handledWithNOP, nil
+	return handledWithNoOp, nil
 }
 
 // flattenedPropertyHandler generates conversions for properties that
@@ -361,7 +360,7 @@ func (builder *convertFromARMBuilder) flattenedPropertyHandler(
 
 	return notHandled,
 		errors.Errorf(
-			"couldn’t find source ARM property ‘%s’ that k8s property ‘%s’ was flattened from",
+			"couldn’t find source ARM property %q that k8s property %q was flattened from",
 			toProp.FlattenedFrom()[0],
 			toProp.PropertyName())
 }
@@ -380,7 +379,7 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 
 		return notHandled,
 			errors.Errorf(
-				"need to implement multiple levels of flattening: property ‘%s’ on %s was flattened from ‘%s’",
+				"need to implement multiple levels of flattening: property %q on %s was flattened from %q",
 				toProp.PropertyName(),
 				builder.receiverIdent,
 				strings.Join(props, "."))
@@ -432,7 +431,7 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 		// see pipeline_flatten_properties.go:flattenPropType which will only flatten from (optional) object types
 		return notHandled,
 			errors.Errorf(
-				"property ‘%s’ marked as flattened from non-object type %T, which shouldn’t be possible",
+				"property %q marked as flattened from non-object type %T, which shouldn’t be possible",
 				toProp.PropertyName(),
 				fromPropType)
 	}
@@ -444,7 +443,7 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 	if !ok {
 		return notHandled,
 			errors.Errorf(
-				"couldn't find source of flattened property ‘%s’ on %s",
+				"couldn't find source of flattened property %q on %s",
 				toProp.PropertyName(),
 				builder.receiverIdent)
 	}

--- a/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
@@ -7,9 +7,10 @@ package armconversion
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"go/token"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
 
@@ -410,7 +411,8 @@ func (builder *convertFromARMBuilder) buildFlattenedAssignment(
 	if fromPropOptType, ok := fromPropType.(*astmodel.OptionalType); ok {
 		generateNilCheck = true
 		// (3.) resolve any inner typename
-		elementType, err := allDefs.FullyResolve(fromPropOptType.Element())
+		var elementType astmodel.Type
+		elementType, err = allDefs.FullyResolve(fromPropOptType.Element())
 		if err != nil {
 			return notHandled,
 				errors.Wrapf(

--- a/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
@@ -820,11 +820,7 @@ func (builder *convertToARMBuilder) convertComplexTypeNameProperty(
 
 	if !destinationType.PackageReference.Equals(conversionBuilder.CodeGenerationContext.CurrentPackage()) {
 		// needs to be qualified
-		packageName, err := conversionBuilder.CodeGenerationContext.GetImportedPackageName(destinationType.PackageReference)
-		if err != nil {
-			panic(err)
-		}
-
+		packageName := conversionBuilder.CodeGenerationContext.MustGetImportedPackageName(destinationType.PackageReference)
 		typeAssertExpr.Type = astbuilder.Dereference(astbuilder.Selector(dst.NewIdent(packageName), destinationType.Name()))
 	}
 

--- a/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
@@ -505,7 +505,10 @@ func (builder *convertToARMBuilder) propertiesWithSameNameHandler(
 //		result.UserAssignedIdentities[key] = UserAssignedIdentityDetails_ARM{}
 //	}
 //	return result, nil
-func (builder *convertToARMBuilder) convertUserAssignedIdentitiesCollection(conversionBuilder *astmodel.ConversionFunctionBuilder, params astmodel.ConversionParameters) []dst.Stmt {
+func (builder *convertToARMBuilder) convertUserAssignedIdentitiesCollection(
+	conversionBuilder *astmodel.ConversionFunctionBuilder,
+	params astmodel.ConversionParameters,
+) ([]dst.Stmt, error) {
 	destinationType, isDestinationMap := params.DestinationType.(*astmodel.MapType)
 	if !isDestinationMap {
 		return nil
@@ -591,7 +594,10 @@ func (builder *convertToARMBuilder) convertUserAssignedIdentitiesCollection(conv
 //		return nil, err
 //	}
 //	<destination> = <namehint>ARMID
-func (builder *convertToARMBuilder) convertReferenceProperty(_ *astmodel.ConversionFunctionBuilder, params astmodel.ConversionParameters) []dst.Stmt {
+func (builder *convertToARMBuilder) convertReferenceProperty(
+	_ *astmodel.ConversionFunctionBuilder,
+	params astmodel.ConversionParameters,
+) ([]dst.Stmt, error) {
 	isString := astmodel.TypeEquals(params.DestinationType, astmodel.StringType)
 	if !isString {
 		return nil
@@ -627,7 +633,10 @@ func (builder *convertToARMBuilder) convertReferenceProperty(_ *astmodel.Convers
 //		return nil, errors.Wrap(err, "looking up secret for <source>")
 //	}
 //	<destination> = <namehint>Secret
-func (builder *convertToARMBuilder) convertSecretProperty(_ *astmodel.ConversionFunctionBuilder, params astmodel.ConversionParameters) []dst.Stmt {
+func (builder *convertToARMBuilder) convertSecretProperty(
+	_ *astmodel.ConversionFunctionBuilder,
+	params astmodel.ConversionParameters,
+) ([]dst.Stmt, error) {
 	isString := astmodel.TypeEquals(params.DestinationType, astmodel.StringType)
 	if !isString {
 		return nil
@@ -668,7 +677,10 @@ func (builder *convertToARMBuilder) convertSecretProperty(_ *astmodel.Conversion
 //		return nil, errors.Wrap(err, "looking up config map value for <source>")
 //	}
 //	<destination> = <namehint>Value
-func (builder *convertToARMBuilder) convertConfigMapProperty(_ *astmodel.ConversionFunctionBuilder, params astmodel.ConversionParameters) []dst.Stmt {
+func (builder *convertToARMBuilder) convertConfigMapProperty(
+	_ *astmodel.ConversionFunctionBuilder,
+	params astmodel.ConversionParameters,
+) ([]dst.Stmt, error) {
 	isString := astmodel.TypeEquals(params.DestinationType, astmodel.StringType)
 	if !isString {
 		return nil
@@ -709,7 +721,10 @@ func (builder *convertToARMBuilder) convertConfigMapProperty(_ *astmodel.Convers
 //		return nil, err
 //	}
 //	<destination> = <nameHint>.(*FooARM)
-func (builder *convertToARMBuilder) convertComplexTypeNameProperty(conversionBuilder *astmodel.ConversionFunctionBuilder, params astmodel.ConversionParameters) []dst.Stmt {
+func (builder *convertToARMBuilder) convertComplexTypeNameProperty(
+	conversionBuilder *astmodel.ConversionFunctionBuilder,
+	params astmodel.ConversionParameters,
+) ([]dst.Stmt, error) {
 	destinationType, ok := params.DestinationType.(astmodel.TypeName)
 	if !ok {
 		return nil

--- a/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
@@ -511,28 +511,28 @@ func (builder *convertToARMBuilder) convertUserAssignedIdentitiesCollection(
 ) ([]dst.Stmt, error) {
 	destinationType, isDestinationMap := params.DestinationType.(*astmodel.MapType)
 	if !isDestinationMap {
-		return nil
+		return nil, nil
 	}
 
 	sourceType, isSourceArray := params.SourceType.(*astmodel.ArrayType)
 	if !isSourceArray {
-		return nil
+		return nil, nil
 	}
 
 	typeName, ok := astmodel.AsTypeName(sourceType.Element())
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	if typeName.Name() != astmodel.UserAssignedIdentitiesTypeName {
-		return nil
+		return nil, nil
 	}
 
 	uaiDef := conversionBuilder.CodeGenerationContext.MustGetDefinition(typeName)
 
 	uaiType, ok := astmodel.AsObjectType(uaiDef.Type())
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	// There should be a single "Reference" property
@@ -600,12 +600,12 @@ func (builder *convertToARMBuilder) convertReferenceProperty(
 ) ([]dst.Stmt, error) {
 	isString := astmodel.TypeEquals(params.DestinationType, astmodel.StringType)
 	if !isString {
-		return nil
+		return nil, nil
 	}
 
 	isReference := astmodel.TypeEquals(params.SourceType, astmodel.ResourceReferenceType)
 	if !isReference {
-		return nil
+		return nil, nil
 	}
 
 	// Don't need to worry about conflicting names here since the property name was unique to begin with
@@ -639,12 +639,12 @@ func (builder *convertToARMBuilder) convertSecretProperty(
 ) ([]dst.Stmt, error) {
 	isString := astmodel.TypeEquals(params.DestinationType, astmodel.StringType)
 	if !isString {
-		return nil
+		return nil, nil
 	}
 
 	isSecretReference := astmodel.TypeEquals(params.SourceType, astmodel.SecretReferenceType)
 	if !isSecretReference {
-		return nil
+		return nil, nil
 	}
 
 	errorsPackage := builder.codeGenerationContext.MustGetImportedPackageName(astmodel.GitHubErrorsReference)
@@ -683,12 +683,12 @@ func (builder *convertToARMBuilder) convertConfigMapProperty(
 ) ([]dst.Stmt, error) {
 	isString := astmodel.TypeEquals(params.DestinationType, astmodel.StringType)
 	if !isString {
-		return nil
+		return nil, nil
 	}
 
 	isConfigMapReference := astmodel.TypeEquals(params.SourceType, astmodel.ConfigMapReferenceType)
 	if !isConfigMapReference {
-		return nil
+		return nil, nil
 	}
 
 	errorsPackage := builder.codeGenerationContext.MustGetImportedPackageName(astmodel.GitHubErrorsReference)
@@ -727,17 +727,17 @@ func (builder *convertToARMBuilder) convertComplexTypeNameProperty(
 ) ([]dst.Stmt, error) {
 	destinationType, ok := params.DestinationType.(astmodel.TypeName)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	sourceType, ok := params.SourceType.(astmodel.TypeName)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	// This is for handling type names that aren't equal
 	if astmodel.TypeEquals(sourceType, destinationType) {
-		return nil
+		return nil, nil
 	}
 
 	var results []dst.Stmt
@@ -770,7 +770,7 @@ func (builder *convertToARMBuilder) convertComplexTypeNameProperty(
 
 	results = append(results, params.AssignmentHandlerOrDefault()(params.GetDestination(), finalAssignmentExpr))
 
-	return results
+	return results, nil
 }
 
 func callToARMFunction(source dst.Expr, destination dst.Expr, methodName string) []dst.Stmt {

--- a/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
@@ -622,7 +622,7 @@ func (builder *convertToARMBuilder) convertReferenceProperty(
 
 	result := params.AssignmentHandlerOrDefault()(params.Destination, dst.NewIdent(localVarName))
 
-	return []dst.Stmt{armIDLookup, returnIfNotNil, result}
+	return astbuilder.Statements(armIDLookup, returnIfNotNil, result), nil
 }
 
 // convertSecretProperty handles conversion of secret properties.
@@ -666,7 +666,7 @@ func (builder *convertToARMBuilder) convertSecretProperty(
 
 	result := params.AssignmentHandlerOrDefault()(params.Destination, dst.NewIdent(localVarName))
 
-	return []dst.Stmt{secretLookup, returnIfNotNil, result}
+	return astbuilder.Statements(secretLookup, returnIfNotNil, result), nil
 }
 
 // convertConfigMapProperty handles conversion of configMap properties.
@@ -710,7 +710,7 @@ func (builder *convertToARMBuilder) convertConfigMapProperty(
 
 	result := params.AssignmentHandlerOrDefault()(params.Destination, dst.NewIdent(localVarName))
 
-	return []dst.Stmt{configMapLookup, returnIfNotNil, result}
+	return astbuilder.Statements(configMapLookup, returnIfNotNil, result), nil
 }
 
 // convertComplexTypeNameProperty handles conversion of complex TypeName properties.

--- a/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
@@ -7,10 +7,10 @@ package armconversion
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"go/token"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -166,7 +166,7 @@ func (builder *convertToARMBuilder) operatorSpecPropertyHandler(
 	}
 
 	// Do nothing with this property, it exists for the operator only and is not sent to Azure
-	return handledWithNOP, nil
+	return handledWithNoOp, nil
 }
 
 func (builder *convertToARMBuilder) configMapReferencePropertyHandler(
@@ -824,7 +824,11 @@ func (builder *convertToARMBuilder) convertComplexTypeNameProperty(
 
 	if !destinationType.PackageReference.Equals(conversionBuilder.CodeGenerationContext.CurrentPackage()) {
 		// needs to be qualified
-		packageName := conversionBuilder.CodeGenerationContext.MustGetImportedPackageName(destinationType.PackageReference)
+		packageName, err := conversionBuilder.CodeGenerationContext.GetImportedPackageName(destinationType.PackageReference)
+		if err != nil {
+			return nil, err
+		}
+
 		typeAssertExpr.Type = astbuilder.Dereference(astbuilder.Selector(dst.NewIdent(packageName), destinationType.Name()))
 	}
 

--- a/v2/tools/generator/internal/armconversion/shared.go
+++ b/v2/tools/generator/internal/armconversion/shared.go
@@ -52,9 +52,9 @@ func (builder conversionBuilder) propertyConversionHandler(
 ) ([]dst.Stmt, error) {
 	var err error
 	for _, conversionHandler := range builder.propertyConversionHandlers {
-		conversion, convErr := conversionHandler(toProp, fromType)
-		if convErr != nil {
-			err = convErr
+		var conversion propertyConversionHandlerResult
+		conversion, err = conversionHandler(toProp, fromType)
+		if err != nil {
 			break
 		}
 
@@ -98,8 +98,8 @@ var notHandled = propertyConversionHandlerResult{
 	matched: false,
 }
 
-// handledWithNOP is a result to use when a handler wants to return an empty set of statements for a conversion
-var handledWithNOP = propertyConversionHandlerResult{
+// handledWithNoOp is a result to use when a handler wants to return an empty set of statements for a conversion
+var handledWithNoOp = propertyConversionHandlerResult{
 	matched: true,
 }
 
@@ -163,7 +163,7 @@ func generateTypeConversionAssignments(
 				Decs: dst.EmptyStmtDecorations{
 					NodeDecs: dst.NodeDecs{
 						Before: dst.EmptyLine,
-						End:    []string{fmt.Sprintf("// Set property ‘%s’:", toField.PropertyName())},
+						End:    []string{fmt.Sprintf("// Set property %q:", toField.PropertyName())},
 					},
 				},
 			})
@@ -173,7 +173,7 @@ func generateTypeConversionAssignments(
 				Decs: dst.EmptyStmtDecorations{
 					NodeDecs: dst.NodeDecs{
 						Before: dst.EmptyLine,
-						End:    []string{fmt.Sprintf("// no assignment for property ‘%s’", toField.PropertyName())},
+						End:    []string{fmt.Sprintf("// no assignment for property %q", toField.PropertyName())},
 					},
 				},
 			})

--- a/v2/tools/generator/internal/astbuilder/builder.go
+++ b/v2/tools/generator/internal/astbuilder/builder.go
@@ -464,7 +464,7 @@ func BinaryExpr(lhs dst.Expr, op token.Token, rhs dst.Expr) *dst.BinaryExpr {
 
 // Statements creates a sequence of statements from the provided values, each of which may be a
 // single dst.Stmt or a slice of multiple []dst.Stmts
-func Statements(statements ...interface{}) []dst.Stmt {
+func Statements(statements ...any) []dst.Stmt {
 	var stmts []dst.Stmt
 	for _, s := range statements {
 		switch s := s.(type) {

--- a/v2/tools/generator/internal/astmodel/conversion_function_builder.go
+++ b/v2/tools/generator/internal/astmodel/conversion_function_builder.go
@@ -118,6 +118,7 @@ type ConversionHandler func(builder *ConversionFunctionBuilder, params Conversio
 // TODO: There feels like overlap between this and the Storage Conversion Factories? Need further thinking to combine them?
 // ConversionFunctionBuilder is used to build a function converting between two similar types.
 // It has a set of built-in conversions and can be configured with additional conversions.
+
 type ConversionFunctionBuilder struct {
 	// TODO: Better way to let you fuss with this? How can you pick out what I've already put in here to overwrite it?
 	conversions []ConversionHandler

--- a/v2/tools/generator/internal/astmodel/conversion_function_builder.go
+++ b/v2/tools/generator/internal/astmodel/conversion_function_builder.go
@@ -163,7 +163,7 @@ func (builder *ConversionFunctionBuilder) BuildConversion(params ConversionParam
 	for _, conversion := range builder.conversions {
 		result := conversion(builder, params)
 		if len(result) > 0 {
-			return result
+			return result, nil
 		}
 	}
 
@@ -187,12 +187,12 @@ func IdentityConvertComplexOptionalProperty(
 ) ([]dst.Stmt, error) {
 	destinationType, ok := params.DestinationType.(*OptionalType)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	sourceType, ok := params.SourceType.(*OptionalType)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	locals := params.Locals.Clone()
@@ -237,12 +237,12 @@ func IdentityConvertComplexArrayProperty(
 ) ([]dst.Stmt, error) {
 	destinationType, ok := params.DestinationType.(*ArrayType)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	sourceType, ok := params.SourceType.(*ArrayType)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	var results []dst.Stmt
@@ -295,7 +295,7 @@ func IdentityConvertComplexArrayProperty(
 		results = append(results, params.AssignmentHandler(params.GetDestination(), dst.Clone(destination).(dst.Expr)))
 	}
 
-	return results
+	return results, nil
 }
 
 // IdentityConvertComplexMapProperty handles conversion for map properties with complex values.
@@ -315,12 +315,12 @@ func IdentityConvertComplexMapProperty(
 ) ([]dst.Stmt, error) {
 	destinationType, ok := params.DestinationType.(*MapType)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	sourceType, ok := params.SourceType.(*MapType)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	if _, ok := destinationType.KeyType().(*PrimitiveType); !ok {
@@ -393,7 +393,7 @@ func IdentityConvertComplexMapProperty(
 		result.Body.List = append(result.Body.List, params.AssignmentHandler(params.GetDestination(), dst.Clone(destination).(dst.Expr)))
 	}
 
-	return []dst.Stmt{result}
+	return []dst.Stmt{result}, nil
 }
 
 // IdentityAssignTypeName handles conversion for TypeName's that are the same
@@ -408,17 +408,17 @@ func IdentityAssignTypeName(
 ) ([]dst.Stmt, error) {
 	destinationType, ok := params.DestinationType.(TypeName)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	sourceType, ok := params.SourceType.(TypeName)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	// Can only apply basic assignment for typeNames that are the same
 	if !TypeEquals(sourceType, destinationType) {
-		return nil
+		return nil, nil
 	}
 
 	return astbuilder.Statements(
@@ -435,11 +435,11 @@ func IdentityAssignPrimitiveType(
 	params ConversionParameters,
 ) ([]dst.Stmt, error) {
 	if _, ok := params.DestinationType.(*PrimitiveType); !ok {
-		return nil
+		return nil, nil
 	}
 
 	if _, ok := params.SourceType.(*PrimitiveType); !ok {
-		return nil
+		return nil, nil
 	}
 
 	return astbuilder.Statements(
@@ -462,7 +462,7 @@ func AssignToOptional(
 ) ([]dst.Stmt, error) {
 	optDest, ok := params.DestinationType.(*OptionalType)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	if TypeEquals(optDest.Element(), params.SourceType) {
@@ -518,7 +518,7 @@ func AssignFromOptional(
 ) ([]dst.Stmt, error) {
 	optSrc, ok := params.SourceType.(*OptionalType)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	if TypeEquals(optSrc.Element(), params.DestinationType) {
@@ -546,7 +546,7 @@ func AssignFromOptional(
 		})
 
 	if len(conversion) == 0 {
-		return nil // unable to build inner conversion
+		return nil, nil // unable to build inner conversion
 	}
 
 	var result []dst.Stmt
@@ -567,7 +567,7 @@ func IdentityAssignValidatedTypeDestination(
 ) ([]dst.Stmt, error) {
 	validatedType, ok := params.DestinationType.(*ValidatedType)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	// pass through to underlying type
@@ -582,7 +582,7 @@ func IdentityAssignValidatedTypeSource(
 ) ([]dst.Stmt, error) {
 	validatedType, ok := params.SourceType.(*ValidatedType)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	// pass through to underlying type
@@ -599,7 +599,7 @@ func IdentityDeepCopyJSON(
 	params ConversionParameters,
 ) ([]dst.Stmt, error) {
 	if !TypeEquals(params.DestinationType, JSONType) {
-		return nil
+		return nil, nil
 	}
 
 	newSource := astbuilder.Dereference(

--- a/v2/tools/generator/internal/astmodel/conversion_function_builder.go
+++ b/v2/tools/generator/internal/astmodel/conversion_function_builder.go
@@ -421,9 +421,10 @@ func IdentityAssignTypeName(
 		return nil
 	}
 
-	return []dst.Stmt{
-		params.AssignmentHandlerOrDefault()(params.GetDestination(), params.GetSource()),
-	}
+	return astbuilder.Statements(
+		params.AssignmentHandlerOrDefault()(
+			params.GetDestination(),
+			params.GetSource())), nil
 }
 
 // IdentityAssignPrimitiveType just assigns source to destination directly, no conversion needed.
@@ -441,9 +442,11 @@ func IdentityAssignPrimitiveType(
 		return nil
 	}
 
-	return []dst.Stmt{
-		params.AssignmentHandlerOrDefault()(params.GetDestination(), params.GetSource()),
-	}
+	return astbuilder.Statements(
+		params.AssignmentHandlerOrDefault()(
+			params.GetDestination(),
+			params.GetSource())), nil
+
 }
 
 // AssignToOptional assigns address of source to destination.
@@ -463,9 +466,11 @@ func AssignToOptional(
 	}
 
 	if TypeEquals(optDest.Element(), params.SourceType) {
-		return []dst.Stmt{
-			params.AssignmentHandlerOrDefault()(params.GetDestination(), astbuilder.AddrOf(params.GetSource())),
-		}
+		return astbuilder.Statements(
+			params.AssignmentHandlerOrDefault()(
+				params.GetDestination(),
+				astbuilder.AddrOf(params.GetSource()))), nil
+
 	}
 
 	// a more complex conversion is needed
@@ -517,11 +522,10 @@ func AssignFromOptional(
 	}
 
 	if TypeEquals(optSrc.Element(), params.DestinationType) {
-		return []dst.Stmt{
+		return astbuilder.Statements(
 			astbuilder.IfNotNil(params.GetSource(),
 				params.AssignmentHandlerOrDefault()(params.GetDestination(), astbuilder.Dereference(params.GetSource())),
-			),
-		}
+			)), nil
 	}
 
 	// a more complex conversion is needed
@@ -550,11 +554,10 @@ func AssignFromOptional(
 	result = append(result, conversion...)
 	result = append(result, params.AssignmentHandlerOrDefault()(params.GetDestination(), dst.NewIdent(tmpLocal)))
 
-	return []dst.Stmt{
+	return astbuilder.Statements(
 		astbuilder.IfNotNil(
 			params.GetSource(),
-			result...),
-	}
+			result...)), nil
 }
 
 // IdentityAssignValidatedTypeDestination generates an assignment to the underlying validated type Element
@@ -605,9 +608,8 @@ func IdentityDeepCopyJSON(
 			Args: []dst.Expr{},
 		})
 
-	return []dst.Stmt{
-		params.AssignmentHandlerOrDefault()(params.GetDestination(), newSource),
-	}
+	return astbuilder.Statements(
+		params.AssignmentHandlerOrDefault()(params.GetDestination(), newSource)), nil
 }
 
 // AssignmentHandlerDefine is an assignment handler for definitions, using :=

--- a/v2/tools/generator/internal/astmodel/conversion_function_builder.go
+++ b/v2/tools/generator/internal/astmodel/conversion_function_builder.go
@@ -7,11 +7,11 @@ package astmodel
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"go/token"
 	"strings"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 )

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateARMTypeWithConfigMap_CreatesExpectedConversions/person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateARMTypeWithConfigMap_CreatesExpectedConversions/person-v20200101.golden
@@ -75,10 +75,10 @@ func (person *Person_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &Person_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if person.Properties != nil {
 		properties_ARM, err := (*person.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -102,10 +102,10 @@ func (person *Person_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Person_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	person.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 PersonProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -139,7 +139,7 @@ func (person *Person_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Person_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	person.Status = typedInput.Status
 
 	// No error
@@ -190,7 +190,7 @@ func (properties *PersonProperties) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 	result := &PersonProperties_ARM{}
 
-	// Set property ‘FamilyName’:
+	// Set property "FamilyName":
 	if properties.FamilyName != nil {
 		familyName := *properties.FamilyName
 		result.FamilyName = &familyName
@@ -204,17 +204,17 @@ func (properties *PersonProperties) ConvertToARM(resolved genruntime.ConvertToAR
 		result.FamilyName = &familyName
 	}
 
-	// Set property ‘FullName’:
+	// Set property "FullName":
 	fullNameValue, err := resolved.ResolvedConfigMaps.Lookup(properties.FullName)
 	if err != nil {
 		return nil, errors.Wrap(err, "looking up configmap for property FullName")
 	}
 	result.FullName = fullNameValue
 
-	// Set property ‘KnownAs’:
+	// Set property "KnownAs":
 	result.KnownAs = properties.KnownAs
 
-	// Set property ‘RestrictedName’:
+	// Set property "RestrictedName":
 	if properties.RestrictedName != nil {
 		restrictedName := *properties.RestrictedName
 		result.RestrictedName = &restrictedName
@@ -242,26 +242,26 @@ func (properties *PersonProperties) PopulateFromARM(owner genruntime.ArbitraryOw
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected PersonProperties_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FamilyName’:
+	// Set property "FamilyName":
 	if typedInput.FamilyName != nil {
 		familyName := *typedInput.FamilyName
 		properties.FamilyName = &familyName
 	}
 
-	// no assignment for property ‘FamilyNameFromConfig’
+	// no assignment for property "FamilyNameFromConfig"
 
-	// no assignment for property ‘FullName’
+	// no assignment for property "FullName"
 
-	// Set property ‘KnownAs’:
+	// Set property "KnownAs":
 	properties.KnownAs = typedInput.KnownAs
 
-	// Set property ‘RestrictedName’:
+	// Set property "RestrictedName":
 	if typedInput.RestrictedName != nil {
 		restrictedName := *typedInput.RestrictedName
 		properties.RestrictedName = &restrictedName
 	}
 
-	// no assignment for property ‘RestrictedNameFromConfig’
+	// no assignment for property "RestrictedNameFromConfig"
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateFlattenedARMTypeWithConfigMap_CreatesExpectedConversions/person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateFlattenedARMTypeWithConfigMap_CreatesExpectedConversions/person-v20200101.golden
@@ -86,10 +86,10 @@ func (person *Person_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &Person_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if person.FamilyName != nil ||
 		person.FamilyNameFromConfig != nil ||
 		person.FullName != nil ||
@@ -135,10 +135,10 @@ func (person *Person_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Person_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	person.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘FamilyName’:
+	// Set property "FamilyName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.FamilyName != nil {
@@ -147,11 +147,11 @@ func (person *Person_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		}
 	}
 
-	// no assignment for property ‘FamilyNameFromConfig’
+	// no assignment for property "FamilyNameFromConfig"
 
-	// no assignment for property ‘FullName’
+	// no assignment for property "FullName"
 
-	// Set property ‘KnownAs’:
+	// Set property "KnownAs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		person.KnownAs = &typedInput.Properties.KnownAs
@@ -180,7 +180,7 @@ func (person *Person_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Person_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	person.Status = typedInput.Status
 
 	// No error

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateFlattenedARMTypeWithResourceRef_CreatesExpectedConversions/person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateFlattenedARMTypeWithResourceRef_CreatesExpectedConversions/person-v20200101.golden
@@ -82,10 +82,10 @@ func (person *Person_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &Person_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if person.FamilyNameReference != nil ||
 		person.FullName != nil ||
 		person.KnownAs != nil {
@@ -120,18 +120,18 @@ func (person *Person_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Person_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	person.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// no assignment for property ‘FamilyNameReference’
+	// no assignment for property "FamilyNameReference"
 
-	// Set property ‘FullName’:
+	// Set property "FullName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		person.FullName = &typedInput.Properties.FullName
 	}
 
-	// Set property ‘KnownAs’:
+	// Set property "KnownAs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		person.KnownAs = &typedInput.Properties.KnownAs
@@ -160,7 +160,7 @@ func (person *Person_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Person_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	person.Status = typedInput.Status
 
 	// No error

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateFlattenedARMType_CreatesExpectedConversions/person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestCreateFlattenedARMType_CreatesExpectedConversions/person-v20200101.golden
@@ -82,10 +82,10 @@ func (person *Person_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 	result := &Person_Spec_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if person.FamilyName != nil ||
 		person.FullName != nil ||
 		person.KnownAs != nil {
@@ -115,22 +115,22 @@ func (person *Person_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Person_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	person.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘FamilyName’:
+	// Set property "FamilyName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		person.FamilyName = &typedInput.Properties.FamilyName
 	}
 
-	// Set property ‘FullName’:
+	// Set property "FullName":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		person.FullName = &typedInput.Properties.FullName
 	}
 
-	// Set property ‘KnownAs’:
+	// Set property "KnownAs":
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		person.KnownAs = &typedInput.Properties.KnownAs
@@ -159,7 +159,7 @@ func (person *Person_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Person_STATUS_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Status’:
+	// Set property "Status":
 	person.Status = typedInput.Status
 
 	// No error

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only_azure.golden
@@ -308,13 +308,13 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FakeResource_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = resource.APIVersion
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = resource.Type
 	return result, nil
 }
@@ -331,16 +331,16 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FakeResource_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	resource.APIVersion = typedInput.APIVersion
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	resource.Type = typedInput.Type
 
 	// No error

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership_azure.golden
@@ -1057,13 +1057,13 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	}
 	result := &A_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = a.APIVersion
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = a.Type
 	return result, nil
 }
@@ -1080,16 +1080,16 @@ func (a *A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected A_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	a.APIVersion = typedInput.APIVersion
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	a.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	a.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	a.Type = typedInput.Type
 
 	// No error
@@ -1266,13 +1266,13 @@ func (b *B_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	}
 	result := &B_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = b.APIVersion
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = b.Type
 	return result, nil
 }
@@ -1289,16 +1289,16 @@ func (b *B_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected B_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	b.APIVersion = typedInput.APIVersion
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	b.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	b.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	b.Type = typedInput.Type
 
 	// No error
@@ -1470,13 +1470,13 @@ func (c *C_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	}
 	result := &C_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = c.APIVersion
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = c.Type
 	return result, nil
 }
@@ -1493,16 +1493,16 @@ func (c *C_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected C_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	c.APIVersion = typedInput.APIVersion
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	c.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	c.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	c.Type = typedInput.Type
 
 	// No error
@@ -1674,13 +1674,13 @@ func (d *D_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	}
 	result := &D_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = d.APIVersion
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = d.Type
 	return result, nil
 }
@@ -1697,16 +1697,16 @@ func (d *D_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected D_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	d.APIVersion = typedInput.APIVersion
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	d.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	d.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	d.Type = typedInput.Type
 
 	// No error

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure.golden
@@ -314,13 +314,13 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FakeResource_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = resource.APIVersion
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if resource.Properties != nil {
 		properties_ARM, err := (*resource.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -330,7 +330,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties = &properties
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = resource.Type
 	return result, nil
 }
@@ -347,16 +347,16 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FakeResource_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	resource.APIVersion = typedInput.APIVersion
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 FakeResourceProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -367,7 +367,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		resource.Properties = &properties
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	resource.Type = typedInput.Type
 
 	// No error
@@ -567,7 +567,7 @@ func (properties *FakeResourceProperties) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &FakeResourceProperties_ARM{}
 
-	// Set property ‘Id’:
+	// Set property "Id":
 	if properties.Reference != nil {
 		referenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.Reference)
 		if err != nil {
@@ -577,7 +577,7 @@ func (properties *FakeResourceProperties) ConvertToARM(resolved genruntime.Conve
 		result.Id = &reference
 	}
 
-	// Set property ‘NsgIds’:
+	// Set property "NsgIds":
 	for _, item := range properties.NsgReferences {
 		itemARMID, err := resolved.ResolvedReferences.Lookup(item)
 		if err != nil {
@@ -586,7 +586,7 @@ func (properties *FakeResourceProperties) ConvertToARM(resolved genruntime.Conve
 		result.NsgIds = append(result.NsgIds, itemARMID)
 	}
 
-	// Set property ‘NsgMap’:
+	// Set property "NsgMap":
 	if properties.NsgMapReferences != nil {
 		result.NsgMap = make(map[string]string, len(properties.NsgMapReferences))
 		for key, value := range properties.NsgMapReferences {
@@ -598,7 +598,7 @@ func (properties *FakeResourceProperties) ConvertToARM(resolved genruntime.Conve
 		}
 	}
 
-	// Set property ‘SubnetId’:
+	// Set property "SubnetId":
 	if properties.SubnetReference != nil {
 		subnetReferenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.SubnetReference)
 		if err != nil {
@@ -622,13 +622,13 @@ func (properties *FakeResourceProperties) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FakeResourceProperties_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘NsgMapReferences’
+	// no assignment for property "NsgMapReferences"
 
-	// no assignment for property ‘NsgReferences’
+	// no assignment for property "NsgReferences"
 
-	// no assignment for property ‘Reference’
+	// no assignment for property "Reference"
 
-	// no assignment for property ‘SubnetReference’
+	// no assignment for property "SubnetReference"
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure.golden
@@ -314,13 +314,13 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FakeResource_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = resource.APIVersion
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if resource.Properties != nil {
 		properties_ARM, err := (*resource.Properties).ConvertToARM(resolved)
 		if err != nil {
@@ -330,7 +330,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Properties = &properties
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = resource.Type
 	return result, nil
 }
@@ -347,16 +347,16 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FakeResource_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	resource.APIVersion = typedInput.APIVersion
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Properties’:
+	// Set property "Properties":
 	if typedInput.Properties != nil {
 		var properties1 FakeResourceProperties
 		err := properties1.PopulateFromARM(owner, *typedInput.Properties)
@@ -367,7 +367,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		resource.Properties = &properties
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	resource.Type = typedInput.Type
 
 	// No error
@@ -558,7 +558,7 @@ func (properties *FakeResourceProperties) ConvertToARM(resolved genruntime.Conve
 	}
 	result := &FakeResourceProperties_ARM{}
 
-	// Set property ‘OptionalVNet’:
+	// Set property "OptionalVNet":
 	if properties.OptionalVNetReference != nil {
 		optionalVNetReferenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.OptionalVNetReference)
 		if err != nil {
@@ -568,7 +568,7 @@ func (properties *FakeResourceProperties) ConvertToARM(resolved genruntime.Conve
 		result.OptionalVNet = &optionalVNetReference
 	}
 
-	// Set property ‘RequiredVNet’:
+	// Set property "RequiredVNet":
 	if properties.RequiredVNetReference != nil {
 		requiredVNetReferenceARMID, err := resolved.ResolvedReferences.Lookup(*properties.RequiredVNetReference)
 		if err != nil {
@@ -592,9 +592,9 @@ func (properties *FakeResourceProperties) PopulateFromARM(owner genruntime.Arbit
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FakeResourceProperties_ARM, got %T", armInput)
 	}
 
-	// no assignment for property ‘OptionalVNetReference’
+	// no assignment for property "OptionalVNetReference"
 
-	// no assignment for property ‘RequiredVNetReference’
+	// no assignment for property "RequiredVNetReference"
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties_azure.golden
@@ -330,10 +330,10 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FakeResource_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = resource.APIVersion
 
-	// Set property ‘ArrayFoo’:
+	// Set property "ArrayFoo":
 	for _, item := range resource.ArrayFoo {
 		item_ARM, err := item.ConvertToARM(resolved)
 		if err != nil {
@@ -342,7 +342,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.ArrayFoo = append(result.ArrayFoo, *item_ARM.(*Foo_ARM))
 	}
 
-	// Set property ‘ArrayOfArrays’:
+	// Set property "ArrayOfArrays":
 	for _, item := range resource.ArrayOfArrays {
 		var itemTemp []Foo_ARM
 		for _, item1 := range item {
@@ -355,7 +355,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.ArrayOfArrays = append(result.ArrayOfArrays, itemTemp)
 	}
 
-	// Set property ‘ArrayOfArraysOfArrays’:
+	// Set property "ArrayOfArraysOfArrays":
 	for _, item := range resource.ArrayOfArraysOfArrays {
 		var itemTemp [][]Foo_ARM
 		for _, item1 := range item {
@@ -372,12 +372,12 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.ArrayOfArraysOfArrays = append(result.ArrayOfArraysOfArrays, itemTemp)
 	}
 
-	// Set property ‘ArrayOfEnums’:
+	// Set property "ArrayOfEnums":
 	for _, item := range resource.ArrayOfEnums {
 		result.ArrayOfEnums = append(result.ArrayOfEnums, item)
 	}
 
-	// Set property ‘ArrayOfMaps’:
+	// Set property "ArrayOfMaps":
 	for _, item := range resource.ArrayOfMaps {
 		if item != nil {
 			itemTemp := make(map[string]Foo_ARM, len(item))
@@ -392,10 +392,10 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = resource.Type
 	return result, nil
 }
@@ -412,10 +412,10 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FakeResource_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	resource.APIVersion = typedInput.APIVersion
 
-	// Set property ‘ArrayFoo’:
+	// Set property "ArrayFoo":
 	for _, item := range typedInput.ArrayFoo {
 		var item1 Foo
 		err := item1.PopulateFromARM(owner, item)
@@ -425,7 +425,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		resource.ArrayFoo = append(resource.ArrayFoo, item1)
 	}
 
-	// Set property ‘ArrayOfArrays’:
+	// Set property "ArrayOfArrays":
 	for _, item := range typedInput.ArrayOfArrays {
 		var itemTemp []Foo
 		for _, item1 := range item {
@@ -439,7 +439,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		resource.ArrayOfArrays = append(resource.ArrayOfArrays, itemTemp)
 	}
 
-	// Set property ‘ArrayOfArraysOfArrays’:
+	// Set property "ArrayOfArraysOfArrays":
 	for _, item := range typedInput.ArrayOfArraysOfArrays {
 		var itemTemp [][]Foo
 		for _, item1 := range item {
@@ -457,12 +457,12 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		resource.ArrayOfArraysOfArrays = append(resource.ArrayOfArraysOfArrays, itemTemp)
 	}
 
-	// Set property ‘ArrayOfEnums’:
+	// Set property "ArrayOfEnums":
 	for _, item := range typedInput.ArrayOfEnums {
 		resource.ArrayOfEnums = append(resource.ArrayOfEnums, item)
 	}
 
-	// Set property ‘ArrayOfMaps’:
+	// Set property "ArrayOfMaps":
 	for _, item := range typedInput.ArrayOfMaps {
 		if item != nil {
 			itemTemp := make(map[string]Foo, len(item))
@@ -478,13 +478,13 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	resource.Type = typedInput.Type
 
 	// No error
@@ -893,7 +893,7 @@ func (foo *Foo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Foo_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if foo.Name != nil {
 		name := *foo.Name
 		result.Name = &name
@@ -913,7 +913,7 @@ func (foo *Foo) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Foo_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		foo.Name = &name

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure.golden
@@ -332,16 +332,16 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FakeResource_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = resource.APIVersion
 
-	// Set property ‘Color’:
+	// Set property "Color":
 	if resource.Color != nil {
 		color := *resource.Color
 		result.Color = &color
 	}
 
-	// Set property ‘Foo’:
+	// Set property "Foo":
 	if resource.Foo != nil {
 		foo_ARM, err := (*resource.Foo).ConvertToARM(resolved)
 		if err != nil {
@@ -351,10 +351,10 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Foo = &foo
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘OptionalFoo’:
+	// Set property "OptionalFoo":
 	if resource.OptionalFoo != nil {
 		optionalFoo_ARM, err := (*resource.OptionalFoo).ConvertToARM(resolved)
 		if err != nil {
@@ -364,7 +364,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.OptionalFoo = &optionalFoo
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = resource.Type
 	return result, nil
 }
@@ -381,19 +381,19 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FakeResource_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	resource.APIVersion = typedInput.APIVersion
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Color’:
+	// Set property "Color":
 	if typedInput.Color != nil {
 		color := *typedInput.Color
 		resource.Color = &color
 	}
 
-	// Set property ‘Foo’:
+	// Set property "Foo":
 	if typedInput.Foo != nil {
 		var foo1 Foo
 		err := foo1.PopulateFromARM(owner, *typedInput.Foo)
@@ -404,7 +404,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		resource.Foo = &foo
 	}
 
-	// Set property ‘OptionalFoo’:
+	// Set property "OptionalFoo":
 	if typedInput.OptionalFoo != nil {
 		var optionalFoo1 Foo
 		err := optionalFoo1.PopulateFromARM(owner, *typedInput.OptionalFoo)
@@ -415,10 +415,10 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		resource.OptionalFoo = &optionalFoo
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	resource.Type = typedInput.Type
 
 	// No error
@@ -641,7 +641,7 @@ func (foo *Foo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Foo_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if foo.Name != nil {
 		name := *foo.Name
 		result.Name = &name
@@ -661,7 +661,7 @@ func (foo *Foo) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Foo_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		foo.Name = &name

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure.golden
@@ -319,10 +319,10 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FakeResource_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = resource.APIVersion
 
-	// Set property ‘JsonObject’:
+	// Set property "JsonObject":
 	if resource.JsonObject != nil {
 		result.JsonObject = make(map[string]v1.JSON, len(resource.JsonObject))
 		for key, value := range resource.JsonObject {
@@ -330,22 +330,22 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		}
 	}
 
-	// Set property ‘MandatoryJson’:
+	// Set property "MandatoryJson":
 	if resource.MandatoryJson != nil {
 		mandatoryJson := *(*resource.MandatoryJson).DeepCopy()
 		result.MandatoryJson = &mandatoryJson
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘OptionalJson’:
+	// Set property "OptionalJson":
 	if resource.OptionalJson != nil {
 		optionalJson := *(*resource.OptionalJson).DeepCopy()
 		result.OptionalJson = &optionalJson
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = resource.Type
 	return result, nil
 }
@@ -362,13 +362,13 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FakeResource_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	resource.APIVersion = typedInput.APIVersion
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘JsonObject’:
+	// Set property "JsonObject":
 	if typedInput.JsonObject != nil {
 		resource.JsonObject = make(map[string]v1.JSON, len(typedInput.JsonObject))
 		for key, value := range typedInput.JsonObject {
@@ -376,22 +376,22 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MandatoryJson’:
+	// Set property "MandatoryJson":
 	if typedInput.MandatoryJson != nil {
 		mandatoryJson := *(*typedInput.MandatoryJson).DeepCopy()
 		resource.MandatoryJson = &mandatoryJson
 	}
 
-	// Set property ‘OptionalJson’:
+	// Set property "OptionalJson":
 	if typedInput.OptionalJson != nil {
 		optionalJson := *(*typedInput.OptionalJson).DeepCopy()
 		resource.OptionalJson = &optionalJson
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	resource.Type = typedInput.Type
 
 	// No error

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties_azure.golden
@@ -334,10 +334,10 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FakeResource_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = resource.APIVersion
 
-	// Set property ‘MapFoo’:
+	// Set property "MapFoo":
 	if resource.MapFoo != nil {
 		result.MapFoo = make(map[string]Foo_ARM, len(resource.MapFoo))
 		for key, value := range resource.MapFoo {
@@ -349,7 +349,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		}
 	}
 
-	// Set property ‘MapOfArrays’:
+	// Set property "MapOfArrays":
 	if resource.MapOfArrays != nil {
 		result.MapOfArrays = make(map[string][]Foo_ARM, len(resource.MapOfArrays))
 		for key, value := range resource.MapOfArrays {
@@ -365,7 +365,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		}
 	}
 
-	// Set property ‘MapOfEnums’:
+	// Set property "MapOfEnums":
 	if resource.MapOfEnums != nil {
 		result.MapOfEnums = make(map[string]Color, len(resource.MapOfEnums))
 		for key, value := range resource.MapOfEnums {
@@ -373,7 +373,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		}
 	}
 
-	// Set property ‘MapOfMaps’:
+	// Set property "MapOfMaps":
 	if resource.MapOfMaps != nil {
 		result.MapOfMaps = make(map[string]map[string]Foo_ARM, len(resource.MapOfMaps))
 		for key, value := range resource.MapOfMaps {
@@ -391,7 +391,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		}
 	}
 
-	// Set property ‘MapOfMapsOfMaps’:
+	// Set property "MapOfMapsOfMaps":
 	if resource.MapOfMapsOfMaps != nil {
 		result.MapOfMapsOfMaps = make(map[string]map[string]map[string]Foo_ARM, len(resource.MapOfMapsOfMaps))
 		for key, value := range resource.MapOfMapsOfMaps {
@@ -415,7 +415,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		}
 	}
 
-	// Set property ‘MapOfMapsOfMapsOfStrings’:
+	// Set property "MapOfMapsOfMapsOfStrings":
 	if resource.MapOfMapsOfMapsOfStrings != nil {
 		result.MapOfMapsOfMapsOfStrings = make(map[string]map[string]map[string]string, len(resource.MapOfMapsOfMapsOfStrings))
 		for key, value := range resource.MapOfMapsOfMapsOfStrings {
@@ -435,7 +435,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		}
 	}
 
-	// Set property ‘MapOfStrings’:
+	// Set property "MapOfStrings":
 	if resource.MapOfStrings != nil {
 		result.MapOfStrings = make(map[string]string, len(resource.MapOfStrings))
 		for key, value := range resource.MapOfStrings {
@@ -443,10 +443,10 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		}
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = resource.Type
 	return result, nil
 }
@@ -463,13 +463,13 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FakeResource_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	resource.APIVersion = typedInput.APIVersion
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘MapFoo’:
+	// Set property "MapFoo":
 	if typedInput.MapFoo != nil {
 		resource.MapFoo = make(map[string]Foo, len(typedInput.MapFoo))
 		for key, value := range typedInput.MapFoo {
@@ -482,7 +482,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MapOfArrays’:
+	// Set property "MapOfArrays":
 	if typedInput.MapOfArrays != nil {
 		resource.MapOfArrays = make(map[string][]Foo, len(typedInput.MapOfArrays))
 		for key, value := range typedInput.MapOfArrays {
@@ -499,7 +499,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MapOfEnums’:
+	// Set property "MapOfEnums":
 	if typedInput.MapOfEnums != nil {
 		resource.MapOfEnums = make(map[string]Color, len(typedInput.MapOfEnums))
 		for key, value := range typedInput.MapOfEnums {
@@ -507,7 +507,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MapOfMaps’:
+	// Set property "MapOfMaps":
 	if typedInput.MapOfMaps != nil {
 		resource.MapOfMaps = make(map[string]map[string]Foo, len(typedInput.MapOfMaps))
 		for key, value := range typedInput.MapOfMaps {
@@ -526,7 +526,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MapOfMapsOfMaps’:
+	// Set property "MapOfMapsOfMaps":
 	if typedInput.MapOfMapsOfMaps != nil {
 		resource.MapOfMapsOfMaps = make(map[string]map[string]map[string]Foo, len(typedInput.MapOfMapsOfMaps))
 		for key, value := range typedInput.MapOfMapsOfMaps {
@@ -551,7 +551,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MapOfMapsOfMapsOfStrings’:
+	// Set property "MapOfMapsOfMapsOfStrings":
 	if typedInput.MapOfMapsOfMapsOfStrings != nil {
 		resource.MapOfMapsOfMapsOfStrings = make(map[string]map[string]map[string]string, len(typedInput.MapOfMapsOfMapsOfStrings))
 		for key, value := range typedInput.MapOfMapsOfMapsOfStrings {
@@ -571,7 +571,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘MapOfStrings’:
+	// Set property "MapOfStrings":
 	if typedInput.MapOfStrings != nil {
 		resource.MapOfStrings = make(map[string]string, len(typedInput.MapOfStrings))
 		for key, value := range typedInput.MapOfStrings {
@@ -579,10 +579,10 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		}
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	resource.Type = typedInput.Type
 
 	// No error
@@ -1043,7 +1043,7 @@ func (foo *Foo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Foo_ARM{}
 
-	// Set property ‘FooName’:
+	// Set property "FooName":
 	if foo.FooName != nil {
 		fooName := *foo.FooName
 		result.FooName = &fooName
@@ -1063,7 +1063,7 @@ func (foo *Foo) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Foo_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FooName’:
+	// Set property "FooName":
 	if typedInput.FooName != nil {
 		fooName := *typedInput.FooName
 		foo.FooName = &fooName

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec_azure.golden
@@ -308,13 +308,13 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FakeResource_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = resource.APIVersion
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = resource.Type
 	return result, nil
 }
@@ -331,16 +331,16 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FakeResource_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	resource.APIVersion = typedInput.APIVersion
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	resource.Type = typedInput.Type
 
 	// No error

--- a/v2/tools/generator/internal/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
+++ b/v2/tools/generator/internal/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
@@ -339,16 +339,16 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	}
 	result := &FakeResource_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = resource.APIVersion
 
-	// Set property ‘Color’:
+	// Set property "Color":
 	if resource.Color != nil {
 		color := *resource.Color
 		result.Color = &color
 	}
 
-	// Set property ‘Foo’:
+	// Set property "Foo":
 	if resource.Foo != nil {
 		foo_ARM, err := (*resource.Foo).ConvertToARM(resolved)
 		if err != nil {
@@ -358,10 +358,10 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.Foo = &foo
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘OptionalFoo’:
+	// Set property "OptionalFoo":
 	if resource.OptionalFoo != nil {
 		optionalFoo_ARM, err := (*resource.OptionalFoo).ConvertToARM(resolved)
 		if err != nil {
@@ -371,7 +371,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		result.OptionalFoo = &optionalFoo
 	}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = resource.Type
 	return result, nil
 }
@@ -388,19 +388,19 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FakeResource_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	resource.APIVersion = typedInput.APIVersion
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Color’:
+	// Set property "Color":
 	if typedInput.Color != nil {
 		color := *typedInput.Color
 		resource.Color = &color
 	}
 
-	// Set property ‘Foo’:
+	// Set property "Foo":
 	if typedInput.Foo != nil {
 		var foo1 Foo
 		err := foo1.PopulateFromARM(owner, *typedInput.Foo)
@@ -411,7 +411,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		resource.Foo = &foo
 	}
 
-	// Set property ‘OptionalFoo’:
+	// Set property "OptionalFoo":
 	if typedInput.OptionalFoo != nil {
 		var optionalFoo1 Foo
 		err := optionalFoo1.PopulateFromARM(owner, *typedInput.OptionalFoo)
@@ -422,10 +422,10 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 		resource.OptionalFoo = &optionalFoo
 	}
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	resource.Type = typedInput.Type
 
 	// No error
@@ -648,7 +648,7 @@ func (testType *EmbeddedTestType) ConvertToARM(resolved genruntime.ConvertToARMR
 	}
 	result := &EmbeddedTestType_ARM{}
 
-	// Set property ‘FancyProp’:
+	// Set property "FancyProp":
 	result.FancyProp = testType.FancyProp
 	return result, nil
 }
@@ -665,7 +665,7 @@ func (testType *EmbeddedTestType) PopulateFromARM(owner genruntime.ArbitraryOwne
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EmbeddedTestType_ARM, got %T", armInput)
 	}
 
-	// Set property ‘FancyProp’:
+	// Set property "FancyProp":
 	testType.FancyProp = typedInput.FancyProp
 
 	// No error
@@ -717,7 +717,7 @@ func (foo *Foo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 	result := &Foo_ARM{}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if foo.Name != nil {
 		name := *foo.Name
 		result.Name = &name
@@ -737,7 +737,7 @@ func (foo *Foo) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected Foo_ARM, got %T", armInput)
 	}
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	if typedInput.Name != nil {
 		name := *typedInput.Name
 		foo.Name = &name

--- a/v2/tools/generator/internal/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
+++ b/v2/tools/generator/internal/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
@@ -308,13 +308,13 @@ func (resource *AResource_Spec) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &AResource_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = resource.APIVersion
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = resource.Type
 	return result, nil
 }
@@ -331,16 +331,16 @@ func (resource *AResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AResource_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	resource.APIVersion = typedInput.APIVersion
 
-	// Set property ‘AzureName’:
+	// Set property "AzureName":
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	resource.Type = typedInput.Type
 
 	// No error

--- a/v2/tools/generator/internal/codegen/testdata/EnumNames/Single_valued_enum_name.golden
+++ b/v2/tools/generator/internal/codegen/testdata/EnumNames/Single_valued_enum_name.golden
@@ -297,13 +297,13 @@ func (resource *AResource_Spec) ConvertToARM(resolved genruntime.ConvertToARMRes
 	}
 	result := &AResource_Spec_ARM{}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	result.APIVersion = resource.APIVersion
 
-	// Set property ‘Name’:
+	// Set property "Name":
 	result.Name = resolved.Name
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	result.Type = resource.Type
 	return result, nil
 }
@@ -320,13 +320,13 @@ func (resource *AResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected AResource_Spec_ARM, got %T", armInput)
 	}
 
-	// Set property ‘APIVersion’:
+	// Set property "APIVersion":
 	resource.APIVersion = typedInput.APIVersion
 
-	// Set property ‘Owner’:
+	// Set property "Owner":
 	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
-	// Set property ‘Type’:
+	// Set property "Type":
 	resource.Type = typedInput.Type
 
 	// No error


### PR DESCRIPTION
**What this PR does / why we need it**:

Modifies `astmodel.ConversionHandler` to allow for returning an error, and propagates that change.

Resolved #2966 

**Special notes for your reviewer**:

This is one of a sequence of changes addressing Technical Debt before it causes us greater issues.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/OnXxypiWwrLdS/giphy.gif)
