### PR TITLE
Fix bugs related to beta resource removal

### DIFF
--- a/v2/cmd/asoctl/internal/crd/cleaner.go
+++ b/v2/cmd/asoctl/internal/crd/cleaner.go
@@ -92,7 +92,7 @@ func (c *Cleaner) Run(ctx context.Context) error {
 
 	var updated int
 	var asoCRDsSeen int
-	deprecatedVersionRegexp := regexp.MustCompile(`(v1alpha1api|v1beta)\d{8}(preview)?(storage)?`)
+	deprecatedVersionRegexp := regexp.MustCompile(`((v1alpha1api|v1beta)\d{8}(preview)?(storage)?|v1beta1)`) // handcrafted (non-ARM) resources have v1beta1 version
 
 	for _, crd := range crds {
 		crd := crd


### PR DESCRIPTION
* asoctl was not removing "v1beta" usage, which was a version used for handcrafted resources such mysql user.
* The operator needs to translate beta versions into GA versions when doing ARM version conversion.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://giphy.com/)

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
