### PR TITLE
Improve generator performance

### DIFF
--- a/v2/tools/generator/internal/codegen/pipeline/determine_resource_ownership.go
+++ b/v2/tools/generator/internal/codegen/pipeline/determine_resource_ownership.go
@@ -66,7 +66,9 @@ func (o *ownershipStage) indexByParent() {
 		rt, _ := astmodel.AsResourceType(def.Type())
 		canonical := o.canonicalizeURI(rt.ARMURI())
 		parent := o.uriOfParentResource(canonical)
-		o.resourcesByParentURI[parent] = append(o.resourcesByParentURI[parent], def.Name())
+		if parent != "" {
+			o.resourcesByParentURI[parent] = append(o.resourcesByParentURI[parent], def.Name())
+		}
 	}
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/determine_resource_ownership_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/determine_resource_ownership_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onsi/gomega"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
 )
 
 var pr astmodel.InternalPackageReference = astmodel.MakeLocalPackageReference("prefix", "group", "v", "20000101")
@@ -20,13 +21,17 @@ func Test_FindChildren_ResourceDoesNotOwnItself(t *testing.T) {
 
 	g := gomega.NewWithT(t)
 
+	cfg := config.NewConfiguration()
 	resources := make(astmodel.TypeDefinitionSet)
 
 	ownerType := astmodel.NewResourceType(nil, nil).WithARMURI("/resources/owner")
 	ownerName := astmodel.MakeInternalTypeName(pr, "Owner")
-	resources.Add(astmodel.MakeTypeDefinition(ownerName, ownerType))
+	owner := astmodel.MakeTypeDefinition(ownerName, ownerType)
+	resources.Add(owner)
 
-	children := findChildren(ownerType, ownerName, resources)
+	stage := newOwnershipStage(cfg, resources)
+
+	children := stage.findChildren(owner)
 	g.Expect(children).To(gomega.BeEmpty())
 }
 
@@ -35,17 +40,21 @@ func Test_FindChildren_ResourceOwnsChild(t *testing.T) {
 
 	g := gomega.NewWithT(t)
 
+	cfg := config.NewConfiguration()
 	resources := make(astmodel.TypeDefinitionSet)
 
 	ownerType := astmodel.NewResourceType(nil, nil).WithARMURI("/resources/owner")
 	ownerName := astmodel.MakeInternalTypeName(pr, "Owner")
-	resources.Add(astmodel.MakeTypeDefinition(ownerName, ownerType))
+	owner := astmodel.MakeTypeDefinition(ownerName, ownerType)
+	resources.Add(owner)
 
 	childType := astmodel.NewResourceType(nil, nil).WithARMURI("/resources/owner/subresources/child")
 	childName := astmodel.MakeInternalTypeName(pr, "Child")
-	resources.Add(astmodel.MakeTypeDefinition(childName, childType))
+	child := astmodel.MakeTypeDefinition(childName, childType)
+	resources.Add(child)
 
-	children := findChildren(ownerType, ownerName, resources)
+	stage := newOwnershipStage(cfg, resources)
+	children := stage.findChildren(owner)
 	g.Expect(children).To(gomega.ConsistOf(childName))
 }
 
@@ -54,17 +63,21 @@ func Test_FindChildren_ResourceOwnsChildWhenNameParametersAreDifferent(t *testin
 
 	g := gomega.NewWithT(t)
 
+	cfg := config.NewConfiguration()
 	resources := make(astmodel.TypeDefinitionSet)
 
 	ownerType := astmodel.NewResourceType(nil, nil).WithARMURI("/resources/{name}")
 	ownerName := astmodel.MakeInternalTypeName(pr, "Owner")
-	resources.Add(astmodel.MakeTypeDefinition(ownerName, ownerType))
+	owner := astmodel.MakeTypeDefinition(ownerName, ownerType)
+	resources.Add(owner)
 
 	childType := astmodel.NewResourceType(nil, nil).WithARMURI("/resources/{otherName}/subresources/child")
 	childName := astmodel.MakeInternalTypeName(pr, "Child")
-	resources.Add(astmodel.MakeTypeDefinition(childName, childType))
+	child := astmodel.MakeTypeDefinition(childName, childType)
+	resources.Add(child)
 
-	children := findChildren(ownerType, ownerName, resources)
+	stage := newOwnershipStage(cfg, resources)
+	children := stage.findChildren(owner)
 	g.Expect(children).To(gomega.ConsistOf(childName))
 }
 
@@ -73,17 +86,21 @@ func Test_FindChildren_ResourceOwnsChildWhenNameIsDefault(t *testing.T) {
 
 	g := gomega.NewWithT(t)
 
+	cfg := config.NewConfiguration()
 	resources := make(astmodel.TypeDefinitionSet)
 
 	ownerType := astmodel.NewResourceType(nil, nil).WithARMURI("/resources/default")
 	ownerName := astmodel.MakeInternalTypeName(pr, "Owner")
-	resources.Add(astmodel.MakeTypeDefinition(ownerName, ownerType))
+	owner := astmodel.MakeTypeDefinition(ownerName, ownerType)
+	resources.Add(owner)
 
 	childType := astmodel.NewResourceType(nil, nil).WithARMURI("/resources/default/subresources/child")
 	childName := astmodel.MakeInternalTypeName(pr, "Child")
-	resources.Add(astmodel.MakeTypeDefinition(childName, childType))
+	child := astmodel.MakeTypeDefinition(childName, childType)
+	resources.Add(child)
 
-	children := findChildren(ownerType, ownerName, resources)
+	stage := newOwnershipStage(cfg, resources)
+	children := stage.findChildren(owner)
 	g.Expect(children).To(gomega.ConsistOf(childName))
 }
 
@@ -92,17 +109,21 @@ func Test_FindChildren_ResourceDoesNotOwnGrandChild(t *testing.T) {
 
 	g := gomega.NewWithT(t)
 
+	cfg := config.NewConfiguration()
 	resources := make(astmodel.TypeDefinitionSet)
 
 	ownerType := astmodel.NewResourceType(nil, nil).WithARMURI("/resources/owner")
 	ownerName := astmodel.MakeInternalTypeName(pr, "Owner")
-	resources.Add(astmodel.MakeTypeDefinition(ownerName, ownerType))
+	owner := astmodel.MakeTypeDefinition(ownerName, ownerType)
+	resources.Add(owner)
 
 	grandChildType := astmodel.NewResourceType(nil, nil).WithARMURI("/resources/owner/subresources/child/subsubresources/grandchild")
 	grandChildName := astmodel.MakeInternalTypeName(pr, "GrandChild")
-	resources.Add(astmodel.MakeTypeDefinition(grandChildName, grandChildType))
+	grandChild := astmodel.MakeTypeDefinition(grandChildName, grandChildType)
+	resources.Add(grandChild)
 
-	children := findChildren(ownerType, ownerName, resources)
+	stage := newOwnershipStage(cfg, resources)
+	children := stage.findChildren(owner)
 	g.Expect(children).To(gomega.BeEmpty())
 }
 
@@ -111,16 +132,20 @@ func Test_FindChildren_ResourceDoesNotOwnExtendedVersionOfName(t *testing.T) {
 
 	g := gomega.NewWithT(t)
 
+	cfg := config.NewConfiguration()
 	resources := make(astmodel.TypeDefinitionSet)
 
 	ownerType := astmodel.NewResourceType(nil, nil).WithARMURI("/resources/owner")
 	ownerName := astmodel.MakeInternalTypeName(pr, "Owner")
-	resources.Add(astmodel.MakeTypeDefinition(ownerName, ownerType))
+	owner := astmodel.MakeTypeDefinition(ownerName, ownerType)
+	resources.Add(owner)
 
 	grandChildType := astmodel.NewResourceType(nil, nil).WithARMURI("/resources/ownerLonger")
 	grandChildName := astmodel.MakeInternalTypeName(pr, "GrandChild")
-	resources.Add(astmodel.MakeTypeDefinition(grandChildName, grandChildType))
+	grandChild := astmodel.MakeTypeDefinition(grandChildName, grandChildType)
+	resources.Add(grandChild)
 
-	children := findChildren(ownerType, ownerName, resources)
+	stage := newOwnershipStage(cfg, resources)
+	children := stage.findChildren(owner)
 	g.Expect(children).To(gomega.BeEmpty())
 }

--- a/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
@@ -101,9 +101,6 @@ func (r *ResourceRegistrationFile) AsAst() (*dst.File, error) {
 
 	// Create Resource Extensions
 	resourceExtensionTypes := r.createGetResourceExtensions(codeGenContext)
-	if err != nil {
-		return nil, err
-	}
 	decls = append(decls, resourceExtensionTypes)
 
 	// All the index functions


### PR DESCRIPTION
**What this PR does / why we need it**:

The _Determine ARM resource relationships_ stage was taking around a minute to run on my laptop, so I took a look at it - and discovered it's performance was O(n<sup>2</sup>); I modified it to run in O(n) time.

Performance change on my laptop:

| Before  | After  |
| -------:| ------:|
| 1m9.73s | 6.378s |
|  52.48s | 3.014s |

Performance change in CI:

| Before  | After  |
| -------:| ------:|
| 15.258s | 1.333s |
| 15.239s |        |

**Special notes for your reviewer**:

The `findChildren()` method is no longer strictly necessary, but retaining it meant I could keep the tests largely intact.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbnR5MG84bm5yb3UwdW9pamY2ejd4dzRheHRmM3hlY2thdmdzNHJsNyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ZSvAC5c9RkW4g/giphy.gif)

**If applicable**:
- [x] this PR contains tests
