### PR TITLE
Allow Function Handlers to return errors

### DIFF
--- a/v2/tools/generator/internal/armconversion/arm_spec_interface.go
+++ b/v2/tools/generator/internal/armconversion/arm_spec_interface.go
@@ -38,7 +38,10 @@ func NewARMSpecInterfaceImpl(
 		return nil, err
 	}
 
-	getNameFunc := functions.NewObjectFunction("Get"+astmodel.NameProperty, idFactory, getNameFunction)
+	getNameFunc := functions.NewObjectFunction(
+		"Get"+astmodel.NameProperty,
+		idFactory,
+		getNameFunction)
 	getNameFunc.AddPackageReference(astmodel.GenRuntimeReference)
 
 	getTypeFunc := functions.NewGetTypeFunction(resource.ARMType(), idFactory, functions.ReceiverTypePtr)
@@ -62,7 +65,7 @@ func getNameFunction(
 	genContext *astmodel.CodeGenerationContext,
 	receiver astmodel.TypeName,
 	methodName string,
-) *dst.FuncDecl {
+) (*dst.FuncDecl, error) {
 	return armSpecInterfaceSimpleGetFunction(
 		fn,
 		genContext,
@@ -79,7 +82,7 @@ func armSpecInterfaceSimpleGetFunction(
 	methodName string,
 	propertyName string,
 	castToString bool,
-) *dst.FuncDecl {
+) (*dst.FuncDecl, error) {
 	receiverIdent := fn.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -104,5 +107,5 @@ func armSpecInterfaceSimpleGetFunction(
 	details.AddComments(fmt.Sprintf("returns the %s of the resource", propertyName))
 	details.AddReturns("string")
 
-	return details.DefineFunc()
+	return details.DefineFunc(), nil
 }

--- a/v2/tools/generator/internal/astmodel/std_references.go
+++ b/v2/tools/generator/internal/astmodel/std_references.go
@@ -84,6 +84,7 @@ var (
 	LocatableResourceInterfaceName   = MakeExternalTypeName(GenRuntimeReference, "LocatableResource")
 	ImportableResourceType           = MakeExternalTypeName(GenRuntimeReference, "ImportableResource")
 	ResourceOperationType            = MakeExternalTypeName(GenRuntimeReference, "ResourceOperation")
+	ResourceOperationTypeArray       = NewArrayType(ResourceOperationType)
 
 	// Optional types - GenRuntime
 	OptionalConfigMapReferenceType     = NewOptionalType(ConfigMapReferenceType)

--- a/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
@@ -181,7 +181,12 @@ func NewValidateSecretDestinationsFunction(resource *astmodel.ResourceType, idFa
 		astmodel.NewPackageReferenceSet(astmodel.GenRuntimeReference))
 }
 
-func validateSecretDestinations(k *functions.ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func validateSecretDestinations(
+	k *functions.ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -201,7 +206,8 @@ func validateSecretDestinations(k *functions.ResourceFunction, codeGenerationCon
 	fn.AddReturn(astbuilder.QualifiedTypeName(codeGenerationContext.MustGetImportedPackageName(astmodel.ControllerRuntimeAdmission), "Warnings"))
 	fn.AddReturn(dst.NewIdent("error"))
 	fn.AddComments("validates there are no colliding genruntime.SecretDestination's")
-	return fn.DefineFunc()
+
+	return fn.DefineFunc(), nil
 }
 
 func NewValidateConfigMapDestinationsFunction(resource *astmodel.ResourceType, idFactory astmodel.IdentifierFactory) *functions.ResourceFunction {
@@ -213,7 +219,12 @@ func NewValidateConfigMapDestinationsFunction(resource *astmodel.ResourceType, i
 		astmodel.NewPackageReferenceSet(astmodel.GenRuntimeReference))
 }
 
-func validateConfigMapDestinations(k *functions.ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func validateConfigMapDestinations(
+	k *functions.ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -230,10 +241,12 @@ func validateConfigMapDestinations(k *functions.ResourceFunction, codeGeneration
 			"ValidateConfigMapDestinations"),
 	}
 
-	fn.AddReturn(astbuilder.QualifiedTypeName(codeGenerationContext.MustGetImportedPackageName(astmodel.ControllerRuntimeAdmission), "Warnings"))
+	runtimeAdmission := codeGenerationContext.MustGetImportedPackageName(astmodel.ControllerRuntimeAdmission)
+	fn.AddReturn(astbuilder.QualifiedTypeName(runtimeAdmission, "Warnings"))
 	fn.AddReturn(dst.NewIdent("error"))
 	fn.AddComments("validates there are no colliding genruntime.ConfigMapDestinations")
-	return fn.DefineFunc()
+
+	return fn.DefineFunc(), nil
 }
 
 // validateOperatorSpecSliceBody helps generate the body of the validateResourceReferences function:

--- a/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
@@ -181,14 +181,20 @@ func (f propertyAssignmentFunctionsFactory) injectBetween(
 
 func createAssignPropertiesOverrideStub(
 	paramName string,
-	paramType astmodel.Type) func(f *functions.ObjectFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
-	return func(f *functions.ObjectFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+	paramType astmodel.Type,
+) functions.ObjectFunctionHandler {
+	return func(
+		f *functions.ObjectFunction,
+		codeGenerationContext *astmodel.CodeGenerationContext,
+		receiver astmodel.TypeName,
+		methodName string,
+	) (*dst.FuncDecl, error) {
 		funcDetails := &astbuilder.FuncDetails{
 			Name: methodName,
 		}
 		funcDetails.AddParameter(paramName, paramType.AsType(codeGenerationContext))
 		funcDetails.AddReturn(dst.NewIdent("error"))
 
-		return funcDetails.DefineFuncHeader()
+		return funcDetails.DefineFuncHeader(), nil
 	}
 }

--- a/v2/tools/generator/internal/functions/common.go
+++ b/v2/tools/generator/internal/functions/common.go
@@ -17,7 +17,7 @@ func createBodyReturningLiteralString(
 	result string,
 	comment string,
 	receiverTypeEnum ReceiverType,
-) func(k *ObjectFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+) ObjectFunctionHandler {
 	return createBodyReturningValue(
 		astbuilder.StringLiteral(result),
 		astmodel.StringType,
@@ -30,8 +30,13 @@ func createBodyReturningValue(
 	returnType astmodel.Type,
 	comment string,
 	receiverTypeEnum ReceiverType,
-) func(k *ObjectFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
-	return func(k *ObjectFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+) ObjectFunctionHandler {
+	return func(
+		k *ObjectFunction,
+		codeGenerationContext *astmodel.CodeGenerationContext,
+		receiver astmodel.TypeName,
+		methodName string,
+	) (*dst.FuncDecl, error) {
 		receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 
 		// Support both ptr and non-ptr receivers
@@ -53,6 +58,6 @@ func createBodyReturningValue(
 		fn.AddComments(comment)
 		fn.AddReturn(returnType.AsType(codeGenerationContext))
 
-		return fn.DefineFunc()
+		return fn.DefineFunc(), nil
 	}
 }

--- a/v2/tools/generator/internal/functions/conditions_functions.go
+++ b/v2/tools/generator/internal/functions/conditions_functions.go
@@ -19,7 +19,12 @@ import (
 //	func (r *<receiver>) GetConditions() genruntime.Conditions {
 //	    return r.Status.Conditions
 //	}
-func GetConditionsFunction(k *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func GetConditionsFunction(
+	k *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -37,7 +42,7 @@ func GetConditionsFunction(k *ResourceFunction, codeGenerationContext *astmodel.
 	fn.AddComments("returns the conditions of the resource")
 	fn.AddReturn(astmodel.ConditionsType.AsType(codeGenerationContext))
 
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
 // SetConditionsFunction returns a function declaration containing the implementation of the SetConditions() function.
@@ -45,7 +50,12 @@ func GetConditionsFunction(k *ResourceFunction, codeGenerationContext *astmodel.
 //	func (r *<receiver>) SetConditions(conditions genruntime.Conditions) {
 //	    r.Status.Conditions = conditions
 //	}
-func SetConditionsFunction(k *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func SetConditionsFunction(
+	k *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	conditionsParameterName := k.IdFactory().CreateIdentifier(astmodel.ConditionsProperty, astmodel.NotExported)
 
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
@@ -66,5 +76,5 @@ func SetConditionsFunction(k *ResourceFunction, codeGenerationContext *astmodel.
 		astmodel.ConditionsType.AsType(codeGenerationContext))
 	fn.AddComments("sets the conditions on the resource status")
 
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }

--- a/v2/tools/generator/internal/functions/empty_status_function.go
+++ b/v2/tools/generator/internal/functions/empty_status_function.go
@@ -16,7 +16,10 @@ import (
 func NewEmptyStatusFunction(
 	status astmodel.TypeName,
 	idFactory astmodel.IdentifierFactory) *ObjectFunction {
-	result := NewObjectFunction("NewEmptyStatus", idFactory, createNewEmptyStatusFunction(status))
+	result := NewObjectFunction(
+		"NewEmptyStatus",
+		idFactory,
+		createNewEmptyStatusFunction(status))
 	result.AddReferencedTypes(astmodel.ConvertibleStatusInterfaceType)
 	return result
 }
@@ -26,8 +29,8 @@ func createNewEmptyStatusFunction(
 	f *ObjectFunction,
 	genContext *astmodel.CodeGenerationContext,
 	receiver astmodel.TypeName,
-	_ string) *dst.FuncDecl {
-	return func(f *ObjectFunction, genContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, _ string) *dst.FuncDecl {
+	_ string) (*dst.FuncDecl, error) {
+	return func(f *ObjectFunction, genContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, _ string) (*dst.FuncDecl, error) {
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 		receiverType := astmodel.NewOptionalType(receiver)
 
@@ -50,6 +53,6 @@ func createNewEmptyStatusFunction(
 		fn.AddReturn(astmodel.ConvertibleStatusInterfaceType.AsType(genContext))
 		fn.AddComments("returns a new empty (blank) status")
 
-		return fn.DefineFunc()
+		return fn.DefineFunc(), nil
 	}
 }

--- a/v2/tools/generator/internal/functions/get_resource_type_function.go
+++ b/v2/tools/generator/internal/functions/get_resource_type_function.go
@@ -29,7 +29,10 @@ func NewGetTypeFunction(
 	armType = strings.Trim(armType, "\"")
 
 	comment := fmt.Sprintf("returns the ARM Type of the resource. This is always %q", armType)
-	result := NewObjectFunction("Get"+astmodel.TypeProperty, idFactory, createBodyReturningLiteralString(armType, comment, receiverType))
+	result := NewObjectFunction(
+		"Get"+astmodel.TypeProperty,
+		idFactory,
+		createBodyReturningLiteralString(armType, comment, receiverType))
 	result.AddPackageReference(astmodel.GenRuntimeReference)
 	return result
 }

--- a/v2/tools/generator/internal/functions/get_spec_function.go
+++ b/v2/tools/generator/internal/functions/get_spec_function.go
@@ -23,7 +23,8 @@ func createGetSpecFunction(
 	f *ObjectFunction,
 	genContext *astmodel.CodeGenerationContext,
 	receiver astmodel.TypeName,
-	_ string) *dst.FuncDecl {
+	_ string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
 
@@ -39,5 +40,5 @@ func createGetSpecFunction(
 	fn.AddReturn(astmodel.ConvertibleSpecInterfaceType.AsType(genContext))
 	fn.AddComments("returns the specification of this resource")
 
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }

--- a/v2/tools/generator/internal/functions/get_status_function.go
+++ b/v2/tools/generator/internal/functions/get_status_function.go
@@ -23,7 +23,8 @@ func createGetStatusFunction(
 	f *ObjectFunction,
 	genContext *astmodel.CodeGenerationContext,
 	receiver astmodel.TypeName,
-	_ string) *dst.FuncDecl {
+	_ string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
 
@@ -39,5 +40,5 @@ func createGetStatusFunction(
 	fn.AddReturn(astmodel.ConvertibleStatusInterfaceType.AsType(genContext))
 	fn.AddComments("returns the status of this resource")
 
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }

--- a/v2/tools/generator/internal/functions/hub_function.go
+++ b/v2/tools/generator/internal/functions/hub_function.go
@@ -24,7 +24,12 @@ func NewHubFunction(idFactory astmodel.IdentifierFactory) astmodel.Function {
 	return result
 }
 
-func createHubFunctionBody(fn *ObjectFunction, genContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func createHubFunctionBody(
+	fn *ObjectFunction,
+	genContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	// Create a sensible name for our receiver
 	receiverName := fn.IdFactory().CreateReceiver(receiver.Name())
 
@@ -40,5 +45,5 @@ func createHubFunctionBody(fn *ObjectFunction, genContext *astmodel.CodeGenerati
 
 	details.AddComments(fmt.Sprintf("marks that this %s is the hub type for conversion", receiver.Name()))
 
-	return details.DefineFunc()
+	return details.DefineFunc(), nil
 }

--- a/v2/tools/generator/internal/functions/initialize_spec_function.go
+++ b/v2/tools/generator/internal/functions/initialize_spec_function.go
@@ -44,7 +44,7 @@ func NewInitializeSpecFunction(
 		codeGenerationContext *astmodel.CodeGenerationContext,
 		receiver astmodel.TypeName,
 		methodName string,
-	) *dst.FuncDecl {
+	) (*dst.FuncDecl, error) {
 		fmtPackage := codeGenerationContext.MustGetImportedPackageName(astmodel.FmtReference)
 
 		receiverType := receiver.AsType(codeGenerationContext)
@@ -93,7 +93,7 @@ func NewInitializeSpecFunction(
 		funcDetails.AddParameter(statusParam, astmodel.ConvertibleStatusInterfaceType.AsType(codeGenerationContext))
 		funcDetails.AddReturns("error")
 
-		return funcDetails.DefineFunc()
+		return funcDetails.DefineFunc(), nil
 	}
 
 	return NewResourceFunction(

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
@@ -105,7 +105,12 @@ func (d *DefaulterBuilder) ToInterfaceImplementation() *astmodel.InterfaceImplem
 		funcs...).WithAnnotation(annotation)
 }
 
-func (d *DefaulterBuilder) localDefault(k *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func (d *DefaulterBuilder) localDefault(
+	k *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -124,10 +129,15 @@ func (d *DefaulterBuilder) localDefault(k *ResourceFunction, codeGenerationConte
 	}
 
 	fn.AddComments(fmt.Sprintf("applies the code generated defaults to the %s resource", receiver.Name()))
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
-func (d *DefaulterBuilder) defaultFunction(k *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func (d *DefaulterBuilder) defaultFunction(
+	k *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 	tempVarIdent := "temp"
@@ -151,5 +161,5 @@ func (d *DefaulterBuilder) defaultFunction(k *ResourceFunction, codeGenerationCo
 	}
 
 	fn.AddComments(fmt.Sprintf("applies defaults to the %s resource", receiver.Name()))
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaults.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaults.go
@@ -24,7 +24,12 @@ func NewDefaultAzureNameFunction(resource *astmodel.ResourceType, idFactory astm
 
 // defaultAzureNameFunction returns a function that defaults the AzureName property of the resource spec
 // to the Name property of the resource spec
-func defaultAzureNameFunction(k *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func defaultAzureNameFunction(
+	k *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -43,5 +48,5 @@ func defaultAzureNameFunction(k *ResourceFunction, codeGenerationContext *astmod
 	}
 
 	fn.AddComments("defaults the Azure name of the resource to the Kubernetes name")
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
@@ -50,7 +50,12 @@ func NewValidateOptionalConfigMapReferenceFunction(resource *astmodel.ResourceTy
 		astmodel.NewPackageReferenceSet(astmodel.GenRuntimeReference, astmodel.ReflectHelpersReference))
 }
 
-func validateResourceReferences(k *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func validateResourceReferences(
+	k *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -64,7 +69,7 @@ func validateResourceReferences(k *ResourceFunction, codeGenerationContext *astm
 	fn.AddReturn(astbuilder.QualifiedTypeName(codeGenerationContext.MustGetImportedPackageName(astmodel.ControllerRuntimeAdmission), "Warnings"))
 	fn.AddReturn(dst.NewIdent("error"))
 	fn.AddComments("validates all resource references")
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
 // validateResourceReferencesBody helps generate the body of the validateResourceReferences function:
@@ -101,7 +106,12 @@ func validateResourceReferencesBody(codeGenerationContext *astmodel.CodeGenerati
 	return body
 }
 
-func validateOwnerReferences(k *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func validateOwnerReferences(
+	k *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -117,7 +127,7 @@ func validateOwnerReferences(k *ResourceFunction, codeGenerationContext *astmode
 	fn.AddReturn(astbuilder.QualifiedTypeName(admissionPkg, "Warnings"))
 	fn.AddReturn(dst.NewIdent("error"))
 	fn.AddComments("validates the owner field")
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
 // validateOwnerReferencesBody helps generate the body of the validateOwnerReferences function:
@@ -139,8 +149,12 @@ func validateOwnerReferencesBody(codeGenerationContext *astmodel.CodeGenerationC
 	return body
 }
 
-func validateWriteOncePropertiesFunction(resourceFn *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
-
+func validateWriteOncePropertiesFunction(
+	resourceFn *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := resourceFn.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -158,7 +172,7 @@ func validateWriteOncePropertiesFunction(resourceFn *ResourceFunction, codeGener
 	fn.AddParameter("old", astbuilder.QualifiedTypeName(runtimePackage, "Object"))
 	fn.AddComments("validates all WriteOnce properties")
 
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
 // validateWriteOncePropertiesFunctionBody helps generate the body of the validateWriteOncePropertiesFunctionBody function:
@@ -192,7 +206,12 @@ func validateWriteOncePropertiesFunctionBody(receiver astmodel.TypeName, codeGen
 		returnStmt)
 }
 
-func validateOptionalConfigMapReferences(k *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func validateOptionalConfigMapReferences(
+	k *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -206,7 +225,7 @@ func validateOptionalConfigMapReferences(k *ResourceFunction, codeGenerationCont
 	fn.AddReturn(astbuilder.QualifiedTypeName(codeGenerationContext.MustGetImportedPackageName(astmodel.ControllerRuntimeAdmission), "Warnings"))
 	fn.AddReturn(dst.NewIdent("error"))
 	fn.AddComments("validates all optional configmap reference pairs to ensure that at most 1 is set")
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
 // validateOptionalConfigMapReferencesBody helps generate the body of the validateResourceReferences function:

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
@@ -147,7 +147,12 @@ func (v *ValidatorBuilder) ToInterfaceImplementation() *astmodel.InterfaceImplem
 }
 
 // validateCreate returns a function that performs validation of creation for the resource
-func (v *ValidatorBuilder) validateCreate(k *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func (v *ValidatorBuilder) validateCreate(
+	k *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -167,11 +172,16 @@ func (v *ValidatorBuilder) validateCreate(k *ResourceFunction, codeGenerationCon
 	fn.AddReturn(astbuilder.QualifiedTypeName(codeGenerationContext.MustGetImportedPackageName(astmodel.ControllerRuntimeAdmission), "Warnings"))
 	fn.AddReturn(dst.NewIdent("error"))
 	fn.AddComments("validates the creation of the resource")
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
 // validateUpdate returns a function that performs validation of update for the resource
-func (v *ValidatorBuilder) validateUpdate(k *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func (v *ValidatorBuilder) validateUpdate(
+	k *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -193,11 +203,16 @@ func (v *ValidatorBuilder) validateUpdate(k *ResourceFunction, codeGenerationCon
 	}
 
 	fn.AddComments("validates an update of the resource")
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
 // validateDelete returns a function that performs validation of deletion for the resource
-func (v *ValidatorBuilder) validateDelete(k *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func (v *ValidatorBuilder) validateDelete(
+	k *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -217,7 +232,7 @@ func (v *ValidatorBuilder) validateDelete(k *ResourceFunction, codeGenerationCon
 	fn.AddReturn(astbuilder.QualifiedTypeName(codeGenerationContext.MustGetImportedPackageName(astmodel.ControllerRuntimeAdmission), "Warnings"))
 	fn.AddReturn(dst.NewIdent("error"))
 	fn.AddComments("validates the deletion of the resource")
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
 // validateBody returns the body for the generic validation function which invokes all local (code generated) validations
@@ -272,22 +287,37 @@ func (v *ValidatorBuilder) validateBody(
 	return body
 }
 
-func (v *ValidatorBuilder) localCreateValidations(_ *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func (v *ValidatorBuilder) localCreateValidations(
+	_ *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	fn := v.makeLocalValidationFuncDetails(ValidationKindCreate, codeGenerationContext, receiver, methodName)
 	fn.AddComments("validates the creation of the resource")
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
-func (v *ValidatorBuilder) localUpdateValidations(_ *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func (v *ValidatorBuilder) localUpdateValidations(
+	_ *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	fn := v.makeLocalValidationFuncDetails(ValidationKindUpdate, codeGenerationContext, receiver, methodName)
 	fn.AddComments("validates the update of the resource")
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
-func (v *ValidatorBuilder) localDeleteValidations(_ *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func (v *ValidatorBuilder) localDeleteValidations(
+	_ *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	fn := v.makeLocalValidationFuncDetails(ValidationKindDelete, codeGenerationContext, receiver, methodName)
 	fn.AddComments("validates the deletion of the resource")
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
 func (v *ValidatorBuilder) makeLocalValidationFuncDetails(kind ValidationKind, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *astbuilder.FuncDetails {

--- a/v2/tools/generator/internal/functions/locatable_resource_function.go
+++ b/v2/tools/generator/internal/functions/locatable_resource_function.go
@@ -28,7 +28,12 @@ func NewLocatableResource(
 }
 
 // validateDelete returns a function that performs validation of deletion for the resource
-func locatableResourceLocationFunc(k *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func locatableResourceLocationFunc(
+	k *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -49,5 +54,5 @@ func locatableResourceLocationFunc(k *ResourceFunction, codeGenerationContext *a
 
 	fn.AddComments("returns the location of the resource")
 	fn.AddReturn(astmodel.StringType.AsType(codeGenerationContext))
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }

--- a/v2/tools/generator/internal/functions/new_empty_arm_value_function.go
+++ b/v2/tools/generator/internal/functions/new_empty_arm_value_function.go
@@ -25,8 +25,13 @@ func NewNewEmptyARMValueFunc(
 	return result
 }
 
-func newEmptyARMValueBody(instanceType astmodel.TypeName) func(fn *ObjectFunction, genContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
-	return func(fn *ObjectFunction, genContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func newEmptyARMValueBody(instanceType astmodel.TypeName) ObjectFunctionHandler {
+	return func(
+		fn *ObjectFunction,
+		genContext *astmodel.CodeGenerationContext,
+		receiver astmodel.TypeName,
+		methodName string,
+	) (*dst.FuncDecl, error) {
 		receiverName := fn.IdFactory().CreateReceiver(receiver.Name())
 		receiverType := astbuilder.PointerTo(receiver.AsType(genContext))
 		instance := astbuilder.NewCompositeLiteralBuilder(dst.NewIdent(instanceType.Name()))
@@ -41,6 +46,6 @@ func newEmptyARMValueBody(instanceType astmodel.TypeName) func(fn *ObjectFunctio
 		details.AddReturn(astmodel.ARMResourceStatusType.AsType(genContext))
 		details.AddComments("returns an empty ARM value suitable for deserializing into")
 
-		return details.DefineFunc()
+		return details.DefineFunc(), nil
 	}
 }

--- a/v2/tools/generator/internal/functions/object_function.go
+++ b/v2/tools/generator/internal/functions/object_function.go
@@ -37,7 +37,12 @@ func NewObjectFunction(
 	}
 }
 
-type ObjectFunctionHandler func(f *ObjectFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl
+type ObjectFunctionHandler func(
+	f *ObjectFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error)
 
 // Name returns the unique name of this function
 // (You can't have two functions with the same name on the same object or resource)
@@ -66,7 +71,7 @@ func (fn *ObjectFunction) AsFunc(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	receiver astmodel.InternalTypeName,
 ) (*dst.FuncDecl, error) {
-	return fn.asFunc(fn, codeGenerationContext, receiver, fn.name), nil
+	return fn.asFunc(fn, codeGenerationContext, receiver, fn.name)
 }
 
 // Equals checks if this function is equal to the passed in function

--- a/v2/tools/generator/internal/functions/resource_function.go
+++ b/v2/tools/generator/internal/functions/resource_function.go
@@ -11,7 +11,12 @@ import (
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
 
-type ResourceFunctionHandler func(f *ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl
+type ResourceFunctionHandler func(
+	f *ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error)
 
 // ResourceFunction is a simple helper that implements the Function interface. It is intended for use for functions
 // that only need information about the resource they are operating on
@@ -73,7 +78,7 @@ func (fn *ResourceFunction) AsFunc(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	receiver astmodel.InternalTypeName,
 ) (*dst.FuncDecl, error) {
-	return fn.asFunc(fn, codeGenerationContext, receiver, fn.name), nil
+	return fn.asFunc(fn, codeGenerationContext, receiver, fn.name)
 }
 
 // Equals determines if this Function is equal to another one

--- a/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
@@ -475,6 +475,9 @@ func getSupportedOperationsFunction(
 		),
 	}
 
+	fn.AddComments("returns the operations supported by the resource")
+	fn.AddReturn(astmodel.ResourceOperationTypeArray.AsType(codeGenerationContext))
+
 	return fn.DefineFunc(), nil
 }
 

--- a/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
@@ -223,7 +223,12 @@ func getAzureNameFunctionsForType(
 // getEnumAzureNameFunction adds an AzureName() function that casts the AzureName property
 // with an enum value to a string
 func getEnumAzureNameFunction(enumType astmodel.TypeName) functions.ObjectFunctionHandler {
-	return func(f *functions.ObjectFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+	return func(
+		f *functions.ObjectFunction,
+		codeGenerationContext *astmodel.CodeGenerationContext,
+		receiver astmodel.TypeName,
+		methodName string,
+	) (*dst.FuncDecl, error) {
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 		receiverType := receiver.AsType(codeGenerationContext)
 
@@ -238,14 +243,19 @@ func getEnumAzureNameFunction(enumType astmodel.TypeName) functions.ObjectFuncti
 
 		fn.AddComments(fmt.Sprintf("returns the Azure name of the resource (string representation of %s)", enumType.String()))
 		fn.AddReturns("string")
-		return fn.DefineFunc()
+		return fn.DefineFunc(), nil
 	}
 }
 
 // setEnumAzureNameFunction returns a function that sets the AzureName property to the result of casting
 // the argument string to the given enum type
 func setEnumAzureNameFunction(enumType astmodel.TypeName) functions.ObjectFunctionHandler {
-	return func(f *functions.ObjectFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+	return func(
+		f *functions.ObjectFunction,
+		codeGenerationContext *astmodel.CodeGenerationContext,
+		receiver astmodel.TypeName,
+		methodName string,
+	) (*dst.FuncDecl, error) {
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 		receiverType := receiver.AsType(codeGenerationContext)
 
@@ -263,7 +273,7 @@ func setEnumAzureNameFunction(enumType astmodel.TypeName) functions.ObjectFuncti
 
 		fn.AddComments(fmt.Sprintf("sets the Azure name from the given %s value", enumType.String()))
 		fn.AddParameter("azureName", dst.NewIdent("string"))
-		return fn.DefineFunc()
+		return fn.DefineFunc(), nil
 	}
 }
 
@@ -279,7 +289,12 @@ func fixedValueGetAzureNameFunction(fixedValue string) functions.ObjectFunctionH
 		fixedValue = fmt.Sprintf("%q", fixedValue)
 	}
 
-	return func(f *functions.ObjectFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+	return func(
+		f *functions.ObjectFunction,
+		codeGenerationContext *astmodel.CodeGenerationContext,
+		receiver astmodel.TypeName,
+		methodName string,
+	) (*dst.FuncDecl, error) {
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 		receiverType := receiver.AsType(codeGenerationContext)
 
@@ -294,7 +309,7 @@ func fixedValueGetAzureNameFunction(fixedValue string) functions.ObjectFunctionH
 
 		fn.AddComments(fmt.Sprintf("returns the Azure name of the resource (always %s)", fixedValue))
 		fn.AddReturns("string")
-		return fn.DefineFunc()
+		return fn.DefineFunc(), nil
 	}
 }
 
@@ -311,7 +326,12 @@ func fixedValueGetAzureNameFunction(fixedValue string) functions.ObjectFunctionH
 //	func (<receiver> *<receiver>) Owner() *genruntime.ResourceReference {
 //		return <receiver>.Spec.Owner.AsKnownResourceReference()
 //	}
-func getOwnerFunction(r *functions.ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func getOwnerFunction(
+    r *functions.ResourceFunction, 
+    codeGenerationContext *astmodel.CodeGenerationContext, 
+    receiver astmodel.TypeName, 
+    methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := r.IdFactory().CreateReceiver(receiver.Name())
 
 	specSelector := astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec")
@@ -355,8 +375,7 @@ func getOwnerFunction(r *functions.ResourceFunction, codeGenerationContext *astm
 		panic(fmt.Sprintf("unknown resource kind: %s", r.Resource().Scope()))
 	}
 
-	return fn.DefineFunc()
-
+	return fn.DefineFunc(), nil
 }
 
 // getResourceScopeFunction creates a function that returns the scope of the resource.
@@ -364,7 +383,12 @@ func getOwnerFunction(r *functions.ResourceFunction, codeGenerationContext *astm
 //	func (<receiver> *<receiver>) GetResourceScope() genruntime.ResourceScope {
 //		return genruntime.ResourceScopeResourceGroup
 //	}
-func getResourceScopeFunction(r *functions.ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func getResourceScopeFunction(
+    r *functions.ResourceFunction, 
+    codeGenerationContext *astmodel.CodeGenerationContext, 
+    receiver astmodel.TypeName, 
+    methodName string,
+) *dst.FuncDecl {
 	receiverIdent := r.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
 
@@ -446,10 +470,7 @@ func getSupportedOperationsFunction(r *functions.ResourceFunction, codeGeneratio
 		),
 	}
 
-	fn.AddComments("returns the operations supported by the resource")
-	fn.AddReturn(astmodel.NewArrayType(astmodel.ResourceOperationType).AsType(codeGenerationContext))
-
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
 func lookupGroupAndKindStmt(
@@ -488,7 +509,12 @@ func createResourceReference(
 
 // setStringAzureNameFunction returns a function that sets the Name property of
 // the resource spec to the argument string
-func setStringAzureNameFunction(k *functions.ObjectFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func setStringAzureNameFunction(
+	k *functions.ObjectFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -507,11 +533,16 @@ func setStringAzureNameFunction(k *functions.ObjectFunction, codeGenerationConte
 
 	fn.AddComments("sets the Azure name of the resource")
 	fn.AddParameter("azureName", dst.NewIdent("string"))
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
 // getStringAzureNameFunction returns a function that returns the Name property of the resource spec
-func getStringAzureNameFunction(k *functions.ObjectFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func getStringAzureNameFunction(
+	k *functions.ObjectFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := receiver.AsType(codeGenerationContext)
 
@@ -526,5 +557,5 @@ func getStringAzureNameFunction(k *functions.ObjectFunction, codeGenerationConte
 
 	fn.AddComments("returns the Azure name of the resource")
 	fn.AddReturns("string")
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }

--- a/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
@@ -327,10 +327,10 @@ func fixedValueGetAzureNameFunction(fixedValue string) functions.ObjectFunctionH
 //		return <receiver>.Spec.Owner.AsKnownResourceReference()
 //	}
 func getOwnerFunction(
-    r *functions.ResourceFunction, 
-    codeGenerationContext *astmodel.CodeGenerationContext, 
-    receiver astmodel.TypeName, 
-    methodName string,
+	r *functions.ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := r.IdFactory().CreateReceiver(receiver.Name())
 
@@ -384,11 +384,11 @@ func getOwnerFunction(
 //		return genruntime.ResourceScopeResourceGroup
 //	}
 func getResourceScopeFunction(
-    r *functions.ResourceFunction, 
-    codeGenerationContext *astmodel.CodeGenerationContext, 
-    receiver astmodel.TypeName, 
-    methodName string,
-) *dst.FuncDecl {
+	r *functions.ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := r.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
 
@@ -419,7 +419,7 @@ func getResourceScopeFunction(
 	fn.AddComments("returns the scope of the resource")
 	fn.AddReturn(astmodel.ResourceScopeType.AsType(codeGenerationContext))
 
-	return fn.DefineFunc()
+	return fn.DefineFunc(), nil
 }
 
 // getSupportedOperationsFunction creates a function that returns the supported operations of the resource.
@@ -431,7 +431,12 @@ func getResourceScopeFunction(
 //			genruntime.ResourceOperationDelete,
 //		}
 //	}
-func getSupportedOperationsFunction(r *functions.ResourceFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl {
+func getSupportedOperationsFunction(
+	r *functions.ResourceFunction,
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	receiver astmodel.TypeName,
+	methodName string,
+) (*dst.FuncDecl, error) {
 	receiverIdent := r.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the definitions of `ResourceFunctionHandler` and `ObjectFunctionHandler` have to resort to **panic** if something goes wrong; this results in the ASO generator aborting instead of returning context for the problem. 

This PR changes the signatures to allow for errors to be returned, modifying some **panic** calls into errors.

Closes #2968

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/woqpkjFSVulzRH33Ze/giphy.gif)
