### PR TITLE
Improve/vcr tracking

### DIFF
--- a/v2/internal/testcommon/vcr/v1/counting_roundtripper.go
+++ b/v2/internal/testcommon/vcr/v1/counting_roundtripper.go
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
 
-package vcr
+package v1
 
 import (
 	"fmt"
@@ -36,10 +36,13 @@ var COUNT_HEADER string = "TEST-REQUEST-ATTEMPT"
 
 func (rt *requestCounter) RoundTrip(req *http.Request) (*http.Response, error) {
 	key := req.Method + ":" + req.URL.String()
+
+	// Read the current
 	rt.countsMutex.Lock()
 	count := rt.counts[key]
 	rt.counts[key] = count + 1
 	rt.countsMutex.Unlock()
+
 	req.Header.Set(COUNT_HEADER, fmt.Sprintf("%d", count))
 	return rt.inner.RoundTrip(req)
 }

--- a/v2/internal/testcommon/vcr/v1/error_translating_roundtripper.go
+++ b/v2/internal/testcommon/vcr/v1/error_translating_roundtripper.go
@@ -94,7 +94,7 @@ func (w errorTranslation) RoundTrip(req *http.Request) (*http.Response, error) {
 				w.cassetteName,
 				req.Method,
 				req.URL.String(),
-				req.Header.Get(vcr.COUNT_HEADER)),
+				req.Header.Get(COUNT_HEADER)),
 			conditions.ConditionSeverityError,
 			conditions.ReasonReconciliationFailedPermanently)
 	}
@@ -125,7 +125,7 @@ func (w errorTranslation) findMatchingBodies(r *http.Request) []string {
 	var result []string
 	for _, interaction := range w.ensureCassette().Interactions {
 		if urlString == interaction.URL && r.Method == interaction.Request.Method &&
-			r.Header.Get(vcr.COUNT_HEADER) == interaction.Request.Headers.Get(vcr.COUNT_HEADER) {
+			r.Header.Get(COUNT_HEADER) == interaction.Request.Headers.Get(COUNT_HEADER) {
 			result = append(result, interaction.Request.Body)
 		}
 	}

--- a/v2/internal/testcommon/vcr/v1/test_replayer.go
+++ b/v2/internal/testcommon/vcr/v1/test_replayer.go
@@ -77,7 +77,7 @@ func NewTestPlayer(
 		}
 
 		// verify custom request count header (see counting_roundtripper.go)
-		if r.Header.Get(vcr.COUNT_HEADER) != i.Headers.Get(vcr.COUNT_HEADER) {
+		if r.Header.Get(COUNT_HEADER) != i.Headers.Get(COUNT_HEADER) {
 			return false
 		}
 
@@ -132,7 +132,10 @@ func (r *player) IsReplaying() bool {
 // t is a reference to the test currently executing.
 // TODO: Remove the reference to t to reduce coupling
 func (r *player) CreateClient(t *testing.T) *http.Client {
+	withErrorTranslation := translateErrors(r.recorder, r.cassetteName, t)
+	withCountHeader := AddCountHeader(withErrorTranslation)
+
 	return &http.Client{
-		Transport: vcr.AddCountHeader(translateErrors(r.recorder, r.cassetteName, t)),
+		Transport: withCountHeader,
 	}
 }

--- a/v2/internal/testcommon/vcr/v3/replay_roundtripper_test.go
+++ b/v2/internal/testcommon/vcr/v3/replay_roundtripper_test.go
@@ -7,6 +7,7 @@ package v3
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -14,6 +15,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"gopkg.in/dnaeon/go-vcr.v3/cassette"
 
 	"github.com/go-logr/logr"
 
@@ -101,41 +103,22 @@ func TestReplayRoundTripperRoundTrip_GivenSinglePut_ReturnsOnceExtra(t *testing.
 
 func TestReplayRoundTripperRoundTrip_GivenMultiplePUTsToSameURL_ReturnsExpectedBodies(t *testing.T) {
 	t.Parallel()
-	g := NewGomegaWithT(t)
 
 	// Arrange
-	alphaRequest := &http.Request{
-		URL:    &url.URL{Path: "/foo"},
-		Method: http.MethodPut,
-		Body:   io.NopCloser(strings.NewReader("PUT body Alpha goes here")),
-	}
+	alphaRequest, alphaResponse := createPutRequestAndResponse(
+		"/foo",
+		"Alpha goes here",
+		200)
 
-	alphaResponse := &http.Response{
-		StatusCode: 200,
-		Body:       io.NopCloser(strings.NewReader("PUT response Alpha goes here")),
-	}
+	betaRequest, betaResponse := createPutRequestAndResponse(
+		"/foo",
+		"Beta goes here",
+		203)
 
-	betaRequest := &http.Request{
-		URL:    &url.URL{Path: "/foo"},
-		Method: http.MethodPut,
-		Body:   io.NopCloser(strings.NewReader("PUT body Beta goes here")),
-	}
-
-	betaResponse := &http.Response{
-		StatusCode: 203,
-		Body:       io.NopCloser(strings.NewReader("PUT response Beta goes here")),
-	}
-
-	gammaRequest := &http.Request{
-		URL:    &url.URL{Path: "/foo"},
-		Method: http.MethodPut,
-		Body:   io.NopCloser(strings.NewReader("PUT body Gamma goes here")),
-	}
-
-	gammaResponse := &http.Response{
-		StatusCode: 200,
-		Body:       io.NopCloser(strings.NewReader("PUT response Gamma goes here")),
-	}
+	gammaRequest, gammaResponse := createPutRequestAndResponse(
+		"/foo",
+		"Gamma goes here",
+		200)
 
 	fake := vcr.NewFakeRoundTripper()
 	fake.AddResponse(alphaRequest, alphaResponse)
@@ -146,55 +129,109 @@ func TestReplayRoundTripperRoundTrip_GivenMultiplePUTsToSameURL_ReturnsExpectedB
 	replayer := NewReplayRoundTripper(fake, logr.Discard())
 
 	// Assert - first alpha request works
-	//nolint:bodyclose // there's no actual body in this response to close
-	actual, err := replayer.RoundTrip(alphaRequest)
-	g.Expect(err).ToNot(HaveOccurred())
-	assertResponse(t, actual, 200, "PUT response Alpha goes here")
+	assertExpectedResponse(t, replayer, alphaRequest, 200, "Alpha goes here")
 
 	// Assert - first beta request works
-	//nolint:bodyclose // there's no actual body in this response to close
-	actual, err = replayer.RoundTrip(betaRequest)
-	g.Expect(err).ToNot(HaveOccurred())
-	assertResponse(t, actual, 203, "PUT response Beta goes here")
+	assertExpectedResponse(t, replayer, betaRequest, 203, "Beta goes here")
 
 	// Assert - first gamma request works
-	//nolint:bodyclose // there's no actual body in this response to close
-	actual, err = replayer.RoundTrip(gammaRequest)
-	g.Expect(err).ToNot(HaveOccurred())
-	assertResponse(t, actual, 200, "PUT response Gamma goes here")
+	assertExpectedResponse(t, replayer, gammaRequest, 200, "Gamma goes here")
 
 	// Assert - second alpha request works by replaying the first
-	//nolint:bodyclose // there's no actual body in this response to close
-	actual, err = replayer.RoundTrip(alphaRequest)
-	g.Expect(err).ToNot(HaveOccurred())
-	assertResponse(t, actual, 200, "PUT response Alpha goes here")
+	assertExpectedResponse(t, replayer, alphaRequest, 200, "Alpha goes here")
 
 	// Assert - second beta request works by replaying the first
-	//nolint:bodyclose // there's no actual body in this response to close
-	actual, err = replayer.RoundTrip(betaRequest)
-	g.Expect(err).ToNot(HaveOccurred())
-	assertResponse(t, actual, 203, "PUT response Beta goes here")
+	assertExpectedResponse(t, replayer, betaRequest, 203, "Beta goes here")
 
 	// Assert - second gamma request works by replaying the first
-	//nolint:bodyclose // there's no actual body in this response to close
-	actual, err = replayer.RoundTrip(gammaRequest)
-	g.Expect(err).ToNot(HaveOccurred())
-	assertResponse(t, actual, 200, "PUT response Gamma goes here")
+	assertExpectedResponse(t, replayer, gammaRequest, 200, "Gamma goes here")
 }
 
-func assertResponse(
+func Test_ReplayRoundTripper_WhenCombinedWithTrackingRoundTripper_GivesDesiredResult(t *testing.T) {
+	t.Parallel()
+
+	// Arrange - Request and response to create the resource
+	//nolint:bodyclose // there's no actual body in this response to close
+	creationRequest, creationResponse := createPutRequestAndResponse(
+		"/sub/id/resource/A",
+		"create resource A",
+		200)
+
+	// Arrange - Request and response to update the resource
+	//nolint:bodyclose // there's no actual body in this response to close
+	updateRequest, updateResponse := createPutRequestAndResponse(
+		"/sub/id/resource/A",
+		"update resource A",
+		200)
+
+	// Arrange - set up fake replayer
+	fake := vcr.NewFakeRoundTripper()
+	fake.AddResponse(creationRequest, creationResponse)
+	fake.AddError(creationRequest, cassette.ErrInteractionNotFound)
+	fake.AddResponse(updateRequest, updateResponse)
+	fake.AddError(updateRequest, cassette.ErrInteractionNotFound)
+
+	// Act
+	replayer := AddTrackingHeaders(
+		NewReplayRoundTripper(fake, logr.Discard()))
+
+	// Assert - first PUT to create the resource works
+	assertExpectedResponse(t, replayer, creationRequest, 200, "create resource A")
+
+	// Assert - second PUT to create the resource works because of replay
+	assertExpectedResponse(t, replayer, creationRequest, 200, "create resource A")
+
+	// Assert - first PUT to update the resource works
+	assertExpectedResponse(t, replayer, updateRequest, 200, "update resource A")
+
+	// Assert - second PUT to update the resource works due to replay
+	assertExpectedResponse(t, replayer, updateRequest, 200, "update resource A")
+}
+
+func createPutRequestAndResponse(
+	urlpath string,
+	body string,
+	statusCode int,
+) (*http.Request, *http.Response) {
+	req := &http.Request{
+		URL:    &url.URL{Path: urlpath},
+		Method: http.MethodPut,
+		Body: io.NopCloser(
+			bytes.NewBufferString(
+				fmt.Sprintf("PUT for %s", body),
+			)),
+	}
+
+	res := &http.Response{
+		StatusCode: statusCode,
+		Body: io.NopCloser(
+			bytes.NewBufferString(
+				fmt.Sprintf("PUT response for %s", body),
+			)),
+	}
+
+	return req, res
+}
+
+func assertExpectedResponse(
 	t *testing.T,
-	response *http.Response,
+	client http.RoundTripper,
+	request *http.Request,
 	expectedStatus int,
 	expectedBodyContent string,
 ) {
 	t.Helper()
 	g := NewGomegaWithT(t)
 
+	// Get the response
+	//nolint:bodyclose // there's no actual body in this response to close
+	response, err := client.RoundTrip(request)
+	g.Expect(err).ToNot(HaveOccurred())
+
 	g.Expect(response.StatusCode).To(Equal(expectedStatus))
 
 	var body bytes.Buffer
-	_, err := body.ReadFrom(response.Body)
+	_, err = body.ReadFrom(response.Body)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	g.Expect(string(body.String())).To(ContainSubstring(expectedBodyContent))

--- a/v2/internal/testcommon/vcr/v3/replay_roundtripper_test.go
+++ b/v2/internal/testcommon/vcr/v3/replay_roundtripper_test.go
@@ -82,6 +82,7 @@ func TestReplayRoundTripperRoundTrip_GivenSinglePut_ReturnsOnceExtra(t *testing.
 	assertExpectedResponse(t, replayer, req, 200, "PUT response goes here")
 
 	// Assert - third request fails because we've had our one replay
+	//nolint:bodyclose // response body is a string, no need to close
 	_, err := replayer.RoundTrip(req)
 	g.Expect(err).To(HaveOccurred())
 }

--- a/v2/internal/testcommon/vcr/v3/test_recorder.go
+++ b/v2/internal/testcommon/vcr/v3/test_recorder.go
@@ -92,7 +92,7 @@ func NewTestRecorder(
 		}
 
 		// verify custom request count header (see counting_roundtripper.go)
-		if r.Header.Get(vcr.COUNT_HEADER) != i.Headers.Get(vcr.COUNT_HEADER) {
+		if r.Header.Get(COUNT_HEADER) != i.Headers.Get(COUNT_HEADER) {
 			return false
 		}
 
@@ -222,9 +222,9 @@ func (r *recorderDetails) IsReplaying() bool {
 func (r *recorderDetails) CreateClient(t *testing.T) *http.Client {
 	withReplay := NewReplayRoundTripper(r.recorder, r.log)
 	withErrorTranslation := translateErrors(withReplay, r.cassetteName, t)
-	withCountHeader := vcr.AddCountHeader(withErrorTranslation)
+	withTrackingHeaders := AddTrackingHeaders(withErrorTranslation)
 
 	return &http.Client{
-		Transport: withCountHeader,
+		Transport: withTrackingHeaders,
 	}
 }

--- a/v2/internal/testcommon/vcr/v3/test_recorder.go
+++ b/v2/internal/testcommon/vcr/v3/test_recorder.go
@@ -104,6 +104,7 @@ func NewTestRecorder(
 		}
 
 		if r.Body == nil {
+			// Empty bodies are stored by go-vcr as empty strings
 			return i.Body == ""
 		}
 

--- a/v2/internal/testcommon/vcr/v3/tracking_roundtripper.go
+++ b/v2/internal/testcommon/vcr/v3/tracking_roundtripper.go
@@ -49,7 +49,7 @@ var _ http.RoundTripper = &requestCounter{}
 
 func (rt *requestCounter) RoundTrip(req *http.Request) (*http.Response, error) {
 	if rt.useHash(req) {
-		rt.addHashHeader(req)
+		rt.addContentHeaders(req)
 	} else {
 		rt.addCountHeader(req)
 	}
@@ -68,6 +68,7 @@ func (rt *requestCounter) useHash(req *http.Request) bool {
 	return req.Body != nil
 }
 
+// addCountHeader adds a header to the request based on the URL requested
 func (rt *requestCounter) addCountHeader(req *http.Request) {
 	// Count keys are based on method and URL
 	key := req.Method + ":" + req.URL.String()
@@ -82,7 +83,8 @@ func (rt *requestCounter) addCountHeader(req *http.Request) {
 	req.Header.Set(COUNT_HEADER, fmt.Sprintf("%d", count))
 }
 
-func (rt *requestCounter) addHashHeader(request *http.Request) {
+// addContentHeaders adds headers to the request based on the content of the request body
+func (rt *requestCounter) addContentHeaders(request *http.Request) {
 	// Read all the content of the request body
 	var body bytes.Buffer
 	_, err := body.ReadFrom(request.Body)

--- a/v2/internal/testcommon/vcr/v3/tracking_roundtripper.go
+++ b/v2/internal/testcommon/vcr/v3/tracking_roundtripper.go
@@ -86,8 +86,18 @@ func (rt *requestCounter) addHashHeader(req *http.Request) {
 	// Calculate a hash based on body string
 	hash := sha256.Sum256([]byte(bodyString))
 
-	// Set the header
+	// Format hash as a hex string
+	hashString := fmt.Sprintf("%x", hash)
+
+	// Allocate a number
+	rt.countsMutex.Lock()
+	count := rt.counts[hashString]
+	rt.counts[hashString] = count + 1
+	rt.countsMutex.Unlock()
+
+	// Set the headers
 	req.Header.Set(HASH_HEADER, fmt.Sprintf("%x", hash))
+	req.Header.Set(COUNT_HEADER, fmt.Sprintf("%d", count))
 
 	// Reset the body so it can be read again
 	_, _ = rsc.Seek(0, io.SeekStart)

--- a/v2/internal/testcommon/vcr/v3/tracking_roundtripper.go
+++ b/v2/internal/testcommon/vcr/v3/tracking_roundtripper.go
@@ -1,0 +1,94 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package v3
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/Azure/azure-service-operator/v2/internal/testcommon/vcr"
+)
+
+// Wraps an inner HTTP roundtripper to add a
+// counter for duplicated request URIs. This
+// is then used to match up requests in the recorder
+// - it is needed as we have multiple requests with
+// the same Request URL and it will return the first
+// one that matches.
+type requestCounter struct {
+	inner http.RoundTripper
+
+	countsMutex sync.Mutex
+	counts      map[string]uint32
+}
+
+func AddTrackingHeaders(inner http.RoundTripper) *requestCounter {
+	return &requestCounter{
+		inner:       inner,
+		counts:      make(map[string]uint32),
+		countsMutex: sync.Mutex{},
+	}
+}
+
+const (
+	COUNT_HEADER string = "TEST-REQUEST-ATTEMPT"
+	HASH_HEADER  string = "TEST-REQUEST-HASH"
+)
+
+var _ http.RoundTripper = &requestCounter{}
+
+func (rt *requestCounter) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method == "PUT" || req.Method == "POST" {
+		rt.addHashHeader(req)
+	} else {
+		rt.addCountHeader(req)
+	}
+
+	return rt.inner.RoundTrip(req)
+}
+
+func (rt *requestCounter) addCountHeader(req *http.Request) {
+	// Count keys are based on method and URL
+	key := req.Method + ":" + req.URL.String()
+
+	// Allocate a number
+	rt.countsMutex.Lock()
+	count := rt.counts[key]
+	rt.counts[key] = count + 1
+	rt.countsMutex.Unlock()
+
+	// Apply the header
+	req.Header.Set(COUNT_HEADER, fmt.Sprintf("%d", count))
+}
+
+func (rt *requestCounter) addHashHeader(req *http.Request) {
+	rsc, ok := req.Body.(io.ReadSeekCloser)
+	if !ok {
+		panic(fmt.Sprintf("req.Body is not an io.ReadSeekCloser, it is a %T", req.Body))
+	}
+
+	// Calculate a hash based on the request body, but sanitise it first so it's the same for each test run
+	bodyBytes, bodyErr := io.ReadAll(rsc)
+	if bodyErr != nil {
+		// see invocation of SetMatcher in the createRecorder, which does this
+		panic("io.ReadAll(req.Body) failed, this should always succeed because req.Body has been replaced by a buffer")
+	}
+
+	// Apply the same body filtering that we do in recordings so that the hash is consistent
+	bodyString := vcr.HideRecordingData(string(bodyBytes))
+
+	// Calculate a hash based on body string
+	hash := sha256.Sum256([]byte(bodyString))
+
+	// Set the header
+	req.Header.Set(HASH_HEADER, fmt.Sprintf("%x", hash))
+
+	// Reset the body so it can be read again
+	_, _ = rsc.Seek(0, io.SeekStart)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

@matthchr identified an issue with #3753 where an extra reconcile early in a recorded test (resulting in an extra PUT) would increment the `TEST-REQUEST-ATTEMPT` header value, resulting in all future PUT requests to that URL failing.

This PR fixes that by using a separate count sequence for each distinct PUT hash.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcjJxaXlnM3NibjczenR5MDNpdmk0cWdtdzQ2dXM4MHRycTNyeWptNSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ibv7Gt66ynoZEzY18M/giphy.gif)
