### PR TITLE
Change triggering condition for merge queues

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -160,10 +160,9 @@ jobs:
   integration-tests:
     runs-on: [self-hosted, 1ES.Pool=aso-1es-pool]
     if: 
-      # Only run on pull requests in this repo, that are not created by dependendabot
-      ( github.event_name == 'pull_request' || github.event_name == 'merge_group' ) && 
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.actor != 'dependabot[bot]'
+      # Run on ppull requests in this repository that are not from @dependabot, and run for merge groups
+      ( ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) || github.event_name == 'merge_group' ) && 
+      github.event.pull_request.head.repo.full_name == github.repository 
     permissions:
       packages: read
       checks: write


### PR DESCRIPTION
**What this PR does / why we need it**:

I suspect the previous condition was excluding merge-queue builds for dependabot PRs, so I'm changing it.
