### PR TITLE
Support resource types that aren't quite "really" resources

### DIFF
--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -8,6 +8,7 @@ package codegen
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -325,9 +326,9 @@ func (generator *CodeGenerator) executeStage(
 	defer func() {
 		if r := recover(); r != nil {
 			if e, ok := r.(error); ok {
-				err = e
+				err = errors.Wrapf(e, "panic: %s", string(debug.Stack()))
 			} else {
-				err = errors.Errorf("panic: %s", r)
+				err = errors.Errorf("panic: %s\n%s", r, string(debug.Stack()))
 			}
 		}
 	}()

--- a/v2/tools/generator/internal/codegen/embeddedresources/remove_empty_objects.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/remove_empty_objects.go
@@ -40,6 +40,10 @@ func findEmptyObjectTypes(
 ) astmodel.TypeNameSet {
 	result := astmodel.NewTypeNameSet()
 
+	// Get all top level spec and status types
+	specs := astmodel.FindSpecDefinitions(definitions)
+	statuses := astmodel.FindStatusDefinitions(definitions)
+
 	for _, def := range definitions {
 		ot, ok := astmodel.AsObjectType(def.Type())
 		if !ok {
@@ -52,6 +56,11 @@ func findEmptyObjectTypes(
 		}
 
 		if astmodel.DoNotPrune.IsOn(def.Type()) {
+			continue
+		}
+
+		// Don't prune top level status or spec types, they are allowed to be empty
+		if specs.Contains(def.Name()) || statuses.Contains(def.Name()) {
 			continue
 		}
 


### PR DESCRIPTION
They have a HEAD rather than a GET and no body parameters


**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
