### PR TITLE
Remove generation of UniqueItems validation

### DIFF
--- a/v2/tools/generator/internal/astmodel/kubebuilder_validations.go
+++ b/v2/tools/generator/internal/astmodel/kubebuilder_validations.go
@@ -149,10 +149,6 @@ func MakeMaxItemsValidation(length int64) KubeBuilderValidation {
 	return KubeBuilderValidation{MaxItemsValidationName, length}
 }
 
-func MakeUniqueItemsValidation() KubeBuilderValidation {
-	return KubeBuilderValidation{UniqueItemsValidationName, true}
-}
-
 func MakeMaximumValidation(value *big.Rat) KubeBuilderValidation {
 	if value.IsInt() {
 		return KubeBuilderValidation{MaximumValidationName, value.RatString()}

--- a/v2/tools/generator/internal/astmodel/validated_type.go
+++ b/v2/tools/generator/internal/astmodel/validated_type.go
@@ -15,13 +15,8 @@ import (
 )
 
 type ArrayValidations struct {
-	MaxItems    *int64
-	MinItems    *int64
-	UniqueItems bool
-	/*
-		maxContains *int
-		minContains *int
-	*/
+	MaxItems *int64
+	MinItems *int64
 }
 
 func (av ArrayValidations) Equals(other Validations) bool {
@@ -31,8 +26,7 @@ func (av ArrayValidations) Equals(other Validations) bool {
 	}
 
 	return equalOptionalInt64s(av.MaxItems, o.MaxItems) &&
-		equalOptionalInt64s(av.MinItems, o.MinItems) &&
-		av.UniqueItems == o.UniqueItems
+		equalOptionalInt64s(av.MinItems, o.MinItems)
 }
 
 func (av ArrayValidations) ToKubeBuilderValidations() []KubeBuilderValidation {
@@ -43,10 +37,6 @@ func (av ArrayValidations) ToKubeBuilderValidations() []KubeBuilderValidation {
 
 	if av.MinItems != nil {
 		result = append(result, MakeMinItemsValidation(*av.MinItems))
-	}
-
-	if av.UniqueItems {
-		result = append(result, MakeUniqueItemsValidation())
 	}
 
 	return result

--- a/v2/tools/generator/internal/codegen/testdata/Validations/Validate_property_type.golden
+++ b/v2/tools/generator/internal/codegen/testdata/Validations/Validate_property_type.golden
@@ -13,7 +13,6 @@ type Test struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxItems=2
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:UniqueItems=true
 	Apple []float64 `json:"apple,omitempty"`
 
 	// +kubebuilder:validation:Required

--- a/v2/tools/generator/internal/codegen/testdata/Validations/Validate_property_type.json
+++ b/v2/tools/generator/internal/codegen/testdata/Validations/Validate_property_type.json
@@ -18,7 +18,6 @@
             "type": "array",
             "minItems": 1,
             "maxItems": 2,
-            "uniqueItems": true,
             "items": {"type":"number"}
         },
         "sun": {

--- a/v2/tools/generator/internal/jsonast/jsonast.go
+++ b/v2/tools/generator/internal/jsonast/jsonast.go
@@ -846,13 +846,11 @@ func arrayHandler(ctx context.Context, scanner *SchemaScanner, schema Schema, lo
 func withArrayValidations(schema Schema, t *astmodel.ArrayType) astmodel.Type {
 	maxItems := schema.maxItems()
 	minItems := schema.minItems()
-	uniqueItems := schema.uniqueItems()
 
-	if maxItems != nil || minItems != nil || uniqueItems {
+	if maxItems != nil || minItems != nil {
 		return astmodel.NewValidatedType(t, astmodel.ArrayValidations{
-			MaxItems:    maxItems,
-			MinItems:    minItems,
-			UniqueItems: uniqueItems,
+			MaxItems: maxItems,
+			MinItems: minItems,
 		})
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We've had this implemented for a long time, and have never used it before.

During import of a new version of ManagedCluster (see #3629), I got this error during testing:

```
Forbidden: uniqueItems cannot be set to true since the runtime complexity becomes quadratic
```

Turns out this potential validation is now [forbidden by Kubernetes](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/):

> The field uniqueItems cannot be set to true.

Since we can't use it, I'm removing it from the generator.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/A06UFEx8jxEwU/giphy.gif)
