### PR TITLE
Fix/asoctl resource listing

### DIFF
--- a/v2/cmd/asoctl/internal/importing/importable_arm_resource.go
+++ b/v2/cmd/asoctl/internal/importing/importable_arm_resource.go
@@ -69,7 +69,7 @@ func NewImportableARMResource(
 }
 
 // GroupKind returns the GroupKind of the resource being imported.
-// (may be empty if the GK can't be determined)
+// Returned value may be empty if the GK can't be determined.
 func (i *importableARMResource) GroupKind() schema.GroupKind {
 	gk, _ := FindGroupKindForResourceType(i.armID.ResourceType.String())
 	return gk

--- a/v2/cmd/asoctl/internal/importing/importable_resource.go
+++ b/v2/cmd/asoctl/internal/importing/importable_resource.go
@@ -38,7 +38,13 @@ type ImportableResource interface {
 	// Import does the actual import, updating the Spec on the wrapped resource.
 	// ctx allows for cancellation of the import.
 	// If there are any additional resources that also need to be imported, they should be returned.
-	Import(ctx context.Context, bar *mpb.Bar) ([]ImportableResource, error)
+	Import(ctx context.Context, bar *mpb.Bar) error
+
+	// FindChildren returns any child resources that need to be imported.
+	// ctx allows for cancellation of the import.
+	// Returns any additional resources that also need to be imported, as well as any errors that occur.
+	// Partial success is allowed, but the caller should be notified of any errors.
+	FindChildren(ctx context.Context, bar *mpb.Bar) ([]ImportableResource, error)
 }
 
 // importableResource is a core of common data and support methods for implementing ImportableResource


### PR DESCRIPTION
**What this PR does / why we need it**:

It's possible to encounter an error querying ARM for child resources that don't exist. 
This currently causes `asoctl` to abort the import run but shouldn't.

Fixes #3200

**Special notes for your reviewer**:

Amongst other causes, errors mayoccur if the subscription hasn't onboarded for a particular resource provider, or if the subscription doesn't have access to a particular new feature.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/9SIDvP0CJ3pYpWwUNW/giphy.gif)
