### PR TITLE
Allow newer versions of Go than we require in dev.sh

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -103,10 +103,21 @@ fi
 GOVER=$(go version)
 write-info "Go version: ${GOVER[*]}"
 
+GOVERREGEX=".*go1.([0-9]+).([0-9]+).*"
 GOVERREQUIRED="go1.20.*"
 GOVERACTUAL=$(go version | { read _ _ ver _; echo "$ver"; })
-if ! [[ "$GOVERACTUAL" =~ $GOVERREQUIRED ]]; then
-    write-error "Go must be version $GOVERREQUIRED, not $GOVERACTUAL; see : https://golang.org/doc/install"
+
+if ! [[ $GOVERACTUAL =~ $GOVERREGEX ]]; then
+    write-error "Unexpected Go version format: $GOVERACTUAL"
+    exit 1
+fi
+
+GOMINORVER="${BASH_REMATCH[1]}"
+GOMINORREQUIRED=20
+
+# We allow for Go versions above the min version, but prevent versions below. This is safe given Go's back-compat guarantees
+if ! [[ $GOMINORVER -ge $GOMINORREQUIRED ]]; then
+    write-error "Go must be version 1.$GOMINORREQUIRED, not $GOVERACTUAL; see : https://golang.org/doc/install"
     exit 1
 fi
 


### PR DESCRIPTION
This should be safe given Go's compatibility guarantees and it makes using ASO easier with dev.sh and other Go projects which may have moved to a newer Go version before we did easier.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
