### PR TITLE
Allow AsDeclarations to return an error

### DIFF
--- a/v2/tools/generator/internal/astmodel/allof_type.go
+++ b/v2/tools/generator/internal/astmodel/allof_type.go
@@ -119,7 +119,7 @@ func (allOf *AllOfType) AsDeclarations(
 	codeGenerationContext *CodeGenerationContext,
 	declContext DeclarationContext,
 ) ([]dst.Decl, error) {
-	return nil, errors.New(allOfFailureMsg)
+	panic(errors.New(allOfFailureMsg))
 }
 
 // AsZero always panics; AllOf cannot be represented by the Go AST and must be

--- a/v2/tools/generator/internal/astmodel/allof_type.go
+++ b/v2/tools/generator/internal/astmodel/allof_type.go
@@ -105,30 +105,33 @@ func (allOf *AllOfType) References() TypeNameSet {
 	return result
 }
 
-var allOfPanicMsg = "AllOfType should have been replaced by generation time by 'convertAllOfAndOneOf' phase"
+var allOfFailureMsg = "AllOfType should have been replaced by generation time by 'convertAllOfAndOneOf' phase"
 
 // AsType always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
 func (allOf *AllOfType) AsType(_ *CodeGenerationContext) dst.Expr {
-	panic(errors.New(allOfPanicMsg))
+	panic(errors.New(allOfFailureMsg))
 }
 
 // AsDeclarations always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (allOf *AllOfType) AsDeclarations(_ *CodeGenerationContext, _ DeclarationContext) []dst.Decl {
-	panic(errors.New(allOfPanicMsg))
+func (allOf *AllOfType) AsDeclarations(
+	codeGenerationContext *CodeGenerationContext,
+	declContext DeclarationContext,
+) ([]dst.Decl, error) {
+	return nil, errors.New(allOfFailureMsg)
 }
 
 // AsZero always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
 func (allOf *AllOfType) AsZero(_ TypeDefinitionSet, _ *CodeGenerationContext) dst.Expr {
-	panic(errors.New(allOfPanicMsg))
+	panic(errors.New(allOfFailureMsg))
 }
 
 // RequiredPackageReferences always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
 func (allOf *AllOfType) RequiredPackageReferences() *PackageReferenceSet {
-	panic(errors.New(allOfPanicMsg))
+	panic(errors.New(allOfFailureMsg))
 }
 
 // Equals returns true if the other Type is a AllOf that contains

--- a/v2/tools/generator/internal/astmodel/allof_type_test.go
+++ b/v2/tools/generator/internal/astmodel/allof_type_test.go
@@ -103,6 +103,16 @@ func TestAllOfAsTypePanics(t *testing.T) {
 	}).To(PanicWith(MatchError(expectedAllOfPanic)))
 }
 
+func TestAllOfAsDeclarationsPanics(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	x := AllOfType{}
+	g.Expect(func() {
+		x.AsDeclarations(&CodeGenerationContext{}, DeclarationContext{})
+	}).To(PanicWith(MatchError(expectedAllOfPanic)))
+}
+
 func TestAllOfRequiredImportsPanics(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/v2/tools/generator/internal/astmodel/allof_type_test.go
+++ b/v2/tools/generator/internal/astmodel/allof_type_test.go
@@ -109,6 +109,7 @@ func TestAllOfAsDeclarationsPanics(t *testing.T) {
 
 	x := AllOfType{}
 	g.Expect(func() {
+		//nolint:errcheck // error will never be returned due to panic
 		x.AsDeclarations(&CodeGenerationContext{}, DeclarationContext{})
 	}).To(PanicWith(MatchError(expectedAllOfPanic)))
 }

--- a/v2/tools/generator/internal/astmodel/allof_type_test.go
+++ b/v2/tools/generator/internal/astmodel/allof_type_test.go
@@ -103,16 +103,6 @@ func TestAllOfAsTypePanics(t *testing.T) {
 	}).To(PanicWith(MatchError(expectedAllOfPanic)))
 }
 
-func TestAllOfAsDeclarationsPanics(t *testing.T) {
-	t.Parallel()
-	g := NewGomegaWithT(t)
-
-	x := AllOfType{}
-	g.Expect(func() {
-		x.AsDeclarations(&CodeGenerationContext{}, DeclarationContext{})
-	}).To(PanicWith(MatchError(expectedAllOfPanic)))
-}
-
 func TestAllOfRequiredImportsPanics(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/v2/tools/generator/internal/astmodel/array_type.go
+++ b/v2/tools/generator/internal/astmodel/array_type.go
@@ -45,8 +45,8 @@ func (array *ArrayType) WithElement(t Type) *ArrayType {
 // assert we implemented Type correctly
 var _ Type = (*ArrayType)(nil)
 
-func (array *ArrayType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
-	return AsSimpleDeclarations(codeGenerationContext, declContext, array)
+func (array *ArrayType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
+	return AsSimpleDeclarations(codeGenerationContext, declContext, array), nil
 }
 
 // AsType renders the Go abstract syntax tree for an array type

--- a/v2/tools/generator/internal/astmodel/enum_type.go
+++ b/v2/tools/generator/internal/astmodel/enum_type.go
@@ -65,7 +65,7 @@ func (enum *EnumType) WithValidation() *EnumType {
 }
 
 // AsDeclarations converts the EnumType to a series of Go AST Decls
-func (enum *EnumType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
+func (enum *EnumType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
 	result := []dst.Decl{enum.createBaseDeclaration(codeGenerationContext, declContext.Name, declContext.Description, declContext.Validations)}
 
 	specs := make([]dst.Spec, 0, len(enum.options))
@@ -83,7 +83,7 @@ func (enum *EnumType) AsDeclarations(codeGenerationContext *CodeGenerationContex
 		result = append(result, declaration)
 	}
 
-	return result
+	return result, nil
 }
 
 func (enum *EnumType) createBaseDeclaration(

--- a/v2/tools/generator/internal/astmodel/external_type_name.go
+++ b/v2/tools/generator/internal/astmodel/external_type_name.go
@@ -43,8 +43,8 @@ func (tn ExternalTypeName) PackageReference() PackageReference {
 	return tn.packageReference
 }
 
-func (tn ExternalTypeName) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
-	return AsSimpleDeclarations(codeGenerationContext, declContext, tn)
+func (tn ExternalTypeName) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
+	return AsSimpleDeclarations(codeGenerationContext, declContext, tn), nil
 }
 
 // AsType implements Type for TypeName

--- a/v2/tools/generator/internal/astmodel/flagged_type.go
+++ b/v2/tools/generator/internal/astmodel/flagged_type.go
@@ -107,8 +107,11 @@ func (ft *FlaggedType) AsType(ctx *CodeGenerationContext) dst.Expr {
 }
 
 // AsDeclarations renders as a Go abstract syntax tree for a declaration
-func (ft *FlaggedType) AsDeclarations(ctx *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
-	return ft.element.AsDeclarations(ctx, declContext)
+func (ft *FlaggedType) AsDeclarations(
+	codeGenerationContext *CodeGenerationContext,
+	declContext DeclarationContext,
+) ([]dst.Decl, error) {
+	return ft.element.AsDeclarations(codeGenerationContext, declContext)
 }
 
 // AsZero renders an expression for the "zero" value of the type

--- a/v2/tools/generator/internal/astmodel/interface_type.go
+++ b/v2/tools/generator/internal/astmodel/interface_type.go
@@ -109,7 +109,7 @@ func (i *InterfaceType) AsType(codeGenerationContext *CodeGenerationContext) dst
 	}
 }
 
-func (i *InterfaceType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
+func (i *InterfaceType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
 	declaration := &dst.GenDecl{
 		Decs: dst.GenDeclDecorations{
 			NodeDecs: dst.NodeDecs{
@@ -130,7 +130,7 @@ func (i *InterfaceType) AsDeclarations(codeGenerationContext *CodeGenerationCont
 	AddValidationComments(&declaration.Decs.Start, declContext.Validations)
 
 	result := []dst.Decl{declaration}
-	return result
+	return result, nil
 }
 
 // AsZero always panics; Interface does not have a zero type

--- a/v2/tools/generator/internal/astmodel/internal_type_name.go
+++ b/v2/tools/generator/internal/astmodel/internal_type_name.go
@@ -58,8 +58,8 @@ func (tn InternalTypeName) WithPackageReference(ref InternalPackageReference) In
 // it is simply a reference to the name.
 var _ Type = InternalTypeName{}
 
-func (tn InternalTypeName) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
-	return AsSimpleDeclarations(codeGenerationContext, declContext, tn)
+func (tn InternalTypeName) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
+	return AsSimpleDeclarations(codeGenerationContext, declContext, tn), nil
 }
 
 // AsType implements Type for TypeName

--- a/v2/tools/generator/internal/astmodel/map_type.go
+++ b/v2/tools/generator/internal/astmodel/map_type.go
@@ -63,8 +63,8 @@ func NewStringMapType(value Type) *MapType {
 // assert that we implemented Type correctly
 var _ Type = (*MapType)(nil)
 
-func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
-	return AsSimpleDeclarations(codeGenerationContext, declContext, m)
+func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
+	return AsSimpleDeclarations(codeGenerationContext, declContext, m), nil
 }
 
 // AsType implements Type for MapType to create the abstract syntax tree for a map

--- a/v2/tools/generator/internal/astmodel/object_type.go
+++ b/v2/tools/generator/internal/astmodel/object_type.go
@@ -61,7 +61,7 @@ func NewObjectType() *ObjectType {
 	}
 }
 
-func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
+func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
 	declaration := &dst.GenDecl{
 		Decs: dst.GenDeclDecorations{
 			NodeDecs: dst.NodeDecs{
@@ -92,7 +92,7 @@ func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerati
 	}
 
 	result = append(result, decls...)
-	return result
+	return result, nil
 }
 
 func (objectType *ObjectType) generateMethodDecls(

--- a/v2/tools/generator/internal/astmodel/oneof_type.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type.go
@@ -149,29 +149,32 @@ func (oneOf *OneOfType) References() TypeNameSet {
 	return result
 }
 
-var oneOfPanicMsg = "OneOfType should have been replaced by generation time by 'convertAllOfAndOneOf' phase"
+var oneOFailureMsg = "OneOfType should have been replaced by generation time by 'convertAllOfAndOneOf' phase"
 
 // AsType always panics; OneOf cannot be represented by the Go AST and must be
 // lowered to an object type
 func (oneOf *OneOfType) AsType(_ *CodeGenerationContext) dst.Expr {
-	panic(errors.New(oneOfPanicMsg))
+	panic(errors.New(oneOFailureMsg))
 }
 
 // AsDeclarations always panics; OneOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (oneOf *OneOfType) AsDeclarations(_ *CodeGenerationContext, _ DeclarationContext) []dst.Decl {
-	panic(errors.New(oneOfPanicMsg))
+func (oneOf *OneOfType) AsDeclarations(
+	codeGenerationContext *CodeGenerationContext,
+	declContext DeclarationContext,
+) ([]dst.Decl, error) {
+	return nil, errors.New(oneOFailureMsg)
 }
 
 // AsZero always panics; OneOf cannot be represented by the Go AST and must be
 // lowered to an object type
 func (oneOf *OneOfType) AsZero(_ TypeDefinitionSet, _ *CodeGenerationContext) dst.Expr {
-	panic(errors.New(oneOfPanicMsg))
+	panic(errors.New(oneOFailureMsg))
 }
 
 // RequiredPackageReferences returns the union of the required imports of all the oneOf types
 func (oneOf *OneOfType) RequiredPackageReferences() *PackageReferenceSet {
-	panic(errors.New(oneOfPanicMsg))
+	panic(errors.New(oneOFailureMsg))
 }
 
 // Equals returns true if the other Type is a OneOfType that contains

--- a/v2/tools/generator/internal/astmodel/oneof_type.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type.go
@@ -163,7 +163,7 @@ func (oneOf *OneOfType) AsDeclarations(
 	codeGenerationContext *CodeGenerationContext,
 	declContext DeclarationContext,
 ) ([]dst.Decl, error) {
-	return nil, errors.New(oneOFailureMsg)
+	panic(errors.New(oneOFailureMsg))
 }
 
 // AsZero always panics; OneOf cannot be represented by the Go AST and must be

--- a/v2/tools/generator/internal/astmodel/oneof_type_test.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type_test.go
@@ -56,6 +56,16 @@ func TestOneOfAsTypePanics(t *testing.T) {
 	}).To(PanicWith(MatchError(expectedOneOfPanic)))
 }
 
+func TestOneOfAsDeclarationsPanics(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	x := OneOfType{}
+	g.Expect(func() {
+		x.AsDeclarations(&CodeGenerationContext{}, DeclarationContext{})
+	}).To(PanicWith(MatchError(expectedOneOfPanic)))
+}
+
 func TestOneOfRequiredImportsPanics(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/v2/tools/generator/internal/astmodel/oneof_type_test.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type_test.go
@@ -56,16 +56,6 @@ func TestOneOfAsTypePanics(t *testing.T) {
 	}).To(PanicWith(MatchError(expectedOneOfPanic)))
 }
 
-func TestOneOfAsDeclarationsPanics(t *testing.T) {
-	t.Parallel()
-	g := NewGomegaWithT(t)
-
-	x := OneOfType{}
-	g.Expect(func() {
-		x.AsDeclarations(&CodeGenerationContext{}, DeclarationContext{})
-	}).To(PanicWith(MatchError(expectedOneOfPanic)))
-}
-
 func TestOneOfRequiredImportsPanics(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/v2/tools/generator/internal/astmodel/oneof_type_test.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type_test.go
@@ -62,6 +62,7 @@ func TestOneOfAsDeclarationsPanics(t *testing.T) {
 
 	x := OneOfType{}
 	g.Expect(func() {
+		//nolint:errcheck // error will never be returned due to panic
 		x.AsDeclarations(&CodeGenerationContext{}, DeclarationContext{})
 	}).To(PanicWith(MatchError(expectedOneOfPanic)))
 }

--- a/v2/tools/generator/internal/astmodel/optional_type.go
+++ b/v2/tools/generator/internal/astmodel/optional_type.go
@@ -120,8 +120,8 @@ func (optional *OptionalType) WithElement(t Type) Type {
 	return &result
 }
 
-func (optional *OptionalType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
-	return AsSimpleDeclarations(codeGenerationContext, declContext, optional)
+func (optional *OptionalType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
+	return AsSimpleDeclarations(codeGenerationContext, declContext, optional), nil
 }
 
 // AsType renders the Go abstract syntax tree for an optional type

--- a/v2/tools/generator/internal/astmodel/primitive_type.go
+++ b/v2/tools/generator/internal/astmodel/primitive_type.go
@@ -52,8 +52,11 @@ func (prim *PrimitiveType) AsType(_ *CodeGenerationContext) dst.Expr {
 	return dst.NewIdent(prim.name)
 }
 
-func (prim *PrimitiveType) AsDeclarations(genContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
-	return AsSimpleDeclarations(genContext, declContext, prim)
+func (prim *PrimitiveType) AsDeclarations(
+	codeGenerationContext *CodeGenerationContext,
+	declContext DeclarationContext,
+) ([]dst.Decl, error) {
+	return AsSimpleDeclarations(codeGenerationContext, declContext, prim), nil
 }
 
 // RequiredPackageReferences returns a list of package required by this

--- a/v2/tools/generator/internal/astmodel/resource_type.go
+++ b/v2/tools/generator/internal/astmodel/resource_type.go
@@ -582,7 +582,10 @@ func (resource *ResourceType) RequiredPackageReferences() *PackageReferenceSet {
 }
 
 // AsDeclarations converts the resource type to a set of go declarations
-func (resource *ResourceType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
+func (resource *ResourceType) AsDeclarations(
+	codeGenerationContext *CodeGenerationContext,
+	declContext DeclarationContext,
+) ([]dst.Decl, error) {
 	/*
 		start off with:
 			metav1.TypeMeta   `json:",inline"`
@@ -669,16 +672,17 @@ func (resource *ResourceType) AsDeclarations(codeGenerationContext *CodeGenerati
 
 	decls, err := resource.generateMethodDecls(codeGenerationContext, declContext.Name)
 	if err != nil {
-		// Something went wrong; once AsDeclarations is refactored to have an error return,
-		// we can return them, but in the meantime panic
-		panic(err)
+		return nil, err
 	}
 
-	declarations = append(declarations, decls...)
+	declarations = append(
+		declarations,
+		decls...)
+	declarations = append(
+		declarations,
+		resource.resourceListTypeDecls(codeGenerationContext, declContext.Name, declContext.Description)...)
 
-	declarations = append(declarations, resource.resourceListTypeDecls(codeGenerationContext, declContext.Name, declContext.Description)...)
-
-	return declarations
+	return declarations, nil
 }
 
 func (resource *ResourceType) generateMethodDecls(

--- a/v2/tools/generator/internal/astmodel/type.go
+++ b/v2/tools/generator/internal/astmodel/type.go
@@ -27,7 +27,7 @@ type Type interface {
 	AsType(codeGenerationContext *CodeGenerationContext) dst.Expr
 
 	// AsDeclarations renders as a Go abstract syntax tree for a declaration
-	AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) []dst.Decl
+	AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error)
 
 	// AsZero renders an expression for the "zero" value of the type
 	// definitions allows TypeName to resolve to the underlying type

--- a/v2/tools/generator/internal/astmodel/type_definition.go
+++ b/v2/tools/generator/internal/astmodel/type_definition.go
@@ -73,17 +73,11 @@ func (def TypeDefinition) WithName(typeName InternalTypeName) TypeDefinition {
 	return result
 }
 
-func (def TypeDefinition) AsDeclarations(codeGenerationContext *CodeGenerationContext) []dst.Decl {
+func (def TypeDefinition) AsDeclarations(codeGenerationContext *CodeGenerationContext) ([]dst.Decl, error) {
 	declContext := DeclarationContext{
 		Name:        def.name,
 		Description: def.description,
 	}
-
-	defer func() {
-		if p := recover(); p != nil {
-			panic(fmt.Sprintf("generating %s: %s", def.name, p))
-		}
-	}()
 
 	return def.theType.AsDeclarations(codeGenerationContext, declContext)
 }

--- a/v2/tools/generator/internal/astmodel/type_definition_test.go
+++ b/v2/tools/generator/internal/astmodel/type_definition_test.go
@@ -71,8 +71,8 @@ func Test_TypeDefinitionAsAst_GivenValidStruct_ReturnsNonNilResult(t *testing.T)
 
 	ref := MakeInternalTypeName(makeTestLocalPackageReference("group", "2020-01-01"), "name")
 	definition := MakeTypeDefinition(ref, NewObjectType())
-	node := definition.AsDeclarations(nil)
-
+	node, err := definition.AsDeclarations(nil)
+	g.Expect(err).To(Succeed())
 	g.Expect(node).NotTo(BeNil())
 }
 

--- a/v2/tools/generator/internal/astmodel/validated_type.go
+++ b/v2/tools/generator/internal/astmodel/validated_type.go
@@ -177,9 +177,12 @@ func (v *ValidatedType) WithType(newElement Type) *ValidatedType {
 	return &result
 }
 
-func (v *ValidatedType) AsDeclarations(c *CodeGenerationContext, declContext DeclarationContext) []dst.Decl {
+func (v *ValidatedType) AsDeclarations(
+	codeGenerationContext *CodeGenerationContext,
+	declContext DeclarationContext,
+) ([]dst.Decl, error) {
 	declContext.Validations = append(declContext.Validations, v.validations.ToKubeBuilderValidations()...)
-	return v.ElementType().AsDeclarations(c, declContext)
+	return v.ElementType().AsDeclarations(codeGenerationContext, declContext)
 }
 
 // AsType panics because validated types should always be named

--- a/v2/tools/generator/internal/conversions/property_bag_member_type.go
+++ b/v2/tools/generator/internal/conversions/property_bag_member_type.go
@@ -6,6 +6,7 @@
 package conversions
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 

--- a/v2/tools/generator/internal/conversions/property_bag_member_type.go
+++ b/v2/tools/generator/internal/conversions/property_bag_member_type.go
@@ -65,8 +65,11 @@ func (b *PropertyBagMemberType) AsType(ctx *astmodel.CodeGenerationContext) dst.
 }
 
 // AsDeclarations panics because this is a metatype that will never be rendered
-func (b *PropertyBagMemberType) AsDeclarations(_ *astmodel.CodeGenerationContext, _ astmodel.DeclarationContext) []dst.Decl {
-	panic("should never try to render a PropertyBagMemberType as declarations")
+func (b *PropertyBagMemberType) AsDeclarations(
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	declContext astmodel.DeclarationContext,
+) ([]dst.Decl, error) {
+	return nil, errors.New("should never try to render a PropertyBagMemberType into declarations")
 }
 
 // AsZero renders an expression for the "zero" value of the type

--- a/v2/tools/generator/internal/conversions/property_bag_member_type.go
+++ b/v2/tools/generator/internal/conversions/property_bag_member_type.go
@@ -70,7 +70,7 @@ func (b *PropertyBagMemberType) AsDeclarations(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	declContext astmodel.DeclarationContext,
 ) ([]dst.Decl, error) {
-	return nil, errors.New("should never try to render a PropertyBagMemberType into declarations")
+	panic(errors.New("should never try to render a PropertyBagMemberType into declarations"))
 }
 
 // AsZero renders an expression for the "zero" value of the type


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes `Type.AsDeclarations()` to allow for an error return, and removes use of **panic** for when things go predictably awry.

Part of a sequence of changes designed to remove the use of **panic** for errors that are expected because they can be triggered by external factors.

Closes #2969 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/6rIkjTllV1K7KPE7J2/giphy.gif)
