### PR TITLE
Force ASO to install under `azureserviceoperator-system` namespace

### DIFF
--- a/docs/hugo/content/_index.md
+++ b/docs/hugo/content/_index.md
@@ -188,6 +188,7 @@ C:\> helm upgrade --install aso2 aso2/azure-service-operator ^
     --set crdPattern=resources.azure.com/*;containerservice.azure.com/*;keyvault.azure.com/*;managedidentity.azure.com/*;eventhub.azure.com/*
 ```
 {{% /tab %}}
+Note: ASO is recommended to be _only_ installed under `azureserviceoperator-system` namespace
 {{< /tabpane >}}
 
 {{% alert title="Warning" color="warning" %}}

--- a/scripts/v2/generate-helm-manifest.sh
+++ b/scripts/v2/generate-helm-manifest.sh
@@ -60,7 +60,6 @@ sed -i 's/containerPort: 8080/containerPort: {{ .Values.metrics.port | default 8
 sed -i '1 i {{- if .Values.metrics.enable -}}' "$GEN_FILES_DIR"/*controller-manager-metrics-service*
 sed -i 's/port: 8080/port: {{ .Values.metrics.port | default 8080 }}/g' "$GEN_FILES_DIR"/*controller-manager-metrics-service*
 sed -i -e '$a{{- end }}' "$GEN_FILES_DIR"/*controller-manager-metrics-service*
-find "$GEN_FILES_DIR" -type f -exec sed -i 's/azureserviceoperator-system/{{ .Release.Namespace }}/g' {} \;
 
 # Apply CRD guards
 sed -i "1 s/^/$IF_CRDS\n/;$ a {{- end }}" "$GEN_FILES_DIR"/*crd-manager-role*

--- a/v2/charts/azure-service-operator/templates/networkpolicies.yaml
+++ b/v2/charts/azure-service-operator/templates/networkpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: azure-service-operator-allow-ingress
-  namespace: {{ .Release.Namespace }}
+  namespace: azureserviceoperator-system
 spec:
   ingress:
   - from:
@@ -19,7 +19,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: azure-service-operator-allow-egress
-  namespace: {{ .Release.Namespace }}
+  namespace: azureserviceoperator-system
 spec:
   egress:
   # Required for communication with DNS

--- a/v2/charts/azure-service-operator/templates/pre-release-hook/rbac.authorization.k8s.io_v1_clusterrolebinding_azureserviceoperator-pre-upgrade-checker-rolebinding.yaml
+++ b/v2/charts/azure-service-operator/templates/pre-release-hook/rbac.authorization.k8s.io_v1_clusterrolebinding_azureserviceoperator-pre-upgrade-checker-rolebinding.yaml
@@ -13,4 +13,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: azureserviceoperator-pre-upgrade-checker
-  namespace: {{ .Release.Namespace }}
+  namespace: azureserviceoperator-system

--- a/v2/charts/azure-service-operator/templates/pre-release-hook/v1_serviceaccount_azureserviceoperator-pre-upgrade-checker.yaml
+++ b/v2/charts/azure-service-operator/templates/pre-release-hook/v1_serviceaccount_azureserviceoperator-pre-upgrade-checker.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: azureserviceoperator-pre-upgrade-checker
-  namespace: {{ .Release.Namespace }}
+  namespace: azureserviceoperator-system
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-1"

--- a/v2/charts/azure-service-operator/templates/secret.yaml
+++ b/v2/charts/azure-service-operator/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: aso-controller-settings
-  namespace: {{.Release.Namespace}}
+  namespace: azureserviceoperator-system
 type: Opaque
 data:
   AZURE_SUBSCRIPTION_ID: {{ .Values.azureSubscriptionID | b64enc | quote }}


### PR DESCRIPTION


Closes #3715 

**What this PR does / why we need it**:

This PR replaces the `{{ .Release.Namespace }}` with `azureserviceoperator-system` in the helm chart to force ASO to install in `azureserviceoperator-system` namespace. 

**Special notes for your reviewer**:

The installation process stays the same.