### PR TITLE
Improve debug naming of internal type names

### DIFF
--- a/hack/crossplane/apis/cache/v1api20200601/structure.txt
+++ b/hack/crossplane/apis/cache/v1api20200601/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/hack/crossplane/apis/cache/v1api20200601
 ├── APIVersion: Enum (1 value)
 │   └── "2020-06-01"
 └── Redis: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/hack/crossplane/apis/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (1 property)
     │   └── ForProvider: Object (17 properties)
     │       ├── EnableNonSslPort: *bool

--- a/hack/crossplane/apis/sql/v1api20201101preview/structure.txt
+++ b/hack/crossplane/apis/sql/v1api20201101preview/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/hack/crossplane/apis/sql/v1api20201101pr
 ├── APIVersion: Enum (1 value)
 │   └── "2020-11-01-preview"
 ├── Server: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/hack/crossplane/apis/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (1 property)
 │   │   └── ForProvider: Object (15 properties)
 │   │       ├── AdministratorLogin: *string

--- a/hack/crossplane/apis/sql/v1api20211101/structure.txt
+++ b/hack/crossplane/apis/sql/v1api20211101/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/hack/crossplane/apis/sql/v1api20211101
 ├── APIVersion: Enum (1 value)
 │   └── "2021-11-01"
 └── Server: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/hack/crossplane/apis/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (1 property)
     │   └── ForProvider: Object (17 properties)
     │       ├── AdministratorLogin: *string

--- a/v2/api/apimanagement/v1api20220801/storage/structure.txt
+++ b/v2/api/apimanagement/v1api20220801/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801/stora
 ├── APIVersion: Enum (1 value)
 │   └── "2022-08-01"
 ├── Api: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801.Service
+│   ├── Owner: apimanagement/v1api20220801.Service
 │   ├── Spec: Object (29 properties)
 │   │   ├── APIVersion: *string
 │   │   ├── ApiRevision: *string
@@ -133,7 +133,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801/stora
 │       ├── TermsOfServiceUrl: *string
 │       └── Type: *string
 ├── ApiVersionSet: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801.Service
+│   ├── Owner: apimanagement/v1api20220801.Service
 │   ├── Spec: Object (9 properties)
 │   │   ├── AzureName: string
 │   │   ├── Description: *string
@@ -156,7 +156,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801/stora
 │       ├── VersionQueryName: *string
 │       └── VersioningScheme: *string
 ├── Backend: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801.Service
+│   ├── Owner: apimanagement/v1api20220801.Service
 │   ├── Spec: Object (13 properties)
 │   │   ├── AzureName: string
 │   │   ├── Credentials: *Object (6 properties)
@@ -242,7 +242,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801/stora
 │       ├── Type: *string
 │       └── Url: *string
 ├── NamedValue: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801.Service
+│   ├── Owner: apimanagement/v1api20220801.Service
 │   ├── Spec: Object (9 properties)
 │   │   ├── AzureName: string
 │   │   ├── DisplayName: *string
@@ -277,7 +277,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801/stora
 │       ├── Type: *string
 │       └── Value: *string
 ├── Policy: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801.Service
+│   ├── Owner: apimanagement/v1api20220801.Service
 │   ├── Spec: Object (5 properties)
 │   │   ├── Format: *string
 │   │   ├── OriginalVersion: string
@@ -293,7 +293,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801/stora
 │       ├── Type: *string
 │       └── Value: *string
 ├── PolicyFragment: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801.Service
+│   ├── Owner: apimanagement/v1api20220801.Service
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── Description: *string
@@ -312,7 +312,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801/stora
 │       ├── Type: *string
 │       └── Value: *string
 ├── Product: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801.Service
+│   ├── Owner: apimanagement/v1api20220801.Service
 │   ├── Spec: Object (11 properties)
 │   │   ├── ApprovalRequired: *bool
 │   │   ├── AzureName: string
@@ -339,7 +339,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801/stora
 │       ├── Terms: *string
 │       └── Type: *string
 ├── ProductApi: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801.Product
+│   ├── Owner: apimanagement/v1api20220801.Product
 │   ├── Spec: Object (4 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string
@@ -349,7 +349,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801/stora
 │       ├── Conditions: conditions.Condition[]
 │       └── PropertyBag: genruntime.PropertyBag
 ├── ProductPolicy: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801.Product
+│   ├── Owner: apimanagement/v1api20220801.Product
 │   ├── Spec: Object (5 properties)
 │   │   ├── Format: *string
 │   │   ├── OriginalVersion: string
@@ -365,7 +365,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801/stora
 │       ├── Type: *string
 │       └── Value: *string
 ├── Service: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (25 properties)
 │   │   ├── AdditionalLocations: Object (8 properties)[]
 │   │   │   ├── DisableGateway: *bool
@@ -574,7 +574,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801/stora
 │       ├── VirtualNetworkType: *string
 │       └── Zones: string[]
 └── Subscription: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801.Service
+    ├── Owner: apimanagement/v1api20220801.Service
     ├── Spec: Object (12 properties)
     │   ├── AllowTracing: *bool
     │   ├── AzureName: string

--- a/v2/api/apimanagement/v1api20220801/structure.txt
+++ b/v2/api/apimanagement/v1api20220801/structure.txt
@@ -443,7 +443,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20220801
 │       ├── Type: *string
 │       └── Value: *string
 ├── Service: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (23 properties)
 │   │   ├── AdditionalLocations: Object (7 properties)[]
 │   │   │   ├── DisableGateway: *bool

--- a/v2/api/apimanagement/v1api20230501preview/storage/structure.txt
+++ b/v2/api/apimanagement/v1api20230501preview/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501previe
 ├── APIVersion: Enum (1 value)
 │   └── "2023-05-01-preview"
 ├── Api: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501preview.Service
+│   ├── Owner: apimanagement/v1api20230501preview.Service
 │   ├── Spec: Object (29 properties)
 │   │   ├── APIVersion: *string
 │   │   ├── ApiRevision: *string
@@ -134,7 +134,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501previe
 │       ├── TermsOfServiceUrl: *string
 │       └── Type: *string
 ├── ApiVersionSet: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501preview.Service
+│   ├── Owner: apimanagement/v1api20230501preview.Service
 │   ├── Spec: Object (9 properties)
 │   │   ├── AzureName: string
 │   │   ├── Description: *string
@@ -157,7 +157,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501previe
 │       ├── VersionQueryName: *string
 │       └── VersioningScheme: *string
 ├── Backend: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501preview.Service
+│   ├── Owner: apimanagement/v1api20230501preview.Service
 │   ├── Spec: Object (16 properties)
 │   │   ├── AzureName: string
 │   │   ├── CircuitBreaker: *Object (2 properties)
@@ -287,7 +287,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501previe
 │       ├── Type: *string
 │       └── Url: *string
 ├── NamedValue: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501preview.Service
+│   ├── Owner: apimanagement/v1api20230501preview.Service
 │   ├── Spec: Object (9 properties)
 │   │   ├── AzureName: string
 │   │   ├── DisplayName: *string
@@ -323,7 +323,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501previe
 │       ├── Type: *string
 │       └── Value: *string
 ├── Policy: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501preview.Service
+│   ├── Owner: apimanagement/v1api20230501preview.Service
 │   ├── Spec: Object (5 properties)
 │   │   ├── Format: *string
 │   │   ├── OriginalVersion: string
@@ -339,7 +339,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501previe
 │       ├── Type: *string
 │       └── Value: *string
 ├── PolicyFragment: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501preview.Service
+│   ├── Owner: apimanagement/v1api20230501preview.Service
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── Description: *string
@@ -359,7 +359,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501previe
 │       ├── Type: *string
 │       └── Value: *string
 ├── Product: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501preview.Service
+│   ├── Owner: apimanagement/v1api20230501preview.Service
 │   ├── Spec: Object (11 properties)
 │   │   ├── ApprovalRequired: *bool
 │   │   ├── AzureName: string
@@ -386,7 +386,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501previe
 │       ├── Terms: *string
 │       └── Type: *string
 ├── ProductApi: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501preview.Product
+│   ├── Owner: apimanagement/v1api20230501preview.Product
 │   ├── Spec: Object (4 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string
@@ -396,7 +396,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501previe
 │       ├── Conditions: conditions.Condition[]
 │       └── PropertyBag: genruntime.PropertyBag
 ├── ProductPolicy: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501preview.Product
+│   ├── Owner: apimanagement/v1api20230501preview.Product
 │   ├── Spec: Object (5 properties)
 │   │   ├── Format: *string
 │   │   ├── OriginalVersion: string
@@ -412,7 +412,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501previe
 │       ├── Type: *string
 │       └── Value: *string
 ├── Service: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (28 properties)
 │   │   ├── AdditionalLocations: Object (8 properties)[]
 │   │   │   ├── DisableGateway: *bool
@@ -631,7 +631,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501previe
 │       ├── VirtualNetworkType: *string
 │       └── Zones: string[]
 ├── Subscription: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501preview.Service
+│   ├── Owner: apimanagement/v1api20230501preview.Service
 │   ├── Spec: Object (12 properties)
 │   │   ├── AllowTracing: *bool
 │   │   ├── AzureName: string

--- a/v2/api/apimanagement/v1api20230501preview/structure.txt
+++ b/v2/api/apimanagement/v1api20230501preview/structure.txt
@@ -508,7 +508,7 @@ github.com/Azure/azure-service-operator/v2/api/apimanagement/v1api20230501previe
 │       ├── Type: *string
 │       └── Value: *string
 ├── Service: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (26 properties)
 │   │   ├── AdditionalLocations: Object (7 properties)[]
 │   │   │   ├── DisableGateway: *bool

--- a/v2/api/appconfiguration/v1api20220501/storage/structure.txt
+++ b/v2/api/appconfiguration/v1api20220501/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/appconfiguration/v1api20220501/st
 ├── APIVersion: Enum (1 value)
 │   └── "2022-05-01"
 └── ConfigurationStore: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (16 properties)
     │   ├── AzureName: string
     │   ├── CreateMode: *string

--- a/v2/api/appconfiguration/v1api20220501/structure.txt
+++ b/v2/api/appconfiguration/v1api20220501/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/appconfiguration/v1api20220501
 ├── APIVersion: Enum (1 value)
 │   └── "2022-05-01"
 ├── ConfigurationStore: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (14 properties)
 │   │   ├── AzureName: Validated<string> (3 rules)
 │   │   │   ├── Rule 0: MaxLength: 50

--- a/v2/api/batch/v1api20210101/storage/structure.txt
+++ b/v2/api/batch/v1api20210101/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/batch/v1api20210101/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2021-01-01"
 └── BatchAccount: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (12 properties)
     │   ├── AutoStorage: *Object (2 properties)
     │   │   ├── PropertyBag: genruntime.PropertyBag

--- a/v2/api/batch/v1api20210101/structure.txt
+++ b/v2/api/batch/v1api20210101/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/batch/v1api20210101
 ├── APIVersion: Enum (1 value)
 │   └── "2021-01-01"
 ├── BatchAccount: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (10 properties)
 │   │   ├── AutoStorage: *Object (1 property)
 │   │   │   └── StorageAccountReference: *genruntime.ResourceReference

--- a/v2/api/cache/v1api20201201/storage/structure.txt
+++ b/v2/api/cache/v1api20201201/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20201201/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2020-12-01"
 ├── Redis: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (20 properties)
 │   │   ├── AzureName: string
 │   │   ├── EnableNonSslPort: *bool
@@ -111,7 +111,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20201201/storage
 │       ├── Type: *string
 │       └── Zones: string[]
 ├── RedisFirewallRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/cache/v1api20201201.Redis
+│   ├── Owner: cache/v1api20201201.Redis
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── EndIP: *string
@@ -128,7 +128,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20201201/storage
 │       ├── StartIP: *string
 │       └── Type: *string
 ├── RedisLinkedServer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/cache/v1api20201201.Redis
+│   ├── Owner: cache/v1api20201201.Redis
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── LinkedRedisCacheLocation: *string
@@ -148,7 +148,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20201201/storage
 │       ├── ServerRole: *string
 │       └── Type: *string
 ├── RedisPatchSchedule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/cache/v1api20201201.Redis
+│   ├── Owner: cache/v1api20201201.Redis
 │   ├── Spec: Object (4 properties)
 │   │   ├── OriginalVersion: string
 │   │   ├── Owner: *genruntime.KnownResourceReference

--- a/v2/api/cache/v1api20201201/structure.txt
+++ b/v2/api/cache/v1api20201201/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20201201
 ├── APIVersion: Enum (1 value)
 │   └── "2020-12-01"
 ├── Redis: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (18 properties)
 │   │   ├── AzureName: string
 │   │   ├── EnableNonSslPort: *bool

--- a/v2/api/cache/v1api20210301/storage/structure.txt
+++ b/v2/api/cache/v1api20210301/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20210301/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2021-03-01"
 ├── RedisEnterprise: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (9 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -39,7 +39,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20210301/storage
 │       ├── Type: *string
 │       └── Zones: string[]
 ├── RedisEnterpriseDatabase: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/cache/v1api20210301.RedisEnterprise
+│   ├── Owner: cache/v1api20210301.RedisEnterprise
 │   ├── Spec: Object (10 properties)
 │   │   ├── AzureName: string
 │   │   ├── ClientProtocol: *string

--- a/v2/api/cache/v1api20210301/structure.txt
+++ b/v2/api/cache/v1api20210301/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20210301
 ├── APIVersion: Enum (1 value)
 │   └── "2021-03-01"
 ├── RedisEnterprise: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string

--- a/v2/api/cache/v1api20230401/storage/structure.txt
+++ b/v2/api/cache/v1api20230401/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20230401/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2023-04-01"
 ├── Redis: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (21 properties)
 │   │   ├── AzureName: string
 │   │   ├── EnableNonSslPort: *bool
@@ -129,7 +129,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20230401/storage
 │       ├── Type: *string
 │       └── Zones: string[]
 ├── RedisFirewallRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/cache/v1api20230401.Redis
+│   ├── Owner: cache/v1api20230401.Redis
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── EndIP: *string
@@ -146,7 +146,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20230401/storage
 │       ├── StartIP: *string
 │       └── Type: *string
 ├── RedisLinkedServer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/cache/v1api20230401.Redis
+│   ├── Owner: cache/v1api20230401.Redis
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── LinkedRedisCacheLocation: *string
@@ -168,7 +168,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20230401/storage
 │       ├── ServerRole: *string
 │       └── Type: *string
 ├── RedisPatchSchedule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/cache/v1api20230401.Redis
+│   ├── Owner: cache/v1api20230401.Redis
 │   ├── Spec: Object (4 properties)
 │   │   ├── OriginalVersion: string
 │   │   ├── Owner: *genruntime.KnownResourceReference

--- a/v2/api/cache/v1api20230401/structure.txt
+++ b/v2/api/cache/v1api20230401/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20230401
 ├── APIVersion: Enum (1 value)
 │   └── "2023-04-01"
 ├── Redis: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (19 properties)
 │   │   ├── AzureName: string
 │   │   ├── EnableNonSslPort: *bool

--- a/v2/api/cache/v1api20230701/storage/structure.txt
+++ b/v2/api/cache/v1api20230701/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20230701/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2023-07-01"
 ├── RedisEnterprise: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (9 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -39,7 +39,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20230701/storage
 │       ├── Type: *string
 │       └── Zones: string[]
 └── RedisEnterpriseDatabase: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/cache/v1api20230701.RedisEnterprise
+    ├── Owner: cache/v1api20230701.RedisEnterprise
     ├── Spec: Object (11 properties)
     │   ├── AzureName: string
     │   ├── ClientProtocol: *string

--- a/v2/api/cache/v1api20230701/structure.txt
+++ b/v2/api/cache/v1api20230701/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/cache/v1api20230701
 ├── APIVersion: Enum (1 value)
 │   └── "2023-07-01"
 ├── RedisEnterprise: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string

--- a/v2/api/cdn/v1api20210601/storage/structure.txt
+++ b/v2/api/cdn/v1api20210601/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1api20210601/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2021-06-01"
 ├── Profile: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -40,7 +40,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1api20210601/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 └── ProfilesEndpoint: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/cdn/v1api20210601.Profile
+    ├── Owner: cdn/v1api20210601.Profile
     ├── Spec: Object (22 properties)
     │   ├── AzureName: string
     │   ├── ContentTypesToCompress: string[]

--- a/v2/api/cdn/v1api20210601/structure.txt
+++ b/v2/api/cdn/v1api20210601/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1api20210601
 ├── APIVersion: Enum (1 value)
 │   └── "2021-06-01"
 ├── Profile: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string

--- a/v2/api/compute/v1api20200930/storage/structure.txt
+++ b/v2/api/compute/v1api20200930/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20200930/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2020-09-30"
 ├── Disk: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (25 properties)
 │   │   ├── AzureName: string
 │   │   ├── BurstingEnabled: *bool
@@ -160,7 +160,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20200930/storage
 │       ├── UniqueId: *string
 │       └── Zones: string[]
 ├── Snapshot: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (19 properties)
 │   │   ├── AzureName: string
 │   │   ├── CreationData: *Object (9 properties)

--- a/v2/api/compute/v1api20200930/structure.txt
+++ b/v2/api/compute/v1api20200930/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20200930
 ├── APIVersion: Enum (1 value)
 │   └── "2020-09-30"
 ├── Disk: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (23 properties)
 │   │   ├── AzureName: string
 │   │   ├── BurstingEnabled: *bool
@@ -355,7 +355,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20200930
 │   ├── Tags: map[string]string
 │   └── Zones: string[]
 ├── Snapshot: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (17 properties)
 │   │   ├── AzureName: string
 │   │   ├── CreationData: *Object (8 properties)

--- a/v2/api/compute/v1api20201201/storage/structure.txt
+++ b/v2/api/compute/v1api20201201/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20201201/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2020-12-01"
 ├── VirtualMachine: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (28 properties)
 │   │   ├── AdditionalCapabilities: *Object (2 properties)
 │   │   │   ├── PropertyBag: genruntime.PropertyBag
@@ -609,7 +609,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20201201/storage
 │       ├── VmId: *string
 │       └── Zones: string[]
 ├── VirtualMachineScaleSet: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (24 properties)
 │   │   ├── AdditionalCapabilities: *Object (2 properties)
 │   │   │   ├── PropertyBag: genruntime.PropertyBag

--- a/v2/api/compute/v1api20201201/structure.txt
+++ b/v2/api/compute/v1api20201201/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20201201
 ├── APIVersion: Enum (1 value)
 │   └── "2020-12-01"
 ├── VirtualMachine: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (26 properties)
 │   │   ├── AdditionalCapabilities: *Object (1 property)
 │   │   │   └── UltraSSDEnabled: *bool
@@ -792,7 +792,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20201201
 │       ├── VmId: *string
 │       └── Zones: string[]
 ├── VirtualMachineScaleSet: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (22 properties)
 │   │   ├── AdditionalCapabilities: *Object (1 property)
 │   │   │   └── UltraSSDEnabled: *bool

--- a/v2/api/compute/v1api20210701/storage/structure.txt
+++ b/v2/api/compute/v1api20210701/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20210701/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2021-07-01"
 ├── Image: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (10 properties)
 │   │   ├── AzureName: string
 │   │   ├── ExtendedLocation: *Object (3 properties)

--- a/v2/api/compute/v1api20210701/structure.txt
+++ b/v2/api/compute/v1api20210701/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20210701
 ├── APIVersion: Enum (1 value)
 │   └── "2021-07-01"
 ├── Image: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── ExtendedLocation: *Object (2 properties)

--- a/v2/api/compute/v1api20220301/storage/structure.txt
+++ b/v2/api/compute/v1api20220301/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20220301/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2022-03-01"
 ├── Image: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (10 properties)
 │   │   ├── AzureName: string
 │   │   ├── ExtendedLocation: *Object (3 properties)
@@ -109,7 +109,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20220301/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── VirtualMachine: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (32 properties)
 │   │   ├── AdditionalCapabilities: *Object (3 properties)
 │   │   │   ├── HibernationEnabled: *bool
@@ -939,7 +939,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20220301/storage
 │       ├── VmId: *string
 │       └── Zones: string[]
 ├── VirtualMachineScaleSet: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (25 properties)
 │   │   ├── AdditionalCapabilities: *Object (3 properties)
 │   │   │   ├── HibernationEnabled: *bool

--- a/v2/api/compute/v1api20220301/structure.txt
+++ b/v2/api/compute/v1api20220301/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20220301
 ├── APIVersion: Enum (1 value)
 │   └── "2022-03-01"
 ├── Image: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── ExtendedLocation: *Object (2 properties)
@@ -271,7 +271,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20220301
 │   │       └── ZoneResilient: *bool
 │   └── Tags: map[string]string
 ├── VirtualMachine: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (30 properties)
 │   │   ├── AdditionalCapabilities: *Object (2 properties)
 │   │   │   ├── HibernationEnabled: *bool
@@ -1308,7 +1308,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20220301
 │       ├── VmId: *string
 │       └── Zones: string[]
 ├── VirtualMachineScaleSet: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (23 properties)
 │   │   ├── AdditionalCapabilities: *Object (2 properties)
 │   │   │   ├── HibernationEnabled: *bool

--- a/v2/api/compute/v1api20220702/storage/structure.txt
+++ b/v2/api/compute/v1api20220702/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20220702/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2022-07-02"
 └── DiskEncryptionSet: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (12 properties)
     │   ├── ActiveKey: *Object (4 properties)
     │   │   ├── KeyUrl: *string

--- a/v2/api/compute/v1api20220702/structure.txt
+++ b/v2/api/compute/v1api20220702/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/compute/v1api20220702
 ├── APIVersion: Enum (1 value)
 │   └── "2022-07-02"
 ├── DiskEncryptionSet: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (10 properties)
 │   │   ├── ActiveKey: *Object (3 properties)
 │   │   │   ├── KeyUrl: *string

--- a/v2/api/containerinstance/v1api20211001/storage/structure.txt
+++ b/v2/api/containerinstance/v1api20211001/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerinstance/v1api20211001/s
 ├── APIVersion: Enum (1 value)
 │   └── "2021-10-01"
 └── ContainerGroup: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (20 properties)
     │   ├── AzureName: string
     │   ├── Containers: Object (10 properties)[]

--- a/v2/api/containerinstance/v1api20211001/structure.txt
+++ b/v2/api/containerinstance/v1api20211001/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerinstance/v1api20211001
 ├── APIVersion: Enum (1 value)
 │   └── "2021-10-01"
 ├── ContainerGroup: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (18 properties)
 │   │   ├── AzureName: string
 │   │   ├── Containers: Object (9 properties)[]

--- a/v2/api/containerregistry/v1api20210901/storage/structure.txt
+++ b/v2/api/containerregistry/v1api20210901/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerregistry/v1api20210901/s
 ├── APIVersion: Enum (1 value)
 │   └── "2021-09-01"
 └── Registry: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (16 properties)
     │   ├── AdminUserEnabled: *bool
     │   ├── AzureName: string

--- a/v2/api/containerregistry/v1api20210901/structure.txt
+++ b/v2/api/containerregistry/v1api20210901/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerregistry/v1api20210901
 ├── APIVersion: Enum (1 value)
 │   └── "2021-09-01"
 ├── Registry: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (14 properties)
 │   │   ├── AdminUserEnabled: *bool
 │   │   ├── AzureName: Validated<string> (3 rules)

--- a/v2/api/containerservice/v1api20210501/storage/structure.txt
+++ b/v2/api/containerservice/v1api20210501/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20210501/st
 ├── APIVersion: Enum (1 value)
 │   └── "2021-05-01"
 ├── ManagedCluster: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (32 properties)
 │   │   ├── AadProfile: *Object (8 properties)
 │   │   │   ├── AdminGroupObjectIDs: string[]
@@ -528,7 +528,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20210501/st
 │           ├── LicenseType: *string
 │           └── PropertyBag: genruntime.PropertyBag
 ├── ManagedClustersAgentPool: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20210501.ManagedCluster
+│   ├── Owner: containerservice/v1api20210501.ManagedCluster
 │   ├── Spec: Object (37 properties)
 │   │   ├── AvailabilityZones: string[]
 │   │   ├── AzureName: string

--- a/v2/api/containerservice/v1api20210501/structure.txt
+++ b/v2/api/containerservice/v1api20210501/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20210501
 ├── APIVersion: Enum (1 value)
 │   └── "2021-05-01"
 ├── ManagedCluster: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (30 properties)
 │   │   ├── AadProfile: *Object (7 properties)
 │   │   │   ├── AdminGroupObjectIDs: string[]

--- a/v2/api/containerservice/v1api20230201/storage/structure.txt
+++ b/v2/api/containerservice/v1api20230201/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230201/st
 ├── APIVersion: Enum (1 value)
 │   └── "2023-02-01"
 ├── ManagedCluster: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (38 properties)
 │   │   ├── AadProfile: *Object (8 properties)
 │   │   │   ├── AdminGroupObjectIDs: string[]
@@ -707,7 +707,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230201/st
 │           │   └── PropertyBag: genruntime.PropertyBag
 │           └── PropertyBag: genruntime.PropertyBag
 ├── ManagedClustersAgentPool: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230201.ManagedCluster
+│   ├── Owner: containerservice/v1api20230201.ManagedCluster
 │   ├── Spec: Object (42 properties)
 │   │   ├── AvailabilityZones: string[]
 │   │   ├── AzureName: string

--- a/v2/api/containerservice/v1api20230201/structure.txt
+++ b/v2/api/containerservice/v1api20230201/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230201
 ├── APIVersion: Enum (1 value)
 │   └── "2023-02-01"
 ├── ManagedCluster: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (36 properties)
 │   │   ├── AadProfile: *Object (7 properties)
 │   │   │   ├── AdminGroupObjectIDs: string[]

--- a/v2/api/containerservice/v1api20230202preview/storage/structure.txt
+++ b/v2/api/containerservice/v1api20230202preview/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230202pre
 ├── APIVersion: Enum (1 value)
 │   └── "2023-02-02-preview"
 ├── ManagedCluster: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (45 properties)
 │   │   ├── AadProfile: *Object (8 properties)
 │   │   │   ├── AdminGroupObjectIDs: string[]
@@ -868,7 +868,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230202pre
 │               ├── PropertyBag: genruntime.PropertyBag
 │               └── UpdateMode: *string
 ├── ManagedClustersAgentPool: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230202preview.ManagedCluster
+│   ├── Owner: containerservice/v1api20230202preview.ManagedCluster
 │   ├── Spec: Object (47 properties)
 │   │   ├── AvailabilityZones: string[]
 │   │   ├── AzureName: string
@@ -1100,7 +1100,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230202pre
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── WorkloadRuntime: *string
 ├── TrustedAccessRoleBinding: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230202preview.ManagedCluster
+│   ├── Owner: containerservice/v1api20230202preview.ManagedCluster
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string

--- a/v2/api/containerservice/v1api20230202preview/structure.txt
+++ b/v2/api/containerservice/v1api20230202preview/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230202pre
 ├── APIVersion: Enum (1 value)
 │   └── "2023-02-02-preview"
 ├── ManagedCluster: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (43 properties)
 │   │   ├── AadProfile: *Object (7 properties)
 │   │   │   ├── AdminGroupObjectIDs: string[]

--- a/v2/api/containerservice/v1api20230315preview/storage/structure.txt
+++ b/v2/api/containerservice/v1api20230315preview/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315pre
 ├── APIVersion: Enum (1 value)
 │   └── "2023-03-15-preview"
 ├── Fleet: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── HubProfile: *Object (2 properties)
@@ -43,7 +43,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315pre
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── FleetsMember: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315preview.Fleet
+│   ├── Owner: containerservice/v1api20230315preview.Fleet
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── ClusterResourceReference: *genruntime.ResourceReference
@@ -70,7 +70,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315pre
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── FleetsUpdateRun: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315preview.Fleet
+│   ├── Owner: containerservice/v1api20230315preview.Fleet
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── ManagedClusterUpdate: *Object (2 properties)

--- a/v2/api/containerservice/v1api20230315preview/structure.txt
+++ b/v2/api/containerservice/v1api20230315preview/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315pre
 ├── APIVersion: Enum (1 value)
 │   └── "2023-03-15-preview"
 ├── Fleet: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: Validated<string> (3 rules)
 │   │   │   ├── Rule 0: MaxLength: 63

--- a/v2/api/containerservice/v1api20231001/storage/structure.txt
+++ b/v2/api/containerservice/v1api20231001/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001/st
 ├── APIVersion: Enum (1 value)
 │   └── "2023-10-01"
 ├── ManagedCluster: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (41 properties)
 │   │   ├── AadProfile: *Object (8 properties)
 │   │   │   ├── AdminGroupObjectIDs: string[]
@@ -820,7 +820,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001/st
 │               ├── Enabled: *bool
 │               └── PropertyBag: genruntime.PropertyBag
 └── ManagedClustersAgentPool: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001.ManagedCluster
+    ├── Owner: containerservice/v1api20231001.ManagedCluster
     ├── Spec: Object (44 properties)
     │   ├── AvailabilityZones: string[]
     │   ├── AzureName: string

--- a/v2/api/containerservice/v1api20231001/structure.txt
+++ b/v2/api/containerservice/v1api20231001/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001
 ├── APIVersion: Enum (1 value)
 │   └── "2023-10-01"
 ├── ManagedCluster: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (39 properties)
 │   │   ├── AadProfile: *Object (7 properties)
 │   │   │   ├── AdminGroupObjectIDs: string[]

--- a/v2/api/datafactory/v1api20180601/storage/structure.txt
+++ b/v2/api/datafactory/v1api20180601/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/datafactory/v1api20180601/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2018-06-01"
 └── Factory: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (13 properties)
     │   ├── AdditionalProperties: map[string]v1.JSON
     │   ├── AzureName: string

--- a/v2/api/datafactory/v1api20180601/structure.txt
+++ b/v2/api/datafactory/v1api20180601/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/datafactory/v1api20180601
 ├── APIVersion: Enum (1 value)
 │   └── "2018-06-01"
 ├── Factory: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (11 properties)
 │   │   ├── AdditionalProperties: map[string]v1.JSON
 │   │   ├── AzureName: Validated<string> (3 rules)

--- a/v2/api/dataprotection/v1api20230101/storage/structure.txt
+++ b/v2/api/dataprotection/v1api20230101/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dataprotection/v1api20230101/stor
 ├── APIVersion: Enum (1 value)
 │   └── "2023-01-01"
 ├── BackupVault: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── Identity: *Object (2 properties)
@@ -97,7 +97,7 @@ github.com/Azure/azure-service-operator/v2/api/dataprotection/v1api20230101/stor
 │       ├── Tags: map[string]string
 │       └── Type: *string
 └── BackupVaultsBackupPolicy: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/dataprotection/v1api20230101.BackupVault
+    ├── Owner: dataprotection/v1api20230101.BackupVault
     ├── Spec: Object (5 properties)
     │   ├── AzureName: string
     │   ├── OriginalVersion: string

--- a/v2/api/dataprotection/v1api20230101/structure.txt
+++ b/v2/api/dataprotection/v1api20230101/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dataprotection/v1api20230101
 ├── APIVersion: Enum (1 value)
 │   └── "2023-01-01"
 ├── BackupVault: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── Identity: *Object (1 property)

--- a/v2/api/dbformariadb/v1api20180601/storage/structure.txt
+++ b/v2/api/dbformariadb/v1api20180601/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformariadb/v1api20180601/storag
 ├── APIVersion: Enum (1 value)
 │   └── "2018-06-01"
 ├── Configuration: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbformariadb/v1api20180601.Server
+│   ├── Owner: dbformariadb/v1api20180601.Server
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string
@@ -24,7 +24,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformariadb/v1api20180601/storag
 │       ├── Type: *string
 │       └── Value: *string
 ├── Database: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbformariadb/v1api20180601.Server
+│   ├── Owner: dbformariadb/v1api20180601.Server
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── Charset: *string
@@ -41,7 +41,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformariadb/v1api20180601/storag
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 └── Server: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (9 properties)
     │   ├── AzureName: string
     │   ├── Location: *string

--- a/v2/api/dbformariadb/v1api20180601/structure.txt
+++ b/v2/api/dbformariadb/v1api20180601/structure.txt
@@ -35,7 +35,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformariadb/v1api20180601
 │       ├── Name: *string
 │       └── Type: *string
 ├── Server: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string

--- a/v2/api/dbformysql/v1api20210501/storage/structure.txt
+++ b/v2/api/dbformysql/v1api20210501/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformysql/v1api20210501/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2021-05-01"
 ├── FlexibleServer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (23 properties)
 │   │   ├── AdministratorLogin: *string
 │   │   ├── AdministratorLoginPassword: *genruntime.SecretReference
@@ -135,7 +135,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformysql/v1api20210501/storage
 │       ├── Type: *string
 │       └── Version: *string
 ├── FlexibleServersDatabase: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbformysql/v1api20210501.FlexibleServer
+│   ├── Owner: dbformysql/v1api20210501.FlexibleServer
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── Charset: *string
@@ -160,7 +160,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformysql/v1api20210501/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── FlexibleServersFirewallRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbformysql/v1api20210501.FlexibleServer
+│   ├── Owner: dbformysql/v1api20210501.FlexibleServer
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── EndIpAddress: *string

--- a/v2/api/dbformysql/v1api20210501/structure.txt
+++ b/v2/api/dbformysql/v1api20210501/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformysql/v1api20210501
 ├── APIVersion: Enum (1 value)
 │   └── "2021-05-01"
 ├── FlexibleServer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (21 properties)
 │   │   ├── AdministratorLogin: *string
 │   │   ├── AdministratorLoginPassword: *genruntime.SecretReference

--- a/v2/api/dbformysql/v1api20220101/storage/structure.txt
+++ b/v2/api/dbformysql/v1api20220101/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformysql/v1api20220101/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2022-01-01"
 ├── FlexibleServersAdministrator: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbformysql/v1api20220101.FlexibleServer
+│   ├── Owner: dbformysql/v1api20220101.FlexibleServer
 │   ├── Spec: Object (10 properties)
 │   │   ├── AdministratorType: *string
 │   │   ├── IdentityResourceReference: *genruntime.ResourceReference
@@ -35,7 +35,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformysql/v1api20220101/storage
 │       ├── TenantId: *string
 │       └── Type: *string
 └── FlexibleServersConfiguration: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbformysql/v1api20220101.FlexibleServer
+    ├── Owner: dbformysql/v1api20220101.FlexibleServer
     ├── Spec: Object (7 properties)
     │   ├── AzureName: string
     │   ├── CurrentValue: *string

--- a/v2/api/dbforpostgresql/v1api20210601/storage/structure.txt
+++ b/v2/api/dbforpostgresql/v1api20210601/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20210601/sto
 ├── APIVersion: Enum (1 value)
 │   └── "2021-06-01"
 ├── FlexibleServer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (20 properties)
 │   │   ├── AdministratorLogin: *string
 │   │   ├── AdministratorLoginPassword: *genruntime.SecretReference
@@ -102,7 +102,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20210601/sto
 │       ├── Type: *string
 │       └── Version: *string
 ├── FlexibleServersConfiguration: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20210601.FlexibleServer
+│   ├── Owner: dbforpostgresql/v1api20210601.FlexibleServer
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string
@@ -136,7 +136,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20210601/sto
 │       ├── Unit: *string
 │       └── Value: *string
 ├── FlexibleServersDatabase: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20210601.FlexibleServer
+│   ├── Owner: dbforpostgresql/v1api20210601.FlexibleServer
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── Charset: *string
@@ -161,7 +161,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20210601/sto
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── FlexibleServersFirewallRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20210601.FlexibleServer
+│   ├── Owner: dbforpostgresql/v1api20210601.FlexibleServer
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── EndIpAddress: *string

--- a/v2/api/dbforpostgresql/v1api20210601/structure.txt
+++ b/v2/api/dbforpostgresql/v1api20210601/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20210601
 ├── APIVersion: Enum (1 value)
 │   └── "2021-06-01"
 ├── FlexibleServer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (18 properties)
 │   │   ├── AdministratorLogin: *string
 │   │   ├── AdministratorLoginPassword: *genruntime.SecretReference

--- a/v2/api/dbforpostgresql/v1api20220120preview/storage/structure.txt
+++ b/v2/api/dbforpostgresql/v1api20220120preview/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20220120prev
 ├── APIVersion: Enum (1 value)
 │   └── "2022-01-20-preview"
 ├── FlexibleServer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (20 properties)
 │   │   ├── AdministratorLogin: *string
 │   │   ├── AdministratorLoginPassword: *genruntime.SecretReference
@@ -105,7 +105,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20220120prev
 │       ├── Type: *string
 │       └── Version: *string
 ├── FlexibleServersConfiguration: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20220120preview.FlexibleServer
+│   ├── Owner: dbforpostgresql/v1api20220120preview.FlexibleServer
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string
@@ -139,7 +139,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20220120prev
 │       ├── Unit: *string
 │       └── Value: *string
 ├── FlexibleServersDatabase: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20220120preview.FlexibleServer
+│   ├── Owner: dbforpostgresql/v1api20220120preview.FlexibleServer
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── Charset: *string
@@ -164,7 +164,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20220120prev
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── FlexibleServersFirewallRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20220120preview.FlexibleServer
+│   ├── Owner: dbforpostgresql/v1api20220120preview.FlexibleServer
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── EndIpAddress: *string

--- a/v2/api/dbforpostgresql/v1api20220120preview/structure.txt
+++ b/v2/api/dbforpostgresql/v1api20220120preview/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20220120prev
 ├── APIVersion: Enum (1 value)
 │   └── "2022-01-20-preview"
 ├── FlexibleServer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (18 properties)
 │   │   ├── AdministratorLogin: *string
 │   │   ├── AdministratorLoginPassword: *genruntime.SecretReference

--- a/v2/api/dbforpostgresql/v1api20221201/storage/structure.txt
+++ b/v2/api/dbforpostgresql/v1api20221201/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20221201/sto
 ├── APIVersion: Enum (1 value)
 │   └── "2022-12-01"
 ├── FlexibleServer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (24 properties)
 │   │   ├── AdministratorLogin: *string
 │   │   ├── AdministratorLoginPassword: *genruntime.SecretReference
@@ -142,7 +142,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20221201/sto
 │       ├── Type: *string
 │       └── Version: *string
 ├── FlexibleServersConfiguration: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20221201.FlexibleServer
+│   ├── Owner: dbforpostgresql/v1api20221201.FlexibleServer
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string
@@ -176,7 +176,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20221201/sto
 │       ├── Unit: *string
 │       └── Value: *string
 ├── FlexibleServersDatabase: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20221201.FlexibleServer
+│   ├── Owner: dbforpostgresql/v1api20221201.FlexibleServer
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── Charset: *string
@@ -201,7 +201,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20221201/sto
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 └── FlexibleServersFirewallRule: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20221201.FlexibleServer
+    ├── Owner: dbforpostgresql/v1api20221201.FlexibleServer
     ├── Spec: Object (6 properties)
     │   ├── AzureName: string
     │   ├── EndIpAddress: *string

--- a/v2/api/dbforpostgresql/v1api20221201/structure.txt
+++ b/v2/api/dbforpostgresql/v1api20221201/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20221201
 ├── APIVersion: Enum (1 value)
 │   └── "2022-12-01"
 ├── FlexibleServer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (22 properties)
 │   │   ├── AdministratorLogin: *string
 │   │   ├── AdministratorLoginPassword: *genruntime.SecretReference

--- a/v2/api/dbforpostgresql/v1api20230601preview/storage/structure.txt
+++ b/v2/api/dbforpostgresql/v1api20230601preview/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20230601prev
 ├── APIVersion: Enum (1 value)
 │   └── "2023-06-01-preview"
 ├── FlexibleServer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (25 properties)
 │   │   ├── AdministratorLogin: *string
 │   │   ├── AdministratorLoginPassword: *genruntime.SecretReference
@@ -176,7 +176,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20230601prev
 │       ├── Type: *string
 │       └── Version: *string
 ├── FlexibleServersConfiguration: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20230601preview.FlexibleServer
+│   ├── Owner: dbforpostgresql/v1api20230601preview.FlexibleServer
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string
@@ -210,7 +210,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20230601prev
 │       ├── Unit: *string
 │       └── Value: *string
 ├── FlexibleServersDatabase: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20230601preview.FlexibleServer
+│   ├── Owner: dbforpostgresql/v1api20230601preview.FlexibleServer
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── Charset: *string
@@ -235,7 +235,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20230601prev
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── FlexibleServersFirewallRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20230601preview.FlexibleServer
+│   ├── Owner: dbforpostgresql/v1api20230601preview.FlexibleServer
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── EndIpAddress: *string

--- a/v2/api/dbforpostgresql/v1api20230601preview/structure.txt
+++ b/v2/api/dbforpostgresql/v1api20230601preview/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20230601prev
 ├── APIVersion: Enum (1 value)
 │   └── "2023-06-01-preview"
 ├── FlexibleServer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (23 properties)
 │   │   ├── AdministratorLogin: *string
 │   │   ├── AdministratorLoginPassword: *genruntime.SecretReference

--- a/v2/api/devices/v1api20210702/storage/structure.txt
+++ b/v2/api/devices/v1api20210702/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/devices/v1api20210702/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2021-07-02"
 └── IotHub: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (10 properties)
     │   ├── AzureName: string
     │   ├── Identity: *Object (3 properties)

--- a/v2/api/devices/v1api20210702/structure.txt
+++ b/v2/api/devices/v1api20210702/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/devices/v1api20210702
 ├── APIVersion: Enum (1 value)
 │   └── "2021-07-02"
 ├── IotHub: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── Identity: *Object (2 properties)

--- a/v2/api/documentdb/v1api20210515/storage/structure.txt
+++ b/v2/api/documentdb/v1api20210515/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2021-05-15"
 ├── DatabaseAccount: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (32 properties)
 │   │   ├── AnalyticalStorageConfiguration: *Object (2 properties)
 │   │   │   ├── PropertyBag: genruntime.PropertyBag
@@ -193,7 +193,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515/storage
 │           ├── PropertyBag: genruntime.PropertyBag
 │           └── ProvisioningState: *string
 ├── MongodbDatabase: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515.DatabaseAccount
+│   ├── Owner: documentdb/v1api20210515.DatabaseAccount
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -231,7 +231,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── MongodbDatabaseCollection: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515.MongodbDatabase
+│   ├── Owner: documentdb/v1api20210515.MongodbDatabase
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -291,7 +291,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── MongodbDatabaseCollectionThroughputSetting: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515.MongodbDatabaseCollection
+│   ├── Owner: documentdb/v1api20210515.MongodbDatabaseCollection
 │   ├── Spec: Object (6 properties)
 │   │   ├── Location: *string
 │   │   ├── OriginalVersion: string
@@ -337,7 +337,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── MongodbDatabaseThroughputSetting: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515.MongodbDatabase
+│   ├── Owner: documentdb/v1api20210515.MongodbDatabase
 │   ├── Spec: Object (6 properties)
 │   │   ├── Location: *string
 │   │   ├── OriginalVersion: string
@@ -383,7 +383,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── SqlDatabase: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515.DatabaseAccount
+│   ├── Owner: documentdb/v1api20210515.DatabaseAccount
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -423,7 +423,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── SqlDatabaseContainer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515.SqlDatabase
+│   ├── Owner: documentdb/v1api20210515.SqlDatabase
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -542,7 +542,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── SqlDatabaseContainerStoredProcedure: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515.SqlDatabaseContainer
+│   ├── Owner: documentdb/v1api20210515.SqlDatabaseContainer
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -576,7 +576,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── SqlDatabaseContainerThroughputSetting: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515.SqlDatabaseContainer
+│   ├── Owner: documentdb/v1api20210515.SqlDatabaseContainer
 │   ├── Spec: Object (6 properties)
 │   │   ├── Location: *string
 │   │   ├── OriginalVersion: string
@@ -622,7 +622,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── SqlDatabaseContainerTrigger: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515.SqlDatabaseContainer
+│   ├── Owner: documentdb/v1api20210515.SqlDatabaseContainer
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -660,7 +660,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── SqlDatabaseContainerUserDefinedFunction: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515.SqlDatabaseContainer
+│   ├── Owner: documentdb/v1api20210515.SqlDatabaseContainer
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -694,7 +694,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── SqlDatabaseThroughputSetting: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515.SqlDatabase
+│   ├── Owner: documentdb/v1api20210515.SqlDatabase
 │   ├── Spec: Object (6 properties)
 │   │   ├── Location: *string
 │   │   ├── OriginalVersion: string
@@ -740,7 +740,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 └── SqlRoleAssignment: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515.DatabaseAccount
+    ├── Owner: documentdb/v1api20210515.DatabaseAccount
     ├── Spec: Object (8 properties)
     │   ├── AzureName: string
     │   ├── OriginalVersion: string

--- a/v2/api/documentdb/v1api20210515/structure.txt
+++ b/v2/api/documentdb/v1api20210515/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1api20210515
 ├── APIVersion: Enum (1 value)
 │   └── "2021-05-15"
 ├── DatabaseAccount: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (30 properties)
 │   │   ├── AnalyticalStorageConfiguration: *Object (1 property)
 │   │   │   └── SchemaType: *Enum (2 values)

--- a/v2/api/eventgrid/v1api20200601/storage/structure.txt
+++ b/v2/api/eventgrid/v1api20200601/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1api20200601/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2020-06-01"
 ├── Domain: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (10 properties)
 │   │   ├── AzureName: string
 │   │   ├── InboundIpRules: Object (3 properties)[]
@@ -98,7 +98,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1api20200601/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── DomainsTopic: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/eventgrid/v1api20200601.Domain
+│   ├── Owner: eventgrid/v1api20200601.Domain
 │   ├── Spec: Object (4 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string
@@ -380,7 +380,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1api20200601/storage
 │       ├── Topic: *string
 │       └── Type: *string
 └── Topic: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (11 properties)
     │   ├── AzureName: string
     │   ├── InboundIpRules: Object (3 properties)[]

--- a/v2/api/eventgrid/v1api20200601/structure.txt
+++ b/v2/api/eventgrid/v1api20200601/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1api20200601
 ├── APIVersion: Enum (1 value)
 │   └── "2020-06-01"
 ├── Domain: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── InboundIpRules: Object (2 properties)[]
@@ -813,7 +813,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1api20200601
 │           ├── EventTimeToLiveInMinutes: *int
 │           └── MaxDeliveryAttempts: *int
 ├── Topic: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (9 properties)
 │   │   ├── AzureName: string
 │   │   ├── InboundIpRules: Object (2 properties)[]

--- a/v2/api/eventhub/v1api20211101/storage/structure.txt
+++ b/v2/api/eventhub/v1api20211101/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/eventhub/v1api20211101/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2021-11-01"
 ├── Namespace: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (16 properties)
 │   │   ├── AlternateName: *string
 │   │   ├── AzureName: string
@@ -100,7 +100,7 @@ github.com/Azure/azure-service-operator/v2/api/eventhub/v1api20211101/storage
 │       ├── UpdatedAt: *string
 │       └── ZoneRedundant: *bool
 ├── NamespacesAuthorizationRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/eventhub/v1api20211101.Namespace
+│   ├── Owner: eventhub/v1api20211101.Namespace
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string
@@ -124,7 +124,7 @@ github.com/Azure/azure-service-operator/v2/api/eventhub/v1api20211101/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── NamespacesEventhub: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/eventhub/v1api20211101.Namespace
+│   ├── Owner: eventhub/v1api20211101.Namespace
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── CaptureDescription: *Object (7 properties)
@@ -186,7 +186,7 @@ github.com/Azure/azure-service-operator/v2/api/eventhub/v1api20211101/storage
 │       ├── Type: *string
 │       └── UpdatedAt: *string
 ├── NamespacesEventhubsAuthorizationRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/eventhub/v1api20211101.NamespacesEventhub
+│   ├── Owner: eventhub/v1api20211101.NamespacesEventhub
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string
@@ -210,7 +210,7 @@ github.com/Azure/azure-service-operator/v2/api/eventhub/v1api20211101/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 └── NamespacesEventhubsConsumerGroup: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/eventhub/v1api20211101.NamespacesEventhub
+    ├── Owner: eventhub/v1api20211101.NamespacesEventhub
     ├── Spec: Object (5 properties)
     │   ├── AzureName: string
     │   ├── OriginalVersion: string

--- a/v2/api/eventhub/v1api20211101/structure.txt
+++ b/v2/api/eventhub/v1api20211101/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/eventhub/v1api20211101
 ├── APIVersion: Enum (1 value)
 │   └── "2021-11-01"
 ├── Namespace: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (14 properties)
 │   │   ├── AlternateName: *string
 │   │   ├── AzureName: Validated<string> (3 rules)

--- a/v2/api/insights/v1api20180301/storage/structure.txt
+++ b/v2/api/insights/v1api20180301/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/insights/v1api20180301/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2018-03-01"
 └── MetricAlert: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (17 properties)
     │   ├── Actions: Object (3 properties)[]
     │   │   ├── ActionGroupId: *string

--- a/v2/api/insights/v1api20180301/structure.txt
+++ b/v2/api/insights/v1api20180301/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/insights/v1api20180301
 ├── APIVersion: Enum (1 value)
 │   └── "2018-03-01"
 ├── MetricAlert: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (15 properties)
 │   │   ├── Actions: Object (2 properties)[]
 │   │   │   ├── ActionGroupId: *string

--- a/v2/api/insights/v1api20180501preview/storage/structure.txt
+++ b/v2/api/insights/v1api20180501preview/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/insights/v1api20180501preview/sto
 ├── APIVersion: Enum (1 value)
 │   └── "2018-05-01-preview"
 └── Webtest: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (18 properties)
     │   ├── AzureName: string
     │   ├── Configuration: *Object (2 properties)

--- a/v2/api/insights/v1api20180501preview/structure.txt
+++ b/v2/api/insights/v1api20180501preview/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/insights/v1api20180501preview
 ├── APIVersion: Enum (1 value)
 │   └── "2018-05-01-preview"
 ├── Webtest: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (16 properties)
 │   │   ├── AzureName: string
 │   │   ├── Configuration: *Object (1 property)

--- a/v2/api/insights/v1api20200202/storage/structure.txt
+++ b/v2/api/insights/v1api20200202/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/insights/v1api20200202/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2020-02-02"
 └── Component: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (23 properties)
     │   ├── Application_Type: *string
     │   ├── AzureName: string

--- a/v2/api/insights/v1api20200202/structure.txt
+++ b/v2/api/insights/v1api20200202/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/insights/v1api20200202
 ├── APIVersion: Enum (1 value)
 │   └── "2020-02-02"
 ├── Component: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (21 properties)
 │   │   ├── Application_Type: *Enum (2 values)
 │   │   │   ├── "other"

--- a/v2/api/insights/v1api20220615/storage/structure.txt
+++ b/v2/api/insights/v1api20220615/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/insights/v1api20220615/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2022-06-15"
 ├── ScheduledQueryRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (22 properties)
 │   │   ├── Actions: *Object (3 properties)
 │   │   │   ├── ActionGroupsReferences: genruntime.ResourceReference[]

--- a/v2/api/insights/v1api20220615/structure.txt
+++ b/v2/api/insights/v1api20220615/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/insights/v1api20220615
 ├── APIVersion: Enum (1 value)
 │   └── "2022-06-15"
 ├── ScheduledQueryRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (20 properties)
 │   │   ├── Actions: *Object (2 properties)
 │   │   │   ├── ActionGroupsReferences: genruntime.ResourceReference[]

--- a/v2/api/insights/v1api20221001/storage/structure.txt
+++ b/v2/api/insights/v1api20221001/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/insights/v1api20221001/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2022-10-01"
 └── AutoscaleSetting: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (13 properties)
     │   ├── AzureName: string
     │   ├── Enabled: *bool

--- a/v2/api/insights/v1api20221001/structure.txt
+++ b/v2/api/insights/v1api20221001/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/insights/v1api20221001
 ├── APIVersion: Enum (1 value)
 │   └── "2022-10-01"
 ├── AutoscaleSetting: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (11 properties)
 │   │   ├── AzureName: string
 │   │   ├── Enabled: *bool

--- a/v2/api/insights/v1api20230101/storage/structure.txt
+++ b/v2/api/insights/v1api20230101/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/insights/v1api20230101/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2023-01-01"
 └── ActionGroup: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (19 properties)
     │   ├── ArmRoleReceivers: Object (4 properties)[]
     │   │   ├── Name: *string

--- a/v2/api/insights/v1api20230101/structure.txt
+++ b/v2/api/insights/v1api20230101/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/insights/v1api20230101
 ├── APIVersion: Enum (1 value)
 │   └── "2023-01-01"
 ├── ActionGroup: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (17 properties)
 │   │   ├── ArmRoleReceivers: Object (3 properties)[]
 │   │   │   ├── Name: *string

--- a/v2/api/keyvault/v1api20210401preview/storage/structure.txt
+++ b/v2/api/keyvault/v1api20210401preview/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/keyvault/v1api20210401preview/sto
 ├── APIVersion: Enum (1 value)
 │   └── "2021-04-01-preview"
 ├── Vault: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string

--- a/v2/api/keyvault/v1api20210401preview/structure.txt
+++ b/v2/api/keyvault/v1api20210401preview/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/keyvault/v1api20210401preview
 ├── APIVersion: Enum (1 value)
 │   └── "2021-04-01-preview"
 ├── Vault: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: Validated<string> (1 rule)
 │   │   │   └── Rule 0: Pattern: "^[a-zA-Z0-9-]{3,24}$"

--- a/v2/api/keyvault/v1api20230701/storage/structure.txt
+++ b/v2/api/keyvault/v1api20230701/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/keyvault/v1api20230701/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2023-07-01"
 └── Vault: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (7 properties)
     │   ├── AzureName: string
     │   ├── Location: *string

--- a/v2/api/keyvault/v1api20230701/structure.txt
+++ b/v2/api/keyvault/v1api20230701/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/keyvault/v1api20230701
 ├── APIVersion: Enum (1 value)
 │   └── "2023-07-01"
 ├── Vault: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: Validated<string> (1 rule)
 │   │   │   └── Rule 0: Pattern: "^[a-zA-Z0-9-]{3,24}$"

--- a/v2/api/machinelearningservices/v1api20210701/storage/structure.txt
+++ b/v2/api/machinelearningservices/v1api20210701/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1api2021
 ├── APIVersion: Enum (1 value)
 │   └── "2021-07-01"
 ├── Workspace: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (25 properties)
 │   │   ├── AllowPublicAccessWhenBehindVnet: *bool
 │   │   ├── ApplicationInsightsReference: *genruntime.ResourceReference
@@ -159,7 +159,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1api2021
 │       ├── Type: *string
 │       └── WorkspaceId: *string
 ├── WorkspacesCompute: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1api20210701.Workspace
+│   ├── Owner: machinelearningservices/v1api20210701.Workspace
 │   ├── Spec: Object (10 properties)
 │   │   ├── AzureName: string
 │   │   ├── Identity: *Object (3 properties)
@@ -960,7 +960,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1api2021
 │       ├── Tags: map[string]string
 │       └── Type: *string
 └── WorkspacesConnection: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1api20210701.Workspace
+    ├── Owner: machinelearningservices/v1api20210701.Workspace
     ├── Spec: Object (9 properties)
     │   ├── AuthType: *string
     │   ├── AzureName: string

--- a/v2/api/machinelearningservices/v1api20210701/structure.txt
+++ b/v2/api/machinelearningservices/v1api20210701/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1api2021
 ├── APIVersion: Enum (1 value)
 │   └── "2021-07-01"
 ├── Workspace: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (23 properties)
 │   │   ├── AllowPublicAccessWhenBehindVnet: *bool
 │   │   ├── ApplicationInsightsReference: *genruntime.ResourceReference

--- a/v2/api/managedidentity/v1api20181130/storage/structure.txt
+++ b/v2/api/managedidentity/v1api20181130/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20181130/sto
 ├── APIVersion: Enum (1 value)
 │   └── "2018-11-30"
 ├── UserAssignedIdentity: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string

--- a/v2/api/managedidentity/v1api20181130/structure.txt
+++ b/v2/api/managedidentity/v1api20181130/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20181130
 ├── APIVersion: Enum (1 value)
 │   └── "2018-11-30"
 ├── UserAssignedIdentity: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string

--- a/v2/api/managedidentity/v1api20220131preview/storage/structure.txt
+++ b/v2/api/managedidentity/v1api20220131preview/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20220131prev
 ├── APIVersion: Enum (1 value)
 │   └── "2022-01-31-preview"
 ├── FederatedIdentityCredential: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20220131preview.UserAssignedIdentity
+│   ├── Owner: managedidentity/v1api20220131preview.UserAssignedIdentity
 │   ├── Spec: Object (9 properties)
 │   │   ├── Audiences: string[]
 │   │   ├── AzureName: string

--- a/v2/api/managedidentity/v1api20230131/storage/structure.txt
+++ b/v2/api/managedidentity/v1api20230131/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20230131/sto
 ├── APIVersion: Enum (1 value)
 │   └── "2023-01-31"
 ├── FederatedIdentityCredential: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20230131.UserAssignedIdentity
+│   ├── Owner: managedidentity/v1api20230131.UserAssignedIdentity
 │   ├── Spec: Object (9 properties)
 │   │   ├── Audiences: string[]
 │   │   ├── AzureName: string
@@ -32,7 +32,7 @@ github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20230131/sto
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 └── UserAssignedIdentity: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (7 properties)
     │   ├── AzureName: string
     │   ├── Location: *string

--- a/v2/api/managedidentity/v1api20230131/structure.txt
+++ b/v2/api/managedidentity/v1api20230131/structure.txt
@@ -66,7 +66,7 @@ github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20230131
 │       ├── Issuer: *string
 │       └── Subject: *string
 ├── UserAssignedIdentity: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string

--- a/v2/api/network/v1api20180501/storage/structure.txt
+++ b/v2/api/network/v1api20180501/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20180501/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2018-05-01"
 ├── DnsZone: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (9 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -39,7 +39,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20180501/storage
 │       ├── Type: *string
 │       └── ZoneType: *string
 ├── DnsZonesAAAARecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20180501.DnsZone
+│   ├── Owner: network/v1api20180501.DnsZone
 │   ├── Spec: Object (17 properties)
 │   │   ├── AAAARecords: Object (2 properties)[]
 │   │   │   ├── Ipv6Address: *string
@@ -149,7 +149,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20180501/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── DnsZonesARecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20180501.DnsZone
+│   ├── Owner: network/v1api20180501.DnsZone
 │   ├── Spec: Object (18 properties)
 │   │   ├── AAAARecords: Object (2 properties)[]
 │   │   │   ├── Ipv6Address: *string
@@ -260,7 +260,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20180501/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── DnsZonesCAARecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20180501.DnsZone
+│   ├── Owner: network/v1api20180501.DnsZone
 │   ├── Spec: Object (17 properties)
 │   │   ├── AAAARecords: Object (2 properties)[]
 │   │   │   ├── Ipv6Address: *string
@@ -370,7 +370,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20180501/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── DnsZonesCNAMERecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20180501.DnsZone
+│   ├── Owner: network/v1api20180501.DnsZone
 │   ├── Spec: Object (17 properties)
 │   │   ├── AAAARecords: Object (2 properties)[]
 │   │   │   ├── Ipv6Address: *string
@@ -480,7 +480,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20180501/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── DnsZonesMXRecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20180501.DnsZone
+│   ├── Owner: network/v1api20180501.DnsZone
 │   ├── Spec: Object (17 properties)
 │   │   ├── AAAARecords: Object (2 properties)[]
 │   │   │   ├── Ipv6Address: *string
@@ -590,7 +590,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20180501/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── DnsZonesNSRecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20180501.DnsZone
+│   ├── Owner: network/v1api20180501.DnsZone
 │   ├── Spec: Object (17 properties)
 │   │   ├── AAAARecords: Object (2 properties)[]
 │   │   │   ├── Ipv6Address: *string
@@ -700,7 +700,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20180501/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── DnsZonesPTRRecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20180501.DnsZone
+│   ├── Owner: network/v1api20180501.DnsZone
 │   ├── Spec: Object (17 properties)
 │   │   ├── AAAARecords: Object (2 properties)[]
 │   │   │   ├── Ipv6Address: *string
@@ -810,7 +810,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20180501/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── DnsZonesSRVRecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20180501.DnsZone
+│   ├── Owner: network/v1api20180501.DnsZone
 │   ├── Spec: Object (17 properties)
 │   │   ├── AAAARecords: Object (2 properties)[]
 │   │   │   ├── Ipv6Address: *string
@@ -920,7 +920,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20180501/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── DnsZonesTXTRecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20180501.DnsZone
+│   ├── Owner: network/v1api20180501.DnsZone
 │   ├── Spec: Object (17 properties)
 │   │   ├── AAAARecords: Object (2 properties)[]
 │   │   │   ├── Ipv6Address: *string

--- a/v2/api/network/v1api20180501/structure.txt
+++ b/v2/api/network/v1api20180501/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20180501
 ├── APIVersion: Enum (1 value)
 │   └── "2018-05-01"
 ├── DnsZone: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string

--- a/v2/api/network/v1api20180901/storage/structure.txt
+++ b/v2/api/network/v1api20180901/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20180901/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2018-09-01"
 └── PrivateDnsZone: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (7 properties)
     │   ├── AzureName: string
     │   ├── Etag: *string

--- a/v2/api/network/v1api20180901/structure.txt
+++ b/v2/api/network/v1api20180901/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20180901
 ├── APIVersion: Enum (1 value)
 │   └── "2018-09-01"
 ├── PrivateDnsZone: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: string
 │   │   ├── Etag: *string

--- a/v2/api/network/v1api20200601/storage/structure.txt
+++ b/v2/api/network/v1api20200601/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20200601/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2020-06-01"
 ├── PrivateDnsZonesAAAARecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20200601.PrivateDnsZone
+│   ├── Owner: network/v1api20200601.PrivateDnsZone
 │   ├── Spec: Object (15 properties)
 │   │   ├── ARecords: Object (2 properties)[]
 │   │   │   ├── Ipv4Address: *string
@@ -92,7 +92,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20200601/storage
 │       │   └── Value: string[]
 │       └── Type: *string
 ├── PrivateDnsZonesARecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20200601.PrivateDnsZone
+│   ├── Owner: network/v1api20200601.PrivateDnsZone
 │   ├── Spec: Object (15 properties)
 │   │   ├── ARecords: Object (2 properties)[]
 │   │   │   ├── Ipv4Address: *string
@@ -181,7 +181,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20200601/storage
 │       │   └── Value: string[]
 │       └── Type: *string
 ├── PrivateDnsZonesCNAMERecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20200601.PrivateDnsZone
+│   ├── Owner: network/v1api20200601.PrivateDnsZone
 │   ├── Spec: Object (15 properties)
 │   │   ├── ARecords: Object (2 properties)[]
 │   │   │   ├── Ipv4Address: *string
@@ -270,7 +270,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20200601/storage
 │       │   └── Value: string[]
 │       └── Type: *string
 ├── PrivateDnsZonesMXRecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20200601.PrivateDnsZone
+│   ├── Owner: network/v1api20200601.PrivateDnsZone
 │   ├── Spec: Object (15 properties)
 │   │   ├── ARecords: Object (2 properties)[]
 │   │   │   ├── Ipv4Address: *string
@@ -359,7 +359,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20200601/storage
 │       │   └── Value: string[]
 │       └── Type: *string
 ├── PrivateDnsZonesPTRRecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20200601.PrivateDnsZone
+│   ├── Owner: network/v1api20200601.PrivateDnsZone
 │   ├── Spec: Object (15 properties)
 │   │   ├── ARecords: Object (2 properties)[]
 │   │   │   ├── Ipv4Address: *string
@@ -448,7 +448,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20200601/storage
 │       │   └── Value: string[]
 │       └── Type: *string
 ├── PrivateDnsZonesSRVRecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20200601.PrivateDnsZone
+│   ├── Owner: network/v1api20200601.PrivateDnsZone
 │   ├── Spec: Object (15 properties)
 │   │   ├── ARecords: Object (2 properties)[]
 │   │   │   ├── Ipv4Address: *string
@@ -537,7 +537,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20200601/storage
 │       │   └── Value: string[]
 │       └── Type: *string
 ├── PrivateDnsZonesTXTRecord: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20200601.PrivateDnsZone
+│   ├── Owner: network/v1api20200601.PrivateDnsZone
 │   ├── Spec: Object (15 properties)
 │   │   ├── ARecords: Object (2 properties)[]
 │   │   │   ├── Ipv4Address: *string
@@ -626,7 +626,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20200601/storage
 │       │   └── Value: string[]
 │       └── Type: *string
 ├── PrivateDnsZonesVirtualNetworkLink: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20200601.PrivateDnsZone
+│   ├── Owner: network/v1api20200601.PrivateDnsZone
 │   ├── Spec: Object (9 properties)
 │   │   ├── AzureName: string
 │   │   ├── Etag: *string

--- a/v2/api/network/v1api20201101/storage/structure.txt
+++ b/v2/api/network/v1api20201101/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2020-11-01"
 ├── LoadBalancer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (15 properties)
 │   │   ├── AzureName: string
 │   │   ├── BackendAddressPools: Object (3 properties)[]
@@ -296,7 +296,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── LoadBalancersInboundNatRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20201101.LoadBalancer
+│   ├── Owner: network/v1api20201101.LoadBalancer
 │   ├── Spec: Object (11 properties)
 │   │   ├── AzureName: string
 │   │   ├── BackendPort: *int
@@ -332,7 +332,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101/storage
 │       ├── ProvisioningState: *string
 │       └── Type: *string
 ├── NetworkInterface: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (14 properties)
 │   │   ├── AzureName: string
 │   │   ├── DnsSettings: *Object (3 properties)
@@ -470,7 +470,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101/storage
 │           ├── Id: *string
 │           └── PropertyBag: genruntime.PropertyBag
 ├── NetworkSecurityGroup: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -502,7 +502,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── NetworkSecurityGroupsSecurityRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20201101.NetworkSecurityGroup
+│   ├── Owner: network/v1api20201101.NetworkSecurityGroup
 │   ├── Spec: Object (19 properties)
 │   │   ├── Access: *string
 │   │   ├── AzureName: string
@@ -555,7 +555,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101/storage
 │       ├── SourcePortRanges: string[]
 │       └── Type: *string
 ├── PublicIPAddress: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (20 properties)
 │   │   ├── AzureName: string
 │   │   ├── DdosSettings: *Object (4 properties)
@@ -655,7 +655,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101/storage
 │       ├── Type: *string
 │       └── Zones: string[]
 ├── RouteTable: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── DisableBgpRoutePropagation: *bool
@@ -677,7 +677,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── RouteTablesRoute: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20201101.RouteTable
+│   ├── Owner: network/v1api20201101.RouteTable
 │   ├── Spec: Object (8 properties)
 │   │   ├── AddressPrefix: *string
 │   │   ├── AzureName: string
@@ -700,7 +700,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101/storage
 │       ├── ProvisioningState: *string
 │       └── Type: *string
 ├── VirtualNetwork: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (14 properties)
 │   │   ├── AddressSpace: *Object (2 properties)
 │   │   │   ├── AddressPrefixes: string[]
@@ -763,7 +763,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── VirtualNetworkGateway: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (21 properties)
 │   │   ├── ActiveActive: *bool
 │   │   ├── AzureName: string
@@ -949,7 +949,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101/storage
 │       ├── VpnGatewayGeneration: *string
 │       └── VpnType: *string
 ├── VirtualNetworksSubnet: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20201101.VirtualNetwork
+│   ├── Owner: network/v1api20201101.VirtualNetwork
 │   ├── Spec: Object (16 properties)
 │   │   ├── AddressPrefix: *string
 │   │   ├── AddressPrefixes: string[]
@@ -1046,7 +1046,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101/storage
 │       │   └── Service: *string
 │       └── Type: *string
 ├── VirtualNetworksVirtualNetworkPeering: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20201101.VirtualNetwork
+│   ├── Owner: network/v1api20201101.VirtualNetwork
 │   ├── Spec: Object (13 properties)
 │   │   ├── AllowForwardedTraffic: *bool
 │   │   ├── AllowGatewayTransit: *bool

--- a/v2/api/network/v1api20201101/structure.txt
+++ b/v2/api/network/v1api20201101/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101
 ├── APIVersion: Enum (1 value)
 │   └── "2020-11-01"
 ├── LoadBalancer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (13 properties)
 │   │   ├── AzureName: string
 │   │   ├── BackendAddressPools: Object (2 properties)[]
@@ -733,7 +733,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101
 │           ├── "Tcp"
 │           └── "Udp"
 ├── NetworkInterface: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (12 properties)
 │   │   ├── AzureName: string
 │   │   ├── DnsSettings: *Object (2 properties)
@@ -999,7 +999,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101
 │   │       └── Id: *string
 │   └── Tags: map[string]string
 ├── NetworkSecurityGroup: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (4 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -1225,7 +1225,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101
 │       ├── SourcePortRange: *string
 │       └── SourcePortRanges: string[]
 ├── PublicIPAddress: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (18 properties)
 │   │   ├── AzureName: string
 │   │   ├── DdosSettings: *Object (3 properties)
@@ -1441,7 +1441,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101
 │   ├── Tags: map[string]string
 │   └── Zones: string[]
 ├── RouteTable: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: string
 │   │   ├── DisableBgpRoutePropagation: *bool
@@ -1565,7 +1565,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101
 │           ├── "VirtualNetworkGateway"
 │           └── "VnetLocal"
 ├── VirtualNetwork: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (12 properties)
 │   │   ├── AddressSpace: *Object (1 property)
 │   │   │   └── AddressPrefixes: string[]
@@ -1619,7 +1619,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20201101
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── VirtualNetworkGateway: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (19 properties)
 │   │   ├── ActiveActive: *bool
 │   │   ├── AzureName: string

--- a/v2/api/network/v1api20220401/storage/structure.txt
+++ b/v2/api/network/v1api20220401/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220401/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2022-04-01"
 ├── TrafficManagerProfile: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (15 properties)
 │   │   ├── AllowedEndpointRecordTypes: string[]
 │   │   ├── AzureName: string
@@ -82,7 +82,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220401/storage
 │       ├── TrafficViewEnrollmentStatus: *string
 │       └── Type: *string
 ├── TrafficManagerProfilesAzureEndpoint: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20220401.TrafficManagerProfile
+│   ├── Owner: network/v1api20220401.TrafficManagerProfile
 │   ├── Spec: Object (19 properties)
 │   │   ├── AlwaysServe: *string
 │   │   ├── AzureName: string
@@ -138,7 +138,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220401/storage
 │       ├── Type: *string
 │       └── Weight: *int
 ├── TrafficManagerProfilesExternalEndpoint: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20220401.TrafficManagerProfile
+│   ├── Owner: network/v1api20220401.TrafficManagerProfile
 │   ├── Spec: Object (19 properties)
 │   │   ├── AlwaysServe: *string
 │   │   ├── AzureName: string
@@ -194,7 +194,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220401/storage
 │       ├── Type: *string
 │       └── Weight: *int
 └── TrafficManagerProfilesNestedEndpoint: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20220401.TrafficManagerProfile
+    ├── Owner: network/v1api20220401.TrafficManagerProfile
     ├── Spec: Object (19 properties)
     │   ├── AlwaysServe: *string
     │   ├── AzureName: string

--- a/v2/api/network/v1api20220401/structure.txt
+++ b/v2/api/network/v1api20220401/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220401
 ├── APIVersion: Enum (1 value)
 │   └── "2022-04-01"
 ├── TrafficManagerProfile: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (13 properties)
 │   │   ├── AllowedEndpointRecordTypes: Enum (4 values)[]
 │   │   │   ├── "Any"

--- a/v2/api/network/v1api20220701/storage/structure.txt
+++ b/v2/api/network/v1api20220701/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2022-07-01"
 ├── ApplicationGateway: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (39 properties)
 │   │   ├── AuthenticationCertificates: Object (3 properties)[]
 │   │   │   ├── Data: *genruntime.SecretReference
@@ -491,7 +491,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701/storage
 │       │   └── RuleSetVersion: *string
 │       └── Zones: string[]
 ├── BastionHost: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (15 properties)
 │   │   ├── AzureName: string
 │   │   ├── DisableCopyPaste: *bool
@@ -543,7 +543,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── DnsForwardingRuleSetsForwardingRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20220701.DnsForwardingRuleset
+│   ├── Owner: network/v1api20220701.DnsForwardingRuleset
 │   ├── Spec: Object (8 properties)
 │   │   ├── AzureName: string
 │   │   ├── DomainName: *string
@@ -581,7 +581,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── DnsForwardingRuleset: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── DnsResolverOutboundEndpoints: Object (2 properties)[]
@@ -615,7 +615,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── DnsResolver: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -650,7 +650,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701/storage
 │           ├── Id: *string
 │           └── PropertyBag: genruntime.PropertyBag
 ├── DnsResolversInboundEndpoint: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20220701.DnsResolver
+│   ├── Owner: network/v1api20220701.DnsResolver
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── IpConfigurations: Object (4 properties)[]
@@ -692,7 +692,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── DnsResolversOutboundEndpoint: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20220701.DnsResolver
+│   ├── Owner: network/v1api20220701.DnsResolver
 │   ├── Spec: Object (7 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -726,7 +726,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── NatGateway: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (11 properties)
 │   │   ├── AzureName: string
 │   │   ├── IdleTimeoutInMinutes: *int
@@ -771,7 +771,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701/storage
 │       ├── Type: *string
 │       └── Zones: string[]
 ├── PrivateEndpoint: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (13 properties)
 │   │   ├── ApplicationSecurityGroups: Object (2 properties)[]
 │   │   │   ├── PropertyBag: genruntime.PropertyBag
@@ -885,7 +885,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── PrivateEndpointsPrivateDnsZoneGroup: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/network/v1api20220701.PrivateEndpoint
+│   ├── Owner: network/v1api20220701.PrivateEndpoint
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string
@@ -915,7 +915,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701/storage
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── ProvisioningState: *string
 ├── PrivateLinkService: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (14 properties)
 │   │   ├── AutoApproval: *Object (2 properties)
 │   │   │   ├── PropertyBag: genruntime.PropertyBag
@@ -1000,7 +1000,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701/storage
 │           ├── PropertyBag: genruntime.PropertyBag
 │           └── Subscriptions: string[]
 └── PublicIPPrefix: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (14 properties)
     │   ├── AzureName: string
     │   ├── CustomIPPrefix: *Object (2 properties)

--- a/v2/api/network/v1api20220701/structure.txt
+++ b/v2/api/network/v1api20220701/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701
 ├── APIVersion: Enum (1 value)
 │   └── "2022-07-01"
 ├── ApplicationGateway: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (37 properties)
 │   │   ├── AuthenticationCertificates: Object (2 properties)[]
 │   │   │   ├── Data: *genruntime.SecretReference
@@ -1204,7 +1204,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701
 │   ├── Tags: map[string]string
 │   └── Zones: string[]
 ├── BastionHost: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (13 properties)
 │   │   ├── AzureName: string
 │   │   ├── DisableCopyPaste: *bool
@@ -1361,7 +1361,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701
 │       │   └── Port: *int
 │       └── Type: *string
 ├── DnsForwardingRuleset: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: string
 │   │   ├── DnsResolverOutboundEndpoints: Object (1 property)[]
@@ -1490,7 +1490,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701
 │           ├── IpAddress: *string
 │           └── Port: *int
 ├── DnsResolver: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: string
 │   │   ├── Location: *string
@@ -1762,7 +1762,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701
 │   │       └── Id: *string
 │   └── Tags: map[string]string
 ├── NatGateway: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (9 properties)
 │   │   ├── AzureName: string
 │   │   ├── IdleTimeoutInMinutes: *int
@@ -1842,7 +1842,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701
 │   ├── Tags: map[string]string
 │   └── Zones: string[]
 ├── PrivateEndpoint: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (11 properties)
 │   │   ├── ApplicationSecurityGroups: Object (1 property)[]
 │   │   │   └── Reference: *genruntime.ResourceReference
@@ -2124,7 +2124,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701
 │           └── Properties: *Object (1 property)
 │               └── PrivateDnsZoneId: *string
 ├── PrivateLinkService: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (12 properties)
 │   │   ├── AutoApproval: *Object (1 property)
 │   │   │   └── Subscriptions: string[]
@@ -2289,7 +2289,7 @@ github.com/Azure/azure-service-operator/v2/api/network/v1api20220701
 │   │       └── Subscriptions: string[]
 │   └── Tags: map[string]string
 ├── PublicIPPrefix: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (12 properties)
 │   │   ├── AzureName: string
 │   │   ├── CustomIPPrefix: *Object (1 property)

--- a/v2/api/operationalinsights/v1api20210601/storage/structure.txt
+++ b/v2/api/operationalinsights/v1api20210601/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/operationalinsights/v1api20210601
 ├── APIVersion: Enum (1 value)
 │   └── "2021-06-01"
 └── Workspace: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (15 properties)
     │   ├── AzureName: string
     │   ├── Etag: *string

--- a/v2/api/operationalinsights/v1api20210601/structure.txt
+++ b/v2/api/operationalinsights/v1api20210601/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/operationalinsights/v1api20210601
 ├── APIVersion: Enum (1 value)
 │   └── "2021-06-01"
 ├── Workspace: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (13 properties)
 │   │   ├── AzureName: Validated<string> (3 rules)
 │   │   │   ├── Rule 0: MaxLength: 63

--- a/v2/api/search/v1api20220901/storage/structure.txt
+++ b/v2/api/search/v1api20220901/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/search/v1api20220901/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2022-09-01"
 └── SearchService: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (17 properties)
     │   ├── AuthOptions: *Object (2 properties)
     │   │   ├── AadOrApiKey: *Object (2 properties)

--- a/v2/api/search/v1api20220901/structure.txt
+++ b/v2/api/search/v1api20220901/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/search/v1api20220901
 ├── APIVersion: Enum (1 value)
 │   └── "2022-09-01"
 ├── SearchService: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (15 properties)
 │   │   ├── AuthOptions: *Object (1 property)
 │   │   │   └── AadOrApiKey: *Object (1 property)

--- a/v2/api/servicebus/v1api20210101preview/storage/structure.txt
+++ b/v2/api/servicebus/v1api20210101preview/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20210101preview/s
 ├── APIVersion: Enum (1 value)
 │   └── "2021-01-01-preview"
 ├── Namespace: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (11 properties)
 │   │   ├── AzureName: string
 │   │   ├── Encryption: *Object (4 properties)
@@ -97,7 +97,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20210101preview/s
 │       ├── UpdatedAt: *string
 │       └── ZoneRedundant: *bool
 ├── NamespacesAuthorizationRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20210101preview.Namespace
+│   ├── Owner: servicebus/v1api20210101preview.Namespace
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── OperatorSpec: *Object (2 properties)
@@ -128,7 +128,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20210101preview/s
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── NamespacesQueue: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20210101preview.Namespace
+│   ├── Owner: servicebus/v1api20210101preview.Namespace
 │   ├── Spec: Object (18 properties)
 │   │   ├── AutoDeleteOnIdle: *string
 │   │   ├── AzureName: string
@@ -190,7 +190,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20210101preview/s
 │       ├── Type: *string
 │       └── UpdatedAt: *string
 ├── NamespacesTopic: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20210101preview.Namespace
+│   ├── Owner: servicebus/v1api20210101preview.Namespace
 │   ├── Spec: Object (13 properties)
 │   │   ├── AutoDeleteOnIdle: *string
 │   │   ├── AzureName: string
@@ -242,7 +242,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20210101preview/s
 │       ├── Type: *string
 │       └── UpdatedAt: *string
 ├── NamespacesTopicsSubscription: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20210101preview.NamespacesTopic
+│   ├── Owner: servicebus/v1api20210101preview.NamespacesTopic
 │   ├── Spec: Object (15 properties)
 │   │   ├── AutoDeleteOnIdle: *string
 │   │   ├── AzureName: string
@@ -297,7 +297,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20210101preview/s
 │       ├── Type: *string
 │       └── UpdatedAt: *string
 ├── NamespacesTopicsSubscriptionsRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20210101preview.NamespacesTopicsSubscription
+│   ├── Owner: servicebus/v1api20210101preview.NamespacesTopicsSubscription
 │   ├── Spec: Object (8 properties)
 │   │   ├── Action: *Object (4 properties)
 │   │   │   ├── CompatibilityLevel: *int

--- a/v2/api/servicebus/v1api20210101preview/structure.txt
+++ b/v2/api/servicebus/v1api20210101preview/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20210101preview
 ├── APIVersion: Enum (1 value)
 │   └── "2021-01-01-preview"
 ├── Namespace: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (9 properties)
 │   │   ├── AzureName: string
 │   │   ├── Encryption: *Object (3 properties)

--- a/v2/api/servicebus/v1api20211101/storage/structure.txt
+++ b/v2/api/servicebus/v1api20211101/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20211101/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2021-11-01"
 ├── Namespace: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (13 properties)
 │   │   ├── AlternateName: *string
 │   │   ├── AzureName: string
@@ -101,7 +101,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20211101/storage
 │       ├── UpdatedAt: *string
 │       └── ZoneRedundant: *bool
 ├── NamespacesAuthorizationRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20211101.Namespace
+│   ├── Owner: servicebus/v1api20211101.Namespace
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── OperatorSpec: *Object (2 properties)
@@ -133,7 +133,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20211101/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── NamespacesQueue: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20211101.Namespace
+│   ├── Owner: servicebus/v1api20211101.Namespace
 │   ├── Spec: Object (19 properties)
 │   │   ├── AutoDeleteOnIdle: *string
 │   │   ├── AzureName: string
@@ -198,7 +198,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20211101/storage
 │       ├── Type: *string
 │       └── UpdatedAt: *string
 ├── NamespacesTopic: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20211101.Namespace
+│   ├── Owner: servicebus/v1api20211101.Namespace
 │   ├── Spec: Object (14 properties)
 │   │   ├── AutoDeleteOnIdle: *string
 │   │   ├── AzureName: string
@@ -253,7 +253,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20211101/storage
 │       ├── Type: *string
 │       └── UpdatedAt: *string
 ├── NamespacesTopicsSubscription: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20211101.NamespacesTopic
+│   ├── Owner: servicebus/v1api20211101.NamespacesTopic
 │   ├── Spec: Object (17 properties)
 │   │   ├── AutoDeleteOnIdle: *string
 │   │   ├── AzureName: string
@@ -321,7 +321,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20211101/storage
 │       ├── Type: *string
 │       └── UpdatedAt: *string
 └── NamespacesTopicsSubscriptionsRule: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20211101.NamespacesTopicsSubscription
+    ├── Owner: servicebus/v1api20211101.NamespacesTopicsSubscription
     ├── Spec: Object (8 properties)
     │   ├── Action: *Object (4 properties)
     │   │   ├── CompatibilityLevel: *int

--- a/v2/api/servicebus/v1api20211101/structure.txt
+++ b/v2/api/servicebus/v1api20211101/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20211101
 ├── APIVersion: Enum (1 value)
 │   └── "2021-11-01"
 ├── Namespace: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (11 properties)
 │   │   ├── AlternateName: *string
 │   │   ├── AzureName: string

--- a/v2/api/servicebus/v1api20221001preview/storage/structure.txt
+++ b/v2/api/servicebus/v1api20221001preview/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20221001preview/s
 ├── APIVersion: Enum (1 value)
 │   └── "2022-10-01-preview"
 ├── Namespace: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (16 properties)
 │   │   ├── AlternateName: *string
 │   │   ├── AzureName: string
@@ -107,7 +107,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20221001preview/s
 │       ├── UpdatedAt: *string
 │       └── ZoneRedundant: *bool
 ├── NamespacesAuthorizationRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20221001preview.Namespace
+│   ├── Owner: servicebus/v1api20221001preview.Namespace
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── OperatorSpec: *Object (2 properties)
@@ -139,7 +139,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20221001preview/s
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── NamespacesQueue: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20221001preview.Namespace
+│   ├── Owner: servicebus/v1api20221001preview.Namespace
 │   ├── Spec: Object (19 properties)
 │   │   ├── AutoDeleteOnIdle: *string
 │   │   ├── AzureName: string
@@ -204,7 +204,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20221001preview/s
 │       ├── Type: *string
 │       └── UpdatedAt: *string
 ├── NamespacesTopic: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20221001preview.Namespace
+│   ├── Owner: servicebus/v1api20221001preview.Namespace
 │   ├── Spec: Object (14 properties)
 │   │   ├── AutoDeleteOnIdle: *string
 │   │   ├── AzureName: string
@@ -259,7 +259,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20221001preview/s
 │       ├── Type: *string
 │       └── UpdatedAt: *string
 ├── NamespacesTopicsSubscription: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20221001preview.NamespacesTopic
+│   ├── Owner: servicebus/v1api20221001preview.NamespacesTopic
 │   ├── Spec: Object (17 properties)
 │   │   ├── AutoDeleteOnIdle: *string
 │   │   ├── AzureName: string
@@ -327,7 +327,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20221001preview/s
 │       ├── Type: *string
 │       └── UpdatedAt: *string
 ├── NamespacesTopicsSubscriptionsRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20221001preview.NamespacesTopicsSubscription
+│   ├── Owner: servicebus/v1api20221001preview.NamespacesTopicsSubscription
 │   ├── Spec: Object (8 properties)
 │   │   ├── Action: *Object (4 properties)
 │   │   │   ├── CompatibilityLevel: *int

--- a/v2/api/servicebus/v1api20221001preview/structure.txt
+++ b/v2/api/servicebus/v1api20221001preview/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/servicebus/v1api20221001preview
 ├── APIVersion: Enum (1 value)
 │   └── "2022-10-01-preview"
 ├── Namespace: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (14 properties)
 │   │   ├── AlternateName: *string
 │   │   ├── AzureName: string

--- a/v2/api/signalrservice/v1api20211001/storage/structure.txt
+++ b/v2/api/signalrservice/v1api20211001/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/signalrservice/v1api20211001/stor
 ├── APIVersion: Enum (1 value)
 │   └── "2021-10-01"
 └── SignalR: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (19 properties)
     │   ├── AzureName: string
     │   ├── Cors: *Object (2 properties)

--- a/v2/api/signalrservice/v1api20211001/structure.txt
+++ b/v2/api/signalrservice/v1api20211001/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/signalrservice/v1api20211001
 ├── APIVersion: Enum (1 value)
 │   └── "2021-10-01"
 ├── SignalR: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (17 properties)
 │   │   ├── AzureName: string
 │   │   ├── Cors: *Object (1 property)

--- a/v2/api/sql/v1api20211101/storage/structure.txt
+++ b/v2/api/sql/v1api20211101/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2021-11-01"
 ├── Server: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (18 properties)
 │   │   ├── AdministratorLogin: *string
 │   │   ├── AdministratorLoginPassword: *genruntime.SecretReference
@@ -92,7 +92,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── Version: *string
 │       └── WorkspaceFeature: *string
 ├── ServersAdministrator: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+│   ├── Owner: sql/v1api20211101.Server
 │   ├── Spec: Object (9 properties)
 │   │   ├── AdministratorType: *string
 │   │   ├── Login: *string
@@ -115,7 +115,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── TenantId: *string
 │       └── Type: *string
 ├── ServersAdvancedThreatProtectionSetting: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+│   ├── Owner: sql/v1api20211101.Server
 │   ├── Spec: Object (4 properties)
 │   │   ├── OriginalVersion: string
 │   │   ├── Owner: *genruntime.KnownResourceReference
@@ -138,7 +138,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── ServersAuditingSetting: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+│   ├── Owner: sql/v1api20211101.Server
 │   ├── Spec: Object (14 properties)
 │   │   ├── AuditActionsAndGroups: string[]
 │   │   ├── IsAzureMonitorTargetEnabled: *bool
@@ -171,7 +171,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── StorageEndpoint: *string
 │       └── Type: *string
 ├── ServersAzureADOnlyAuthentication: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+│   ├── Owner: sql/v1api20211101.Server
 │   ├── Spec: Object (4 properties)
 │   │   ├── AzureADOnlyAuthentication: *bool
 │   │   ├── OriginalVersion: string
@@ -185,7 +185,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── ServersConnectionPolicy: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+│   ├── Owner: sql/v1api20211101.Server
 │   ├── Spec: Object (4 properties)
 │   │   ├── ConnectionType: *string
 │   │   ├── OriginalVersion: string
@@ -201,7 +201,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── ServersDatabase: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+│   ├── Owner: sql/v1api20211101.Server
 │   ├── Spec: Object (33 properties)
 │   │   ├── AutoPauseDelay: *int
 │   │   ├── AzureName: string
@@ -318,7 +318,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── Type: *string
 │       └── ZoneRedundant: *bool
 ├── ServersDatabasesAdvancedThreatProtectionSetting: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.ServersDatabase
+│   ├── Owner: sql/v1api20211101.ServersDatabase
 │   ├── Spec: Object (4 properties)
 │   │   ├── OriginalVersion: string
 │   │   ├── Owner: *genruntime.KnownResourceReference
@@ -341,7 +341,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── ServersDatabasesAuditingSetting: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.ServersDatabase
+│   ├── Owner: sql/v1api20211101.ServersDatabase
 │   ├── Spec: Object (13 properties)
 │   │   ├── AuditActionsAndGroups: string[]
 │   │   ├── IsAzureMonitorTargetEnabled: *bool
@@ -373,7 +373,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── StorageEndpoint: *string
 │       └── Type: *string
 ├── ServersDatabasesBackupLongTermRetentionPolicy: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.ServersDatabase
+│   ├── Owner: sql/v1api20211101.ServersDatabase
 │   ├── Spec: Object (7 properties)
 │   │   ├── MonthlyRetention: *string
 │   │   ├── OriginalVersion: string
@@ -393,7 +393,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── WeeklyRetention: *string
 │       └── YearlyRetention: *string
 ├── ServersDatabasesBackupShortTermRetentionPolicy: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.ServersDatabase
+│   ├── Owner: sql/v1api20211101.ServersDatabase
 │   ├── Spec: Object (5 properties)
 │   │   ├── DiffBackupIntervalInHours: *int
 │   │   ├── OriginalVersion: string
@@ -409,7 +409,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── RetentionDays: *int
 │       └── Type: *string
 ├── ServersDatabasesSecurityAlertPolicy: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.ServersDatabase
+│   ├── Owner: sql/v1api20211101.ServersDatabase
 │   ├── Spec: Object (10 properties)
 │   │   ├── DisabledAlerts: string[]
 │   │   ├── EmailAccountAdmins: *bool
@@ -443,7 +443,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── ServersDatabasesTransparentDataEncryption: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.ServersDatabase
+│   ├── Owner: sql/v1api20211101.ServersDatabase
 │   ├── Spec: Object (4 properties)
 │   │   ├── OriginalVersion: string
 │   │   ├── Owner: *genruntime.KnownResourceReference
@@ -457,7 +457,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── State: *string
 │       └── Type: *string
 ├── ServersDatabasesVulnerabilityAssessment: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.ServersDatabase
+│   ├── Owner: sql/v1api20211101.ServersDatabase
 │   ├── Spec: Object (8 properties)
 │   │   ├── OriginalVersion: string
 │   │   ├── Owner: *genruntime.KnownResourceReference
@@ -484,7 +484,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── StorageContainerPath: *string
 │       └── Type: *string
 ├── ServersElasticPool: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+│   ├── Owner: sql/v1api20211101.Server
 │   ├── Spec: Object (14 properties)
 │   │   ├── AzureName: string
 │   │   ├── HighAvailabilityReplicaCount: *int
@@ -538,7 +538,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── Type: *string
 │       └── ZoneRedundant: *bool
 ├── ServersFailoverGroup: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+│   ├── Owner: sql/v1api20211101.Server
 │   ├── Spec: Object (9 properties)
 │   │   ├── AzureName: string
 │   │   ├── DatabasesReferences: genruntime.ResourceReference[]
@@ -580,7 +580,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── ServersFirewallRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+│   ├── Owner: sql/v1api20211101.Server
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── EndIpAddress: *string
@@ -597,7 +597,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── StartIpAddress: *string
 │       └── Type: *string
 ├── ServersIPV6FirewallRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+│   ├── Owner: sql/v1api20211101.Server
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── EndIPv6Address: *string
@@ -614,7 +614,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── StartIPv6Address: *string
 │       └── Type: *string
 ├── ServersOutboundFirewallRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+│   ├── Owner: sql/v1api20211101.Server
 │   ├── Spec: Object (4 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string
@@ -628,7 +628,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── ProvisioningState: *string
 │       └── Type: *string
 ├── ServersSecurityAlertPolicy: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+│   ├── Owner: sql/v1api20211101.Server
 │   ├── Spec: Object (10 properties)
 │   │   ├── DisabledAlerts: string[]
 │   │   ├── EmailAccountAdmins: *bool
@@ -662,7 +662,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       │   └── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── ServersVirtualNetworkRule: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+│   ├── Owner: sql/v1api20211101.Server
 │   ├── Spec: Object (6 properties)
 │   │   ├── AzureName: string
 │   │   ├── IgnoreMissingVnetServiceEndpoint: *bool
@@ -680,7 +680,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101/storage
 │       ├── Type: *string
 │       └── VirtualNetworkSubnetId: *string
 └── ServersVulnerabilityAssessment: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101.Server
+    ├── Owner: sql/v1api20211101.Server
     ├── Spec: Object (8 properties)
     │   ├── OriginalVersion: string
     │   ├── Owner: *genruntime.KnownResourceReference

--- a/v2/api/sql/v1api20211101/structure.txt
+++ b/v2/api/sql/v1api20211101/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/sql/v1api20211101
 ├── APIVersion: Enum (1 value)
 │   └── "2021-11-01"
 ├── Server: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (16 properties)
 │   │   ├── AdministratorLogin: *string
 │   │   ├── AdministratorLoginPassword: *genruntime.SecretReference

--- a/v2/api/storage/v1api20210401/storage/structure.txt
+++ b/v2/api/storage/v1api20210401/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20210401/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2021-04-01"
 ├── StorageAccount: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (27 properties)
 │   │   ├── AccessTier: *string
 │   │   ├── AllowBlobPublicAccess: *bool
@@ -323,7 +323,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20210401/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── StorageAccountsBlobService: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20210401.StorageAccount
+│   ├── Owner: storage/v1api20210401.StorageAccount
 │   ├── Spec: Object (12 properties)
 │   │   ├── AutomaticSnapshotPolicyEnabled: *bool
 │   │   ├── ChangeFeed: *Object (3 properties)
@@ -409,7 +409,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20210401/storage
 │       │   └── Tier: *string
 │       └── Type: *string
 ├── StorageAccountsBlobServicesContainer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20210401.StorageAccountsBlobService
+│   ├── Owner: storage/v1api20210401.StorageAccountsBlobService
 │   ├── Spec: Object (9 properties)
 │   │   ├── AzureName: string
 │   │   ├── DefaultEncryptionScope: *string
@@ -473,7 +473,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20210401/storage
 │       ├── Type: *string
 │       └── Version: *string
 ├── StorageAccountsManagementPolicy: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20210401.StorageAccount
+│   ├── Owner: storage/v1api20210401.StorageAccount
 │   ├── Spec: Object (4 properties)
 │   │   ├── OriginalVersion: string
 │   │   ├── Owner: *genruntime.KnownResourceReference
@@ -600,7 +600,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20210401/storage
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── StorageAccountsQueueService: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20210401.StorageAccount
+│   ├── Owner: storage/v1api20210401.StorageAccount
 │   ├── Spec: Object (4 properties)
 │   │   ├── Cors: *Object (2 properties)
 │   │   │   ├── CorsRules: Object (6 properties)[]
@@ -630,7 +630,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20210401/storage
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── StorageAccountsQueueServicesQueue: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20210401.StorageAccountsQueueService
+│   ├── Owner: storage/v1api20210401.StorageAccountsQueueService
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: string
 │   │   ├── Metadata: map[string]string

--- a/v2/api/storage/v1api20210401/structure.txt
+++ b/v2/api/storage/v1api20210401/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20210401
 ├── APIVersion: Enum (1 value)
 │   └── "2021-04-01"
 ├── StorageAccount: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (25 properties)
 │   │   ├── AccessTier: *Enum (2 values)
 │   │   │   ├── "Cool"

--- a/v2/api/storage/v1api20220901/storage/structure.txt
+++ b/v2/api/storage/v1api20220901/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2022-09-01"
 ├── StorageAccount: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (34 properties)
 │   │   ├── AccessTier: *string
 │   │   ├── AllowBlobPublicAccess: *bool
@@ -364,7 +364,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── StorageAccountsBlobService: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901.StorageAccount
+│   ├── Owner: storage/v1api20220901.StorageAccount
 │   ├── Spec: Object (12 properties)
 │   │   ├── AutomaticSnapshotPolicyEnabled: *bool
 │   │   ├── ChangeFeed: *Object (3 properties)
@@ -454,7 +454,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901/storage
 │       │   └── Tier: *string
 │       └── Type: *string
 ├── StorageAccountsBlobServicesContainer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901.StorageAccountsBlobService
+│   ├── Owner: storage/v1api20220901.StorageAccountsBlobService
 │   ├── Spec: Object (11 properties)
 │   │   ├── AzureName: string
 │   │   ├── DefaultEncryptionScope: *string
@@ -529,7 +529,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901/storage
 │       ├── Type: *string
 │       └── Version: *string
 ├── StorageAccountsFileService: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901.StorageAccount
+│   ├── Owner: storage/v1api20220901.StorageAccount
 │   ├── Spec: Object (6 properties)
 │   │   ├── Cors: *Object (2 properties)
 │   │   │   ├── CorsRules: Object (6 properties)[]
@@ -595,7 +595,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901/storage
 │       │   └── Tier: *string
 │       └── Type: *string
 ├── StorageAccountsFileServicesShare: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901.StorageAccountsFileService
+│   ├── Owner: storage/v1api20220901.StorageAccountsFileService
 │   ├── Spec: Object (10 properties)
 │   │   ├── AccessTier: *string
 │   │   ├── AzureName: string
@@ -647,7 +647,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901/storage
 │       ├── Type: *string
 │       └── Version: *string
 ├── StorageAccountsManagementPolicy: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901.StorageAccount
+│   ├── Owner: storage/v1api20220901.StorageAccount
 │   ├── Spec: Object (4 properties)
 │   │   ├── OriginalVersion: string
 │   │   ├── Owner: *genruntime.KnownResourceReference
@@ -854,7 +854,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901/storage
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── StorageAccountsQueueService: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901.StorageAccount
+│   ├── Owner: storage/v1api20220901.StorageAccount
 │   ├── Spec: Object (4 properties)
 │   │   ├── Cors: *Object (2 properties)
 │   │   │   ├── CorsRules: Object (6 properties)[]
@@ -884,7 +884,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901/storage
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── StorageAccountsQueueServicesQueue: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901.StorageAccountsQueueService
+│   ├── Owner: storage/v1api20220901.StorageAccountsQueueService
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: string
 │   │   ├── Metadata: map[string]string
@@ -900,7 +900,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901/storage
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── StorageAccountsTableService: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901.StorageAccount
+│   ├── Owner: storage/v1api20220901.StorageAccount
 │   ├── Spec: Object (4 properties)
 │   │   ├── Cors: *Object (2 properties)
 │   │   │   ├── CorsRules: Object (6 properties)[]
@@ -930,7 +930,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901/storage
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── StorageAccountsTableServicesTable: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901.StorageAccountsTableService
+│   ├── Owner: storage/v1api20220901.StorageAccountsTableService
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: string
 │   │   ├── OriginalVersion: string

--- a/v2/api/storage/v1api20220901/structure.txt
+++ b/v2/api/storage/v1api20220901/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20220901
 ├── APIVersion: Enum (1 value)
 │   └── "2022-09-01"
 ├── StorageAccount: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (32 properties)
 │   │   ├── AccessTier: *Enum (3 values)
 │   │   │   ├── "Cool"

--- a/v2/api/storage/v1api20230101/storage/structure.txt
+++ b/v2/api/storage/v1api20230101/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2023-01-01"
 ├── StorageAccount: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (34 properties)
 │   │   ├── AccessTier: *string
 │   │   ├── AllowBlobPublicAccess: *bool
@@ -369,7 +369,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101/storage
 │       ├── Tags: map[string]string
 │       └── Type: *string
 ├── StorageAccountsBlobService: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101.StorageAccount
+│   ├── Owner: storage/v1api20230101.StorageAccount
 │   ├── Spec: Object (12 properties)
 │   │   ├── AutomaticSnapshotPolicyEnabled: *bool
 │   │   ├── ChangeFeed: *Object (3 properties)
@@ -459,7 +459,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101/storage
 │       │   └── Tier: *string
 │       └── Type: *string
 ├── StorageAccountsBlobServicesContainer: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101.StorageAccountsBlobService
+│   ├── Owner: storage/v1api20230101.StorageAccountsBlobService
 │   ├── Spec: Object (11 properties)
 │   │   ├── AzureName: string
 │   │   ├── DefaultEncryptionScope: *string
@@ -534,7 +534,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101/storage
 │       ├── Type: *string
 │       └── Version: *string
 ├── StorageAccountsFileService: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101.StorageAccount
+│   ├── Owner: storage/v1api20230101.StorageAccount
 │   ├── Spec: Object (6 properties)
 │   │   ├── Cors: *Object (2 properties)
 │   │   │   ├── CorsRules: Object (6 properties)[]
@@ -600,7 +600,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101/storage
 │       │   └── Tier: *string
 │       └── Type: *string
 ├── StorageAccountsFileServicesShare: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101.StorageAccountsFileService
+│   ├── Owner: storage/v1api20230101.StorageAccountsFileService
 │   ├── Spec: Object (10 properties)
 │   │   ├── AccessTier: *string
 │   │   ├── AzureName: string
@@ -652,7 +652,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101/storage
 │       ├── Type: *string
 │       └── Version: *string
 ├── StorageAccountsManagementPolicy: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101.StorageAccount
+│   ├── Owner: storage/v1api20230101.StorageAccount
 │   ├── Spec: Object (4 properties)
 │   │   ├── OriginalVersion: string
 │   │   ├── Owner: *genruntime.KnownResourceReference
@@ -859,7 +859,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101/storage
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── StorageAccountsQueueService: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101.StorageAccount
+│   ├── Owner: storage/v1api20230101.StorageAccount
 │   ├── Spec: Object (4 properties)
 │   │   ├── Cors: *Object (2 properties)
 │   │   │   ├── CorsRules: Object (6 properties)[]
@@ -889,7 +889,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101/storage
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── StorageAccountsQueueServicesQueue: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101.StorageAccountsQueueService
+│   ├── Owner: storage/v1api20230101.StorageAccountsQueueService
 │   ├── Spec: Object (5 properties)
 │   │   ├── AzureName: string
 │   │   ├── Metadata: map[string]string
@@ -905,7 +905,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101/storage
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 ├── StorageAccountsTableService: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101.StorageAccount
+│   ├── Owner: storage/v1api20230101.StorageAccount
 │   ├── Spec: Object (4 properties)
 │   │   ├── Cors: *Object (2 properties)
 │   │   │   ├── CorsRules: Object (6 properties)[]
@@ -935,7 +935,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101/storage
 │       ├── PropertyBag: genruntime.PropertyBag
 │       └── Type: *string
 └── StorageAccountsTableServicesTable: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101.StorageAccountsTableService
+    ├── Owner: storage/v1api20230101.StorageAccountsTableService
     ├── Spec: Object (5 properties)
     │   ├── AzureName: string
     │   ├── OriginalVersion: string

--- a/v2/api/storage/v1api20230101/structure.txt
+++ b/v2/api/storage/v1api20230101/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/storage/v1api20230101
 ├── APIVersion: Enum (1 value)
 │   └── "2023-01-01"
 ├── StorageAccount: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (32 properties)
 │   │   ├── AccessTier: *Enum (3 values)
 │   │   │   ├── "Cool"

--- a/v2/api/synapse/v1api20210601/storage/structure.txt
+++ b/v2/api/synapse/v1api20210601/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/synapse/v1api20210601/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2021-06-01"
 ├── Workspace: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (21 properties)
 │   │   ├── AzureADOnlyAuthentication: *bool
 │   │   ├── AzureName: string
@@ -146,7 +146,7 @@ github.com/Azure/azure-service-operator/v2/api/synapse/v1api20210601/storage
 │       │   └── Type: *string
 │       └── WorkspaceUID: *string
 └── WorkspacesBigDataPool: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/synapse/v1api20210601.Workspace
+    ├── Owner: synapse/v1api20210601.Workspace
     ├── Spec: Object (23 properties)
     │   ├── AutoPause: *Object (3 properties)
     │   │   ├── DelayInMinutes: *int

--- a/v2/api/synapse/v1api20210601/structure.txt
+++ b/v2/api/synapse/v1api20210601/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/synapse/v1api20210601
 ├── APIVersion: Enum (1 value)
 │   └── "2021-06-01"
 ├── Workspace: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (19 properties)
 │   │   ├── AzureADOnlyAuthentication: *bool
 │   │   ├── AzureName: string

--- a/v2/api/web/v1api20220301/storage/structure.txt
+++ b/v2/api/web/v1api20220301/storage/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/web/v1api20220301/storage
 ├── APIVersion: Enum (1 value)
 │   └── "2022-03-01"
 ├── ServerFarm: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (24 properties)
 │   │   ├── AzureName: string
 │   │   ├── ElasticScaleEnabled: *bool
@@ -119,7 +119,7 @@ github.com/Azure/azure-service-operator/v2/api/web/v1api20220301/storage
 │       ├── WorkerTierName: *string
 │       └── ZoneRedundant: *bool
 └── Site: Resource
-    ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+    ├── Owner: resources/v1apiv20191001.ResourceGroup
     ├── Spec: Object (36 properties)
     │   ├── AzureName: string
     │   ├── ClientAffinityEnabled: *bool

--- a/v2/api/web/v1api20220301/structure.txt
+++ b/v2/api/web/v1api20220301/structure.txt
@@ -3,7 +3,7 @@ github.com/Azure/azure-service-operator/v2/api/web/v1api20220301
 ├── APIVersion: Enum (1 value)
 │   └── "2022-03-01"
 ├── ServerFarm: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (22 properties)
 │   │   ├── AzureName: string
 │   │   ├── ElasticScaleEnabled: *bool
@@ -219,7 +219,7 @@ github.com/Azure/azure-service-operator/v2/api/web/v1api20220301
 │   │   └── Tier: *string
 │   └── Tags: map[string]string
 ├── Site: Resource
-│   ├── Owner: github.com/Azure/azure-service-operator/v2/api/resources/v1apiv20191001.ResourceGroup
+│   ├── Owner: resources/v1apiv20191001.ResourceGroup
 │   ├── Spec: Object (34 properties)
 │   │   ├── AzureName: string
 │   │   ├── ClientAffinityEnabled: *bool

--- a/v2/tools/generator/internal/astmodel/internal_type_name.go
+++ b/v2/tools/generator/internal/astmodel/internal_type_name.go
@@ -165,7 +165,7 @@ func (tn InternalTypeName) Plural() InternalTypeName {
 func (tn InternalTypeName) WriteDebugDescription(builder *strings.Builder, currentPackage InternalPackageReference) {
 	if tn.packageReference != nil && !tn.packageReference.Equals(currentPackage) {
 		// Reference to a different package, so qualify the output.
-		builder.WriteString(tn.packageReference.String())
+		builder.WriteString(tn.packageReference.FolderPath())
 		builder.WriteString(".")
 	}
 

--- a/v2/tools/generator/internal/astmodel/type_test.go
+++ b/v2/tools/generator/internal/astmodel/type_test.go
@@ -58,7 +58,7 @@ func TestWriteDebugDescription(t *testing.T) {
 		{"Flagged alias shows details of flags", armSuit, "Suit[Flag:arm]"},
 		{"Errored type shows details of errors", erroredAge, "Error[Age|boom|oh oh]"},
 		{"Type name from current package has simple form", personId, "PersonId"},
-		{"Type name from other packages shows full path", otherPersonId, "local/test/v2.PersonId"},
+		{"Type name from other package shows folder path", otherPersonId, "test/v2.PersonId"},
 		{"Type name from external package qualified by package name", SecretReferenceType, "genruntime.SecretReference"},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the debug display of InternalTypeName to use the folder path of the declaring package instead of the full package reference URI, making the references easier to read (the constant repetition of `github.com/Azure/azure-service-operator/v2/api/` adding nothing to clarity).

**Special notes for your reviewer**:

Will also reduce the number of changed files in #3641, allowing for easier review of that critical change.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/MP1TAcYZI1JqYR9rJp/giphy.gif)
