### PR TITLE
Add affinity and tolerations to ASOv2 helm chart

### DIFF
--- a/scripts/v2/generate-helm-manifest.sh
+++ b/scripts/v2/generate-helm-manifest.sh
@@ -50,8 +50,8 @@ sed -i "s@$LOCAL_REGISTRY_CONTROLLER_DOCKER_IMAGE@{{.Values.image.repository}}@g
 perl -0777 -i -pe 's/(template:\n.*metadata:\n.*annotations:\n(\s*))/$1\{\{- if .Values.podAnnotations \}\}\n$2\{\{ toYaml .Values.podAnnotations \}\}\n$2\{\{- end \}\}\n$2/igs' "$GEN_FILES_DIR"/*_deployment_* # Add pod annotations
 
 # Affinity and Toleration
-sed -i '/    spec:/a\    {{- if .Values.affinity }}\n      affinity:\n        {{ toYaml .Values.affinity}}\n    {{- end }}' "$GEN_FILES_DIR"/*_deployment_*
-sed -i '/    spec:/a\    {{- if .Values.affinity }}\n      tolerations:\n        {{ toYaml .Values.tolerations}}\n    {{- end }}' "$GEN_FILES_DIR"/*_deployment_*
+sed -i '/    spec:/a\    {{- with .Values.affinity }}\n      affinity:\n        {{- toYaml . | nindent 8 }}\n    {{- end }}' "$GEN_FILES_DIR"/*_deployment_*
+sed -i '/    spec:/a\    {{- with .Values.tolerations }}\n      tolerations:\n        {{- toYaml . | nindent 8 }}\n    {{- end }}' "$GEN_FILES_DIR"/*_deployment_*
 
 # Metrics Configuration
 flow_control "metrics-addr" "metrics-addr" "{{- if .Values.metrics.enable}}" "$GEN_FILES_DIR"/*_deployment_*

--- a/scripts/v2/generate-helm-manifest.sh
+++ b/scripts/v2/generate-helm-manifest.sh
@@ -49,6 +49,10 @@ sed -i "s@$LOCAL_REGISTRY_CONTROLLER_DOCKER_IMAGE@{{.Values.image.repository}}@g
 # Perl multiline replacements - using this because it's tricky to do these sorts of multiline replacements with sed
 perl -0777 -i -pe 's/(template:\n.*metadata:\n.*annotations:\n(\s*))/$1\{\{- if .Values.podAnnotations \}\}\n$2\{\{ toYaml .Values.podAnnotations \}\}\n$2\{\{- end \}\}\n$2/igs' "$GEN_FILES_DIR"/*_deployment_* # Add pod annotations
 
+# Affinity and Toleration
+sed -i '/    spec:/a\    {{- if .Values.affinity }}\n      affinity:\n        {{ toYaml .Values.affinity}}\n    {{- end }}' "$GEN_FILES_DIR"/*_deployment_*
+sed -i '/    spec:/a\    {{- if .Values.affinity }}\n      tolerations:\n        {{ toYaml .Values.tolerations}}\n    {{- end }}' "$GEN_FILES_DIR"/*_deployment_*
+
 # Metrics Configuration
 flow_control "metrics-addr" "metrics-addr" "{{- if .Values.metrics.enable}}" "$GEN_FILES_DIR"/*_deployment_*
 sed -i "1,/metrics-addr=.*/s/\(metrics-addr=\)\(.*\)/\1{{ tpl .Values.metrics.address . }}/g" "$GEN_FILES_DIR"/*_deployment_*

--- a/scripts/v2/generate-helm-manifest.sh
+++ b/scripts/v2/generate-helm-manifest.sh
@@ -50,10 +50,11 @@ sed -i "s@$LOCAL_REGISTRY_CONTROLLER_DOCKER_IMAGE@{{.Values.image.repository}}@g
 perl -0777 -i -pe 's/(template:\n.*metadata:\n.*annotations:\n(\s*))/$1\{\{- if .Values.podAnnotations \}\}\n$2\{\{ toYaml .Values.podAnnotations \}\}\n$2\{\{- end \}\}\n$2/igs' "$GEN_FILES_DIR"/*_deployment_* # Add pod annotations
 
 # Affinity and Toleration
-sed -i '/    spec:/a\    {{- with .Values.affinity }}\n      affinity:\n        {{- toYaml . | nindent 8 }}\n    {{- end }}' "$GEN_FILES_DIR"/*_deployment_*
-sed -i '/    spec:/a\    {{- with .Values.tolerations }}\n      tolerations:\n        {{- toYaml . | nindent 8 }}\n    {{- end }}' "$GEN_FILES_DIR"/*_deployment_*
+perl -0777 -i -pe 's/(spec:\n.*template:\n.*spec:\n(\s*))/$1\{\{- with .Values.affinity \}\}\n$2affinity:\n$2\{\{- toYaml . | nindent 8 \}\}\n$2\{\{- end \}\}\n$2/igs' "$GEN_FILES_DIR"/*_deployment_* # Add pod annotations
+perl -0777 -i -pe 's/(spec:\n.*template:\n.*spec:\n(\s*))/$1\{\{- with .Values.tolerations \}\}\n$2tolerations:\n$2\{\{- toYaml . | nindent 8 \}\}\n$2\{\{- end \}\}\n$2/igs' "$GEN_FILES_DIR"/*_deployment_* # Add pod annotations
 
 # Metrics Configuration
+
 flow_control "metrics-addr" "metrics-addr" "{{- if .Values.metrics.enable}}" "$GEN_FILES_DIR"/*_deployment_*
 sed -i "1,/metrics-addr=.*/s/\(metrics-addr=\)\(.*\)/\1{{ tpl .Values.metrics.address . }}/g" "$GEN_FILES_DIR"/*_deployment_*
 sed -i 's/containerPort: 8080/containerPort: {{ .Values.metrics.port | default 8080 }}/g' "$GEN_FILES_DIR"/*_deployment_*

--- a/scripts/v2/generate-helm-manifest.sh
+++ b/scripts/v2/generate-helm-manifest.sh
@@ -54,7 +54,6 @@ perl -0777 -i -pe 's/(spec:\n.*template:\n.*spec:\n(\s*))/$1\{\{- with .Values.a
 perl -0777 -i -pe 's/(spec:\n.*template:\n.*spec:\n(\s*))/$1\{\{- with .Values.tolerations \}\}\n$2tolerations:\n$2\{\{- toYaml . | nindent 8 \}\}\n$2\{\{- end \}\}\n$2/igs' "$GEN_FILES_DIR"/*_deployment_* # Add pod annotations
 
 # Metrics Configuration
-
 flow_control "metrics-addr" "metrics-addr" "{{- if .Values.metrics.enable}}" "$GEN_FILES_DIR"/*_deployment_*
 sed -i "1,/metrics-addr=.*/s/\(metrics-addr=\)\(.*\)/\1{{ tpl .Values.metrics.address . }}/g" "$GEN_FILES_DIR"/*_deployment_*
 sed -i 's/containerPort: 8080/containerPort: {{ .Values.metrics.port | default 8080 }}/g' "$GEN_FILES_DIR"/*_deployment_*

--- a/v2/charts/azure-service-operator/values.yaml
+++ b/v2/charts/azure-service-operator/values.yaml
@@ -141,3 +141,15 @@ networkPolicies:
   mysqlCIDR: 0.0.0.0/0
   # Destination CIDR for talking to PostgreSQL servers
   postgresqlCIDR: 0.0.0.0/0
+
+# Tolerations are applied to pods. Tolerations allow the scheduler to schedule pods with matching taints. Tolerations allow scheduling but don't guarantee scheduling
+# For more information, see https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration.
+tolerations: []
+
+# Affinity and anti-affinity expands the types of constraints you can define.
+# The affinity feature consists of two types of affinity:
+# Node affinity functions like the nodeSelector field but is more expressive and allows you to specify soft rules.
+# Inter-pod affinity/anti-affinity allows you to constrain Pods against labels on other Pods.
+# For more information, see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+

--- a/v2/charts/azure-service-operator/values.yaml
+++ b/v2/charts/azure-service-operator/values.yaml
@@ -152,4 +152,3 @@ tolerations: []
 # Inter-pod affinity/anti-affinity allows you to constrain Pods against labels on other Pods.
 # For more information, see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
-


### PR DESCRIPTION


Closes #3646 

**What this PR does / why we need it**:

This PR adds changes to the helm chart generation script to add `Affinity` and `Tolerations` to ASOv2 helm chart. Also updates `values.yaml` to specify the above. 

