### PR TITLE
Improve generator performance

### DIFF
--- a/v2/tools/generator/internal/astmodel/type_definition_set.go
+++ b/v2/tools/generator/internal/astmodel/type_definition_set.go
@@ -160,12 +160,13 @@ func (set TypeDefinitionSet) AddTypesAllowDuplicates(definitions TypeDefinitionS
 // Multiple adds of a type with the same shape are allowed, but attempting to add two
 // types with the same name but different shape will trigger an error.
 func (set TypeDefinitionSet) AddAllowDuplicates(def TypeDefinition) error {
-	if !set.Contains(def.Name()) {
+	existing, found := set[def.Name()]
+	if !found {
+		// Not already in the set
 		set.Add(def)
 		return nil
 	}
 
-	existing := set[def.Name()]
 	if !TypeEquals(def.Type(), existing.Type()) {
 		return errors.Errorf("type definition for %q has two shapes: \r\n%s", existing.Name(), DiffTypes(existing.Type(), def.Type()))
 	}

--- a/v2/tools/generator/internal/codegen/embeddedresources/remover.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/remover.go
@@ -183,14 +183,12 @@ func (e EmbeddedResourceRemover) makeEmbeddedResourceRemovalTypeVisitor() astmod
 				}
 			}
 
-			var keep []*astmodel.PropertyDefinition
-			it.Properties().ForEach(func(def *astmodel.PropertyDefinition) {
-				if def.HasName("Id") {
-					keep = append(keep, def)
-				}
-			})
+			id, ok := it.Property("Id")
+			it = it.WithoutProperties()
+			if ok {
+				it = it.WithProperties(id)
+			}
 
-			it = it.WithoutProperties().WithProperties(keep...)
 			return astmodel.OrderedIdentityVisitOfObjectType(this, it, ctx)
 		},
 	}.Build()

--- a/v2/tools/generator/internal/codegen/embeddedresources/remover.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/remover.go
@@ -106,9 +106,9 @@ func MakeEmbeddedResourceRemover(configuration *config.Configuration, definition
 func (e EmbeddedResourceRemover) RemoveEmbeddedResources(
 	log logr.Logger,
 ) (astmodel.TypeDefinitionSet, error) {
-	result := make(astmodel.TypeDefinitionSet)
+	result := make(astmodel.TypeDefinitionSet, len(e.definitions))
 
-	originalNames := make(map[astmodel.InternalTypeName]embeddedResourceTypeName)
+	originalNames := make(map[astmodel.InternalTypeName]embeddedResourceTypeName, len(e.definitions)/2)
 
 	visitor := e.makeEmbeddedResourceRemovalTypeVisitor()
 	for _, def := range astmodel.FindResourceDefinitions(e.definitions) {

--- a/v2/tools/generator/internal/codegen/embeddedresources/renamer.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/renamer.go
@@ -181,7 +181,7 @@ func simplifyTypeNames(
 	log logr.Logger,
 ) (astmodel.TypeDefinitionSet, error) {
 	// Find all type names that have the flag we're interested in
-	updatedNames := make(map[astmodel.InternalTypeName]astmodel.InternalTypeNameSet)
+	updatedNames := make(map[astmodel.InternalTypeName]astmodel.InternalTypeNameSet, len(definitions))
 	for _, def := range definitions {
 		if flag.IsOn(def.Type()) {
 			en, ok := originalNames[def.Name()]

--- a/v2/tools/generator/internal/config/object_model_configuration.go
+++ b/v2/tools/generator/internal/config/object_model_configuration.go
@@ -144,6 +144,28 @@ func (omc *ObjectModelConfiguration) IsGroupConfigured(pkg astmodel.InternalPack
 	return result
 }
 
+// IsTypeConfigured returns true if we have any configuration for the specified type, false otherwise.
+func (omc *ObjectModelConfiguration) IsTypeConfigured(name astmodel.InternalTypeName) bool {
+	var result bool
+	visitor := newSingleTypeConfigurationVisitor(name, func(configuration *TypeConfiguration) error {
+		result = true
+		return nil
+	})
+
+	err := visitor.Visit(omc)
+	if err != nil {
+		if IsNotConfiguredError(err) {
+			// No configuration for this type, we're not expecting it
+			return false
+		}
+
+		// Some other error, we'll assume we're expecting it
+		return true
+	}
+
+	return result
+}
+
 // AddTypeAlias adds a type alias for the specified type name,
 // allowing configuration related to the type to be accessed via the new name.
 func (omc *ObjectModelConfiguration) AddTypeAlias(name astmodel.InternalTypeName, alias string) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Approximately halves the length of time taken for the _Remove properties that point to embedded resources_ stage to run.

On my laptop, was 64s, now 27s.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/iLUwVbWFVnaBG/giphy.gif)
