### PR TITLE
Add support for subpackages

### DIFF
--- a/v2/tools/generator/internal/astmodel/external_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/external_package_reference.go
@@ -69,3 +69,8 @@ func (pr ExternalPackageReference) ImportAlias(style PackageImportStyle) string 
 	msg := fmt.Sprintf("cannot create import alias for external package reference %s", pr.packagePath)
 	panic(msg)
 }
+
+// Group triggers a panic because external references don't have a group
+func (pr ExternalPackageReference) Group() string {
+	panic(fmt.Sprintf("external package reference %s doesn't have a group", pr))
+}

--- a/v2/tools/generator/internal/astmodel/external_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/external_package_reference.go
@@ -40,6 +40,7 @@ func (pr ExternalPackageReference) ImportPath() string {
 	return pr.packagePath
 }
 
+// FolderPath returns the relative path to this package on disk.
 func (pr ExternalPackageReference) FolderPath() string {
 	panic("external package references don't have a folder path")
 }

--- a/v2/tools/generator/internal/astmodel/external_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/external_package_reference.go
@@ -35,6 +35,11 @@ func (pr ExternalPackageReference) PackagePath() string {
 	return pr.packagePath
 }
 
+// ImportPath returns the path to use when importing this package
+func (pr ExternalPackageReference) ImportPath() string {
+	return pr.packagePath
+}
+
 // Equals returns true if the passed package reference references the same package, false otherwise
 func (pr ExternalPackageReference) Equals(ref PackageReference) bool {
 	if other, ok := ref.(ExternalPackageReference); ok {

--- a/v2/tools/generator/internal/astmodel/external_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/external_package_reference.go
@@ -40,6 +40,10 @@ func (pr ExternalPackageReference) ImportPath() string {
 	return pr.packagePath
 }
 
+func (pr ExternalPackageReference) FolderPath() string {
+	panic("external package references don't have a folder path")
+}
+
 // Equals returns true if the passed package reference references the same package, false otherwise
 func (pr ExternalPackageReference) Equals(ref PackageReference) bool {
 	if other, ok := ref.(ExternalPackageReference); ok {

--- a/v2/tools/generator/internal/astmodel/file_definition.go
+++ b/v2/tools/generator/internal/astmodel/file_definition.go
@@ -47,10 +47,7 @@ func NewFileDefinition(
 		iName := definitions[i].Name().Name()
 		jName := definitions[j].Name().Name()
 
-		iKey := strings.ToLower(iName)
-		jKey := strings.ToLower(jName)
-
-		return iKey < jKey
+		return strings.ToLower(iName) < strings.ToLower(jName)
 	})
 
 	// TODO: check that all definitions are from same package

--- a/v2/tools/generator/internal/astmodel/local_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference.go
@@ -73,8 +73,7 @@ func (pr LocalPackageReference) ImportPath() string {
 	return path.Join(pr.localPathPrefix, pr.group, pr.version)
 }
 
-// FolderPath returns the path to this package on disk.
-// rootFolder is the root folder for all our packages; if omitted, a relative path will be returned
+// FolderPath returns the relative path to this package on disk.
 func (pr LocalPackageReference) FolderPath() string {
 	return path.Join(pr.group, pr.version)
 }

--- a/v2/tools/generator/internal/astmodel/local_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference.go
@@ -73,6 +73,12 @@ func (pr LocalPackageReference) ImportPath() string {
 	return path.Join(pr.localPathPrefix, pr.group, pr.version)
 }
 
+// FolderPath returns the path to this package on disk.
+// rootFolder is the root folder for all our packages; if omitted, a relative path will be returned
+func (pr LocalPackageReference) FolderPath() string {
+	return path.Join(pr.group, pr.version)
+}
+
 // Equals returns true if the passed package reference references the same package, false otherwise
 func (pr LocalPackageReference) Equals(ref PackageReference) bool {
 	if ref == nil {

--- a/v2/tools/generator/internal/astmodel/local_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference.go
@@ -7,6 +7,7 @@ package astmodel
 
 import (
 	"fmt"
+	"path"
 	"strings"
 	"unicode"
 )
@@ -65,6 +66,11 @@ func (pr LocalPackageReference) PackageName() string {
 func (pr LocalPackageReference) PackagePath() string {
 	url := pr.localPathPrefix + "/" + pr.group + "/" + pr.PackageName()
 	return url
+}
+
+// ImportPath returns the path to use when importing this package
+func (pr LocalPackageReference) ImportPath() string {
+	return path.Join(pr.localPathPrefix, pr.group, pr.version)
 }
 
 // Equals returns true if the passed package reference references the same package, false otherwise

--- a/v2/tools/generator/internal/astmodel/local_package_reference_test.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference_test.go
@@ -50,11 +50,12 @@ func TestLocalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name         string
-		group        string
-		version      string
-		pkg          string
-		expectedPath string
+		name        string
+		group       string
+		version     string
+		pkg         string
+		packagePath string
+		folderPath  string
 	}{
 		{
 			"Networking",
@@ -62,6 +63,7 @@ func TestLocalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 			"2020-09-01",
 			"v20200901",
 			"github.com/Azure/azure-service-operator/v2/api/microsoft.networking/v20200901",
+			"microsoft.networking/v20200901",
 		},
 		{
 			"Batch (new)",
@@ -69,6 +71,7 @@ func TestLocalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 			"2020-09-01",
 			"v20200901",
 			"github.com/Azure/azure-service-operator/v2/api/microsoft.batch/v20200901",
+			"microsoft.batch/v20200901",
 		},
 		{
 			"Batch (old)",
@@ -76,6 +79,7 @@ func TestLocalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 			"2015-01-01",
 			"v20150101",
 			"github.com/Azure/azure-service-operator/v2/api/microsoft.batch/v20150101",
+			"microsoft.batch/v20150101",
 		},
 	}
 	for _, c := range cases {
@@ -85,11 +89,11 @@ func TestLocalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 			g := NewGomegaWithT(t)
 
 			ref := makeTestLocalPackageReference(c.group, c.version)
-			grp := ref.Group()
 			g.Expect(ref.PackageName()).To(Equal(c.pkg))
-			g.Expect(ref.PackagePath()).To(Equal(c.expectedPath))
-			g.Expect(ref.String()).To(Equal(c.expectedPath))
-			g.Expect(grp).To(Equal(c.group))
+			g.Expect(ref.PackagePath()).To(Equal(c.packagePath))
+			g.Expect(ref.String()).To(Equal(c.packagePath))
+			g.Expect(ref.Group()).To(Equal(c.group))
+			g.Expect(ref.FolderPath()).To(Equal(c.folderPath))
 		})
 	}
 }

--- a/v2/tools/generator/internal/astmodel/package_definition.go
+++ b/v2/tools/generator/internal/astmodel/package_definition.go
@@ -20,14 +20,20 @@ import (
 
 // PackageDefinition is the definition of a package
 type PackageDefinition struct {
-	GroupName   string
-	PackageName string
-	definitions TypeDefinitionSet
+	PackageName string            // Name  of the package
+	GroupName   string            // Group to which the package belongs
+	Path        string            // relative Path to the package
+	definitions TypeDefinitionSet // set of definitions in this package
 }
 
 // NewPackageDefinition constructs a new package definition
-func NewPackageDefinition(groupName string, packageName string) *PackageDefinition {
-	return &PackageDefinition{groupName, packageName, make(TypeDefinitionSet)}
+func NewPackageDefinition(ref PackageReference) *PackageDefinition {
+	return &PackageDefinition{
+		PackageName: ref.PackageName(),
+		GroupName:   ref.Group(),
+		Path:        ref.FolderPath(),
+		definitions: make(TypeDefinitionSet),
+	}
 }
 
 func (p *PackageDefinition) Definitions() TypeDefinitionSet {

--- a/v2/tools/generator/internal/astmodel/package_definition.go
+++ b/v2/tools/generator/internal/astmodel/package_definition.go
@@ -8,7 +8,7 @@ package astmodel
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -266,7 +266,7 @@ func emitTemplateFile(pkgDef *PackageDefinition, template *template.Template, fi
 		return err
 	}
 
-	err = ioutil.WriteFile(fileRef, buf.Bytes(), 0o600)
+	err = os.WriteFile(fileRef, buf.Bytes(), 0o600)
 	if err != nil {
 		return errors.Wrapf(err, "error writing file %q", fileRef)
 	}

--- a/v2/tools/generator/internal/astmodel/package_import.go
+++ b/v2/tools/generator/internal/astmodel/package_import.go
@@ -7,7 +7,6 @@ package astmodel
 
 import (
 	"fmt"
-
 	"github.com/dave/dst"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"

--- a/v2/tools/generator/internal/astmodel/package_import.go
+++ b/v2/tools/generator/internal/astmodel/package_import.go
@@ -42,7 +42,7 @@ func (pi PackageImport) AsImportSpec() *dst.ImportSpec {
 
 	return &dst.ImportSpec{
 		Name: name,
-		Path: astbuilder.StringLiteral(pi.packageReference.PackagePath()),
+		Path: astbuilder.StringLiteral(pi.packageReference.ImportPath()),
 	}
 }
 

--- a/v2/tools/generator/internal/astmodel/package_import_set.go
+++ b/v2/tools/generator/internal/astmodel/package_import_set.go
@@ -187,11 +187,12 @@ func (set *PackageImportSet) orderImports(i PackageImport, j PackageImport) bool
 func (set *PackageImportSet) createMapByGroup() map[string][]PackageImport {
 	result := make(map[string][]PackageImport)
 	for _, imp := range set.imports {
-		group, _, ok := imp.packageReference.TryGroupVersion()
+		ref, ok := imp.packageReference.(LocalLikePackageReference)
 		if !ok {
 			continue
 		}
 
+		group := ref.Group()
 		result[group] = append(result[group], imp)
 	}
 

--- a/v2/tools/generator/internal/astmodel/package_import_set.go
+++ b/v2/tools/generator/internal/astmodel/package_import_set.go
@@ -181,7 +181,7 @@ func (set *PackageImportSet) orderImports(i PackageImport, j PackageImport) bool
 		}
 	}
 
-	return i.packageReference.PackagePath() < j.packageReference.PackagePath()
+	return i.packageReference.ImportPath() < j.packageReference.ImportPath()
 }
 
 func (set *PackageImportSet) createMapByGroup() map[string][]PackageImport {

--- a/v2/tools/generator/internal/astmodel/package_import_style.go
+++ b/v2/tools/generator/internal/astmodel/package_import_style.go
@@ -9,7 +9,10 @@ package astmodel
 type PackageImportStyle string
 
 const (
-	VersionOnly     PackageImportStyle = "VersionOnly"     // Only need the version of the package to be unique
-	GroupOnly       PackageImportStyle = "GroupOnly"       // Only need the group of the package to be unique
-	GroupAndVersion PackageImportStyle = "GroupAndVersion" // Need both group and version of the package to be unique
+	// VersionOnly is used when using just the version of the package is sufficiently unique
+	VersionOnly PackageImportStyle = "VersionOnly"
+	// GroupOnly is used when using just the group of the package sufficiently unique
+	GroupOnly PackageImportStyle = "GroupOnly"
+	// GroupAndVersion is used when both the group and version of the package are required for it to be unique
+	GroupAndVersion PackageImportStyle = "GroupAndVersion"
 )

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -35,6 +35,9 @@ type PackageReference interface {
 	GroupVersion() (string, string)
 	// ImportAlias returns the import alias to use for this package reference
 	ImportAlias(style PackageImportStyle) string
+
+	// Group returns the group to which this package belongs
+	Group() string
 }
 
 // LocalLikePackageReference describes a package reference that points to a local package (either a storage package

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -41,6 +41,9 @@ type PackageReference interface {
 
 	// ImportPath returns the path to use when importing this package
 	ImportPath() string
+
+	// FolderPath returns the relative path to this package on disk.
+	FolderPath() string
 }
 
 // LocalLikePackageReference describes a package reference that points to a local package (either a storage package

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -38,6 +38,9 @@ type PackageReference interface {
 
 	// Group returns the group to which this package belongs
 	Group() string
+
+	// ImportPath returns the path to use when importing this package
+	ImportPath() string
 }
 
 // LocalLikePackageReference describes a package reference that points to a local package (either a storage package
@@ -64,7 +67,7 @@ func IsExternalPackageReference(ref PackageReference) bool {
 
 func SortPackageReferencesByPathAndVersion(packages []PackageReference) {
 	sort.Slice(packages, func(i, j int) bool {
-		return ComparePathAndVersion(packages[i].PackagePath(), packages[j].PackagePath())
+		return ComparePathAndVersion(packages[i].ImportPath(), packages[j].ImportPath())
 	})
 }
 

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -36,10 +36,10 @@ type PackageReference interface {
 	// ImportAlias returns the import alias to use for this package reference
 	ImportAlias(style PackageImportStyle) string
 
-	// Group returns the group to which this package belongs
+	// Group returns the group to which this package belongs.
 	Group() string
 
-	// ImportPath returns the path to use when importing this package
+	// ImportPath returns the path to use when importing this package.
 	ImportPath() string
 
 	// FolderPath returns the relative path to this package on disk.

--- a/v2/tools/generator/internal/astmodel/property_reference.go
+++ b/v2/tools/generator/internal/astmodel/property_reference.go
@@ -43,6 +43,10 @@ func (ref PropertyReference) IsEmpty() bool {
 
 // String returns a string representation of this property reference
 func (ref PropertyReference) String() string {
-	g, v := ref.declaringType.PackageReference().GroupVersion()
-	return fmt.Sprintf("%s/%s/%s.%s", g, v, ref.declaringType.Name(), ref.property)
+	declaringType := ref.declaringType
+	return fmt.Sprintf(
+		"%s/%s.%s",
+		declaringType.PackageReference().FolderPath(),
+		declaringType.Name(),
+		ref.property)
 }

--- a/v2/tools/generator/internal/astmodel/resource_type.go
+++ b/v2/tools/generator/internal/astmodel/resource_type.go
@@ -579,7 +579,7 @@ func (resource *ResourceType) AsDeclarations(codeGenerationContext *CodeGenerati
 
 	// Add required RBAC annotations, only on storage version
 	if resource.isStorageVersion {
-		group, _ := declContext.Name.PackageReference().GroupVersion()
+		group := declContext.Name.PackageReference().Group()
 		group = strings.ToLower(group + GroupSuffix)
 		resourceName := strings.ToLower(declContext.Name.Plural().Name())
 

--- a/v2/tools/generator/internal/astmodel/storage_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/storage_package_reference.go
@@ -44,7 +44,7 @@ func (s StoragePackageReference) ImportPath() string {
 	return s.inner.ImportPath() + StoragePackageSuffix
 }
 
-// FolderPath returns the path to this package on disk
+// FolderPath returns the relative path to this package on disk.
 func (s StoragePackageReference) FolderPath() string {
 	return s.inner.FolderPath() + StoragePackageSuffix
 }

--- a/v2/tools/generator/internal/astmodel/storage_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/storage_package_reference.go
@@ -93,7 +93,7 @@ func (s StoragePackageReference) TryGroupVersion() (string, string, bool) {
 	return g, v + StoragePackageSuffix, true
 }
 
-// MustGroupVersion returns the group and version of this storage reference.
+// GroupVersion returns the group and version of this storage reference.
 func (s StoragePackageReference) GroupVersion() (string, string) {
 	g, v := s.inner.GroupVersion()
 	return g, v + StoragePackageSuffix

--- a/v2/tools/generator/internal/astmodel/storage_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/storage_package_reference.go
@@ -39,6 +39,11 @@ func (s StoragePackageReference) PackagePath() string {
 	return url
 }
 
+// ImportPath returns the path to use when importing this package
+func (s StoragePackageReference) ImportPath() string {
+	return s.inner.ImportPath() + StoragePackageSuffix
+}
+
 func (s StoragePackageReference) Version() string {
 	return s.inner.Version() + StoragePackageSuffix
 }

--- a/v2/tools/generator/internal/astmodel/storage_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/storage_package_reference.go
@@ -44,6 +44,11 @@ func (s StoragePackageReference) ImportPath() string {
 	return s.inner.ImportPath() + StoragePackageSuffix
 }
 
+// FolderPath returns the path to this package on disk
+func (s StoragePackageReference) FolderPath() string {
+	return s.inner.FolderPath() + StoragePackageSuffix
+}
+
 func (s StoragePackageReference) Version() string {
 	return s.inner.Version() + StoragePackageSuffix
 }

--- a/v2/tools/generator/internal/astmodel/sub_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/sub_package_reference.go
@@ -17,6 +17,7 @@ type SubPackageReference struct {
 
 var _ PackageReference = SubPackageReference{}
 var _ LocalLikePackageReference = SubPackageReference{}
+var _ DerivedPackageReference = SubPackageReference{}
 
 var _ fmt.Stringer = SubPackageReference{}
 

--- a/v2/tools/generator/internal/astmodel/sub_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/sub_package_reference.go
@@ -43,6 +43,11 @@ func (s SubPackageReference) PackagePath() string {
 	return path.Join(s.parent.PackagePath(), s.name)
 }
 
+// ImportPath returns the path to use when importing this package.
+func (s SubPackageReference) ImportPath() string {
+	return path.Join(s.parent.ImportPath(), s.name)
+}
+
 // Equals returns true if the passed package reference is a sub-package reference with the same name and an equal
 // parent.
 func (s SubPackageReference) Equals(ref PackageReference) bool {

--- a/v2/tools/generator/internal/astmodel/sub_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/sub_package_reference.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"fmt"
+	"path"
+)
+
+type SubPackageReference struct {
+	parent PackageReference
+	name   string
+}
+
+var _ PackageReference = SubPackageReference{}
+var _ LocalLikePackageReference = SubPackageReference{}
+
+var _ fmt.Stringer = SubPackageReference{}
+
+// MakeSubPackageReference creates a new SubPackageReference, representing a nested but distinct package.
+// name is the name of the sub-package.
+// parent is the parent package.
+func MakeSubPackageReference(
+	name string,
+	parent PackageReference,
+) SubPackageReference {
+	return SubPackageReference{
+		parent: parent,
+		name:   name,
+	}
+}
+
+// PackageName returns the name of the package.
+func (s SubPackageReference) PackageName() string {
+	return s.name
+}
+
+// PackagePath returns the fully qualified package path.
+func (s SubPackageReference) PackagePath() string {
+	return path.Join(s.parent.PackagePath(), s.name)
+}
+
+// Equals returns true if the passed package reference is a sub-package reference with the same name and an equal
+// parent.
+func (s SubPackageReference) Equals(ref PackageReference) bool {
+	other, ok := ref.(SubPackageReference)
+	if !ok {
+		return false
+	}
+
+	return s.name == other.name && s.parent.Equals(other.parent)
+}
+
+// String returns the string representation of the package reference, and implements fmt.Stringer.
+func (s SubPackageReference) String() string {
+	return path.Join(s.parent.String(), s.name)
+}
+
+// IsPreview returns true if the package reference is a preview version.
+func (s SubPackageReference) IsPreview() bool {
+	return s.parent.IsPreview()
+}
+
+// TryGroupVersion returns the group and version of the package reference, if it has them.
+// Subpackages have the same group/version as their parent.
+func (s SubPackageReference) TryGroupVersion() (string, string, bool) {
+	return s.parent.TryGroupVersion()
+}
+
+// GroupVersion returns the group and version of the package reference.
+// Subpackages have the same group/version as their parent.
+func (s SubPackageReference) GroupVersion() (string, string) {
+	return s.parent.GroupVersion()
+}
+
+// Group returns the group of the package reference.
+// Subpackages have the same group as their parent.
+func (s SubPackageReference) Group() string {
+	return s.parent.Group()
+}
+
+// Parent returns the parent package reference.
+func (s SubPackageReference) Parent() PackageReference {
+	return s.parent
+}
+
+func (s SubPackageReference) LocalPathPrefix() string {
+	if lpr, ok := s.parent.(LocalLikePackageReference); ok {
+		return lpr.LocalPathPrefix()
+	}
+
+	panic("SubPackageReference parent is not a LocalLikePackageReference")
+}
+
+func (s SubPackageReference) Version() string {
+	if lpr, ok := s.parent.(LocalLikePackageReference); ok {
+		return lpr.Version()
+	}
+
+	panic("SubPackageReference parent is not a LocalLikePackageReference")
+}
+
+// ImportAlias returns the import alias to use for this package reference.
+func (s SubPackageReference) ImportAlias(style PackageImportStyle) string {
+	base := s.parent.ImportAlias(style)
+	switch style {
+	case VersionOnly:
+		return base + s.name[0:1]
+	case GroupOnly:
+		return base
+	case GroupAndVersion:
+		return base + s.name[0:1]
+	default:
+		panic(fmt.Sprintf("didn't expect PackageImportStyle %q", style))
+	}
+}
+
+// Base returns the parent of this subpackge for DerivedPackageReference.
+func (s SubPackageReference) Base() PackageReference {
+	return s.parent
+}

--- a/v2/tools/generator/internal/astmodel/sub_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/sub_package_reference.go
@@ -49,7 +49,7 @@ func (s SubPackageReference) ImportPath() string {
 	return path.Join(s.parent.ImportPath(), s.name)
 }
 
-// FolderPath returns the path to this package on disk.
+// FolderPath returns the relative path to this package on disk.
 func (s SubPackageReference) FolderPath() string {
 	return path.Join(s.parent.FolderPath(), s.name)
 }

--- a/v2/tools/generator/internal/astmodel/sub_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/sub_package_reference.go
@@ -48,6 +48,11 @@ func (s SubPackageReference) ImportPath() string {
 	return path.Join(s.parent.ImportPath(), s.name)
 }
 
+// FolderPath returns the path to this package on disk.
+func (s SubPackageReference) FolderPath() string {
+	return path.Join(s.parent.FolderPath(), s.name)
+}
+
 // Equals returns true if the passed package reference is a sub-package reference with the same name and an equal
 // parent.
 func (s SubPackageReference) Equals(ref PackageReference) bool {

--- a/v2/tools/generator/internal/astmodel/sub_package_reference_test.go
+++ b/v2/tools/generator/internal/astmodel/sub_package_reference_test.go
@@ -40,6 +40,7 @@ func Test_NewSubPackageReference_GivenParentAndName_ReturnsExpectedProperties(t 
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewGomegaWithT(t)
 
 			subPackage := MakeSubPackageReference(c.name, c.parent)

--- a/v2/tools/generator/internal/astmodel/sub_package_reference_test.go
+++ b/v2/tools/generator/internal/astmodel/sub_package_reference_test.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_NewSubPackageReference_GivenParentAndName_ReturnsExpectedProperties(t *testing.T) {
+	t.Parallel()
+
+	parent := makeTestLocalPackageReference("group", "version")
+	batch := makeTestLocalPackageReference("microsoft.batch", "2020-09-01")
+
+	cases := []struct {
+		name                string
+		parent              PackageReference
+		expectedPackageName string
+		expectedPackagePath string
+	}{
+		{
+			"simple",
+			parent,
+			"simple",
+			"github.com/Azure/azure-service-operator/v2/api/group/version/simple",
+		},
+		{
+			"sub",
+			batch,
+			"sub",
+			"github.com/Azure/azure-service-operator/v2/api/microsoft.batch/v20200901/sub",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			subPackage := MakeSubPackageReference(c.name, c.parent)
+
+			g.Expect(subPackage.name).To(Equal(c.name))
+			g.Expect(subPackage.parent).To(Equal(c.parent))
+			g.Expect(subPackage.PackageName()).To(Equal(c.expectedPackageName))
+			g.Expect(subPackage.PackagePath()).To(Equal(c.expectedPackagePath))
+		})
+	}
+}
+
+func Test_SubPackageReference_GivenParent_InheritsParentsProperties(t *testing.T) {
+	t.Parallel()
+
+	network := makeTestLocalPackageReference("microsoft.network", "2023-07-01")
+	networkPreview := makeTestLocalPackageReference("microsoft.network", "2023-07-01-preview")
+
+	cases := []struct {
+		name      string
+		parent    PackageReference
+		group     string
+		version   string
+		isPreview bool
+	}{
+		{
+			"Network",
+			network,
+			"microsoft.network",
+			"v20230701",
+			false,
+		},
+		{
+			"NetworkPreview",
+			networkPreview,
+			"microsoft.network",
+			"v20230701preview",
+			true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			sub := MakeSubPackageReference("sub", c.parent)
+
+			grp, ver := sub.GroupVersion()
+			g.Expect(grp).To(Equal(c.group))
+			g.Expect(ver).To(Equal(c.version))
+			g.Expect(sub.IsPreview()).To(Equal(c.isPreview))
+
+			grp, ver = c.parent.GroupVersion()
+			g.Expect(grp).To(Equal(c.group))
+			g.Expect(ver).To(Equal(c.version))
+			g.Expect(c.parent.IsPreview()).To(Equal(c.isPreview))
+		})
+	}
+}

--- a/v2/tools/generator/internal/astmodel/type_name.go
+++ b/v2/tools/generator/internal/astmodel/type_name.go
@@ -44,8 +44,8 @@ type typeName struct {
 func SortTypeName(left, right TypeName) bool {
 	leftRef := left.PackageReference()
 	rightRef := right.PackageReference()
-	return leftRef.PackagePath() < rightRef.PackagePath() ||
-		(leftRef.PackagePath() == rightRef.PackagePath() && left.Name() < right.Name())
+	return leftRef.ImportPath() < rightRef.ImportPath() ||
+		(leftRef.ImportPath() == rightRef.ImportPath() && left.Name() < right.Name())
 }
 
 // MakeTypeName is a factory method for creating a TypeName

--- a/v2/tools/generator/internal/codegen/debug_reporter.go
+++ b/v2/tools/generator/internal/codegen/debug_reporter.go
@@ -39,7 +39,7 @@ func newDebugReporter(groupSelector string, outputFolder string) *debugReporter 
 func (dr *debugReporter) ReportStage(stage int, description string, state *pipeline.State) error {
 	included := state.Definitions().Where(
 		func(def astmodel.TypeDefinition) bool {
-			grp, _ := def.Name().PackageReference().GroupVersion()
+			grp := def.Name().PackageReference().Group()
 			return dr.groupSelector.Matches(grp).Matched
 		})
 

--- a/v2/tools/generator/internal/codegen/embeddedresources/remover.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/remover.go
@@ -394,7 +394,7 @@ type resourceKey struct {
 }
 
 func getResourceKey(name astmodel.TypeName) resourceKey {
-	group, _ := name.PackageReference().GroupVersion()
+	group := name.PackageReference().Group()
 
 	return resourceKey{
 		group: group,

--- a/v2/tools/generator/internal/codegen/golden_files_test.go
+++ b/v2/tools/generator/internal/codegen/golden_files_test.go
@@ -268,8 +268,7 @@ func exportPackagesTestPipelineStage(t *testing.T, testName string) *pipeline.St
 				ref := def.Name().PackageReference()
 				pkg, ok := pkgs[ref]
 				if !ok {
-					g, v := ref.GroupVersion()
-					pkg = astmodel.NewPackageDefinition(g, v)
+					pkg = astmodel.NewPackageDefinition(ref)
 					pkgs[ref] = pkg
 
 					if !astmodel.IsStoragePackageReference(ref) {

--- a/v2/tools/generator/internal/codegen/pipeline/add_arm_conversion_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_arm_conversion_interface.go
@@ -248,7 +248,7 @@ func (c *armConversionApplier) addARMConversionInterface(
 }
 
 func (c *armConversionApplier) createOwnerProperty(ownerTypeName astmodel.TypeName) *astmodel.PropertyDefinition {
-	grp, _ := ownerTypeName.PackageReference().GroupVersion()
+	grp := ownerTypeName.PackageReference().Group()
 	group := grp + astmodel.GroupSuffix
 	kind := ownerTypeName.Name()
 

--- a/v2/tools/generator/internal/codegen/pipeline/create_resource_extension_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_resource_extension_types.go
@@ -30,7 +30,7 @@ func CreateResourceExtensions(localPath string, idFactory astmodel.IdentifierFac
 
 			// Iterate through resource types and aggregate the resource types that share the same extension type in a map.
 			for _, typeDef := range resourceDefs {
-				group, _ := typeDef.Name().PackageReference().GroupVersion()
+				group := typeDef.Name().PackageReference().Group()
 				packageRef := astmodel.MakeLocalPackageReference(
 					localPath,
 					group,

--- a/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
@@ -308,7 +308,7 @@ func (chain *propertyChain) indexMethodName(
 	idFactory astmodel.IdentifierFactory,
 	resourceTypeName astmodel.TypeName,
 ) string {
-	group, _ := resourceTypeName.PackageReference().GroupVersion()
+	group := resourceTypeName.PackageReference().Group()
 	return fmt.Sprintf("index%s%s%s",
 		idFactory.CreateIdentifier(group, astmodel.Exported),
 		resourceTypeName.Name(),

--- a/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
@@ -15,9 +15,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
 
 // ExportPackagesStageID is the unique identifier for this pipeline stage

--- a/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
@@ -8,17 +8,16 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
 	"os"
 	"path/filepath"
-	"sort"
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
-
-	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
 
 // ExportPackagesStageID is the unique identifier for this pipeline stage
@@ -84,11 +83,8 @@ func writeFiles(
 	}
 
 	// Sort the list of packages to ensure we always write them to disk in the same sequence
-	sort.Slice(pkgs, func(i int, j int) bool {
-		iPkg := pkgs[i]
-		jPkg := pkgs[j]
-		return iPkg.GroupName < jPkg.GroupName ||
-			(iPkg.GroupName == jPkg.GroupName && iPkg.PackageName < jPkg.PackageName)
+	slices.SortFunc(pkgs, func(left *astmodel.PackageDefinition, right *astmodel.PackageDefinition) bool {
+		return left.Path < right.Path
 	})
 
 	// emit each package
@@ -100,67 +96,33 @@ func writeFiles(
 	globalProgress := newProgressMeter()
 	groupProgress := newProgressMeter()
 
-	var wg sync.WaitGroup
+	var eg errgroup.Group
+	eg.SetLimit(8)
 
-	pkgQueue := make(chan *astmodel.PackageDefinition, 100)
-	errs := make(chan error, 10) // we will buffer up to 10 errors and ignore any leftovers
-
-	// write outputs with 8 workers
-	// this is parallelized mostly due to 'dst' conversion being slow, see: https://github.com/Azure/k8s-infra/pull/376
-	// potentially we could contribute improvements upstream
-	for c := 0; c < 8; c++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for pkg := range pkgQueue {
-				if ctx.Err() != nil { // check for cancellation
-					return
-				}
-
-				// create directory if not already there
-				outputDir := filepath.Join(outputPath, pkg.GroupName, pkg.PackageName)
-				if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-					err = os.MkdirAll(outputDir, 0o700)
-					if err != nil {
-						select { // try to write to errs, ignore if buffer full
-						case errs <- errors.Wrapf(err, "unable to create directory %q", outputDir):
-						default:
-						}
-						return
-					}
-				}
-
-				count, err := pkg.EmitDefinitions(outputDir, packages, emitDocFiles)
+	for _, pkg := range pkgs {
+		pkg := pkg
+		eg.Go(func() error {
+			// create directory if not already there
+			outputDir := filepath.Join(outputPath, pkg.Path)
+			if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+				err = os.MkdirAll(outputDir, 0o700)
 				if err != nil {
-					select { // try to write to errs, ignore if buffer full
-					case errs <- errors.Wrapf(err, "error writing definitions into %q", outputDir):
-					default:
-					}
-					return
-				} else {
-					globalProgress.LogProgress("", pkg.DefinitionCount(), count, log)
-					groupProgress.LogProgress(pkg.GroupName, pkg.DefinitionCount(), count, log)
+					return errors.Wrapf(err, "unable to create directory %q", outputDir)
 				}
 			}
-		}()
+
+			count, err := pkg.EmitDefinitions(outputDir, packages, emitDocFiles)
+			if err != nil {
+				return errors.Wrapf(err, "error writing definitions into %q", outputDir)
+			}
+
+			globalProgress.LogProgress("", pkg.DefinitionCount(), count, log)
+			groupProgress.LogProgress(pkg.Path, pkg.DefinitionCount(), count, log)
+			return nil
+		})
 	}
 
-	// send to workers
-	// and wait for them to finish
-	for _, pkg := range pkgs {
-		pkgQueue <- pkg
-	}
-	close(pkgQueue)
-	wg.Wait()
-
-	// collect all errors, if any
-	close(errs)
-	totalErrs := make([]error, 0, len(errs))
-	for err := range errs {
-		totalErrs = append(totalErrs, err)
-	}
-
-	err := kerrors.NewAggregate(totalErrs)
+	err := eg.Wait()
 	if err != nil {
 		return err
 	}
@@ -169,6 +131,7 @@ func writeFiles(
 	globalProgress.mutex.Lock()
 	defer globalProgress.mutex.Unlock()
 	globalProgress.Log(log)
+
 	return nil
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
@@ -40,7 +40,7 @@ func ExportPackages(
 				return nil, errors.Wrapf(err, "failed to assign generated definitions to packages")
 			}
 
-			err = writeFiles(ctx, packages, outputPath, emitDocFiles, log)
+			err = writeFiles(packages, outputPath, emitDocFiles, log)
 			if err != nil {
 				return nil, errors.Wrapf(err, "unable to write files into %q", outputPath)
 			}
@@ -72,7 +72,6 @@ func CreatePackagesForDefinitions(definitions astmodel.TypeDefinitionSet) (map[a
 }
 
 func writeFiles(
-	ctx context.Context,
 	packages map[astmodel.PackageReference]*astmodel.PackageDefinition,
 	outputPath string,
 	emitDocFiles bool,

--- a/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
@@ -59,11 +59,10 @@ func CreatePackagesForDefinitions(definitions astmodel.TypeDefinitionSet) (map[a
 	for _, def := range definitions {
 		name := def.Name()
 		ref := name.PackageReference()
-		group, version := ref.GroupVersion()
 		if pkg, ok := packages[ref]; ok {
 			pkg.AddDefinition(def)
 		} else {
-			pkg = astmodel.NewPackageDefinition(group, version)
+			pkg = astmodel.NewPackageDefinition(ref)
 			pkg.AddDefinition(def)
 			packages[ref] = pkg
 		}

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
@@ -91,7 +91,7 @@ func groupResourcesByVersion(definitions astmodel.TypeDefinitionSet) map[unversi
 
 func getUnversionedName(name astmodel.TypeName) unversionedName {
 	ref := name.PackageReference()
-	group, _ := ref.GroupVersion()
+	group := ref.Group()
 	return unversionedName{group, name.Name()}
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
@@ -44,8 +44,8 @@ func MarkLatestResourceVersionsForStorage(definitions astmodel.TypeDefinitionSet
 			allVersionsOfResource := resourceLookup[unversionedName]
 			latestVersionOfResource := allVersionsOfResource[len(allVersionsOfResource)-1]
 
-			thisPackagePath := def.Name().PackageReference().PackagePath()
-			latestPackagePath := latestVersionOfResource.Name().PackageReference().PackagePath()
+			thisPackagePath := def.Name().PackageReference().ImportPath()
+			latestPackagePath := latestVersionOfResource.Name().PackageReference().ImportPath()
 
 			// mark as storage version if it's the latest version
 			isLatestVersion := thisPackagePath == latestPackagePath
@@ -81,8 +81,8 @@ func groupResourcesByVersion(definitions astmodel.TypeDefinitionSet) map[unversi
 	for _, slice := range result {
 		sort.Slice(slice, func(i, j int) bool {
 			return astmodel.ComparePathAndVersion(
-				slice[i].Name().PackageReference().PackagePath(),
-				slice[j].Name().PackageReference().PackagePath())
+				slice[i].Name().PackageReference().ImportPath(),
+				slice[j].Name().PackageReference().ImportPath())
 		})
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_structure.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_structure.go
@@ -47,7 +47,7 @@ func NewResourceStructureReport(defs astmodel.TypeDefinitionSet) *ResourceStruct
 // SaveReports writes the reports to the specified files
 func (report *ResourceStructureReport) SaveReports(baseFolder string) error {
 	for pkg, defs := range report.lists {
-		folder := filepath.Join(pkg.FolderPath(), "structure.txt")
+		folder := filepath.Join(baseFolder, pkg.FolderPath(), "structure.txt")
 		err := report.saveReport(folder, defs)
 		if err != nil {
 			return err

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_structure.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_structure.go
@@ -47,8 +47,8 @@ func NewResourceStructureReport(defs astmodel.TypeDefinitionSet) *ResourceStruct
 // SaveReports writes the reports to the specified files
 func (report *ResourceStructureReport) SaveReports(baseFolder string) error {
 	for pkg, defs := range report.lists {
-		filePath := report.getFilePath(baseFolder, pkg)
-		err := report.saveReport(filePath, defs)
+		folder := filepath.Join(pkg.FolderPath(), "structure.txt")
+		err := report.saveReport(folder, defs)
 		if err != nil {
 			return err
 		}
@@ -68,11 +68,6 @@ func (report *ResourceStructureReport) summarize(definitions astmodel.TypeDefini
 
 		report.lists[pkg].Add(def)
 	}
-}
-
-func (report *ResourceStructureReport) getFilePath(baseFolder string, pkg astmodel.PackageReference) string {
-	grp, ver := pkg.GroupVersion()
-	return filepath.Join(baseFolder, grp, ver, "structure.txt")
 }
 
 func (report *ResourceStructureReport) saveReport(filePath string, defs astmodel.TypeDefinitionSet) error {

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
@@ -194,7 +194,7 @@ func (report *ResourceVersionsReport) summarize(definitions astmodel.TypeDefinit
 }
 
 func (report *ResourceVersionsReport) addItem(item ResourceVersionsReportResourceItem) {
-	grp, _ := item.name.PackageReference().GroupVersion()
+	grp := item.name.PackageReference().Group()
 	report.groups.Add(grp)
 
 	items, ok := report.items[grp]

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
@@ -495,7 +495,7 @@ func (report *ResourceVersionsReport) createTable(
 		}
 
 		// Reversed parameters because we want more recent versions listed first
-		return astmodel.ComparePathAndVersion(right.PackageReference().PackagePath(), left.PackageReference().PackagePath())
+		return astmodel.ComparePathAndVersion(right.PackageReference().ImportPath(), left.PackageReference().ImportPath())
 	})
 
 	sampleLinks, err := report.FindSampleLinks(info.Group)

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph.go
@@ -75,8 +75,8 @@ func (graph *ConversionGraph) FindNextType(name astmodel.TypeName, definitions a
 	// (this be needed if a different type is introduced with the same name in a later version, or if a type is
 	// renamed in one version and renamed back in a later one)
 	if astmodel.ComparePathAndVersion(
-        nextType.PackageReference().ImportPath(), 
-        renamedType.PackageReference().ImportPath()) {
+		nextType.PackageReference().ImportPath(),
+		renamedType.PackageReference().ImportPath()) {
 		// nextType came first
 		return nextType, nil
 	}

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph.go
@@ -74,7 +74,9 @@ func (graph *ConversionGraph) FindNextType(name astmodel.TypeName, definitions a
 	// Now we need to return the earlier type. We can do this by comparing the package paths.
 	// (this be needed if a different type is introduced with the same name in a later version, or if a type is
 	// renamed in one version and renamed back in a later one)
-	if astmodel.ComparePathAndVersion(nextType.PackageReference().PackagePath(), renamedType.PackageReference().PackagePath()) {
+	if astmodel.ComparePathAndVersion(
+        nextType.PackageReference().ImportPath(), 
+        renamedType.PackageReference().ImportPath()) {
 		// nextType came first
 		return nextType, nil
 	}

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph.go
@@ -23,7 +23,7 @@ type ConversionGraph struct {
 // Returns the next version and true if it's found, or an empty type name and false if not.
 func (graph *ConversionGraph) LookupTransition(name astmodel.TypeName) astmodel.TypeName {
 	// Expect to get either a local or a storage reference, not an external one
-	group, _ := name.PackageReference().GroupVersion()
+	group := name.PackageReference().Group()
 	subgraph, ok := graph.subGraphs[group]
 	if !ok {
 		return nil
@@ -39,7 +39,7 @@ func (graph *ConversionGraph) LookupTransition(name astmodel.TypeName) astmodel.
 // This is used to identify the next type needed for property assignment functions, and is a building block for
 // identification of hub definitions.
 func (graph *ConversionGraph) FindNextType(name astmodel.TypeName, definitions astmodel.TypeDefinitionSet) (astmodel.TypeName, error) {
-	group, _ := name.PackageReference().GroupVersion()
+	group := name.PackageReference().Group()
 	subgraph, ok := graph.subGraphs[group]
 	if !ok {
 		return nil, nil

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph_builder.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph_builder.go
@@ -70,7 +70,7 @@ func (b *ConversionGraphBuilder) Build() (*ConversionGraph, error) {
 // getSubBuilder finds the relevant builder for the group of the provided reference, creating one if necessary
 func (b *ConversionGraphBuilder) getSubBuilder(name astmodel.TypeName) *GroupConversionGraphBuilder {
 	// Expect to get either a local or a storage reference, not an external one
-	group, _ := name.PackageReference().GroupVersion()
+	group := name.PackageReference().Group()
 	subBuilder, ok := b.subBuilders[group]
 	if !ok {
 		subBuilder = NewGroupConversionGraphBuilder(group, b.configuration, b.versionPrefix)

--- a/v2/tools/generator/internal/codegen/storage/group_conversion_graph_builder.go
+++ b/v2/tools/generator/internal/codegen/storage/group_conversion_graph_builder.go
@@ -69,7 +69,7 @@ func (b *GroupConversionGraphBuilder) Build() (*GroupConversionGraph, error) {
 	}
 
 	storagePackagesInOrder := b.storagePackages.AsSortedSlice(func(left astmodel.PackageReference, right astmodel.PackageReference) bool {
-		return astmodel.ComparePathAndVersion(left.PackagePath(), right.PackagePath())
+		return astmodel.ComparePathAndVersion(left.ImportPath(), right.ImportPath())
 	})
 
 	result := &GroupConversionGraph{

--- a/v2/tools/generator/internal/codegen/storage/resource_conversion_graph_builder.go
+++ b/v2/tools/generator/internal/codegen/storage/resource_conversion_graph_builder.go
@@ -56,8 +56,8 @@ func (b *ResourceConversionGraphBuilder) Build() (*ResourceConversionGraph, erro
 
 	sort.Slice(toProcess, func(i, j int) bool {
 		return astmodel.ComparePathAndVersion(
-			toProcess[i].PackageReference().PackagePath(),
-			toProcess[j].PackageReference().PackagePath())
+			toProcess[i].PackageReference().ImportPath(),
+			toProcess[j].PackageReference().ImportPath())
 	})
 
 	for _, s := range stages {

--- a/v2/tools/generator/internal/codegen/storage/resource_conversion_graph_builder.go
+++ b/v2/tools/generator/internal/codegen/storage/resource_conversion_graph_builder.go
@@ -152,6 +152,8 @@ func (b *ResourceConversionGraphBuilder) isCompatibilityPackage(ref astmodel.Pac
 		return !r.HasVersionPrefix(b.versionPrefix)
 	case astmodel.StoragePackageReference:
 		return b.isCompatibilityPackage(r.Local())
+	case astmodel.SubPackageReference:
+		return b.isCompatibilityPackage(r.Parent())
 	default:
 		msg := fmt.Sprintf(
 			"unexpected PackageReference implementation %T",

--- a/v2/tools/generator/internal/config/group_configuration.go
+++ b/v2/tools/generator/internal/config/group_configuration.go
@@ -124,6 +124,8 @@ func (gc *GroupConfiguration) findVersion(ref astmodel.PackageReference) (*Versi
 		return gc.findVersion(r.Base())
 	case astmodel.LocalPackageReference:
 		return gc.findVersionForLocalPackageReference(r)
+	case astmodel.SubPackageReference:
+		return gc.findVersion(r.Parent())
 	}
 
 	panic(fmt.Sprintf("didn't expect PackageReference of type %T", ref))

--- a/v2/tools/generator/internal/config/object_model_configuration.go
+++ b/v2/tools/generator/internal/config/object_model_configuration.go
@@ -249,7 +249,7 @@ func (omc *ObjectModelConfiguration) visitGroups(visitor *configurationVisitor) 
 
 // findGroup uses the provided TypeName to work out which nested GroupConfiguration should be used
 func (omc *ObjectModelConfiguration) findGroup(ref astmodel.PackageReference) (*GroupConfiguration, error) {
-	group, _ := ref.GroupVersion()
+	group := ref.Group()
 
 	if omc == nil || omc.groups == nil {
 		msg := fmt.Sprintf("no configuration for group %s", group)
@@ -318,7 +318,7 @@ func (omc *ObjectModelConfiguration) ModifyGroup(
 	ref astmodel.PackageReference,
 	action func(configuration *GroupConfiguration) error,
 ) error {
-	groupName, _ := ref.GroupVersion()
+	groupName := ref.Group()
 	grp, err := omc.findGroup(ref)
 	if err != nil && !IsNotConfiguredError(err) {
 		return errors.Wrapf(err, "configuring groupName %s", groupName)

--- a/v2/tools/generator/internal/config/type_transformer.go
+++ b/v2/tools/generator/internal/config/type_transformer.go
@@ -124,10 +124,10 @@ func (target *TransformTarget) appliesToTypeName(tn astmodel.TypeName) bool {
 		return false
 	}
 
-	g, v := tn.PackageReference().GroupVersion()
+	grp, ver := tn.PackageReference().GroupVersion()
 
 	if target.Group.IsRestrictive() {
-		if !target.Group.Matches(g).Matched {
+		if !target.Group.Matches(grp).Matched {
 			// No match on group
 			return false
 		}
@@ -138,11 +138,11 @@ func (target *TransformTarget) appliesToTypeName(tn astmodel.TypeName) bool {
 		// Need to handle both full (v1beta20200101) and API (2020-01-01) formats
 		switch ref := tn.PackageReference().(type) {
 		case astmodel.LocalPackageReference:
-			if !ref.HasApiVersion(target.Version.String()) && !target.Version.Matches(v).Matched {
+			if !ref.HasApiVersion(target.Version.String()) && !target.Version.Matches(ver).Matched {
 				return false
 			}
 		case astmodel.StoragePackageReference:
-			if !ref.Local().HasApiVersion(target.Version.String()) && target.Version.Matches(v).Matched {
+			if !ref.Local().HasApiVersion(target.Version.String()) && target.Version.Matches(ver).Matched {
 				return false
 			}
 		default:

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
@@ -46,34 +46,34 @@ func (d *DefaulterBuilder) AddDefault(f *ResourceFunction) {
 // as well as helper functions that allow additional handcrafted defaults to be injected by
 // implementing the genruntime.Defaulter interface.
 func (d *DefaulterBuilder) ToInterfaceImplementation() *astmodel.InterfaceImplementation {
-	group, version := d.resourceName.PackageReference().GroupVersion()
+	grp, ver := d.resourceName.PackageReference().GroupVersion()
 
-	// e.g. group = "microsoft.network.azure.com"
+	// e.g. grp = "microsoft.network.azure.com"
 	// e.g. resource = "backendaddresspools"
-	// e.g. version = "v1"
+	// e.g. ver = "v1"
 
 	resource := d.resourceName.Name()
 
-	group = strings.ToLower(group + astmodel.GroupSuffix)
+	grp = strings.ToLower(grp + astmodel.GroupSuffix)
 	nonPluralResource := strings.ToLower(resource)
 	resource = strings.ToLower(d.resourceName.Plural().Name())
 
 	// e.g. "mutate-microsoft-network-azure-com-v1-backendaddresspool"
 	// note that this must match _exactly_ how controller-runtime generates the path
 	// or it will not work!
-	path := fmt.Sprintf("/mutate-%s-%s-%s", strings.ReplaceAll(group, ".", "-"), version, nonPluralResource)
+	path := fmt.Sprintf("/mutate-%s-%s-%s", strings.ReplaceAll(grp, ".", "-"), ver, nonPluralResource)
 
 	// e.g.  "default.v123.backendaddresspool.azure.com"
-	name := fmt.Sprintf("default.%s.%s.%s", version, resource, group)
+	name := fmt.Sprintf("default.%s.%s.%s", ver, resource, grp)
 
 	annotation := fmt.Sprintf(
 		"+kubebuilder:webhook:path=%s,mutating=true,sideEffects=None,"+
 			"matchPolicy=Exact,failurePolicy=fail,groups=%s,resources=%s,"+
 			"verbs=create;update,versions=%s,name=%s,admissionReviewVersions=v1",
 		path,
-		group,
+		grp,
 		resource,
-		version,
+		ver,
 		name)
 
 	funcs := []astmodel.Function{

--- a/v2/tools/generator/internal/reporting/type_catalog_report.go
+++ b/v2/tools/generator/internal/reporting/type_catalog_report.go
@@ -532,7 +532,7 @@ func (tcr *TypeCatalogReport) findPackages() []astmodel.PackageReference {
 
 	result := packages.AsSortedSlice(
 		func(left astmodel.PackageReference, right astmodel.PackageReference) bool {
-			return astmodel.ComparePathAndVersion(left.PackagePath(), right.PackagePath())
+			return astmodel.ComparePathAndVersion(left.ImportPath(), right.ImportPath())
 		})
 
 	return result

--- a/v2/tools/generator/internal/test/file_definition.go
+++ b/v2/tools/generator/internal/test/file_definition.go
@@ -11,8 +11,7 @@ import (
 
 func CreateFileDefinition(definitions ...astmodel.TypeDefinition) *astmodel.FileDefinition {
 	ref := definitions[0].Name().PackageReference()
-	group, version := ref.GroupVersion()
-	pkgDefinition := astmodel.NewPackageDefinition(group, version)
+	pkgDefinition := astmodel.NewPackageDefinition(ref)
 	for _, def := range definitions {
 		pkgDefinition.AddDefinition(def)
 	}
@@ -31,8 +30,7 @@ func CreateTestFileDefinition(definitions ...astmodel.TypeDefinition) *astmodel.
 	// Use the package reference of the first definition for the whole file
 	ref := definitions[0].Name().PackageReference()
 
-	group, version := ref.GroupVersion()
-	pkgDefinition := astmodel.NewPackageDefinition(group, version)
+	pkgDefinition := astmodel.NewPackageDefinition(ref)
 	for _, def := range definitions {
 		pkgDefinition.AddDefinition(def)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

We are intending on pushing some of our type definitions into subpackages, most notably the `arm` types used with the ARM REST API and the `storage` types used for resource persistence. This PR introduces a new `PackageReference` implementation, `SubPackageReference` that unblocks these scenarios.

**Prerequisites**

- [ ] #3174 

**Special notes for your reviewer**:

Requires merge of the prerequisites before CI will run, due to branch targeting.

The `PackageReference` interface has acquired a couple more methods that don't make sense on `ExternalPackageReference` - this is temporary and will be cleaned up in a future PR (I already have the change underway in a WIP branch).

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/lySzu7q4P49u8/giphy.gif)
