### PR TITLE
Update branch triggers for ADO

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,10 +2,8 @@
 # tiggers on push.
 trigger:
   branches:
-    # Run automatically on GitHub Merge Queue branches
+    # Run automatically ONLY on GitHub Merge Queue branches
     include: [ 'gh-readonly-queue/*' ]
-    # But not on anything else
-    exclude: [ '*' ]
 
 # PR Section describes what happens on PR
 pr:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing the ADO triggers so that the pipeline is triggered automaticaly for GitHub merge queue checks.

**Special notes for your reviewer**:

I suspect the `exclude: '*'` was taking precedence over the include.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/tZqHC7vKpBtIalFMbM/giphy.gif)
