### PR TITLE
Let user specifying namespace through a .Values.namespace value when …

### DIFF
--- a/charts/azure-service-operator/templates/_helpers.tpl
+++ b/charts/azure-service-operator/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "azure-service-operator.namespace" -}}
+  {{- if .Values.namespace }}
+    {{- .Values.namespace }}
+  {{- else }}
+    {{- .Release.Namespace}}
+  {{- end }}
+{{- end }}

--- a/charts/azure-service-operator/templates/generated/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_azureoperator-validating-webhook-configuration.yaml
+++ b/charts/azure-service-operator/templates/generated/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_azureoperator-validating-webhook-configuration.yaml
@@ -2,7 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/azureoperator-serving-cert
+    cert-manager.io/inject-ca-from: {{ include "azure-service-operator.namespace" . }}/azureoperator-serving-cert
   name: azureoperator-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -11,7 +11,7 @@ webhooks:
   clientConfig:
     service:
       name: azureoperator-webhook-service
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ include "azure-service-operator.namespace" . }}
       path: /validate-azure-microsoft-com-v1alpha2-mysqlaaduser
   failurePolicy: Fail
   name: vmysqlaaduser.kb.io
@@ -32,7 +32,7 @@ webhooks:
   clientConfig:
     service:
       name: azureoperator-webhook-service
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ include "azure-service-operator.namespace" . }}
       path: /validate-azure-microsoft-com-v1alpha2-mysqluser
   failurePolicy: Fail
   name: vmysqluser.kb.io
@@ -53,7 +53,7 @@ webhooks:
   clientConfig:
     service:
       name: azureoperator-webhook-service
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ include "azure-service-operator.namespace" . }}
       path: /validate-azure-microsoft-com-v1alpha1-azuresqlmanageduser
   failurePolicy: Fail
   name: vazuresqlmanageduser.kb.io
@@ -74,7 +74,7 @@ webhooks:
   clientConfig:
     service:
       name: azureoperator-webhook-service
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ include "azure-service-operator.namespace" . }}
       path: /validate-azure-microsoft-com-v1alpha1-azuresqluser
   failurePolicy: Fail
   name: vazuresqluser.kb.io

--- a/charts/azure-service-operator/templates/generated/apps_v1_deployment_azureoperator-controller-manager.yaml
+++ b/charts/azure-service-operator/templates/generated/apps_v1_deployment_azureoperator-controller-manager.yaml
@@ -5,7 +5,7 @@ metadata:
     app: azure-service-operator-v1
     control-plane: controller-manager
   name: azureoperator-controller-manager
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "azure-service-operator.namespace" . }}
 spec:
   replicas: 1
   selector:

--- a/charts/azure-service-operator/templates/generated/cert-manager.io_v1_certificate_azureoperator-serving-cert.yaml
+++ b/charts/azure-service-operator/templates/generated/cert-manager.io_v1_certificate_azureoperator-serving-cert.yaml
@@ -2,11 +2,11 @@ apiVersion: {{ .Values.certManagerResourcesAPIVersion }}
 kind: Certificate
 metadata:
   name: azureoperator-serving-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "azure-service-operator.namespace" . }}
 spec:
   dnsNames:
-  - azureoperator-webhook-service.{{ .Release.Namespace }}.svc
-  - azureoperator-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  - azureoperator-webhook-service.{{ include "azure-service-operator.namespace" . }}.svc
+  - azureoperator-webhook-service.{{ include "azure-service-operator.namespace" . }}.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: azureoperator-selfsigned-issuer

--- a/charts/azure-service-operator/templates/generated/cert-manager.io_v1_issuer_azureoperator-selfsigned-issuer.yaml
+++ b/charts/azure-service-operator/templates/generated/cert-manager.io_v1_issuer_azureoperator-selfsigned-issuer.yaml
@@ -2,6 +2,6 @@ apiVersion: {{ .Values.certManagerResourcesAPIVersion }}
 kind: Issuer
 metadata:
   name: azureoperator-selfsigned-issuer
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "azure-service-operator.namespace" . }}
 spec:
   selfSigned: {}

--- a/charts/azure-service-operator/templates/generated/rbac.authorization.k8s.io_v1_clusterrole_azureoperator-manager-role.yaml
+++ b/charts/azure-service-operator/templates/generated/rbac.authorization.k8s.io_v1_clusterrole_azureoperator-manager-role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: azureoperator-manager-role-{{ .Release.Namespace }}
+  name: azureoperator-manager-role-{{ include "azure-service-operator.namespace" . }}
 rules:
 - apiGroups:
   - aadpodidentity.k8s.io

--- a/charts/azure-service-operator/templates/generated/rbac.authorization.k8s.io_v1_clusterrole_azureoperator-proxy-role.yaml
+++ b/charts/azure-service-operator/templates/generated/rbac.authorization.k8s.io_v1_clusterrole_azureoperator-proxy-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: azureoperator-proxy-role-{{ .Release.Namespace }}
+  name: azureoperator-proxy-role-{{ include "azure-service-operator.namespace" . }}
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/charts/azure-service-operator/templates/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_azureoperator-manager-rolebinding.yaml
+++ b/charts/azure-service-operator/templates/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_azureoperator-manager-rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: azureoperator-manager-rolebinding-{{ .Release.Namespace }}
+  name: azureoperator-manager-rolebinding-{{ include "azure-service-operator.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: azureoperator-manager-role-{{ .Release.Namespace }}
+  name: azureoperator-manager-role-{{ include "azure-service-operator.namespace" . }}
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "azure-service-operator.namespace" . }}

--- a/charts/azure-service-operator/templates/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_azureoperator-proxy-rolebinding.yaml
+++ b/charts/azure-service-operator/templates/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_azureoperator-proxy-rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: azureoperator-proxy-rolebinding-{{ .Release.Namespace }}
+  name: azureoperator-proxy-rolebinding-{{ include "azure-service-operator.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: azureoperator-proxy-role-{{ .Release.Namespace }}
+  name: azureoperator-proxy-role-{{ include "azure-service-operator.namespace" . }}
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "azure-service-operator.namespace" . }}

--- a/charts/azure-service-operator/templates/generated/rbac.authorization.k8s.io_v1_role_azureoperator-leader-election-role.yaml
+++ b/charts/azure-service-operator/templates/generated/rbac.authorization.k8s.io_v1_role_azureoperator-leader-election-role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: azureoperator-leader-election-role
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "azure-service-operator.namespace" . }}
 rules:
 - apiGroups:
   - ""

--- a/charts/azure-service-operator/templates/generated/rbac.authorization.k8s.io_v1_rolebinding_azureoperator-leader-election-rolebinding.yaml
+++ b/charts/azure-service-operator/templates/generated/rbac.authorization.k8s.io_v1_rolebinding_azureoperator-leader-election-rolebinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: azureoperator-leader-election-rolebinding
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "azure-service-operator.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "azure-service-operator.namespace" . }}

--- a/charts/azure-service-operator/templates/generated/v1_service_azureoperator-controller-manager-metrics-service.yaml
+++ b/charts/azure-service-operator/templates/generated/v1_service_azureoperator-controller-manager-metrics-service.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     control-plane: controller-manager
   name: azureoperator-controller-manager-metrics-service
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "azure-service-operator.namespace" . }}
 spec:
   ports:
   - name: https

--- a/charts/azure-service-operator/templates/generated/v1_service_azureoperator-webhook-service.yaml
+++ b/charts/azure-service-operator/templates/generated/v1_service_azureoperator-webhook-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: azureoperator-webhook-service
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "azure-service-operator.namespace" . }}
 spec:
   ports:
   - port: 443

--- a/charts/azure-service-operator/templates/secret.yaml
+++ b/charts/azure-service-operator/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: azureoperatorsettings
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "azure-service-operator.namespace" . }}
 type: Opaque
 data:
   AZURE_SUBSCRIPTION_ID: {{ .Values.azureSubscriptionID | b64enc | quote }}


### PR DESCRIPTION
…running helm template

**What this PR does / why we need it**:
Today namespace of the chart is inherited from 'helm <install|upgrade> --namespace' which is not available when performing 'helm template' or when installing it using ArgoCD.
If .Values.namespace exists, it takes this value otherwise it still uses .Release.Namespace

**Special notes for your reviewer**:
Without this PR, helm template renders an empty namespace (even if you specify --namespace)
With it, helm template --set namespace=test renders .Values.namespace.

**How does this PR make you feel**:
![gif](https://giphy.com/)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
