### PR TITLE
Add owner-name label on resources

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reconcilers"
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/internal/resolver"
+	"github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
@@ -162,6 +163,7 @@ func (r *azureDeploymentReconcilerInstance) AddInitialResourceState(ctx context.
 		return err
 	}
 	genruntime.SetResourceID(r.Obj, armResource.GetID())
+	annotations.SetOwnedByAnnotation(r.Obj)
 	return nil
 }
 

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reconcilers"
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/internal/resolver"
-	"github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
+	"github.com/Azure/azure-service-operator/v2/pkg/common/labels"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
@@ -163,7 +163,7 @@ func (r *azureDeploymentReconcilerInstance) AddInitialResourceState(ctx context.
 		return err
 	}
 	genruntime.SetResourceID(r.Obj, armResource.GetID())
-	annotations.SetOwnedByAnnotation(r.Obj)
+	labels.SetOwnerNameLabel(r.Obj)
 	return nil
 }
 

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -164,6 +164,7 @@ func (r *azureDeploymentReconcilerInstance) AddInitialResourceState(ctx context.
 	}
 	genruntime.SetResourceID(r.Obj, armResource.GetID())
 	labels.SetOwnerNameLabel(r.Obj)
+	labels.SetOwnerGroupKindLabel(r.Obj)
 	return nil
 }
 

--- a/v2/pkg/common/annotations/annotations.go
+++ b/v2/pkg/common/annotations/annotations.go
@@ -3,15 +3,4 @@
 
 package annotations
 
-import "github.com/Azure/azure-service-operator/v2/pkg/genruntime"
-
-const (
-	PerResourceSecret = "serviceoperator.azure.com/credential-from"
-	OwnedByAnnotation = "serviceoperator.azure.com/owned-by"
-)
-
-func SetOwnedByAnnotation(obj genruntime.ARMMetaObject) {
-	if obj.Owner() != nil && obj.Owner().Name != "" {
-		genruntime.AddAnnotation(obj, OwnedByAnnotation, obj.Owner().Name)
-	}
-}
+const PerResourceSecret = "serviceoperator.azure.com/credential-from"

--- a/v2/pkg/common/annotations/annotations.go
+++ b/v2/pkg/common/annotations/annotations.go
@@ -3,4 +3,15 @@
 
 package annotations
 
-const PerResourceSecret = "serviceoperator.azure.com/credential-from"
+import "github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+
+const (
+	PerResourceSecret = "serviceoperator.azure.com/credential-from"
+	OwnedByAnnotation = "serviceoperator.azure.com/owned-by"
+)
+
+func SetOwnedByAnnotation(obj genruntime.ARMMetaObject) {
+	if obj.Owner() != nil && obj.Owner().Name != "" {
+		genruntime.AddAnnotation(obj, OwnedByAnnotation, obj.Owner().Name)
+	}
+}

--- a/v2/pkg/common/labels/labels.go
+++ b/v2/pkg/common/labels/labels.go
@@ -19,7 +19,7 @@ func SetOwnerNameLabel(obj genruntime.ARMMetaObject) {
 }
 
 func SetOwnerGroupKindLabel(obj genruntime.ARMMetaObject) {
-	if obj.Owner() != nil && obj.Owner().String() != "" {
-		genruntime.AddLabel(obj, OwnerGroupKindLabel, obj.Owner().String())
+	if obj.Owner() != nil && obj.Owner().IsKubernetesReference() {
+		genruntime.AddLabel(obj, OwnerGroupKindLabel, obj.Owner().GroupKind().String())
 	}
 }

--- a/v2/pkg/common/labels/labels.go
+++ b/v2/pkg/common/labels/labels.go
@@ -19,7 +19,7 @@ func SetOwnerNameLabel(obj genruntime.ARMMetaObject) {
 }
 
 func SetOwnerGroupKindLabel(obj genruntime.ARMMetaObject) {
-	if obj.Owner() != nil && obj.Owner().GroupKind().String() != "" {
+	if obj.Owner() != nil && obj.Owner().String() != "" {
 		genruntime.AddLabel(obj, OwnerGroupKindLabel, obj.Owner().String())
 	}
 }

--- a/v2/pkg/common/labels/labels.go
+++ b/v2/pkg/common/labels/labels.go
@@ -3,12 +3,23 @@
 
 package labels
 
-import "github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+import (
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+)
 
-const OwnerNameLabel = "serviceoperator.azure.com/owner-name"
+const (
+	OwnerNameLabel      = "serviceoperator.azure.com/owner-name"
+	OwnerGroupKindLabel = "serviceoperator.azure.com/owner-group-kind"
+)
 
 func SetOwnerNameLabel(obj genruntime.ARMMetaObject) {
 	if obj.Owner() != nil && obj.Owner().Name != "" {
 		genruntime.AddLabel(obj, OwnerNameLabel, obj.Owner().Name)
+	}
+}
+
+func SetOwnerGroupKindLabel(obj genruntime.ARMMetaObject) {
+	if obj.Owner() != nil && obj.Owner().GroupKind().String() != "" {
+		genruntime.AddLabel(obj, OwnerGroupKindLabel, obj.Owner().String())
 	}
 }

--- a/v2/pkg/common/labels/labels.go
+++ b/v2/pkg/common/labels/labels.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package labels
 
 import "github.com/Azure/azure-service-operator/v2/pkg/genruntime"

--- a/v2/pkg/common/labels/labels.go
+++ b/v2/pkg/common/labels/labels.go
@@ -1,0 +1,11 @@
+package labels
+
+import "github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+
+const OwnerNameLabel = "serviceoperator.azure.com/owner-name"
+
+func SetOwnerNameLabel(obj genruntime.ARMMetaObject) {
+	if obj.Owner() != nil && obj.Owner().Name != "" {
+		genruntime.AddLabel(obj, OwnerNameLabel, obj.Owner().Name)
+	}
+}

--- a/v2/pkg/genruntime/base_types.go
+++ b/v2/pkg/genruntime/base_types.go
@@ -84,7 +84,7 @@ type ARMOwnedMetaObject interface {
 // of empty string will result in the removal of that annotation.
 func AddAnnotation(obj MetaObject, k string, v string) {
 	annotations := obj.GetAnnotations()
-	AddToMap(annotations, v, k)
+	annotations = AddToMap(annotations, v, k)
 	obj.SetAnnotations(annotations)
 }
 
@@ -98,11 +98,11 @@ func RemoveAnnotation(obj MetaObject, k string) {
 // of empty string will result in the removal of that label.
 func AddLabel(obj MetaObject, k string, v string) {
 	labels := obj.GetLabels()
-	AddToMap(labels, v, k)
+	labels = AddToMap(labels, v, k)
 	obj.SetLabels(labels)
 }
 
-func AddToMap(labels map[string]string, v string, k string) {
+func AddToMap(labels map[string]string, v string, k string) map[string]string {
 	if labels == nil {
 		labels = map[string]string{}
 	}
@@ -112,9 +112,10 @@ func AddToMap(labels map[string]string, v string, k string) {
 	} else {
 		labels[k] = v
 	}
+	return labels
 }
 
-// RemoveAnnotation removes the specified annotation from the object
+// RemoveLabel removes the specified label from the object
 func RemoveLabel(obj MetaObject, k string) {
 	AddLabel(obj, k, "")
 }

--- a/v2/pkg/genruntime/base_types.go
+++ b/v2/pkg/genruntime/base_types.go
@@ -84,7 +84,7 @@ type ARMOwnedMetaObject interface {
 // of empty string will result in the removal of that annotation.
 func AddAnnotation(obj MetaObject, k string, v string) {
 	annotations := obj.GetAnnotations()
-	annotations = AddToMap(annotations, v, k)
+	annotations = AddToMap(annotations, k, v)
 	obj.SetAnnotations(annotations)
 }
 
@@ -98,11 +98,11 @@ func RemoveAnnotation(obj MetaObject, k string) {
 // of empty string will result in the removal of that label.
 func AddLabel(obj MetaObject, k string, v string) {
 	labels := obj.GetLabels()
-	labels = AddToMap(labels, v, k)
+	labels = AddToMap(labels, k, v)
 	obj.SetLabels(labels)
 }
 
-func AddToMap(labels map[string]string, v string, k string) map[string]string {
+func AddToMap(labels map[string]string, k string, v string) map[string]string {
 	if labels == nil {
 		labels = map[string]string{}
 	}

--- a/v2/pkg/genruntime/base_types.go
+++ b/v2/pkg/genruntime/base_types.go
@@ -84,21 +84,39 @@ type ARMOwnedMetaObject interface {
 // of empty string will result in the removal of that annotation.
 func AddAnnotation(obj MetaObject, k string, v string) {
 	annotations := obj.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	// I think this is the behavior we want...
-	if v == "" {
-		delete(annotations, k)
-	} else {
-		annotations[k] = v
-	}
+	AddToMap(annotations, v, k)
 	obj.SetAnnotations(annotations)
 }
 
 // RemoveAnnotation removes the specified annotation from the object
 func RemoveAnnotation(obj MetaObject, k string) {
 	AddAnnotation(obj, k, "")
+}
+
+// AddLabel adds the specified label to the object.
+// Empty string labels are not allowed. Attempting to add a label with a value
+// of empty string will result in the removal of that label.
+func AddLabel(obj MetaObject, k string, v string) {
+	labels := obj.GetLabels()
+	AddToMap(labels, v, k)
+	obj.SetLabels(labels)
+}
+
+func AddToMap(labels map[string]string, v string, k string) {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	// I think this is the behavior we want...
+	if v == "" {
+		delete(labels, k)
+	} else {
+		labels[k] = v
+	}
+}
+
+// RemoveAnnotation removes the specified annotation from the object
+func RemoveLabel(obj MetaObject, k string) {
+	AddLabel(obj, k, "")
 }
 
 // ARMResourceSpec is an ARM resource specification. This interface contains

--- a/v2/pkg/genruntime/base_types.go
+++ b/v2/pkg/genruntime/base_types.go
@@ -102,17 +102,17 @@ func AddLabel(obj MetaObject, k string, v string) {
 	obj.SetLabels(labels)
 }
 
-func AddToMap(labels map[string]string, k string, v string) map[string]string {
-	if labels == nil {
-		labels = map[string]string{}
+func AddToMap(m map[string]string, k string, v string) map[string]string {
+	if m == nil {
+		m = map[string]string{}
 	}
 	// I think this is the behavior we want...
 	if v == "" {
-		delete(labels, k)
+		delete(m, k)
 	} else {
-		labels[k] = v
+		m[k] = v
 	}
-	return labels
+	return m
 }
 
 // RemoveLabel removes the specified label from the object


### PR DESCRIPTION

Closes #3190 
**What this PR does / why we need it**:

This PR enables controller to add `serviceoperator.azure.com/owner-name: <OwnerName>` label at the time of adding the initial resource state

