### PR TITLE
Contributing: arm64 support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,9 @@
 # This is pinned to a particular version of go:
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-1.20
 
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETARCH
+
 # APT dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
@@ -32,7 +35,7 @@ RUN setup-envtest use 1.27.1 --bin-dir /usr/local/envtest/bin
 # (entrypoint is only run on start, not on exec). Due to that, the following approaches do not work:
 # - ~/.bashrc - only works for one user in a shell but we must support -u $(id -u ${USER}):$(id -g ${USER}) which means the container could run as more than 1 user
 # - /etc/profile or /etc/profile.d - only works for one user in a login shell
-ENV KUBEBUILDER_ASSETS=/usr/local/envtest/bin/k8s/1.27.1-linux-amd64
+ENV KUBEBUILDER_ASSETS=/usr/local/envtest/bin/k8s/1.27.1-linux-${TARGETARCH}
 ENV PATH=$KUBEBUILDER_ASSETS:$PATH
 
 # Make kubectl completions work with 'k' alias

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -255,7 +255,7 @@ fi
 # Install yq
 #doc# | YQ | v4.13.0 | https://github.com/mikefarah/yq/ |
 yq_version=v4.13.0
-yq_binary=yq_linux_amd64
+yq_binary=yq_${os}_${arch}
 write-verbose "Checking for $TOOL_DEST/yq"
 if should-install "$TOOL_DEST/yq"; then 
     write-info "Installing yq..."

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -36,7 +36,7 @@ set -eu
 # Be sure to use include the `#doc#` prefix on each line.
 #
 
-VERBOSE=true
+VERBOSE=false
 SKIP=false
 DEVCONTAINER=false
 
@@ -87,7 +87,9 @@ if [ "$DEVCONTAINER" = true ]; then
     BUILDX_DEST=/usr/lib/docker/cli-plugins
 else
     TOOL_DEST=$(git rev-parse --show-toplevel)/hack/tools
+    CROSSPLANE_CONFIG_DIR=$(git rev-parse --show-toplevel)/hack/crossplane/config
     mkdir -p "$TOOL_DEST"
+    mkdir -p "$CROSSPLANE_CONFIG_DIR"
     KUBEBUILDER_DEST="$TOOL_DEST/kubebuilder"
     BUILDX_DEST=$HOME/.docker/cli-plugins
 fi
@@ -139,7 +141,7 @@ write-verbose "Installing tools to $TOOL_DEST"
 TMPDIR=$(mktemp -d)
 clean() { 
     # Macos wants different flag order
-    if [[ ${os} == "darwin" ]]; then 
+    if [[ ${os} == "darwin" ]]; then
         chmod -R +w "$TMPDIR"
     else
         chmod +w -R "$TMPDIR"
@@ -233,7 +235,7 @@ fi
 write-verbose "Checking for $TOOL_DEST/trivy"
 if should-install "$TOOL_DEST/trivy"; then
     write-info "Installing trivy"
-    # This guys decided to use different naming conventions for os and arch despite trivy is 98.6% written in Go
+    # This guys decided to use different naming conventions for os(go env GOOS) and arch(go env GOARCH) despite trivy is 98.6% written in Go
     # This fixes macos arm64 architechture. Every other os/arch is named differently. Consider adding a workaround of your own ¯\_(ツ)_/¯
     if [[ ${os} == "darwin" ]] && [[ ${arch} == "arm64" ]]; then
         curl -sL "https://github.com/aquasecurity/trivy/releases/download/v0.37.3/trivy_0.37.3_macOS-ARM64.tar.gz" | tar xz -C "$TOOL_DEST" trivy

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -87,9 +87,7 @@ if [ "$DEVCONTAINER" = true ]; then
     BUILDX_DEST=/usr/lib/docker/cli-plugins
 else
     TOOL_DEST=$(git rev-parse --show-toplevel)/hack/tools
-    CROSSPLANE_CONFIG_DIR=$(git rev-parse --show-toplevel)/hack/crossplane/config
     mkdir -p "$TOOL_DEST"
-    mkdir -p "$CROSSPLANE_CONFIG_DIR"
     KUBEBUILDER_DEST="$TOOL_DEST/kubebuilder"
     BUILDX_DEST=$HOME/.docker/cli-plugins
 fi

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -36,7 +36,7 @@ set -eu
 # Be sure to use include the `#doc#` prefix on each line.
 #
 
-VERBOSE=false
+VERBOSE=true
 SKIP=false
 DEVCONTAINER=false
 
@@ -121,6 +121,10 @@ if ! [[ $GOMINORVER -ge $GOMINORREQUIRED ]]; then
     exit 1
 fi
 
+# Define os and arch
+os=$(go env GOOS)
+arch=$(go env GOARCH)
+
 # Ensure we have AZ
 
 #doc# | AZ | latest | https://docs.microsoft.com/en-us/cli/azure/install-azure-cli |
@@ -134,7 +138,12 @@ write-verbose "Installing tools to $TOOL_DEST"
 # Install Go tools
 TMPDIR=$(mktemp -d)
 clean() { 
-    chmod +w -R "$TMPDIR"
+    # Macos wants different flag order
+    if [[ ${os} == "darwin" ]]; then 
+        chmod -R +w "$TMPDIR"
+    else
+        chmod +w -R "$TMPDIR"
+    fi
     rm -rf "$TMPDIR"
 }
 trap clean EXIT
@@ -144,7 +153,7 @@ export GOPATH=$TMPDIR
 export GOCACHE=$TMPDIR/cache
 export GO111MODULE=on
 
-write-verbose "Installing Go tools…"
+write-verbose "Installing Go tools..."
 
 # go tools for vscode are preinstalled by base image (see first comment in Dockerfile)
 
@@ -216,7 +225,7 @@ fi
 write-verbose "Checking for $TOOL_DEST/go-task"
 if should-install "$TOOL_DEST/task"; then 
     write-info "Installing go-task"
-    curl -sL "https://github.com/go-task/task/releases/download/v3.31.0/task_linux_amd64.tar.gz" | tar xz -C "$TOOL_DEST" task
+    curl -sL "https://github.com/go-task/task/releases/download/v3.31.0/task_${os}_${arch}.tar.gz" | tar xz -C "$TOOL_DEST" task
 fi
 
 # Install Trivy
@@ -224,15 +233,21 @@ fi
 write-verbose "Checking for $TOOL_DEST/trivy"
 if should-install "$TOOL_DEST/trivy"; then
     write-info "Installing trivy"
-    curl -sL "https://github.com/aquasecurity/trivy/releases/download/v0.37.3/trivy_0.37.3_Linux-64bit.tar.gz" | tar xz -C "$TOOL_DEST" trivy
+    # This guys decided to use different naming conventions for os and arch despite trivy is 98.6% written in Go
+    # This fixes macos arm64 architechture. Every other os/arch is named differently. Consider adding a workaround of your own ¯\_(ツ)_/¯
+    if [[ ${os} == "darwin" ]] && [[ ${arch} == "arm64" ]]; then
+        curl -sL "https://github.com/aquasecurity/trivy/releases/download/v0.37.3/trivy_0.37.3_macOS-ARM64.tar.gz" | tar xz -C "$TOOL_DEST" trivy
+    else
+        curl -sL "https://github.com/aquasecurity/trivy/releases/download/v0.37.3/trivy_0.37.3_Linux-64bit.tar.gz" | tar xz -C "$TOOL_DEST" trivy
+    fi
 fi
 
 # Install helm
 #doc# | Helm | v3.8.0 | https://helm.sh/ |
 write-verbose "Checking for $TOOL_DEST/helm"
 if should-install "$TOOL_DEST/helm"; then
-    write-info "Installing helm…"
-    curl -sL "https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz" | tar -C "$TOOL_DEST" --strip-components=1 -xz linux-amd64/helm
+    write-info "Installing helm..."
+    curl -sL "https://get.helm.sh/helm-v3.8.0-${os}-${arch}.tar.gz" | tar -C "$TOOL_DEST" --strip-components=1 -xz ${os}-${arch}/helm
 fi
 
 # Install yq
@@ -241,36 +256,38 @@ yq_version=v4.13.0
 yq_binary=yq_linux_amd64
 write-verbose "Checking for $TOOL_DEST/yq"
 if should-install "$TOOL_DEST/yq"; then 
-    write-info "Installing yq…"
+    write-info "Installing yq..."
     rm -f "$TOOL_DEST/yq" # remove yq in case we're forcing the install
     wget "https://github.com/mikefarah/yq/releases/download/${yq_version}/${yq_binary}.tar.gz" -O - | tar -xz -C "$TOOL_DEST" && mv "$TOOL_DEST/$yq_binary" "$TOOL_DEST/yq"
 fi
 
 # Install cmctl, used to wait for cert manager installation during some tests cases
 #doc# | cmctl | latest | https://cert-manager.io/docs/reference/cmctl |
-os=$(go env GOOS)
-arch=$(go env GOARCH)
 write-verbose "Checking for $TOOL_DEST/cmctl"
 if should-install "$TOOL_DEST/cmctl"; then 
-    write-info "Installing cmctl-${os}_${arch}…"
+    write-info "Installing cmctl-${os}_${arch}..."
     curl -L "https://github.com/jetstack/cert-manager/releases/latest/download/cmctl-${os}-${arch}.tar.gz" | tar -xz -C "$TOOL_DEST"
 fi
 
 write-verbose "Checking for $BUILDX_DEST/docker-buildx"
 #doc# | BuildX | v0.11.2 | https://github.com/docker/buildx |
 if should-install "$BUILDX_DEST/docker-buildx"; then
-    write-info "Installing buildx-${os}_${arch} to $BUILDX_DEST…"
-    mkdir -p "$BUILDX_DEST"
-    curl  -o "$BUILDX_DEST/docker-buildx" -L "https://github.com/docker/buildx/releases/download/v0.11.2/buildx-v0.11.2.${os}-${arch}"
-    chmod +x "$BUILDX_DEST/docker-buildx"
+    write-info "Installing buildx-${os}_${arch} to $BUILDX_DEST ..."
+    if ! test -f $BUILDX_DEST; then
+        mkdir -p "$BUILDX_DEST"
+    fi
+    if ! test -f $BUILDX_DEST/docker-buildx; then
+        curl  -o "$BUILDX_DEST/docker-buildx" -L "https://github.com/docker/buildx/releases/download/v0.11.2/buildx-v0.11.2.${os}-${arch}"
+        chmod +x "$BUILDX_DEST/docker-buildx"
+    fi
 fi
 
 # Install azwi
-#doc# | AZWI | v1.0.0 | https://github.com/Azure/azure-workload-identity |
+#doc# | AZWI | v1.2.0 | https://github.com/Azure/azure-workload-identity |
 write-verbose "Checking for $TOOL_DEST/azwi"
 if should-install "$TOOL_DEST/azwi"; then
-    write-info "Installing azwi…"
-    curl -sL "https://github.com/Azure/azure-workload-identity/releases/download/v1.0.0/azwi-v1.0.0-${os}-${arch}.tar.gz" | tar xz -C "$TOOL_DEST" azwi
+    write-info "Installing azwi..."
+    curl -sL "https://github.com/Azure/azure-workload-identity/releases/download/v1.2.0/azwi-v1.2.0-${os}-${arch}.tar.gz" | tar xz -C "$TOOL_DEST" azwi
 fi
 
 # Ensure tooling for Hugo is available
@@ -278,6 +295,7 @@ fi
 write-verbose "Checking for /usr/bin/postcss"
 if ! which postcss  > /dev/null 2>&1; then 
     write-info "Installing postcss"
+    npm config set fund false --location=global
     npm install --global postcss postcss-cli autoprefixer
 fi
 

--- a/.devcontainer/library-scripts/docker-debian.sh
+++ b/.devcontainer/library-scripts/docker-debian.sh
@@ -72,7 +72,7 @@ else
         apt-get -y install --no-install-recommends moby-cli moby-buildx
     else
         curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT)
-        echo "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
+        echo "deb [arch=$(go env GOARCH)] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
         apt-get update
         apt-get -y install --no-install-recommends docker-ce-cli
     fi

--- a/.devcontainer/library-scripts/docker-debian.sh
+++ b/.devcontainer/library-scripts/docker-debian.sh
@@ -67,7 +67,7 @@ else
         DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
         CODENAME=$(lsb_release -cs)
         curl -s https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT)
-        echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-${DISTRO}-${CODENAME}-prod ${CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
+        echo "deb [arch=$(go env GOARCH)] https://packages.microsoft.com/repos/microsoft-${DISTRO}-${CODENAME}-prod ${CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
         apt-get update
         apt-get -y install --no-install-recommends moby-cli moby-buildx
     else

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1022,7 +1022,7 @@ tasks:
       OBJECT_OPTIONS: object:headerFile={{.HEADER_FILE}}
       CRD_OPTIONS: crd:crdVersions=v1,allowDangerousTypes=true output:crd:artifacts:config={{.CROSSPLANE_OUTPUT}}/crd/bases
       WEBHOOK_OPTIONS: webhook output:webhook:artifacts:config={{.CROSSPLANE_OUTPUT}}/webhook
-      RBAC_OPTIONS: rbac:roleName=manager-role # output:rbac:artifacts:config={{.CROSSPLANE_OUTPUT}}/rbac # not output currently?
+      RBAC_OPTIONS: rbac:roleName=manager-role output:rbac:artifacts:config={{.CROSSPLANE_OUTPUT}}/rbac
 
   crossplane:generate-types:
     desc: Run {{.GENERATOR_APP}} to generate input files for controller-gen for {{.CROSSPLANE_APP}}.

--- a/docs/hugo/content/contributing/dependencies.md
+++ b/docs/hugo/content/contributing/dependencies.md
@@ -2,13 +2,13 @@
 title: Developer Dependencies
 linktitle: Dependencies
 ---
-Development of Azure Service Operator depends on a number of development tools and libraries that need to be installed. 
+Development of Azure Service Operator depends on a number of development tools and libraries that need to be installed.
 
-If you prefer to install those dependencies manually (instead of using the `.devcontainer/install-dependencies.sh` script), here is a list of what's required. 
+If you prefer to install those dependencies manually (instead of using the `.devcontainer/install-dependencies.sh` script), here is a list of what's required.
 
 | Dependency | Version | Reference |
 |:---------- |:-------:|:--------- |
-| AZWI | v1.0.0 | https://github.com/Azure/azure-workload-identity |
+| AZWI | v1.2.0 | https://github.com/Azure/azure-workload-identity |
 | BuildX | v0.11.2 | https://github.com/docker/buildx |
 | cmctl | latest | https://cert-manager.io/docs/reference/cmctl |
 | controller-gen | v0.13.0 | https://book.kubebuilder.io/reference/controller-gen |

--- a/docs/hugo/content/contributing/developer-setup.md
+++ b/docs/hugo/content/contributing/developer-setup.md
@@ -73,7 +73,6 @@ $ docker run --env-file ~/work/envs.env --env HOSTROOT=$(git rev-parse --show-to
 
 Note: If you mount the source like this from a Windows folder, performance will be poor as file operations between the container and Windows are very slow.
 
-
 ## CLI on Linux
 
 If you are using Linux, instead of using VS Code you can run the `dev.sh` script in the root of the repository. This will install all required tooling into the `hack/tools` directory and then start a new shell with the `PATH` updated to use it.
@@ -115,7 +114,7 @@ If you see a list of tags (as shown above), then you're good to go.
 Otherwise, pull tags from your upstream repo and check again:
 
 ``` bash
-$ git-fetch --all --tags
+$ git fetch --all --tags
 Fetching origin
 $ git tag --list 'v2*'
 v2.0.0

--- a/docs/hugo/content/contributing/developer-setup.md
+++ b/docs/hugo/content/contributing/developer-setup.md
@@ -79,12 +79,13 @@ If you are using Linux, instead of using VS Code you can run the `dev.sh` script
 
 ## CLI on MacOS
 
-Development of ASO on MacOS is possible (one of our team does so), but things are less automated.
+Development of ASO on MacOS is also possible.
 
-You'll need to manually install the tools as listed by `.devcontainer/install-dependencies.sh`.
+You can either use the VS Code devcontainer approach (recommended) which installs all the tools into a container, or you can install the tools directly on your Mac. In case of the latter, you'll need to install the following tools manually running: `.devcontainer/install-dependencies.sh`.
+
+This creates `hack/tools` and downloads all the required tools into it based on the architecture(arm64 or amd64) of your machine.
 
 If you have an ARM based Mac, you'll also need to install [Rosetta](https://support.apple.com/en-nz/HT211861).
-
 
 ## Troubleshooting: Repo health
 

--- a/docs/hugo/content/contributing/developer-setup.md
+++ b/docs/hugo/content/contributing/developer-setup.md
@@ -10,11 +10,11 @@ description: "How to set up your developer environment for Azure Service Operato
 
 We support a number of different approaches to ASO development.
 
-- Dev Container with VS Code on Linux
-- Dev Container with VS Code on Windows
-- Docker on Linux
-- CLI on Linux
-- CLI on MacOS
+- [Dev Container with VS Code on Linux](#dev-container-with-vs-code-on-linux)
+- [Dev Container with VS Code on Windows](#dev-container-with-vs-code-on-windows)
+- [Docker on Linux](#docker-on-linux)
+- [CLI on Linux](#cli-on-linux)
+- [CLI on MacOS](#cli-on-macos)
 
 Each of these is described in a different section below. See also the [troubleshooting](#troubleshooting-repo-health) sections below for help with common problems.
 

--- a/hack/crossplane/.gitignore
+++ b/hack/crossplane/.gitignore
@@ -1,1 +1,1 @@
-config/
+config/crd

--- a/hack/crossplane/.gitignore
+++ b/hack/crossplane/.gitignore
@@ -1,1 +1,2 @@
 config/crd
+config/rbac/role.yaml

--- a/hack/crossplane/config/default/kustomization.yaml
+++ b/hack/crossplane/config/default/kustomization.yaml
@@ -1,0 +1,84 @@
+# Adds namespace to all resources.
+namespace: crossplane-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+resources: []
+
+bases:
+- ../crd
+- ../rbac
+- ../manager
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
+# - ../webhook
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+- ../certmanager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+#- ../prometheus
+
+patchesStrategicMerge:
+  # If you want your controller-manager to expose the /metrics
+  # endpoint w/o any authn/z, uncomment the following line and
+  # comment manager_auth_proxy_patch.yaml.
+  # Only one of manager_auth_proxy_patch.yaml and
+  # manager_prometheus_metrics_patch.yaml should be enabled.
+#- manager_prometheus_metrics_patch.yaml
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
+# - manager_webhook_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+# - webhookcainjection_patch.yaml
+
+# - manager_credentials_patch.yaml
+
+patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --webhook-port=9443
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --webhook-cert-dir=/tmp/k8s-webhook-server/serving-certs
+  target:
+    kind: Deployment
+
+# the following config is for teaching kustomize how to do var substitution
+vars:
+## [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service


### PR DESCRIPTION
**What this PR does / why we need it**:

- This PR fixes issues with packages for ARM64 architecture
- Updates `azwi` as macOS arm64 support has been introduced starting version 1.1.0
- Formats documentation
