### PR TITLE
Disable dependabot automatic rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,18 +10,22 @@ updates:
     directory: "/" 
     schedule:
       interval: "weekly"
+    rebase-strategy: "disabled"
   # ASO v2 controller 
   - package-ecosystem: "gomod" 
     directory: "/v2" 
     schedule:
       interval: "weekly"
+    rebase-strategy: "disabled"
   # ASO v2 asoctl
   - package-ecosystem: "gomod" 
     directory: "/v2/cmd/asoctl" 
     schedule:
       interval: "weekly"
+    rebase-strategy: "disabled"
   # ASO v2 generator
   - package-ecosystem: "gomod" 
     directory: "/v2/tools/generator" 
     schedule:
       interval: "weekly"
+    rebase-strategy: "disabled"


### PR DESCRIPTION

**What this PR does / why we need it**:
As mentioned by @theunrepentantgeek, all Dependabot PRs automatically rebase on making changes to a Dependabot PR. Which results in loading up our CI and result in slower feedback. This PR adds in rebase-strategy to disable automatic rebase and we can manually rebase the PRs using `dependabot rebase` comment.

