### PR TITLE
Fix for skipping job-id step in workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -240,6 +240,7 @@ jobs:
 
       - name: Get Job ID from GH API
         id: get-job-id
+        if: ${{ always() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

The step `Get Job ID from GH API` is currently being skipped if any prior step fails; this causes issues with the following step because no job id is available.

This PR changes the step to always execute.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/26n6GfmpNiRWHCqFG/giphy.gif)
