### PR TITLE
Treat CustomKubeletIdentityMissingPermissionError as retryable

### DIFF
--- a/v2/api/containerservice/customizations/managed_cluster_extensions.go
+++ b/v2/api/containerservice/customizations/managed_cluster_extensions.go
@@ -8,7 +8,6 @@ package customizations
 import (
 	"context"
 	"fmt"
-	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice"
@@ -25,6 +24,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/resolver"
 	"github.com/Azure/azure-service-operator/v2/internal/set"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 )
@@ -201,7 +201,6 @@ func (ext *ManagedClusterExtension) ClassifyError(
 		return core.CloudErrorDetails{}, err
 	}
 
-	// Override is to treat Conflict as retryable for Redis, if the message contains "try again later"
 	if isRetryableClusterError(cloudError) {
 		details.Classification = core.ErrorRetryable
 	}

--- a/v2/api/containerservice/customizations/managed_cluster_extensions.go
+++ b/v2/api/containerservice/customizations/managed_cluster_extensions.go
@@ -8,6 +8,7 @@ package customizations
 import (
 	"context"
 	"fmt"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice"
@@ -180,4 +181,44 @@ func clusterProvisioningStateBlocksReconciliation(provisioningState *string) boo
 	}
 
 	return !nonBlockingManagedClusterProvisioningStates.Contains(strings.ToLower(*provisioningState))
+}
+
+var _ extensions.ErrorClassifier = &ManagedClusterExtension{}
+
+// ClassifyError evaluates the provided error, returning including whether it is fatal or can be retried.
+// cloudError is the error returned from ARM.
+// apiVersion is the ARM API version used for the request.
+// log is a logger than can be used for telemetry.
+// next is the next implementation to call.
+func (ext *ManagedClusterExtension) ClassifyError(
+	cloudError *genericarmclient.CloudError,
+	apiVersion string,
+	log logr.Logger,
+	next extensions.ErrorClassifierFunc,
+) (core.CloudErrorDetails, error) {
+	details, err := next(cloudError)
+	if err != nil {
+		return core.CloudErrorDetails{}, err
+	}
+
+	// Override is to treat Conflict as retryable for Redis, if the message contains "try again later"
+	if isRetryableClusterError(cloudError) {
+		details.Classification = core.ErrorRetryable
+	}
+
+	return details, nil
+}
+
+func isRetryableClusterError(err *genericarmclient.CloudError) bool {
+	if err == nil {
+		return false
+	}
+
+	// A CustomKubeletIdentityMissingPermissionError can occur if the user-assigned identity required by the cluster
+	// hasn't yet been provisioned; we want to retry so that we finish provisioning the cluster once it is available.
+	if err.Code() == "CustomKubeletIdentityMissingPermissionError" {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Treat the error `CustomKubeletIdentityMissingPermissionError` as a retryable error, to avoid a race condition where slow creation of a `UserAssignedIdentity` might cause creation of a `ManagedCluster` to fail with a permanent error.

Closes #3267 

**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/v7WM6sLcnGIc8/giphy.gif)
