### PR TITLE
Fix potential use of wrong statements

### DIFF
--- a/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
@@ -63,6 +63,7 @@ func newConvertFromARMFunctionBuilder(
 	result.typeConversionBuilder.AddConversionHandlers(result.convertComplexTypeNameProperty)
 	result.propertyConversionHandlers = []propertyConversionHandler{
 		// Handlers for specific properties come first
+		skipNonConvertablePropertyHandler,
 		result.namePropertyHandler,
 		result.ownerPropertyHandler,
 		result.conditionsPropertyHandler,

--- a/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
@@ -65,7 +65,7 @@ func newConvertFromARMFunctionBuilder(
 	result.typeConversionBuilder.AddConversionHandlers(result.convertComplexTypeNameProperty)
 	result.propertyConversionHandlers = []propertyConversionHandler{
 		// Handlers for specific properties come first
-		skipNonConvertablePropertyHandler,
+		skipPropertiesFlaggedWithNoARMConversion,
 		result.namePropertyHandler,
 		result.ownerPropertyHandler,
 		result.conditionsPropertyHandler,

--- a/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
@@ -67,7 +67,7 @@ func newConvertToARMFunctionBuilder(
 
 	result.propertyConversionHandlers = []propertyConversionHandler{
 		// Handlers for specific properties come first
-		skipNonConvertablePropertyHandler,
+		skipPropertiesFlaggedWithNoARMConversion,
 		result.namePropertyHandler,
 		result.operatorSpecPropertyHandler,
 		result.configMapReferencePropertyHandler,

--- a/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
@@ -66,6 +66,7 @@ func newConvertToARMFunctionBuilder(
 
 	result.propertyConversionHandlers = []propertyConversionHandler{
 		// Handlers for specific properties come first
+		skipNonConvertablePropertyHandler,
 		result.namePropertyHandler,
 		result.operatorSpecPropertyHandler,
 		result.configMapReferencePropertyHandler,

--- a/v2/tools/generator/internal/armconversion/shared.go
+++ b/v2/tools/generator/internal/armconversion/shared.go
@@ -37,18 +37,13 @@ const (
 	TypeKindStatus
 )
 
-const (
-	ConversionTag        = "conversion"
-	NoARMConversionValue = "noarmconversion"
-)
-
 func (builder conversionBuilder) propertyConversionHandler(
 	toProp *astmodel.PropertyDefinition,
 	fromType *astmodel.ObjectType,
 ) []dst.Stmt {
 	for _, conversionHandler := range builder.propertyConversionHandlers {
 		stmts, matched := conversionHandler(toProp, fromType)
-		if matched || toProp.HasTagValue(ConversionTag, NoARMConversionValue) {
+		if matched {
 			return stmts
 		}
 	}
@@ -193,4 +188,21 @@ func removeEmptyStatements(stmts []dst.Stmt) []dst.Stmt {
 	}
 
 	return result
+}
+
+const (
+	ConversionTag        = "conversion"
+	NoARMConversionValue = "noarmconversion"
+)
+
+func skipNonConvertablePropertyHandler(
+	toProp *astmodel.PropertyDefinition,
+	fromType *astmodel.ObjectType,
+) ([]dst.Stmt, bool) {
+	// If the property has been flagged as not being convertible, skip it
+	if toProp.HasTagValue(ConversionTag, NoARMConversionValue) {
+		return nil, true
+	}
+
+	return nil, false
 }

--- a/v2/tools/generator/internal/armconversion/shared.go
+++ b/v2/tools/generator/internal/armconversion/shared.go
@@ -242,7 +242,7 @@ const (
 	NoARMConversionValue = "noarmconversion"
 )
 
-func skipNonConvertablePropertyHandler(
+func skipPropertiesFlaggedWithNoARMConversion(
 	toProp *astmodel.PropertyDefinition,
 	fromType *astmodel.ObjectType,
 ) ([]dst.Stmt, bool) {

--- a/v2/tools/generator/internal/armconversion/shared.go
+++ b/v2/tools/generator/internal/armconversion/shared.go
@@ -245,11 +245,11 @@ const (
 func skipPropertiesFlaggedWithNoARMConversion(
 	toProp *astmodel.PropertyDefinition,
 	fromType *astmodel.ObjectType,
-) ([]dst.Stmt, bool) {
+) (propertyConversionHandlerResult, error) {
 	// If the property has been flagged as not being convertible, skip it
 	if toProp.HasTagValue(ConversionTag, NoARMConversionValue) {
-		return nil, true
+		return handledWithNoOp, nil
 	}
 
-	return nil, false
+	return notHandled, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Something has been nagging at the back of my brain about this prior fix and when I stumbled across the code today, I realized what it was. It's subtle, but worth fixing.

When the `noarmconversion` tag is found on the property, we want to return an empty set of statements (`[]dst.Stmt`), because no conversion is required.

What we've actually been doing is returning _whatever set of statements the first conversion in the list happened to return_.

In practice, this has been an empty set of statements, so the code has worked, but nothing has required this to be the case. 

Put another way, the contract for `propertyConversionHandler` is:
> If I return **false**, don't use the slice of statements.

But we were.

**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/UIpzEC5QTvuOQ/giphy.gif)
