### PR TITLE
Ensure reconciling condition overwrites AzureResourceNotFound

### DIFF
--- a/v2/pkg/genruntime/conditions/conditions.go
+++ b/v2/pkg/genruntime/conditions/conditions.go
@@ -223,8 +223,12 @@ var reasonPriority = map[string]int{
 	ReasonReferenceNotFound.Name: -2,
 	ReasonSecretNotFound.Name:    -2,
 	ReasonConfigMapNotFound.Name: -2,
-	ReasonWaitingForOwner.Name:   -2,
-	ReasonReconciling.Name:       -1,
+	// AzureResourceNotFound only comes up when ReconcilePolicy is skip. This conditions priority being less than
+	// Reconciling allows skip -> reconcile to immediately update the condition to Reconciling rather than continuing to
+	// report AzureResourceNotFound until the resource is created.
+	ReasonAzureResourceNotFound.Name: -2,
+	ReasonWaitingForOwner.Name:       -2,
+	ReasonReconciling.Name:           -1,
 }
 
 // SetConditionReasonAware sets the provided Condition on the Conditioner. This is similar to SetCondition

--- a/v2/pkg/genruntime/conditions/conditions_test.go
+++ b/v2/pkg/genruntime/conditions/conditions_test.go
@@ -317,6 +317,12 @@ func Test_SetConditionReasonAware_OverwritesAsExpected(t *testing.T) {
 		1,
 		conditions.ReasonSecretNotFound.Name,
 		"a message")
+	azureResourceNotFound := builder.MakeFalseCondition(
+		conditions.ConditionTypeReady,
+		conditions.ConditionSeverityError,
+		1,
+		conditions.ReasonAzureResourceNotFound.Name,
+		"a message")
 	arbitraryInfoCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityInfo,
@@ -355,6 +361,7 @@ func Test_SetConditionReasonAware_OverwritesAsExpected(t *testing.T) {
 		{name: "Reconciling overwrites same generation ReferenceNotFound", initial: &referenceNotFoundCondition, new: reconcilingCondition, expectedOverwrite: true},
 		{name: "Reconciling overwrites same generation SecretNotFound", initial: &secretNotFoundCondition, new: reconcilingCondition, expectedOverwrite: true},
 		{name: "Reconciling overwrites same generation ReferenceNotFound", initial: &referenceNotFoundCondition, new: reconcilingCondition, expectedOverwrite: true},
+		{name: "Reconciling overwrites same generation AzureResourceNotFound ", initial: &azureResourceNotFound, new: reconcilingCondition, expectedOverwrite: true},
 		{name: "Reconciling overwrites same generation Info", initial: &arbitraryInfoCondition, new: reconcilingCondition, expectedOverwrite: true},
 		{name: "Reconciling overwrites same generation WaitingForOwner", initial: &waitingForOwnerWarningCondition, new: reconcilingCondition, expectedOverwrite: true},
 


### PR DESCRIPTION
This fixes #3788.

AzureResourceNotFound only comes up when ReconcilePolicy is skip. This conditions priority being less than Reconciling allows skip -> reconcile to immediately update the condition to Reconciling rather than continuing to report AzureResourceNotFound until the resource is created.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
