### PR TITLE
Install buildx for all container users

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -210,10 +210,10 @@ if should-install "$TOOL_DEST/cmctl"; then
     curl -L "https://github.com/jetstack/cert-manager/releases/latest/download/cmctl-${os}-${arch}.tar.gz" | tar -xz -C "$TOOL_DEST"
 fi
 
-BUILDX_DEST=$HOME/.docker/cli-plugins
+BUILDX_DEST=/usr/lib/docker/cli-plugins
 write-verbose "Checking for $BUILDX_DEST/docker-buildx"
 if should-install "$BUILDX_DEST/docker-buildx"; then
-    write-info "Installing buildx-${os}_${arch}…"
+    write-info "Installing buildx-${os}_${arch} to $BUILDX_DEST…"
     mkdir -p "$BUILDX_DEST"
     curl  -o "$BUILDX_DEST/docker-buildx" -L "https://github.com/docker/buildx/releases/download/v0.11.2/buildx-v0.11.2.${os}-${arch}"
     chmod +x "$BUILDX_DEST/docker-buildx"


### PR DESCRIPTION
This is so that even if somebody launches the container and runs it using their user identity (matching the UID/GID of the files they've mounted into the container locally) docker will still be able to find the buildx extension.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
