### PR TITLE
Improve validation to catch use of armID as name

### DIFF
--- a/v2/internal/resolver/resolver.go
+++ b/v2/internal/resolver/resolver.go
@@ -172,7 +172,7 @@ func (r *Resolver) ResolveReference(ctx context.Context, ref genruntime.Namespac
 			// Check if the user has mistakenly put the armID in 'name' field
 			_, err1 := arm.ParseResourceID(ref.Name)
 			if err1 == nil {
-				return nil, errors.Errorf("couldn't resolve reference %s. Name looks like it might be an ARM ID; did you mean 'armID: %s'?", refNamespacedName, ref.Name)
+				return nil, errors.Errorf("couldn't resolve reference %s. 'name' looks like it might be an ARM ID; did you mean 'armID: %s'?", refNamespacedName.String(), ref.Name)
 			}
 			err := core.NewReferenceNotFoundError(refNamespacedName, err)
 			return nil, errors.WithStack(err)

--- a/v2/internal/resolver/resolver_test.go
+++ b/v2/internal/resolver/resolver_test.go
@@ -464,10 +464,10 @@ func Test_ResolveReference_ReturnsErrorIfReferenceContainsArmIdAsName(t *testing
 	_, err = test.resolver.ResolveReference(ctx, ref.AsNamespacedRef(testNamespace))
 
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Message).To(ContainSubstring("couldn't resolve reference"))
-	g.Expect(err.Message).To(ContainSubstring(fmt.Sprintf("%s/%s", testNamespace, armID))	
-	g.Expect(err.Message).To(ContainSubstring("did you mean 'armID:'))
-	g.Expect(err.Message).To(ContainSubstring(armID)
+	g.Expect(err.Error()).To(ContainSubstring("couldn't resolve reference"))
+	g.Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("%s/%s", testNamespace, armID)))
+	g.Expect(err.Error()).To(ContainSubstring("did you mean 'armID:"))
+	g.Expect(err.Error()).To(ContainSubstring(armID))
 }
 
 func Test_ResolveReferenceToARMID_KubernetesResource_ReturnsExpectedID(t *testing.T) {

--- a/v2/internal/resolver/resolver_test.go
+++ b/v2/internal/resolver/resolver_test.go
@@ -464,7 +464,10 @@ func Test_ResolveReference_ReturnsErrorIfReferenceContainsArmIdAsName(t *testing
 	_, err = test.resolver.ResolveReference(ctx, ref.AsNamespacedRef(testNamespace))
 
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err).To(MatchError(fmt.Sprintf("couldn't resolve reference %s/%s. 'name' looks like it might be an ARM ID; did you mean 'armID: %s'?", testNamespace, armID, armID)))
+	g.Expect(err.Message).To(ContainSubstring("couldn't resolve reference"))
+	g.Expect(err.Message).To(ContainSubstring(fmt.Sprintf("%s/%s", testNamespace, armID))	
+	g.Expect(err.Message).To(ContainSubstring("did you mean 'armID:'))
+	g.Expect(err.Message).To(ContainSubstring(armID)
 }
 
 func Test_ResolveReferenceToARMID_KubernetesResource_ReturnsExpectedID(t *testing.T) {


### PR DESCRIPTION

Closes #3019 

**What this PR does / why we need it**:

This PR adds validation to `ResolveReference` method to catch if the name provided is an armID and output an error message with suggestion. 

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
