### PR TITLE
Fix sequencing of asoctl builds for release

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -105,16 +105,7 @@ tasks:
     deps:
       - controller:run-kustomize
       - controller:make-multitenant-files
-      - task: asoctl:build
-        vars: {GOOS: "linux", GOARCH: "amd64"}
-      - task: asoctl:build
-        vars: {GOOS: "linux", GOARCH: "arm64"}
-      - task: asoctl:build
-        vars: {GOOS: "darwin", GOARCH: "amd64"}
-      - task: asoctl:build
-        vars: {GOOS: "darwin", GOARCH: "arm64"}
-      - task: asoctl:build
-        vars: {GOOS: "windows", GOARCH: "amd64"}
+      - asoctl:make-release-artifacts
     cmds:
       - rm -rf out/release
       - mkdir -p out/release
@@ -172,13 +163,32 @@ tasks:
       - if [ "{{.ARCHIVETYPE}}" = ".zip" ]; then zip -j -r {{.ARCHIVE}} {{.EXECUTABLE}}; fi
       - if [ "{{.ARCHIVETYPE}}" = ".gz" ]; then gzip -v -c {{.EXECUTABLE}} > {{.ARCHIVE}} ; fi
     vars:
+      GOOS: '{{default OS .GOOS}}'
       EXT: '{{if eq .GOOS "windows"}}.exe{{else}}{{end}}'
       ARCHIVETYPE: '{{if eq .GOOS "windows"}}.zip{{else}}.gz{{end}}'
-      GOOS: '{{default OS .GOOS}}'
       GOARCH: '{{default ARCH .GOARCH}}'
       EXECUTABLE: ./bin/{{.GOOS}}-{{.GOARCH}}/{{.ASOCTL_APP}}{{.EXT}}
       ARCHIVE: ../../bin/{{.ASOCTL_APP}}-{{.GOOS}}-{{.GOARCH}}{{.ARCHIVETYPE}}
 
+  asoctl:make-release-artifacts:
+    desc: Produce asoctl files required for an ASOv2 release
+    dir: "{{.CONTROLLER_ROOT}}"
+    deps:
+        # Regenerating the deepcopy files deletes and regenerates them, 
+        # so we have to ensure this runs before we do any asoctl builds
+      - controller:run-kustomize
+    cmds:
+      - task: asoctl:build
+        vars: {GOOS: "linux", GOARCH: "amd64"}
+      - task: asoctl:build
+        vars: {GOOS: "linux", GOARCH: "arm64"}
+      - task: asoctl:build
+        vars: {GOOS: "darwin", GOARCH: "amd64"}
+      - task: asoctl:build
+        vars: {GOOS: "darwin", GOARCH: "arm64"}
+      - task: asoctl:build
+        vars: {GOOS: "windows", GOARCH: "amd64"}
+  
   ############### Generator targets ###############
 
   generator:quick-checks:


### PR DESCRIPTION
**What this PR does / why we need it**:

The Taskfile target `controller:run-kustomize` deletes and regenerates all the `zz_generated.deepcopy.go` files, resulting in build errors for `asoctl` unless we ensure the regeneration runs first.

This PR enforces that ordering so the builds work.

**How does this PR make you feel**:

![gif](https://media.giphy.com/media/FfJU6Rc7Djwcw/giphy.gif)
