### PR TITLE
Improve test summary tool

### DIFF
--- a/v2/tools/mangle-test-json/main.go
+++ b/v2/tools/mangle-test-json/main.go
@@ -25,14 +25,6 @@ type JSONFormat struct {
 	Output  string    `json:"Output"`
 }
 
-type TestRun struct {
-	Action  string
-	Package string
-	Test    string
-	Output  []string
-	RunTime time.Duration
-}
-
 func main() {
 	log := CreateLogger()
 

--- a/v2/tools/mangle-test-json/main.go
+++ b/v2/tools/mangle-test-json/main.go
@@ -28,6 +28,11 @@ type JSONFormat struct {
 func main() {
 	log := CreateLogger()
 
+	if len(os.Args) <= 1 {
+		log.Info("No log file specified on command line.")
+		return
+	}
+
 	for _, testOutputFile := range os.Args[1:] {
 		log.Info(
 			"Parsing",

--- a/v2/tools/mangle-test-json/main.go
+++ b/v2/tools/mangle-test-json/main.go
@@ -129,48 +129,43 @@ func loadJSON(
 			"count", errCount)
 	}
 
-	// track when each test started running
-	startTimes := make(map[string]time.Time)
-	runTimes := make(map[string]time.Duration)
-	outputs := make(map[string][]string)
-	// package → list of tests
-	byPackage := make(map[string][]TestRun, len(data))
+	// Track all the test runs
+	testRuns := make(map[string]*TestRun)
 	for _, d := range data {
-		switch d.Action {
-		case "run":
-			if startTimes[d.key()] != (time.Time{}) {
-				panic("run while already running")
-			}
-			startTimes[d.key()] = d.Time
-		case "pause":
-			if startTimes[d.key()] == (time.Time{}) {
-				panic("pause while not running")
-			}
-			runTimes[d.key()] += d.Time.Sub(startTimes[d.key()])
-			startTimes[d.key()] = time.Time{}
-		case "cont":
-			// cont while still in running state happens sometimes (???)
-			// so don't check
-			startTimes[d.key()] = d.Time
-		case "output":
-			outputs[d.key()] = append(outputs[d.key()], d.Output)
-		case "pass", "fail", "skip":
-			if d.Test != "" && startTimes[d.key()] == (time.Time{}) {
-				panic("finished when not running")
-			}
 
-			runTimes[d.key()] += d.Time.Sub(startTimes[d.key()])
-
-			byPackage[d.Package] = append(byPackage[d.Package], TestRun{
-				Action:  d.Action,
+		// Find (or create) the test run for this item of data
+		testrun, found := testRuns[d.key()]
+		if !found {
+			testrun = &TestRun{
 				Package: d.Package,
 				Test:    d.Test,
-				Output:  outputs[d.key()],
+			}
 
-				// round all runtimes to ms to avoid excessive decimal places
-				RunTime: sensitiveRound(runTimes[d.key()]),
-			})
+			testRuns[d.key()] = testrun
 		}
+
+		switch d.Action {
+		case "run":
+			testrun.run(d.Time)
+
+		case "pause":
+			testrun.pause(d.Time)
+
+		case "cont":
+			testrun.resume(d.Time)
+
+		case "output":
+			testrun.output(d.Output)
+
+		case "pass", "fail", "skip":
+			testrun.complete(d.Action, d.Time)
+		}
+	}
+
+	// package → list of tests
+	byPackage := make(map[string][]TestRun, len(data))
+	for _, v := range testRuns {
+		byPackage[v.Package] = append(byPackage[v.Package], *v)
 	}
 
 	return byPackage
@@ -248,29 +243,37 @@ func printDetails(packages []string, byPackage map[string][]TestRun) {
 		}
 
 		for _, test := range tests[1:] {
-			// only printing failed tests
-			if test.Action == "fail" {
-
-				fmt.Printf("#### Test `%s`\n", test.Test)
-				fmt.Printf("Failed in %s:\n", test.RunTime)
-
-				trimmedOutput, output := escapeOutput(test.Output)
-				summary := "Test output"
-				if trimmedOutput {
-					summary += fmt.Sprintf(" (trimmed to last %d lines) — full details available in log", maxOutputLines)
-				}
-
-				fmt.Printf("<details><summary>%s</summary><pre>%s</pre></details>\n\n", summary, output)
-
-				// Output info on stderr, so that test failure isn’t silent on console
-				// when running `task ci`, and that full logs are available if they get trimmed
-				fmt.Fprintf(os.Stderr, "- Test failed: %s\n", test.Test)
-				fmt.Fprintln(os.Stderr, "=== TEST OUTPUT ===")
-				for _, outputLine := range test.Output {
-					fmt.Fprint(os.Stderr, outputLine) // note that line already has newline attached
-				}
-				fmt.Fprintln(os.Stderr, "=== END TEST OUTPUT ===")
+			// We only want to include "interesting" tests in the output
+			// "interesting" tests are ones that failed, or had a panic, or we don't know what status they have
+			if !test.IsInteresting() {
+				continue
 			}
+
+			fmt.Printf("#### Test `%s`\n", test.Test)
+
+			if test.Action == "fail" {
+				fmt.Printf("Failed in %s:\n", test.RunTime)
+			} else {
+				fmt.Printf("Elapsed %s:\n", test.RunTime)
+				fmt.Printf("Final action %s:\n", test.Action)
+			}
+
+			trimmedOutput, output := escapeOutput(test.Output)
+			summary := "Test output"
+			if trimmedOutput {
+				summary += fmt.Sprintf(" (trimmed to last %d lines) — full details available in log", maxOutputLines)
+			}
+
+			fmt.Printf("<details><summary>%s</summary><pre>%s</pre></details>\n\n", summary, output)
+
+			// Output info on stderr, so that test failure isn’t silent on console
+			// when running `task ci`, and that full logs are available if they get trimmed
+			fmt.Fprintf(os.Stderr, "- Test failed: %s\n", test.Test)
+			fmt.Fprintln(os.Stderr, "=== TEST OUTPUT ===")
+			for _, outputLine := range test.Output {
+				fmt.Fprint(os.Stderr, outputLine) // note that line already has newline attached
+			}
+			fmt.Fprintln(os.Stderr, "=== END TEST OUTPUT ===")
 		}
 
 		fmt.Println()

--- a/v2/tools/mangle-test-json/test_run.go
+++ b/v2/tools/mangle-test-json/test_run.go
@@ -5,13 +5,106 @@
 
 package main
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 // TestRun captures the details of an individual test run
 type TestRun struct {
-	Action  string
-	Package string
-	Test    string
-	Output  []string
-	RunTime time.Duration
+	Action   string
+	Package  string
+	Test     string
+	Output   []string
+	RunTime  time.Duration
+	started  *time.Time
+	hasPanic bool
+}
+
+// run is used to capture the time when a test started execution
+func (tr *TestRun) run(started time.Time) {
+	// Only record the start if we're currently running
+	if tr.started == nil {
+		tr.started = &started
+	}
+
+	tr.Action = "run"
+}
+
+// pause is used to capture the instant when a test was paused and stopped running
+func (tr *TestRun) pause(stopped time.Time) {
+	// If we're not running, panic because this is unexpected
+	if tr.started == nil {
+		msg := fmt.Sprintf(
+			"Test %s in package %s was paused when it was not running",
+			tr.Test,
+			tr.Package)
+		panic(msg)
+	}
+
+	tr.RunTime += stopped.Sub(*tr.started)
+	tr.started = nil
+	tr.Action = "pause"
+}
+
+// resume indicates the test is continuing to run
+// If we don't think we're currently running, capture the start time.
+// Yes, this is very similar implementation to run(), but the semantics are
+// different and I suspect we'll want to diverge them in the future.
+func (tr *TestRun) resume(continued time.Time) {
+	if tr.started == nil {
+		tr.started = &continued
+	}
+
+	tr.Action = "run"
+}
+
+// output adds a line of output to this test
+func (tr *TestRun) output(line string) {
+	tr.Output = append(tr.Output, line)
+
+	if strings.HasPrefix(line, "panic") {
+		tr.hasPanic = true
+	}
+}
+
+// complete captures the final result of the test
+func (tr *TestRun) complete(result string, completed time.Time) {
+	if tr.started != nil {
+		tr.RunTime += completed.Sub(*tr.started)
+		tr.started = nil
+	}
+
+	tr.RunTime = sensitiveRound(tr.RunTime)
+	tr.Action = result
+}
+
+func (tr *TestRun) IsInteresting() bool {
+	result := true
+
+	// Tests that pass, skip, or pause are not interesting
+	switch tr.Action {
+	case "pass":
+		// Tests that pass aren't interesting
+		result = false
+	case "skip":
+		// Tests that are skipped aren't interesting
+		result = false
+	case "pause":
+		// Tests that are paused aren't interesting (another test will have been responsible for the terminating the
+		// test suite before they can resume)
+		result = false
+	case "run":
+		// Tests that are running aren't interesting (another test will be responsible for the terminating the test
+		// suite while they're executing)
+		result = false
+	}
+
+	// Tests that have a panic are interesting, regardless of the result
+	if tr.hasPanic {
+		result = true
+	}
+
+	return result
 }

--- a/v2/tools/mangle-test-json/test_run.go
+++ b/v2/tools/mangle-test-json/test_run.go
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package main
+
+import "time"
+
+// TestRun captures the details of an individual test run
+type TestRun struct {
+	Action  string
+	Package string
+	Test    string
+	Output  []string
+	RunTime time.Duration
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `mangle-test-json` tool that we use to generate summaries of test results has a bug - it only lists the outcome for tests that have an explicit outcome listed in the test output.

Other tests were omitted, including:
* Tests that panic
* Tests that were paused at the time of test suite termination
* Tests that were still running at the time of test suite termination

Of these, the first (omission of tests that panic) was crucial because we had test failures where the identity of the failing test was suppressed.

Instead of tracking information about test execution and only creating a `TestRun` summary once we know the outcome of the test, we instead need to start tracking each test up front, pruning those that aren't _interesting_ once we're finished parsing.

Closes #3495

**Special notes for your reviewer**:

The use of three parallel maps, all tracking information for specific tests, was a significant code smell that prompted the non-trivial refactoring. 

Now we have a single map tracking all test runs.

The `TestRun` abstraction already existed - I've just relocated it into a dedicated file and given it functionality that was originally elsewhere. The main application then becomes a loop creating and updating these TestRuns.

**How does this PR make you feel**:

![gif](https://media.giphy.com/media/iihAyI4wUCW4FqD9jW/giphy.gif)
