### PR TITLE
Allow samples with a hardcoded secret rather than an autogenerated one

### DIFF
--- a/v2/internal/testcommon/kube_per_test_context.go
+++ b/v2/internal/testcommon/kube_per_test_context.go
@@ -411,6 +411,11 @@ func (tc *KubePerTestContext) CreateResourceAndWait(obj client.Object) {
 
 	gen := obj.GetGeneration()
 	tc.CreateResource(obj)
+	// Only wait for ASO objects
+	// TODO: Consider making tc.Match.BeProvisioned(0) work for non-ASO objects with a Ready condition too?
+	if _, ok := obj.(genruntime.MetaObject); !ok {
+		return
+	}
 	tc.Eventually(obj).Should(tc.Match.BeProvisioned(gen))
 }
 
@@ -420,6 +425,10 @@ func (tc *KubePerTestContext) CreateResourceAndWaitWithoutCleanup(obj client.Obj
 	tc.T.Helper()
 	gen := obj.GetGeneration()
 	tc.CreateResourceUntracked(obj)
+	// Only wait for ASO objects
+	if _, ok := obj.(genruntime.MetaObject); !ok {
+		return
+	}
 	tc.Eventually(obj).Should(tc.Match.BeProvisioned(gen))
 }
 
@@ -443,6 +452,11 @@ func (tc *KubePerTestContext) CreateResourcesAndWait(objs ...client.Object) {
 	}
 
 	for _, obj := range objs {
+		// Only wait for ASO objects
+		// TODO: Consider making tc.Match.BeProvisioned(0) work for non-ASO objects with a Ready condition too?
+		if _, ok := obj.(genruntime.MetaObject); !ok {
+			continue
+		}
 		// We can pass 0 for originalGeneration here because we're creating the resource so by definition it doesn't
 		// exist prior to this.
 		tc.Eventually(obj).Should(tc.Match.BeProvisioned(0))


### PR DESCRIPTION
 * This has the advantage of the sample being clearer to users, although it does involve having secrets committed in the repo. I think this is OK for two reasons:
   * The resources in question aren't durably created and exist for sample purposes only.
   * For SecretMapReference, it will not be possible for the test infrastructure to generate the secret, as it doesn't understand the expected payload of the map (what keys should be set).

As part of this change, slightly harden the test helper functions to do the right thing if passed a non-ASO resource (so they don't try to monitor it's Ready condition)

Note: This just enables the capability in the framework, we can still choose to ask PRs to mostly use the secret-autogeneration function if we want to.

**How does this PR make you feel**:
![gif](https://giphy.com/)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
