### PR TITLE
Add configuration to rename types

### DIFF
--- a/v2/azure-arm.yaml
+++ b/v2/azure-arm.yaml
@@ -703,6 +703,18 @@ status:
 #     Establishes a connection between the two types allowing for proper
 #     forward and backward conversion.
 #
+# $renameTo: <string>
+#     Changes the name of any type, allowing selective adjustments to make 
+#     names more idiomatic for Go and/or Kubernetes use.
+#
+#     For resource types, prefer $exportAs
+#     Note: using $export: + $renameTo: for a resource is not quite the same as
+#     using $exportAs because the renaming happens at a different stage of the
+#     pipeline.
+#
+#     If you have two names differing only by letter case, use a TypeTransform
+#     to selectively rename one of the types.
+#
 # $supportedFrom: <version>
 #     Gives the version number of the first release of ASO that provides 
 #     support for this resource.

--- a/v2/tools/generator/internal/config/object_model_configuration.go
+++ b/v2/tools/generator/internal/config/object_model_configuration.go
@@ -34,15 +34,15 @@ type ObjectModelConfiguration struct {
 	PayloadType groupAccess[PayloadType]
 
 	// Type access fields here (alphabetical, please)
-	AzureGeneratedSecrets typeAccess[[]string]
-	DefaultAzureName      typeAccess[bool]
-	Export                typeAccess[bool]
-	ExportAs              typeAccess[string]
-	GeneratedConfigs      typeAccess[map[string]string]
-	Importable            typeAccess[bool]
-	IsResource            typeAccess[bool]
-	ManualConfigs         typeAccess[[]string]
-
+	AzureGeneratedSecrets    typeAccess[[]string]
+	DefaultAzureName         typeAccess[bool]
+	Export                   typeAccess[bool]
+	ExportAs                 typeAccess[string]
+	GeneratedConfigs         typeAccess[map[string]string]
+	Importable               typeAccess[bool]
+	IsResource               typeAccess[bool]
+	ManualConfigs            typeAccess[[]string]
+	RenameTo                 typeAccess[string]
 	ResourceEmbeddedInParent typeAccess[string]
 	SupportedFrom            typeAccess[string]
 	TypeNameInNextVersion    typeAccess[string]
@@ -97,6 +97,8 @@ func NewObjectModelConfiguration() *ObjectModelConfiguration {
 		result, func(c *TypeConfiguration) *configurable[bool] { return &c.IsResource })
 	result.ManualConfigs = makeTypeAccess[[]string](
 		result, func(c *TypeConfiguration) *configurable[[]string] { return &c.ManualConfigs })
+	result.RenameTo = makeTypeAccess[string](
+		result, func(c *TypeConfiguration) *configurable[string] { return &c.RenameTo })
 	result.ResourceEmbeddedInParent = makeTypeAccess[string](
 		result, func(c *TypeConfiguration) *configurable[string] { return &c.ResourceEmbeddedInParent })
 	result.SupportedFrom = makeTypeAccess[string](


### PR DESCRIPTION
**What this PR does / why we need it**:

We've had the ability to rename _resources_ for some time, using `$exportAs` but that doesn't support renaming other types. This PR adds configuration and functionality to do that.

Given that `$exportAs` implies `$export: true`, I didn't want to reuse it for non-resource types; the new configuration option is `$renameTo`.

Closes #3402 

**Special notes for your reviewer**:

This came out of my first attempt at closing #3403 but wasn't actually used for that.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/VFB3cJJne7b5m/giphy.gif)
