### PR TITLE
Modify multitenant test to install operator in custom namespace

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -887,7 +887,7 @@ tasks:
     desc: Waits for the operator and associated CRDs to be ready
     run: always
     cmds:
-      - "{{.SCRIPTS_ROOT}}/wait-for-operator-ready.sh {{.ARGS}}"
+      - "{{.SCRIPTS_ROOT}}/wait-for-operator-ready.sh -n '{{default \"azureserviceoperator-system\" .NAMESPACE}}' {{.ARGS}}"
 
   controller:kind-create-with-service-principal:
     desc: Creates a local kind cluster with ASO using service principal auth.
@@ -941,19 +941,24 @@ tasks:
   controller:kind-create-multitenant-cluster-helm:
     desc: Creates a local kind cluster Helm and ASO in multitenant configuration.
     dir: "{{.CONTROLLER_ROOT}}"
+    vars:
+      # This below is added to test if ASO works fine in namespaces other than 'azureserviceoperator-system"
+      NAMESPACE: "custom-namespace"
     cmds:
-      - task: controller:kind-create
-      - task: controller:install-cert-manager
-      - task: controller:docker-push-local
-      - task: controller:gen-helm-manifest
+#      - task: controller:kind-create
+#      - task: controller:install-cert-manager
+#      - task: controller:docker-push-local
+#      - task: controller:gen-helm-manifest
       # We need the below to wait until cert-manager is up, otherwise the subsequent installation of webhooks fails. See https://cert-manager.io/next-docs/installation/verify/
-      - "cmctl check api --wait=2m"
+#      - "cmctl check api --wait=2m"
       # Install cluster scope chart (mode == webhooks)
       - "helm upgrade --install --set multitenant.enable=true --set azureOperatorMode=webhooks \
            --set image.repository={{.LOCAL_REGISTRY_CONTROLLER_DOCKER_IMAGE}} \
            --set crdPattern=* \
-           aso2 -n {{.ASO_NAMESPACE}} --create-namespace ./charts/azure-service-operator/"
+           aso2 -n {{.NAMESPACE}} --create-namespace ./charts/azure-service-operator/"
       - task: controller:wait-for-operator-ready
+        vars:
+          NAMESPACE: "{{.NAMESPACE}}"
       # Install tenant chart
       - "helm upgrade --install --set azureSubscriptionID=$AZURE_SUBSCRIPTION_ID \ 
            --set azureTenantID=$AZURE_TENANT_ID \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -887,7 +887,7 @@ tasks:
     desc: Waits for the operator and associated CRDs to be ready
     run: always
     cmds:
-      - "{{.SCRIPTS_ROOT}}/wait-for-operator-ready.sh -n '{{default \"azureserviceoperator-system\" .NAMESPACE}}' {{.ARGS}}"
+      - "{{.SCRIPTS_ROOT}}/wait-for-operator-ready.sh -n '{{default .ASO_NAMESPACE .NAMESPACE}}' {{.ARGS}}"
 
   controller:kind-create-with-service-principal:
     desc: Creates a local kind cluster with ASO using service principal auth.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -945,12 +945,12 @@ tasks:
       # This below is added to test if ASO works fine in namespaces other than 'azureserviceoperator-system"
       NAMESPACE: "custom-namespace"
     cmds:
-#      - task: controller:kind-create
-#      - task: controller:install-cert-manager
-#      - task: controller:docker-push-local
-#      - task: controller:gen-helm-manifest
+      - task: controller:kind-create
+      - task: controller:install-cert-manager
+      - task: controller:docker-push-local
+      - task: controller:gen-helm-manifest
       # We need the below to wait until cert-manager is up, otherwise the subsequent installation of webhooks fails. See https://cert-manager.io/next-docs/installation/verify/
-#      - "cmctl check api --wait=2m"
+      - "cmctl check api --wait=2m"
       # Install cluster scope chart (mode == webhooks)
       - "helm upgrade --install --set multitenant.enable=true --set azureOperatorMode=webhooks \
            --set image.repository={{.LOCAL_REGISTRY_CONTROLLER_DOCKER_IMAGE}} \

--- a/scripts/v2/wait-for-operator-ready.sh
+++ b/scripts/v2/wait-for-operator-ready.sh
@@ -10,12 +10,15 @@ set -o pipefail
 print_usage() {
   echo "Usage: wait-for-operator-ready.sh [-c]"
   echo "    -c: Do NOT wait for CRDs to reach established state"
+  echo "    -n: Specify the namespace for the operator (default is 'azureserviceoperator-system')"
 }
 
+OPERATOR_NAMESPACE="azureserviceoperator-system"  # Default namespace
 CHECK_ESTABLISHED=1
-while getopts 'co' flag; do
+while getopts 'c:n:' flag; do
   case "${flag}" in
     c) CHECK_ESTABLISHED=0 ;;
+    n) OPERATOR_NAMESPACE="${OPTARG}" ;;
     *) print_usage
        exit 1 ;;
   esac
@@ -52,7 +55,7 @@ if [[ "$CHECK_ESTABLISHED" -eq 1 ]]; then
 fi
 
 echo "Waiting for pod ready..."
-kubectl wait --for=condition=ready --timeout=3m pod -n azureserviceoperator-system -l control-plane=controller-manager
+kubectl wait --for=condition=ready --timeout=3m pod -n "$OPERATOR_NAMESPACE" -l control-plane=controller-manager
 
 echo "Waiting for CRD cabundle..."
 export -f all_crds_have_cabundle


### PR DESCRIPTION

Closes #3715 

**What this PR does / why we need it**:

The above issue was for ASO beta.5 version and does is not true for current version. As a part of this PR, have modified a multitenant test to confirm ASO works fine in other namespaces as well.

**If applicable**:
- [x] this PR contains tests
