### PR TITLE
Make helm chart version SemVer 2 compatible

### DIFF
--- a/scripts/v2/generate-helm-manifest.sh
+++ b/scripts/v2/generate-helm-manifest.sh
@@ -40,7 +40,7 @@ ${SCRIPT_DIR}/kustomize-build.sh -v "$VERSION" -k operator -o "$GEN_FILES_DIR"
 rm "$GEN_FILES_DIR"/*_namespace_* # remove namespace as we will let Helm manage it
 
 # Chart replacements
-sed -i "s/\(version: \)\(.*\)/\1$VERSION/g" "$ASO_CHART"/Chart.yaml  # find version key and update the value with the current version
+sed -i "s/\(version: \)\(.*\)/\1${VERSION//v}/g" "$ASO_CHART"/Chart.yaml  # find version key and update the value with the current version
 
 # Deployment replacements
 grep -E $KUBE_RBAC_PROXY "$GEN_FILES_DIR"/*_deployment_* > /dev/null # Ensure that what we're about to try to replace actually exists (if it doesn't we want to fail)


### PR DESCRIPTION

Closes #3189 

**What this PR does / why we need it**:

This PR removes `v` from chart versions to make ASOv2 helm chart version SemVer 2 compatible.
The change is made in the `generate-helm-manifest.sh` so that the next time we release the helm chart, we'll have the helm chart version in a new format.

**Special notes for your reviewer**:
Tested it out and upgrades work fine : 
![image](https://github.com/Azure/azure-service-operator/assets/38904804/c098e703-b3c9-4954-8bc7-410dd3971f95)
