### PR TITLE
Reduce the number of types loaded by the generator

### DIFF
--- a/v2/tools/generator/internal/codegen/pipeline/load_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/load_types.go
@@ -313,10 +313,8 @@ func loadSwaggerData(
 ) (jsonast.SwaggerTypes, error) {
 	schemas, err := loadAllSchemas(
 		ctx,
-		config.SchemaRoot,
-		config.LocalPathPrefix(),
 		idFactory,
-		config.Status.Overrides,
+		config,
 		log)
 	if err != nil {
 		return jsonast.SwaggerTypes{}, err
@@ -684,12 +682,14 @@ func shouldSkipDir(filePath string) bool {
 // shouldSkipDir), and returns those files in a map of path→swagger spec.
 func loadAllSchemas(
 	ctx context.Context,
-	rootPath string,
-	localPathPrefix string,
 	idFactory astmodel.IdentifierFactory,
-	overrides []config.SchemaOverride,
+	config *config.Configuration,
 	log logr.Logger,
 ) (map[string]jsonast.PackageAndSwagger, error) {
+	rootPath := config.SchemaRoot
+	localPathPrefix := config.LocalPathPrefix()
+	overrides := config.Status.Overrides
+
 	var mutex sync.Mutex
 	schemas := make(map[string]jsonast.PackageAndSwagger)
 

--- a/v2/tools/generator/internal/codegen/pipeline/load_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/load_types.go
@@ -726,6 +726,15 @@ func loadAllSchemas(
 				astmodel.GeneratorVersion,
 				version)
 
+			// We need the file if the version is short (e.g. "v1") because those are often shared between
+			// resource providers.
+			// Alternatively, we need the file if we have configuration for the group
+			fileNeeded := len(version) < 10 ||
+				config.ObjectModelConfiguration.IsGroupConfigured(pkg)
+			if !fileNeeded {
+				return nil
+			}
+
 			// all files are loaded in parallel to speed this up
 			logInfoSparse(
 				log,


### PR DESCRIPTION
**What this PR does / why we need it**:

As the number of OpenAPI spec files to load grows, performance of the generator is gradually slowing.

Currently, on `main` we're loading 10305 distinct files.

In this PR, we avoid loading _some_ files we know we don't need, loading just 6556 files (a 36% reduction).

**Special notes for your reviewer**:

We're conservative about what we skip, there's probably scope to be more aggressive.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/t1lmQR7sXeZJC/giphy.gif?cid=ecf05e47tcxuliy33llcnmhkhaepwdxxpdr2pzqr36m40mpb&ep=v1_gifs_search&rid=giphy.gif&ct=g)
