### PR TITLE
Hand-crafted conversions need to add package references

### DIFF
--- a/v2/tools/generator/internal/astmodel/object_type.go
+++ b/v2/tools/generator/internal/astmodel/object_type.go
@@ -61,7 +61,10 @@ func NewObjectType() *ObjectType {
 	}
 }
 
-func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
+func (objectType *ObjectType) AsDeclarations(
+	codeGenerationContext *CodeGenerationContext,
+	declContext DeclarationContext,
+) ([]dst.Decl, error) {
 	declaration := &dst.GenDecl{
 		Decs: dst.GenDeclDecorations{
 			NodeDecs: dst.NodeDecs{
@@ -86,9 +89,7 @@ func (objectType *ObjectType) AsDeclarations(codeGenerationContext *CodeGenerati
 
 	decls, err := objectType.generateMethodDecls(codeGenerationContext, declContext.Name)
 	if err != nil {
-		// Something went wrong; once AsDeclarations is refactored to have an error return,
-		// we can return them, but in the meantime panic
-		panic(errors.Wrapf(err, "generating method declarations for %s", declContext.Name))
+		return nil, errors.Wrapf(err, "generating method declarations for %s", declContext.Name)
 	}
 
 	result = append(result, decls...)

--- a/v2/tools/generator/internal/conversions/property_conversions.go
+++ b/v2/tools/generator/internal/conversions/property_conversions.go
@@ -1049,16 +1049,18 @@ func assignHandcraftedImplementations(
 	}
 
 	// Search for a handcrafted conversion to use
-	var conversion *handCraftedConversion
+	conversionFound := false
+	var conversion handCraftedConversion
 	for _, impl := range handCraftedConversions {
 		if astmodel.TypeEquals(sourceEndpoint.Type(), impl.fromType) &&
 			astmodel.TypeEquals(destinationEndpoint.Type(), impl.toType) {
-			conversion = &impl
+			conversion = impl
+			conversionFound = true
 			break
 		}
 	}
 
-	if conversion == nil {
+	if !conversionFound {
 		// No handcrafted conversion found
 		return nil, nil
 	}

--- a/v2/tools/generator/internal/conversions/property_conversions.go
+++ b/v2/tools/generator/internal/conversions/property_conversions.go
@@ -218,8 +218,8 @@ func NameOfPropertyAssignmentFunction(
 func directAssignmentPropertyConversion(
 	reader dst.Expr,
 	writer func(dst.Expr) []dst.Stmt,
-	knownLocals *astmodel.KnownLocalsSet,
-	generationContext *astmodel.CodeGenerationContext,
+	_ *astmodel.KnownLocalsSet,
+	_ *astmodel.CodeGenerationContext,
 ) ([]dst.Stmt, error) {
 	return writer(reader), nil
 }
@@ -1041,29 +1041,51 @@ var handCraftedConversions = []handCraftedConversion{
 func assignHandcraftedImplementations(
 	sourceEndpoint *TypedConversionEndpoint,
 	destinationEndpoint *TypedConversionEndpoint,
-	_ *PropertyConversionContext) (PropertyConversion, error) {
-
+	conversionContext *PropertyConversionContext,
+) (PropertyConversion, error) {
 	// Require both source and destination to not be bag items
 	if sourceEndpoint.IsBagItem() || destinationEndpoint.IsBagItem() {
 		return nil, nil
 	}
 
+	// Search for a handcrafted conversion to use
+	var conversion *handCraftedConversion
 	for _, impl := range handCraftedConversions {
 		if astmodel.TypeEquals(sourceEndpoint.Type(), impl.fromType) &&
 			astmodel.TypeEquals(destinationEndpoint.Type(), impl.toType) {
-			return func(
-				reader dst.Expr,
-				writer func(dst.Expr) []dst.Stmt,
-				knownLocals *astmodel.KnownLocalsSet,
-				generationContext *astmodel.CodeGenerationContext,
-			) ([]dst.Stmt, error) {
-				pkg := generationContext.MustGetImportedPackageName(impl.implPackage)
-				return writer(astbuilder.CallQualifiedFunc(pkg, impl.implFunc, reader)), nil
-			}, nil
+			conversion = &impl
+			break
 		}
 	}
 
-	return nil, nil
+	if conversion == nil {
+		// No handcrafted conversion found
+		return nil, nil
+	}
+
+	// Make sure all the necessary packages are referenced
+	if ftn, ok := astmodel.AsTypeName(conversion.fromType); ok {
+		// Include a reference to the package our from type is found in
+		conversionContext.AddPackageReference(ftn.PackageReference())
+	}
+
+	if ttn, ok := astmodel.AsTypeName(conversion.toType); ok {
+		// Include a reference to the package our to type is found in
+		conversionContext.AddPackageReference(ttn.PackageReference())
+	}
+
+	// Include a reference to the package our implementation is found in
+	conversionContext.AddPackageReference(conversion.implPackage)
+
+	return func(
+		reader dst.Expr,
+		writer func(dst.Expr) []dst.Stmt,
+		knownLocals *astmodel.KnownLocalsSet,
+		generationContext *astmodel.CodeGenerationContext,
+	) ([]dst.Stmt, error) {
+		pkg := generationContext.MustGetImportedPackageName(conversion.implPackage)
+		return writer(astbuilder.CallQualifiedFunc(pkg, conversion.implFunc, reader)), nil
+	}, nil
 }
 
 // forbiddenConversion represents a conversion that we know we shouldn't even attempt to do


### PR DESCRIPTION
**What this PR does / why we need it**:

If a property conversion strategy needs a specific package referenced, that package needs to be added into the provided `propertyConversionContext`.

Our hand-crafted conversions weren't doing this - which was fine as long as those conversions only used packages already referenced, but as soon as one of them needed a new package, we started getting errors during the code generation phase of our generator.

Fix is to ensure all of the packages required by the conversion are explicitly included - the references are set based, so there's no downside to adding the same one multiple times.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTBjZnVtbWJuZHlqYmVjd2l3c3EyYnF3MWppOWhkd3oxYjdudnhjZSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3lvqNXheb679S/giphy.gif)
