### PR TITLE
docs: Link to repo health when shallow clone is used

### DIFF
--- a/scripts/v2/build_version.py
+++ b/scripts/v2/build_version.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
         # Failure may be because there are no tags, give the user some hints
         print(f"git describe failed ({git_describe.returncode}): {git_describe.stderr}", file=sys.stderr)
         print("(Do you have a shallow clone of ASO? try `git fetch --unshallow`)", file=sys.stderr)
-        print("(See https://azure.github.io/azure-service-operator/contributing/ )", file=sys.stderr)
+        print("(See https://azure.github.io/azure-service-operator/contributing/ and https://azure.github.io/azure-service-operator/contributing/developer-setup/#troubleshooting-repo-health )", file=sys.stderr)
         sys.exit(1)
 
     git_version = git_describe.stdout.strip()


### PR DESCRIPTION
**What this PR does / why we need it**:

Point to most specific content to resolve shallow clones of repos, for example a GitHub Codespace.

**Special notes for your reviewer**:
Happy to replace the existing link.

**How does this PR make you feel**:
![](https://media0.giphy.com/media/UyPpKZScnl7na/giphy.gif?cid=ecf05e479rf3toalwwy25p6gmca4p3t1bxql1kozgqg32xtf&ep=v1_gifs_search&rid=giphy.gif&ct=g)

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains tests
