### PR TITLE
Extend generator debug mode to export our conversion graphs

### DIFF
--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -215,7 +215,7 @@ func createAllPipelineStages(
 		// TODO: For now only used for ARM
 		pipeline.InjectOriginalVersionFunction(idFactory).UsedFor(pipeline.ARMTarget),
 		pipeline.CreateStorageTypes().UsedFor(pipeline.ARMTarget),
-		pipeline.CreateConversionGraph(configuration, astmodel.GeneratorVersion, log).UsedFor(pipeline.ARMTarget),
+		pipeline.CreateConversionGraph(configuration, astmodel.GeneratorVersion).UsedFor(pipeline.ARMTarget),
 		pipeline.RepairSkippingProperties().UsedFor(pipeline.ARMTarget),
 
 		// Need to regenerate the conversion graph in case our repairs for Skipping properties changed things

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -214,11 +214,11 @@ func createAllPipelineStages(
 		// TODO: For now only used for ARM
 		pipeline.InjectOriginalVersionFunction(idFactory).UsedFor(pipeline.ARMTarget),
 		pipeline.CreateStorageTypes().UsedFor(pipeline.ARMTarget),
-		pipeline.CreateConversionGraph(configuration, astmodel.GeneratorVersion).UsedFor(pipeline.ARMTarget),
+		pipeline.CreateConversionGraph(configuration, astmodel.GeneratorVersion, log).UsedFor(pipeline.ARMTarget),
 		pipeline.RepairSkippingProperties().UsedFor(pipeline.ARMTarget),
 
 		// Need to regenerate the conversion graph in case our repairs for Skipping properties changed things
-		pipeline.CreateConversionGraph(configuration, astmodel.GeneratorVersion).UsedFor(pipeline.ARMTarget),
+		pipeline.CreateConversionGraph(configuration, astmodel.GeneratorVersion, log).UsedFor(pipeline.ARMTarget),
 
 		pipeline.InjectOriginalVersionProperty().UsedFor(pipeline.ARMTarget),
 		pipeline.InjectPropertyAssignmentFunctions(configuration, idFactory, log).UsedFor(pipeline.ARMTarget),

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -25,6 +25,7 @@ import (
 type CodeGenerator struct {
 	configuration *config.Configuration
 	pipeline      []*pipeline.Stage
+	debugSettings *pipeline.DebugSettings
 	debugReporter *debugReporter
 }
 
@@ -269,10 +270,9 @@ func (generator *CodeGenerator) Generate(
 		"ASO Code Generator",
 		"version", version.BuildVersion)
 
-	if generator.debugReporter != nil {
+	if generator.debugSettings != nil {
 		// Generate a diagram containing our stages
-		outputFolder := generator.debugReporter.outputFolder
-		diagram := pipeline.NewPipelineDiagram(outputFolder)
+		diagram := pipeline.NewPipelineDiagram(generator.debugSettings)
 		err := diagram.WriteDiagram(generator.pipeline)
 		if err != nil {
 			return errors.Wrapf(err, "failed to generate diagram")
@@ -465,5 +465,6 @@ func (generator *CodeGenerator) IndexOfStage(id string) int {
 // groupSpecifier indicates which groups to include (may include  wildcards).
 // outputFolder specifies where to write the debug output.
 func (generator *CodeGenerator) UseDebugMode(groupSpecifier string, outputFolder string) {
-	generator.debugReporter = newDebugReporter(groupSpecifier, outputFolder)
+	generator.debugSettings = pipeline.NewDebugSettings(groupSpecifier, outputFolder)
+	generator.debugReporter = newDebugReporter(generator.debugSettings)
 }

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -371,6 +371,12 @@ func (generator *CodeGenerator) executeStage(
 			// Will be wrapped by our caller with details of the stage
 			return nil, errors.Wrapf(err, "failed to generate debug report for stage")
 		}
+
+		err = stage.RunDiagnostic(generator.debugSettings, stageNumber, newState)
+		if err != nil {
+			// Will be wrapped by our caller with details of the stage
+			return nil, errors.Wrapf(err, "failed to generate diagnostic report for stage")
+		}
 	}
 
 	return

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -219,7 +219,7 @@ func createAllPipelineStages(
 		pipeline.RepairSkippingProperties().UsedFor(pipeline.ARMTarget),
 
 		// Need to regenerate the conversion graph in case our repairs for Skipping properties changed things
-		pipeline.CreateConversionGraph(configuration, astmodel.GeneratorVersion, log).UsedFor(pipeline.ARMTarget),
+		pipeline.CreateConversionGraph(configuration, astmodel.GeneratorVersion).UsedFor(pipeline.ARMTarget),
 
 		pipeline.InjectOriginalVersionProperty().UsedFor(pipeline.ARMTarget),
 		pipeline.InjectPropertyAssignmentFunctions(configuration, idFactory, log).UsedFor(pipeline.ARMTarget),

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -291,17 +291,7 @@ func (generator *CodeGenerator) Generate(
 			return errors.Wrapf(err, "failed to execute stage %d: %s", stageNumber, stage.Description())
 		}
 
-		duration := time.Since(start).Round(time.Millisecond)
-
-		defsAdded := newState.Definitions().Except(state.Definitions())
-		defsRemoved := state.Definitions().Except(newState.Definitions())
-
-		log.Info(
-			stageDescription,
-			"elapsed", duration,
-			"added", len(defsAdded),
-			"removed", len(defsRemoved),
-			"totalDefs", len(newState.Definitions()))
+		generator.logStateChanges(start, newState, state, log, stageDescription)
 
 		state = newState
 	}
@@ -313,6 +303,26 @@ func (generator *CodeGenerator) Generate(
 	log.Info("Finished")
 
 	return nil
+}
+
+func (generator *CodeGenerator) logStateChanges(
+	start time.Time,
+	newState *pipeline.State,
+	state *pipeline.State,
+	log logr.Logger,
+	stageDescription string,
+) {
+	duration := time.Since(start).Round(time.Millisecond)
+
+	defsAdded := newState.Definitions().Except(state.Definitions())
+	defsRemoved := state.Definitions().Except(newState.Definitions())
+
+	log.Info(
+		stageDescription,
+		"elapsed", duration,
+		"added", len(defsAdded),
+		"removed", len(defsRemoved),
+		"totalDefs", len(newState.Definitions()))
 }
 
 // executeStage runs the given stage against the given state, returning the new state.

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
@@ -98,7 +98,10 @@ func CreateConversionGraph(
 				done.Add(key)
 
 				filename := filepath.Join(outputFolder, key)
-				graph.SaveTo(grp, name, filename)
+				err := graph.SaveTo(grp, name, filename)
+				if err != nil {
+					return errors.Wrapf(err, "writing conversion graph for %s", name)
+				}
 			}
 
 			return nil

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
@@ -8,10 +8,11 @@ package pipeline
 import (
 	"context"
 	"fmt"
-	"github.com/Azure/azure-service-operator/v2/internal/set"
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
+
+	"github.com/Azure/azure-service-operator/v2/internal/set"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/storage"
@@ -54,59 +55,60 @@ func CreateConversionGraph(
 			return state.WithConversionGraph(graph), nil
 		})
 
-	stage.AddDiagnostic(
-		func(settings *DebugSettings, index int, state *State) error {
-			graph := state.ConversionGraph()
-			if graph == nil {
-				return errors.New("no conversion graph available")
-			}
-
-			// Create our output folder
-			outputFolder := settings.CreateFileName(fmt.Sprintf("conversion-graph-%d", index))
-			err := os.Mkdir(outputFolder, 0700)
-			if err != nil {
-				return errors.Wrapf(err, "creating output folder for conversion graph diagnostic")
-			}
-
-			done := set.Make[string]()
-			for name, def := range state.Definitions() {
-				if name.IsARMType() {
-					// ARM types don't participate in the conversion graph
-					continue
-				}
-
-				_, isResource := astmodel.AsResourceType(def.Type())
-				_, isObject := astmodel.AsObjectType(def.Type())
-				if !isResource && !isObject {
-					// Not a resource or object, so not a type we're interested in
-					continue
-				}
-
-				if !settings.MatchesGroup(name.InternalPackageReference()) {
-					// Not a group/version we're interested in
-					continue
-				}
-
-				grp := name.InternalPackageReference().Group()
-				name := name.Name()
-				key := fmt.Sprintf("%s-%s.dot", grp, name)
-				if done.Contains(key) {
-					// We've already exported this graph
-					continue
-				}
-
-				done.Add(key)
-
-				filename := filepath.Join(outputFolder, key)
-				err := graph.SaveTo(grp, name, filename)
-				if err != nil {
-					return errors.Wrapf(err, "writing conversion graph for %s", name)
-				}
-			}
-
-			return nil
-		})
+	stage.AddDiagnostic(exportConversionGraph)
 
 	stage.RequiresPrerequisiteStages(CreateStorageTypesStageID)
 	return stage
+}
+
+func exportConversionGraph(settings *DebugSettings, index int, state *State) error {
+	graph := state.ConversionGraph()
+	if graph == nil {
+		return errors.New("no conversion graph available")
+	}
+
+	// Create our output folder
+	outputFolder := settings.CreateFileName(fmt.Sprintf("conversion-graph-%d", index))
+	err := os.Mkdir(outputFolder, 0700)
+	if err != nil {
+		return errors.Wrapf(err, "creating output folder for conversion graph diagnostic")
+	}
+
+	done := set.Make[string]()
+	for name, def := range state.Definitions() {
+		if name.IsARMType() {
+			// ARM types don't participate in the conversion graph
+			continue
+		}
+
+		_, isResource := astmodel.AsResourceType(def.Type())
+		_, isObject := astmodel.AsObjectType(def.Type())
+		if !isResource && !isObject {
+			// Not a resource or object, so not a type we're interested in
+			continue
+		}
+
+		if !settings.MatchesGroup(name.InternalPackageReference()) {
+			// Not a group/version we're interested in
+			continue
+		}
+
+		grp := name.InternalPackageReference().Group()
+		name := name.Name()
+		key := fmt.Sprintf("%s-%s.gv", grp, name)
+		if done.Contains(key) {
+			// We've already exported this graph
+			continue
+		}
+
+		done.Add(key)
+
+		filename := filepath.Join(outputFolder, key)
+		err := graph.SaveTo(grp, name, filename)
+		if err != nil {
+			return errors.Wrapf(err, "writing conversion graph for %s", name)
+		}
+	}
+
+	return nil
 }

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
@@ -7,7 +7,7 @@ package pipeline
 
 import (
 	"context"
-
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -22,7 +22,9 @@ const CreateConversionGraphStageId = "createConversionGraph"
 // convert resources to/from the designated storage (or hub) version
 func CreateConversionGraph(
 	configuration *config.Configuration,
-	generatorPrefix string) *Stage {
+	generatorPrefix string,
+	log logr.Logger,
+) *Stage {
 	stage := NewStage(
 		CreateConversionGraphStageId,
 		"Create the graph of conversions between versions of each resource group",

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/Azure/azure-service-operator/v2/internal/set"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
@@ -27,7 +26,6 @@ const CreateConversionGraphStageId = "createConversionGraph"
 func CreateConversionGraph(
 	configuration *config.Configuration,
 	generatorPrefix string,
-	log logr.Logger,
 ) *Stage {
 	stage := NewStage(
 		CreateConversionGraphStageId,

--- a/v2/tools/generator/internal/codegen/pipeline/debug_settings.go
+++ b/v2/tools/generator/internal/codegen/pipeline/debug_settings.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package pipeline
+
+import (
+	"github.com/Azure/azure-service-operator/v2/internal/util/match"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type DebugSettings struct {
+	outputFolder  string
+	groupSelector match.StringMatcher
+}
+
+// NewDebugSettings creates a new DebugSettings.
+func NewDebugSettings(groupSelector string, outputFolder string) *DebugSettings {
+	return &DebugSettings{
+		groupSelector: match.NewStringMatcher(groupSelector),
+		outputFolder:  outputFolder,
+	}
+}
+
+var dashMatcher = regexp.MustCompile("-+")
+
+// createFileName creates the filename for the debug report from the name of the stage, filtering out any characters
+// that are unsafe in filenames
+func (dr *DebugSettings) CreateFileName(name string) string {
+	// filter symbols and other unsafe characters from the stage name to generate a safe filename for the debug log
+	n := strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
+			return r
+		}
+
+		return '-'
+	}, name)
+
+	// Replace any sequence of dashes with a single one using a regular expression
+	n = dashMatcher.ReplaceAllString(n, "-")
+
+	return filepath.Join(dr.outputFolder, n)
+}
+
+// MatchesGroup returns true if the InternalPackageReference matches the groupSelector.
+func (ds *DebugSettings) MatchesGroup(ref astmodel.InternalPackageReference) bool {
+	grp, ver := ref.GroupVersion()
+	return ds.groupSelector.Matches(grp).Matched || ds.groupSelector.Matches(grp+"/"+ver).Matched
+}

--- a/v2/tools/generator/internal/codegen/pipeline/pipeline_diagram.go
+++ b/v2/tools/generator/internal/codegen/pipeline/pipeline_diagram.go
@@ -24,9 +24,9 @@ type PipelineDiagram struct {
 }
 
 // NewPipelineDiagram creates a new PipelineDiagram to write into the specified directory.
-func NewPipelineDiagram(debugDir string) *PipelineDiagram {
+func NewPipelineDiagram(settings *DebugSettings) *PipelineDiagram {
 	return &PipelineDiagram{
-		debugDir:   debugDir,
+		debugDir:   settings.outputFolder,
 		stageIds:   make(map[*Stage]string, 70),
 		stageNames: make(map[string][]*Stage, 70),
 	}

--- a/v2/tools/generator/internal/codegen/pipeline/stage.go
+++ b/v2/tools/generator/internal/codegen/pipeline/stage.go
@@ -27,7 +27,7 @@ type Stage struct {
 	// Stage implementation
 	action stageAction
 	// Optional diagnostic generator
-	diagnostic diagnosticAction
+	diagnostic DiagnosticAction
 	// Tag used for filtering
 	targets []Target
 	// Identifiers for other stages that must be completed before this one
@@ -38,7 +38,7 @@ type Stage struct {
 
 type stageAction func(context.Context, *State) (*State, error)
 
-type diagnosticAction func(settings *DebugSettings, index int, state *State) error
+type DiagnosticAction func(settings *DebugSettings, index int, state *State) error
 
 // NewStage creates a new pipeline stage that's ready for execution
 func NewStage(
@@ -271,6 +271,6 @@ func (stage *Stage) Targets() []Target {
 
 // AddDiagnostic specifies a diagnostic generator for this stage.
 // The generator will be used if the generator is run with a --debug flag`
-func (stage *Stage) AddDiagnostic(diagnostic diagnosticAction) {
+func (stage *Stage) AddDiagnostic(diagnostic DiagnosticAction) {
 	stage.diagnostic = diagnostic
 }

--- a/v2/tools/generator/internal/codegen/pipeline/stage.go
+++ b/v2/tools/generator/internal/codegen/pipeline/stage.go
@@ -25,7 +25,9 @@ type Stage struct {
 	// Description of the stage to use when logging
 	description string
 	// Stage implementation
-	action func(context.Context, *State) (*State, error)
+	action stageAction
+	// Optional diagnostic generator
+	diagnostic diagnosticAction
 	// Tag used for filtering
 	targets []Target
 	// Identifiers for other stages that must be completed before this one
@@ -33,6 +35,10 @@ type Stage struct {
 	// Identifiers for other stages that must be completed after this one
 	postrequisites []string
 }
+
+type stageAction func(context.Context, *State) (*State, error)
+
+type diagnosticAction func(settings *DebugSettings, index int, state *State) error
 
 // NewStage creates a new pipeline stage that's ready for execution
 func NewStage(
@@ -204,6 +210,15 @@ func (stage *Stage) Run(ctx context.Context, state *State) (*State, error) {
 	return resultState.WithSeenStage(stage.id), nil
 }
 
+// RunDiagnostic triggers our attached diagnostic generator, if any
+func (stage *Stage) RunDiagnostic(settings *DebugSettings, index int, state *State) error {
+	if stage.diagnostic == nil {
+		return nil
+	}
+
+	return stage.diagnostic(settings, index, state)
+}
+
 // checkPreconditions checks to ensure the preconditions of this stage have been satisfied
 func (stage *Stage) checkPreconditions(state *State) error {
 	if err := stage.checkPrerequisites(state); err != nil {
@@ -252,4 +267,10 @@ func (stage *Stage) Postrequisites() []string {
 // If no targets are returned, this stage should always be used
 func (stage *Stage) Targets() []Target {
 	return stage.targets
+}
+
+// AddDiagnostic specifies a diagnostic generator for this stage.
+// The generator will be used if the generator is run with a --debug flag`
+func (stage *Stage) AddDiagnostic(diagnostic diagnosticAction) {
+	stage.diagnostic = diagnostic
 }

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph.go
@@ -6,7 +6,9 @@
 package storage
 
 import (
+	"bytes"
 	"github.com/pkg/errors"
+	"io"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -165,4 +167,24 @@ func (graph *ConversionGraph) FindNextProperty(
 	//TODO: property renaming support goes here (when implemented)
 
 	return astmodel.MakePropertyReference(nextType, ref.Property()), nil
+}
+
+func (graph *ConversionGraph) String(group string, kind string) (string, error) {
+	var content bytes.Buffer
+	err := graph.WriteTo(group, kind, &content)
+	if err != nil {
+		return "", errors.Wrapf(err, "writing conversion graph")
+	}
+
+	return content.String(), nil
+}
+
+// WriteTo gives a debug dump of the conversion graph for a particular type name
+func (graph *ConversionGraph) WriteTo(group string, kind string, writer io.Writer) error {
+	subgraph, ok := graph.subGraphs[group]
+	if !ok {
+		return nil
+	}
+
+	return subgraph.WriteTo(kind, writer)
 }

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"github.com/pkg/errors"
 	"io"
+	"os"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -177,6 +178,22 @@ func (graph *ConversionGraph) String(group string, kind string) (string, error) 
 	}
 
 	return content.String(), nil
+}
+
+func (graph *ConversionGraph) SaveTo(group string, kind string, filename string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return errors.Wrapf(err, "creating %s", filename)
+	}
+
+	defer file.Close()
+
+	err = graph.WriteTo(group, kind, file)
+	if err != nil {
+		return errors.Wrapf(err, "writing conversion graph to %s", filename)
+	}
+
+	return nil
 }
 
 // WriteTo gives a debug dump of the conversion graph for a particular type name

--- a/v2/tools/generator/internal/codegen/storage/group_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/group_conversion_graph.go
@@ -7,6 +7,7 @@ package storage
 
 import (
 	"github.com/pkg/errors"
+	"io"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -87,4 +88,14 @@ func (graph *GroupConversionGraph) searchForRenamedType(
 	// Didn't find the type we're looking for
 	return astmodel.InternalTypeName{},
 		errors.Errorf("rename of %s invalid because no type with name %s was found in any later version", name, rename)
+}
+
+// WriteTo gives a debug dump of the conversion graph for a particular type name
+func (graph *GroupConversionGraph) WriteTo(kind string, writer io.Writer) error {
+	subgraph, ok := graph.subGraphs[kind]
+	if !ok {
+		return nil
+	}
+
+	return subgraph.WriteTo(writer)
 }

--- a/v2/tools/generator/internal/codegen/storage/property_converter.go
+++ b/v2/tools/generator/internal/codegen/storage/property_converter.go
@@ -117,7 +117,7 @@ func (p *PropertyConverter) shortCircuitNamesOfSimpleTypes(
 	return tv.Visit(actualType, ctx)
 }
 
-func (_ *PropertyConverter) tryConvertToStoragePackage(name astmodel.InternalTypeName) (astmodel.InternalTypeName, bool) {
+func (*PropertyConverter) tryConvertToStoragePackage(name astmodel.InternalTypeName) (astmodel.InternalTypeName, bool) {
 	// Map the type name into our storage package
 	localRef := name.InternalPackageReference()
 

--- a/v2/tools/generator/internal/codegen/storage/resource_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/resource_conversion_graph.go
@@ -6,6 +6,14 @@
 package storage
 
 import (
+	"fmt"
+	"github.com/Azure/azure-service-operator/v2/internal/set"
+	"io"
+
+	"github.com/pkg/errors"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
 
@@ -25,4 +33,137 @@ func (graph *ResourceConversionGraph) LookupTransition(name astmodel.InternalTyp
 // TransitionCount returns the number of transitions in the graph
 func (graph *ResourceConversionGraph) TransitionCount() int {
 	return len(graph.links)
+}
+
+// WriteTo gives a debug dump of the conversion graph for a particular type name
+func (graph *ResourceConversionGraph) WriteTo(writer io.Writer) error {
+	linkStarts := maps.Keys(graph.links)
+	slices.SortFunc(linkStarts, func(left astmodel.InternalTypeName, right astmodel.InternalTypeName) int {
+		l := left.InternalPackageReference().FolderPath()
+		r := right.InternalPackageReference().FolderPath()
+		if l < r {
+			return -1
+		}
+
+		if l > r {
+			return 1
+		}
+
+		return 0
+	})
+
+	apiVersions := set.Make[string]()
+	storageVersions := set.Make[string]()
+
+	// API versions can be identified because they are only ever the start of a link (never the end)
+	// This initial list will have too many items in it, but we'll reduce it down later
+	for from, _ := range graph.links {
+		ver := from.InternalPackageReference().ImportAlias(astmodel.VersionOnly)
+		apiVersions.Add(ver)
+	}
+
+	// Everything else is a storage version
+	for _, to := range graph.links {
+		ver := to.InternalPackageReference().ImportAlias(astmodel.VersionOnly)
+		storageVersions.Add(ver)
+		apiVersions.Remove(ver)
+	}
+
+	// Write out a graphviz file
+	err := graph.WriteLines(
+		writer,
+		"graph G {",
+		"    rankdir=LR;",
+		"",
+		"    subgraph apiversions {",
+		"        rank=same;",
+		"        node [shape=ellipse, style=dashed, penwidth=1, rankType=min, group=storage];",
+	)
+	if err != nil {
+		return errors.Wrapf(err, "writing graph header")
+	}
+
+	err = graph.WriteVersions(writer, apiVersions)
+	if err != nil {
+		return errors.Wrapf(err, "writing graph apiversions")
+	}
+
+	err = graph.WriteLines(
+		writer,
+		"    }",
+		"",
+		"    subgraph storageversions {",
+		"        rank=same;",
+		"        node [shape=ellipse, style=dashed, penwidth=1, rankType=min, group=storage];",
+	)
+	if err != nil {
+		return errors.Wrapf(err, "writing graph midsection")
+	}
+
+	err = graph.WriteVersions(writer, storageVersions)
+	if err != nil {
+		return errors.Wrapf(err, "writing graph storageversions")
+	}
+
+	err = graph.WriteLines(
+		writer,
+		"    }",
+		"",
+		"    edge [arrowhead=vee, arrowtail=vee, dir=forward];",
+	)
+	if err != nil {
+		return errors.Wrapf(err, "writing graph endsection")
+	}
+
+	err = graph.writeLinks(writer, linkStarts)
+	if err != nil {
+		return errors.Wrapf(err, "writing graph links")
+	}
+
+	err = graph.WriteLines(
+		writer,
+		"}",
+	)
+	if err != nil {
+		return errors.Wrapf(err, "writing graph end")
+	}
+
+	return nil
+}
+
+func (graph *ResourceConversionGraph) writeLinks(writer io.Writer, linkStarts []astmodel.InternalTypeName) error {
+	var lines []string
+	for _, from := range linkStarts {
+		to := graph.links[from]
+
+		f := from.InternalPackageReference().ImportAlias(astmodel.VersionOnly)
+		t := to.InternalPackageReference().ImportAlias(astmodel.VersionOnly)
+
+		line := fmt.Sprintf("    %s -- %s", f, t)
+		lines = append(lines, line)
+	}
+
+	return graph.WriteLines(writer, lines...)
+}
+
+func (graph *ResourceConversionGraph) WriteLines(writer io.Writer, lines ...string) error {
+	for _, line := range lines {
+		_, err := io.WriteString(writer, line+"\n")
+		if err != nil {
+			return errors.Wrapf(err, "writing %q to writer", line)
+		}
+	}
+
+	return nil
+}
+
+func (graph *ResourceConversionGraph) WriteVersions(writer io.Writer, versions set.Set[string]) error {
+	lines := versions.Values()
+	slices.SortFunc(lines, astmodel.ComparePathAndVersion)
+
+	for i, line := range lines {
+		lines[i] = fmt.Sprintf("        %q;", line)
+	}
+
+	return graph.WriteLines(writer, lines...)
 }

--- a/v2/tools/generator/internal/codegen/storage/resource_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/resource_conversion_graph.go
@@ -7,8 +7,9 @@ package storage
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/v2/internal/set"
 	"io"
+
+	"github.com/Azure/azure-service-operator/v2/internal/set"
 
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
@@ -26,7 +27,7 @@ type ResourceConversionGraph struct {
 // LookupTransition accepts a type name and looks up the transition to the next version in the graph
 // Returns the next version, or an empty type name if not.
 func (graph *ResourceConversionGraph) LookupTransition(name astmodel.InternalTypeName) astmodel.InternalTypeName {
-	next, _ := graph.links[name]
+	next := graph.links[name]
 	return next
 }
 
@@ -72,6 +73,8 @@ func (graph *ResourceConversionGraph) WriteTo(writer io.Writer) error {
 	// Write out a graphviz file
 	err := graph.WriteLines(
 		writer,
+		"# Render with Graphviz using dot",
+		"# or try https://dreampuf.github.io/GraphvizOnline/",
 		"graph G {",
 		"    rankdir=LR;",
 		"",

--- a/v2/tools/generator/internal/codegen/storage/resource_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/resource_conversion_graph.go
@@ -57,7 +57,7 @@ func (graph *ResourceConversionGraph) WriteTo(writer io.Writer) error {
 
 	// API versions can be identified because they are only ever the start of a link (never the end)
 	// This initial list will have too many items in it, but we'll reduce it down later
-	for from, _ := range graph.links {
+	for from := range graph.links {
 		ver := from.InternalPackageReference().ImportAlias(astmodel.VersionOnly)
 		apiVersions.Add(ver)
 	}
@@ -132,7 +132,7 @@ func (graph *ResourceConversionGraph) WriteTo(writer io.Writer) error {
 }
 
 func (graph *ResourceConversionGraph) writeLinks(writer io.Writer, linkStarts []astmodel.InternalTypeName) error {
-	var lines []string
+	lines := make([]string, 0, len(linkStarts))
 	for _, from := range linkStarts {
 		to := graph.links[from]
 

--- a/v2/tools/generator/internal/codegen/storage/testdata/TestGolden_ConversionGraph_WhenCompatPackagePresent_HasExpectedTransitions.golden
+++ b/v2/tools/generator/internal/codegen/storage/testdata/TestGolden_ConversionGraph_WhenCompatPackagePresent_HasExpectedTransitions.golden
@@ -1,0 +1,24 @@
+graph G {
+    rankdir=LR;
+
+    subgraph apiversions {
+        rank=same;
+        node [shape=ellipse, style=dashed, penwidth=1, rankType=min, group=storage];
+        "v20200101";
+        "v20220101";
+    }
+
+    subgraph storageversions {
+        rank=same;
+        node [shape=ellipse, style=dashed, penwidth=1, rankType=min, group=storage];
+        "v20200101s";
+        "v20200101sc";
+        "v20220101s";
+    }
+
+    edge [arrowhead=vee, arrowtail=vee, dir=forward];
+    v20200101 -- v20200101s
+    v20200101s -- v20200101sc
+    v20200101sc -- v20220101s
+    v20220101 -- v20220101s
+}

--- a/v2/tools/generator/internal/codegen/storage/testdata/TestGolden_ConversionGraph_WhenCompatPackagePresent_HasExpectedTransitions.golden
+++ b/v2/tools/generator/internal/codegen/storage/testdata/TestGolden_ConversionGraph_WhenCompatPackagePresent_HasExpectedTransitions.golden
@@ -1,3 +1,5 @@
+# Render with Graphviz using dot
+# or try https://dreampuf.github.io/GraphvizOnline/
 graph G {
     rankdir=LR;
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends the debug mode of the code generator (triggered by using the `--debug` command line option) so that our conversion graphs are also exported for review.

The graphs are exported in GraphViz `dot` format, suitable for dropping into [GraphViz Online](https://dreampuf.github.io/GraphvizOnline) or for local use.

Sample output:

``` dot
graph G {
    rankdir=LR;

    subgraph apiversions {
        rank=same;
        node [shape=ellipse, style=dashed, penwidth=1, rankType=min, group=storage];
        "v20210501";
        "v20230201";
        "v20230202p";
    }

    subgraph storageversions {
        rank=same;
        node [shape=ellipse, style=dashed, penwidth=1, rankType=min, group=storage];
        "v20210501s";
        "v20230201s";
        "v20230202ps";
    }

    edge [arrowhead=vee, arrowtail=vee, dir=forward];
    v20210501 -- v20210501s
    v20210501s -- v20230201s
    v20230201 -- v20230201s
    v20230202p -- v20230202ps
    v20230202ps -- v20230201s
}
```

which produces this graph:
![image](https://github.com/Azure/azure-service-operator/assets/1272094/3ebf66e6-3d42-46a6-8078-6577c7a9f2a5)

**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/3iBcMfGoHJ6KNplykY/giphy.gif)

