### PR TITLE
Update Go-Get, take II

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -41,15 +41,19 @@ jobs:
             sha='${{ github.sha }}'
           fi
 
-          # Sometimes go get will fail initially, so we retry it up to 5 times before giving up
+          # Give GitHub some time to make the commit available
+          sleep 10
+
+          # Sometimes it can take https://proxy.golang.org up to a minute for the latest commit to be available.
+          # See the FAQ at https://proxy.golang.org/
           FAILED=1
           for i in {1..5}; do
             if go get "$repo/v2@$sha" ; then
               FAILED=0
               break
             fi
-            echo "Failed to 'go get' $repo/v2@$sha, retrying in 10 seconds…"
-            sleep 10
+            echo "Failed to 'go get' $repo/v2@$sha, retrying in 60 seconds…"
+            sleep 60
           done
 
           exit $FAILED


### PR DESCRIPTION
**What this PR does / why we need it**:

Often the `go get` step in our CI builds will fail.

This is due to delays in the default proxy used by the `go` CLI, [specifically](https://proxy.golang.org/):

> In order to improve our services' caching and serving latencies, new versions may not show up right away. If you want new code to be immediately available in the mirror, then first make sure there is a semantically versioned tag for this revision in the underlying source repository. Then explicitly request that version via go get module@version. The new version should be available within one minute. 

**Special notes for your reviewer**:

Bypassing the proxy would invalidate the scenario we want to test, so I've juiced up the retries.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/eenzqB2MsGKbK/giphy.gif)
