### PR TITLE
Add guards against using distinct subscriptions between owner and child resources

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -810,7 +810,7 @@ func (r *azureDeploymentReconcilerInstance) deleteResource(
 		return ctrl.Result{}, nil
 	}
 
-	err := r.checkSubscription(resourceID) // TODO: Possibly we should pass this in as a parameter?
+	err := r.checkSubscription(resourceID)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -293,7 +293,7 @@ func (r *azureDeploymentReconcilerInstance) BeginCreateOrUpdateResource(
 
 	resourceID := genruntime.GetResourceIDOrDefault(r.Obj)
 	if resourceID != "" {
-		err := r.checkSubscription(resourceID)
+		err = r.checkSubscription(resourceID)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/v2/internal/resolver/resolver_test.go
+++ b/v2/internal/resolver/resolver_test.go
@@ -7,6 +7,7 @@ package resolver_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -89,6 +90,9 @@ func createResourceGroup(name string) *resources.ResourceGroup {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: testNamespace,
+			Annotations: map[string]string{
+				genruntime.ResourceIDAnnotation: fmt.Sprintf("/subscriptions/1234/resourceGroups/%s", name),
+			},
 		},
 		Spec: resources.ResourceGroup_Spec{
 			Location:  to.Ptr("West US"),

--- a/v2/internal/resolver/resolver_test.go
+++ b/v2/internal/resolver/resolver_test.go
@@ -91,7 +91,7 @@ func createResourceGroup(name string) *resources.ResourceGroup {
 			Name:      name,
 			Namespace: testNamespace,
 			Annotations: map[string]string{
-				genruntime.ResourceIDAnnotation: fmt.Sprintf("/subscriptions/1234/resourceGroups/%s", name),
+				genruntime.ResourceIDAnnotation: fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", name),
 			},
 		},
 		Spec: resources.ResourceGroup_Spec{

--- a/v2/internal/resolver/resource_hierarchy.go
+++ b/v2/internal/resolver/resource_hierarchy.go
@@ -149,6 +149,7 @@ func (h ResourceHierarchy) fullyQualifiedARMIDImpl(subscriptionID string, origin
 			return "", err
 		}
 
+		// Safe to do it this way, Claimer makes sure the owner exists and is Ready and will always have an armId annotation before we reach here.
 		armID, err := genruntime.GetAndParseResourceID(root)
 		if err != nil {
 			return "", err

--- a/v2/internal/resolver/resource_hierarchy_test.go
+++ b/v2/internal/resolver/resource_hierarchy_test.go
@@ -101,6 +101,20 @@ func Test_ResourceHierarchy_ResourceGroup_NestedResource(t *testing.T) {
 	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
 }
 
+func Test_ResourceHierarchy_ResourceGroup_NestedResource_MatchSubscriptionWithOwner(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	resourceGroupName := "myrg"
+	resourceName := "myresource"
+	childResourceName := "mychildresource"
+
+	hierarchy := createDeeplyNestedResource(resourceGroupName, resourceName, childResourceName)
+
+	_, err := hierarchy.FullyQualifiedARMID("4567")
+	g.Expect(err).To(MatchError("resource subscription \"4567\" does not match parent subscription \"1234\""))
+}
+
 func Test_ResourceHierarchy_ExtensionOnResourceGroup(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/v2/internal/resolver/resource_hierarchy_test.go
+++ b/v2/internal/resolver/resource_hierarchy_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/gomega"
 
 	"github.com/Azure/azure-service-operator/v2/internal/resolver"
@@ -29,13 +30,13 @@ func Test_ResourceHierarchy_ResourceGroupOnly(t *testing.T) {
 	_, err := hierarchy.ResourceGroup()
 	g.Expect(err).To(HaveOccurred())
 
-	expectedARMID := fmt.Sprintf("/subscriptions/1234/resourceGroups/%s", resourceGroupName)
+	expectedARMID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", resourceGroupName)
 
 	location, err := hierarchy.Location()
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(a.Spec.Location).To(Equal(to.Ptr(location)))
 	g.Expect(hierarchy.AzureName()).To(Equal(resourceGroupName))
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 }
 
 func Test_ResourceHierarchy_TenantScopeResourceOnly(t *testing.T) {
@@ -56,7 +57,7 @@ func Test_ResourceHierarchy_TenantScopeResourceOnly(t *testing.T) {
 	expectedARMID := fmt.Sprintf("/providers/Microsoft.Subscription/aliases/%s", subscriptionName)
 
 	g.Expect(hierarchy.AzureName()).To(Equal(subscriptionName))
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 }
 
 func Test_ResourceHierarchy_ResourceGroup_TopLevelResource(t *testing.T) {
@@ -69,13 +70,13 @@ func Test_ResourceHierarchy_ResourceGroup_TopLevelResource(t *testing.T) {
 	a, b := createResourceGroupRootedResource(resourceGroupName, name)
 	hierarchy := resolver.ResourceHierarchy{a, b}
 
-	expectedARMID := fmt.Sprintf("/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Batch/batchAccounts/%s", resourceGroupName, name)
+	expectedARMID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Batch/batchAccounts/%s", resourceGroupName, name)
 
 	rg, err := hierarchy.ResourceGroup()
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(rg).To(Equal(resourceGroupName))
 	g.Expect(hierarchy.AzureName()).To(Equal(name))
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 }
 
 func Test_ResourceHierarchy_ResourceGroup_NestedResource(t *testing.T) {
@@ -89,7 +90,7 @@ func Test_ResourceHierarchy_ResourceGroup_NestedResource(t *testing.T) {
 	hierarchy := createDeeplyNestedResource(resourceGroupName, resourceName, childResourceName)
 
 	expectedARMID := fmt.Sprintf(
-		"/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/%s",
+		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/%s",
 		resourceGroupName,
 		resourceName,
 		hierarchy[2].AzureName())
@@ -98,7 +99,7 @@ func Test_ResourceHierarchy_ResourceGroup_NestedResource(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(rg).To(Equal(resourceGroupName))
 	g.Expect(hierarchy.AzureName()).To(Equal(hierarchy[2].AzureName()))
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 }
 
 func Test_ResourceHierarchy_ResourceGroup_NestedResource_MatchSubscriptionWithOwner(t *testing.T) {
@@ -111,8 +112,9 @@ func Test_ResourceHierarchy_ResourceGroup_NestedResource_MatchSubscriptionWithOw
 
 	hierarchy := createDeeplyNestedResource(resourceGroupName, resourceName, childResourceName)
 
-	_, err := hierarchy.FullyQualifiedARMID("4567")
-	g.Expect(err).To(MatchError("resource subscription \"4567\" does not match parent subscription \"1234\""))
+	uuid := uuid.New().String()
+	_, err := hierarchy.FullyQualifiedARMID(uuid)
+	g.Expect(err).To(MatchError(fmt.Sprintf("resource subscription \"%s\" does not match parent subscription \"00000000-0000-0000-0000-000000000000\"", uuid)))
 }
 
 func Test_ResourceHierarchy_ExtensionOnResourceGroup(t *testing.T) {
@@ -126,12 +128,12 @@ func Test_ResourceHierarchy_ExtensionOnResourceGroup(t *testing.T) {
 	hierarchy := resolver.ResourceHierarchy{a, b}
 
 	expectedARMID := fmt.Sprintf(
-		"/subscriptions/1234/resourceGroups/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
+		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
 		resourceGroupName,
 		extensionName)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 	g.Expect(hierarchy.AzureName()).To(Equal(extensionName))
 }
 
@@ -156,7 +158,7 @@ func Test_ResourceHierarchy_ExtensionOnTenantScopeResource(t *testing.T) {
 		subscriptionName,
 		extensionName)
 
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 	g.Expect(hierarchy.AzureName()).To(Equal(extensionName))
 }
 
@@ -171,13 +173,13 @@ func Test_ResourceHierarchy_ExtensionOnResourceInResourceGroup(t *testing.T) {
 	hierarchy := createExtensionResourceOnResourceInResourceGroup(resourceGroupName, resourceName, extensionName)
 
 	expectedARMID := fmt.Sprintf(
-		"/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Batch/batchAccounts/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
+		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Batch/batchAccounts/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
 		resourceGroupName,
 		resourceName,
 		extensionName)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 	g.Expect(hierarchy.AzureName()).To(Equal(extensionName))
 }
 
@@ -193,14 +195,14 @@ func Test_ResourceHierarchy_ExtensionOnDeepHierarchy(t *testing.T) {
 	hierarchy := createExtensionResourceOnDeepHierarchyInResourceGroup(resourceGroupName, resourceName, childResourceName, extensionName)
 
 	expectedARMID := fmt.Sprintf(
-		"/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
+		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
 		resourceGroupName,
 		resourceName,
 		hierarchy[2].AzureName(),
 		extensionName)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 	g.Expect(hierarchy.AzureName()).To(Equal(extensionName))
 }
 
@@ -211,17 +213,17 @@ func Test_ResourceHierarchy_OwnerARMIDResourceGroup(t *testing.T) {
 	resourceGroupName := "myrg"
 	resourceName := "myresource"
 
-	rootARMID := fmt.Sprintf("/subscriptions/1234/resourceGroups/%s", resourceGroupName)
+	rootARMID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", resourceGroupName)
 	resource := createResourceGroupARMIDRootedResource(rootARMID, resourceName)
 	hierarchy := resolver.ResourceHierarchy{resource}
 
 	expectedARMID := fmt.Sprintf(
-		"/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Batch/batchAccounts/%s",
+		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Batch/batchAccounts/%s",
 		resourceGroupName,
 		resourceName)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 	g.Expect(hierarchy.AzureName()).To(Equal(resourceName))
 }
 
@@ -233,17 +235,17 @@ func Test_ResourceHierarchy_OwnerARMIDParent(t *testing.T) {
 	parentName := "parent"
 	resourceName := "myresource"
 
-	rootARMID := fmt.Sprintf("/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s", resourceGroupName, parentName)
+	rootARMID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s", resourceGroupName, parentName)
 	resource := createChildResourceOwnedByARMID(rootARMID, resourceName)
 	hierarchy := resolver.ResourceHierarchy{resource}
 
 	expectedARMID := fmt.Sprintf(
-		"/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/default",
+		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/default",
 		resourceGroupName,
 		parentName)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 	g.Expect(hierarchy.AzureName()).To(Equal("default"))
 }
 
@@ -255,11 +257,11 @@ func Test_ResourceHierarchy_OwnerARMIDWrongProvider_ReturnsError(t *testing.T) {
 	parentName := "parent"
 	resourceName := "myresource"
 
-	rootARMID := fmt.Sprintf("/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Qux/storageAccounts/%s", resourceGroupName, parentName)
+	rootARMID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Qux/storageAccounts/%s", resourceGroupName, parentName)
 	resource := createChildResourceOwnedByARMID(rootARMID, resourceName)
 	hierarchy := resolver.ResourceHierarchy{resource}
 
-	_, err := hierarchy.FullyQualifiedARMID("1234")
+	_, err := hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")
 	g.Expect(err).To(MatchError("expected owner ARM ID to be from provider \"Microsoft.Storage\", but was \"Microsoft.Qux\""))
 }
 
@@ -271,11 +273,11 @@ func Test_ResourceHierarchy_OwnerARMIDWrongType_ReturnsError(t *testing.T) {
 	parentName := "parent"
 	resourceName := "myresource"
 
-	rootARMID := fmt.Sprintf("/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Storage/cats/%s", resourceGroupName, parentName)
+	rootARMID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Storage/cats/%s", resourceGroupName, parentName)
 	resource := createChildResourceOwnedByARMID(rootARMID, resourceName)
 	hierarchy := resolver.ResourceHierarchy{resource}
 
-	_, err := hierarchy.FullyQualifiedARMID("1234")
+	_, err := hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")
 	g.Expect(err).To(MatchError("expected owner ARM ID to be of type \"Microsoft.Storage/storageAccounts\", but was \"Microsoft.Storage/cats\""))
 }
 
@@ -287,11 +289,11 @@ func Test_ResourceHierarchy_OwnerARMIDAnotherWrongType_ReturnsError(t *testing.T
 	parentName := "parent"
 	resourceName := "myresource"
 
-	rootARMID := fmt.Sprintf("/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Storage/cats/%s", resourceGroupName, parentName)
+	rootARMID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Storage/cats/%s", resourceGroupName, parentName)
 	resource := createResourceGroupARMIDRootedResource(rootARMID, resourceName)
 	hierarchy := resolver.ResourceHierarchy{resource}
 
-	_, err := hierarchy.FullyQualifiedARMID("1234")
+	_, err := hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")
 	g.Expect(err).To(MatchError("expected owner ARM ID to be for a resource group, but was \"Microsoft.Storage/cats\""))
 }
 
@@ -302,12 +304,13 @@ func Test_ResourceHierarchy_OwnerARMIDWrongSubscription_ReturnsError(t *testing.
 	resourceGroupName := "myrg"
 	resourceName := "myresource"
 
-	rootARMID := fmt.Sprintf("/subscriptions/4567/resourceGroups/%s", resourceGroupName)
+	uuid := uuid.New().String()
+	rootARMID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", uuid, resourceGroupName)
 	resource := createResourceGroupARMIDRootedResource(rootARMID, resourceName)
 	hierarchy := resolver.ResourceHierarchy{resource}
 
-	_, err := hierarchy.FullyQualifiedARMID("1234")
-	g.Expect(err).To(MatchError("resource subscription \"1234\" does not match parent subscription \"4567\""))
+	_, err := hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")
+	g.Expect(err).To(MatchError(fmt.Sprintf("resource subscription \"00000000-0000-0000-0000-000000000000\" does not match parent subscription \"%s\"", uuid)))
 }
 
 func Test_ResourceHierarchy_OwnerARMIDWithExtension(t *testing.T) {
@@ -318,18 +321,18 @@ func Test_ResourceHierarchy_OwnerARMIDWithExtension(t *testing.T) {
 	resourceName := "myresource"
 	extensionName := "myextension"
 
-	rootARMID := fmt.Sprintf("/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s", resourceGroupName, resourceName)
+	rootARMID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s", resourceGroupName, resourceName)
 	resource := createSimpleExtensionResourceOwnedByARMID(extensionName, rootARMID)
 	hierarchy := resolver.ResourceHierarchy{resource}
 
 	expectedARMID := fmt.Sprintf(
-		"/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
+		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
 		resourceGroupName,
 		resourceName,
 		extensionName)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 	g.Expect(hierarchy.AzureName()).To(Equal(extensionName))
 }
 
@@ -342,18 +345,18 @@ func Test_ResourceHierarchy_OwnerARMIDWithExtensionOnDeepHierarchy(t *testing.T)
 	childResourceName := "mychildresource"
 	extensionName := "myextension"
 
-	rootARMID := fmt.Sprintf("/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s", resourceGroupName, resourceName)
+	rootARMID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s", resourceGroupName, resourceName)
 	hierarchy := createExtensionResourceOnDeepHierarchyOwnedByARMID(rootARMID, childResourceName, extensionName)
 
 	expectedARMID := fmt.Sprintf(
-		"/subscriptions/1234/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
+		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/%s/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
 		resourceGroupName,
 		resourceName,
 		hierarchy[0].AzureName(),
 		extensionName)
 
 	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 	g.Expect(hierarchy.AzureName()).To(Equal(extensionName))
 }
 
@@ -367,13 +370,13 @@ func Test_ResourceHierarchy_ChildResourceIDOverride_DoesNotImpactResourceItself(
 	genruntime.SetChildResourceIDOverride(a, "/a/b/c")
 	hierarchy := resolver.ResourceHierarchy{a}
 
-	expectedARMID := fmt.Sprintf("/subscriptions/1234/resourceGroups/%s", resourceGroupName)
+	expectedARMID := fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", resourceGroupName)
 
 	location, err := hierarchy.Location()
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(a.Spec.Location).To(Equal(to.Ptr(location)))
 	g.Expect(hierarchy.AzureName()).To(Equal(resourceGroupName))
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 }
 
 func Test_ResourceHierarchy_ChildResourceIDOverride_ImpactsExtensionResource(t *testing.T) {
@@ -397,6 +400,6 @@ func Test_ResourceHierarchy_ChildResourceIDOverride_ImpactsExtensionResource(t *
 		"/a/b/c/providers/Microsoft.SimpleExtension/simpleExtensions/%s",
 		extensionName)
 
-	g.Expect(hierarchy.FullyQualifiedARMID("1234")).To(Equal(expectedARMID))
+	g.Expect(hierarchy.FullyQualifiedARMID("00000000-0000-0000-0000-000000000000")).To(Equal(expectedARMID))
 	g.Expect(hierarchy.AzureName()).To(Equal(extensionName))
 }

--- a/v2/internal/testcommon/resource_groups.go
+++ b/v2/internal/testcommon/resource_groups.go
@@ -6,20 +6,27 @@ Licensed under the MIT license.
 package testcommon
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	resources "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
 	"github.com/Azure/azure-service-operator/v2/internal/util/to"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 )
 
 func CreateResourceGroup() *resources.ResourceGroup {
+	name := "myrg"
 	return &resources.ResourceGroup{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "ResourceGroup",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-namespace",
-			Name:      "myrg",
+			Name:      name,
+			Annotations: map[string]string{
+				genruntime.ResourceIDAnnotation: fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s", name),
+			},
 		},
 		Spec: resources.ResourceGroup_Spec{
 			Location: to.Ptr("West US"),

--- a/v2/internal/tests/azure_generic_arm_reconciler_test.go
+++ b/v2/internal/tests/azure_generic_arm_reconciler_test.go
@@ -34,7 +34,7 @@ func Test_ConvertResourceToARMResource(t *testing.T) {
 	account := testcommon.CreateDummyResource()
 	g.Expect(testClient.Create(ctx, account)).To(Succeed())
 
-	subscriptionID := "1234"
+	subscriptionID := "00000000-0000-0000-0000-000000000000"
 
 	resource, err := arm.ConvertToARMResourceImpl(ctx, account, scheme, resolver, subscriptionID)
 	g.Expect(err).ToNot(HaveOccurred())

--- a/v2/pkg/genruntime/arm_id.go
+++ b/v2/pkg/genruntime/arm_id.go
@@ -6,6 +6,8 @@
 package genruntime
 
 import (
+	"strings"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/pkg/errors"
 )
@@ -41,4 +43,14 @@ func SetChildResourceIDOverride(obj ARMMetaObject, id string) {
 func GetChildResourceIDOverride(obj ARMMetaObject) (string, bool) {
 	result, ok := obj.GetAnnotations()[ChildResourceIDOverrideAnnotation]
 	return result, ok
+}
+
+func CheckARMIDMatchesSubscription(subscriptionID string, armID *arm.ResourceID) bool {
+	// armIDSub may be empty if there is no subscription
+	if armID.SubscriptionID != "" {
+		if !strings.EqualFold(armID.SubscriptionID, subscriptionID) {
+			return false
+		}
+	}
+	return true
 }

--- a/v2/test/single_operator_multitenant_test.go
+++ b/v2/test/single_operator_multitenant_test.go
@@ -153,22 +153,6 @@ func Test_Multitenant_SingleOperator_PerResourceCredential_MatchSubscriptionWith
 	tc.CreateResourceAndWaitForFailure(acct)
 	tc.Expect(acct.Status.Conditions[0].Message).To(ContainSubstring("does not match parent subscription"))
 	tc.Expect(acct.Status.Conditions[0].Severity).To(Equal(conditions.ConditionSeverityError))
-
-	// Deleting the per-resource credential annotation would default to applying the global credential with all permissions
-	old := acct.DeepCopy()
-	delete(acct.Annotations, annotations.PerResourceSecret)
-	tc.Patch(old, acct)
-
-	objKey := client.ObjectKeyFromObject(acct)
-	updated := &storage.StorageAccount{}
-	tc.GetResource(objKey, updated)
-
-	resID := genruntime.GetResourceIDOrDefault(updated)
-
-	// Make sure the StorageAccount is created successfully in Azure.
-	exists, _, err := tc.AzureClient.CheckExistenceWithGetByID(tc.Ctx, resID, string(storage.APIVersion_Value))
-	tc.Expect(err).ToNot(HaveOccurred())
-	tc.Expect(exists).To(BeTrue())
 }
 
 func newClientSecretCredential(subscriptionID, tenantID, name, namespace string) (*v1.Secret, error) {

--- a/v2/test/single_operator_multitenant_test.go
+++ b/v2/test/single_operator_multitenant_test.go
@@ -149,8 +149,7 @@ func Test_Multitenant_SingleOperator_PerResourceCredential_MatchSubscriptionWith
 	acct := newStorageAccount(tc, rg)
 	acct.Annotations = map[string]string{annotations.PerResourceSecret: secret.Name}
 
-	// Creating new storage account in with distinct subscription, per resource secret should fail.
-	tc.CreateResourceAndWaitForFailure(acct)
+	// Create a new storage account with a distinct subscription; per resource secret should fail because it does not match
 	tc.Expect(acct.Status.Conditions[0].Message).To(ContainSubstring("does not match parent subscription"))
 	tc.Expect(acct.Status.Conditions[0].Severity).To(Equal(conditions.ConditionSeverityError))
 }

--- a/v2/test/single_operator_multitenant_test.go
+++ b/v2/test/single_operator_multitenant_test.go
@@ -150,6 +150,7 @@ func Test_Multitenant_SingleOperator_PerResourceCredential_MatchSubscriptionWith
 	acct.Annotations = map[string]string{annotations.PerResourceSecret: secret.Name}
 
 	// Create a new storage account with a distinct subscription; per resource secret should fail because it does not match
+	tc.CreateResourceAndWaitForFailure(acct)
 	tc.Expect(acct.Status.Conditions[0].Message).To(ContainSubstring("does not match parent subscription"))
 	tc.Expect(acct.Status.Conditions[0].Severity).To(Equal(conditions.ConditionSeverityError))
 }


### PR DESCRIPTION


Closes #3244 

**What this PR does / why we need it**:

Adding check to match resource credential subscription with owner's subscription.

- [x] this PR contains tests
