### PR TITLE
Fix docs link

### DIFF
--- a/docs/hugo/content/design/ADR-2022-09-Reading-Status-Properties-Of-Resources.md
+++ b/docs/hugo/content/design/ADR-2022-09-Reading-Status-Properties-Of-Resources.md
@@ -272,7 +272,7 @@ Cons:
 
 #### Implementation
 
-For doing dynamic serialization, see the [go-task](https://github.com/go-task/task/blob/master/taskfile/var.go) example
+For doing dynamic serialization, see the [go-task](https://github.com/go-task/task/blob/master/taskfile/ast/var.go) example
 which does this.
 
 ## Decision


### PR DESCRIPTION


**What this PR does / why we need it**:

Minor fix for docs link reference for `Taskfile` project
