### PR TITLE
Redact empty status properties 

### DIFF
--- a/v2/cmd/asoctl/cmd/import_azure_resource.go
+++ b/v2/cmd/asoctl/cmd/import_azure_resource.go
@@ -7,7 +7,6 @@ package cmd
 
 import (
 	"context"
-	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -118,7 +117,7 @@ func importAzureResource(ctx context.Context, armIDs []string, options importAzu
 			return errors.Wrapf(err, "failed to write into folder %s", folder)
 		}
 	} else {
-		err := result.SaveToWriter(os.Stdout)
+		err := result.SaveToWriter(progress)
 		if err != nil {
 			return errors.Wrapf(err, "failed to write to stdout")
 		}

--- a/v2/cmd/asoctl/internal/importing/resource_import_result.go
+++ b/v2/cmd/asoctl/internal/importing/resource_import_result.go
@@ -126,7 +126,7 @@ func (*ResourceImportResult) writeTo(resources []genruntime.MetaObject, destinat
 			return errors.Wrap(err, "unable to save to writer")
 		}
 
-		data = redact(data)
+		data = redactStatus(data)
 
 		_, err = buf.Write(data)
 		if err != nil {
@@ -142,8 +142,11 @@ func (*ResourceImportResult) writeTo(resources []genruntime.MetaObject, destinat
 	return nil
 }
 
-// redact removes any empty `status { }` blocks from the yaml
-func redact(data []byte) []byte {
+// redactStatus removes any empty `status { }` blocks from the yaml.
+// If we start redacting other things, we should rename this method
+// and possibly consider using a more general purpose technique,
+// such as a yaml parser.
+func redactStatus(data []byte) []byte {
 	content := string(data)
 	content = strings.Replace(content, "status: {}", "", -1)
 	return []byte(content)

--- a/v2/cmd/asoctl/internal/importing/resource_import_result.go
+++ b/v2/cmd/asoctl/internal/importing/resource_import_result.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 	"golang.org/x/exp/slices"
@@ -125,6 +126,8 @@ func (*ResourceImportResult) writeTo(resources []genruntime.MetaObject, destinat
 			return errors.Wrap(err, "unable to save to writer")
 		}
 
+		data = redact(data)
+
 		_, err = buf.Write(data)
 		if err != nil {
 			return errors.Wrap(err, "unable to save to writer")
@@ -137,4 +140,11 @@ func (*ResourceImportResult) writeTo(resources []genruntime.MetaObject, destinat
 	}
 
 	return nil
+}
+
+// redact removes any empty `status { }` blocks from the yaml
+func redact(data []byte) []byte {
+	content := string(data)
+	content = strings.Replace(content, "status: {}", "", -1)
+	return []byte(content)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When importing an Azure resource, we have been getting an empty status section in the output, which isn't necessary.

``` 
  ...
  powerState:
    code: Running
  type: Microsoft.ContainerService/managedClusters/agentPools
  vmSize: Standard_D8ds_v5
status: {}
---
Import Azure Resources  [==============================] 100 %
```

This PR redacts that wart to make things cleaner:

```
  powerState:
    code: Running
  type: Microsoft.ContainerService/managedClusters/agentPools
  vmSize: Standard_D8ds_v5

---
Import Azure Resources  [==============================] 100 %
```

**Special notes for your reviewer**:

Also fixes a minor bug where the output was being sent to the wrong stream, giving weird results on screen.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/8vQXZ7P6D9QCOmHDD0/giphy.gif)
