### PR TITLE
Using existing check-run to obtain SHA

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -238,34 +238,48 @@ jobs:
         if: 
           steps.check-changes.outputs.code-changed == 'true' 
 
+      - name: Get Job ID from GH API
+        id: get-job-id
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
+          job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
+          echo "job_id=$job_id" >> $GITHUB_ENV
+    
       # Update check run called "integration-tests-fork"
       - name: update-integration-tests-result
         uses: actions/github-script@v6
         id: update-check-run
         if: ${{ always() }}
         env:
-          number: ${{ github.event.number }}
+          repo: ${{ github.repository }}
+          owner: ${{ github.repository_owner }}
+          run_id: ${{ env.job_id }}
+          server_url: ${{ github.server_url }}
           integration_test_job: 'integration-tests-fork' # This is the name of the job defined in pr-validation-fork.yml
           # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
           conclusion: ${{ job.status }}
-          server_url: ${{ github.server_url }}
-          repo: ${{ github.repository }}
-          run_id: ${{ github.run_id }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const url = `${process.env.server_url}/${process.env.repo}/actions/runs/${process.env.run_id}`
-            const { data: pull } = await github.rest.pulls.get({
-              ...context.repo,
-              pull_number: process.env.number
+            // Get all the details of the check run that's currently executing
+            // This lets us get the SHA we're building regardless of WHY we're building it
+            const { data: check } = await github.rest.checks.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: process.env.run_id
             });
-            const ref = pull.head.sha;
+
+            // update the check result for `integration-tests-fork`
+            const url = `${process.env.server_url}/${process.env.repo}/actions/runs/${process.env.run_id}`
             const { data: result } = await github.rest.checks.create({
               ...context.repo,
               name: process.env.integration_test_job,
-              head_sha: ref,
+              head_sha: check.head_sha,
               status: 'completed',
               conclusion: process.env.conclusion,
               details_url: url,
             });
+
             return result;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,12 +2,10 @@
 # tiggers on push.
 trigger:
   branches:
-    include:
     # Run automatically on GitHub Merge Queue branches
-      - 'gh-readonly-queue/*'
-    exclude:
+    include: [ 'gh-readonly-queue/*' ]
     # But not on anything else
-    - '*'
+    exclude: [ '*' ]
 
 # PR Section describes what happens on PR
 pr:


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting the status of the `integration-test-fork` check requires knowing the SHA of the code we're checking.

Previously we obtained that from the pull request we're testing, which doesn't work for merge queues.

This changes the script to instead obtain the SHA from the metadata of the check we're _currently running_; this should allow us to update `integration-test-fork` regardless of the context within which we're running the checks.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/FGxCmHRK2TDxw2L0m7/giphy.gif)
