### PR TITLE
Exclude ASOv1 from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,6 @@
 
 version: 2
 updates:
-  # ASO v1
-  - package-ecosystem: "gomod" 
-    directory: "/" 
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
   # ASO v2 controller 
   - package-ecosystem: "gomod" 
     directory: "/v2" 


### PR DESCRIPTION

**What this PR does / why we need it**:

As discussed - We're not actively releasing ASOv1 anymore, so makes sense to turn off dependabot for ASOv1 and manually update the dependencies whenever required. 
