### PR TITLE
Fix asoctl import bug 

### DIFF
--- a/v2/cmd/asoctl/internal/importing/importable_arm_resource.go
+++ b/v2/cmd/asoctl/internal/importing/importable_arm_resource.go
@@ -357,12 +357,14 @@ func (*importableARMResource) classifyError(err error) (string, bool) {
 			return "access forbidden", true
 		}
 
-		if responseError.StatusCode == http.StatusBadRequest &&
-			strings.Contains(responseError.Error(), "RequestUrlInvalid") {
-			// We constructed an invalid URL
-			// (Seems that some extension resources aren't permitted on some resource types)
-			// An empty error is special cased as a silent skip, so we don't alarm casual users
-			return "", true
+		if responseError.StatusCode == http.StatusBadRequest {
+			if strings.Contains(responseError.Error(), "RequestUrlInvalid") ||
+				strings.Contains(responseError.Error(), "ValidationFailed") {
+				// We constructed an invalid URL
+				// (Seems that some extension resources aren't permitted on some resource types)
+				// An empty error is special cased as a silent skip, so we don't alarm casual users
+				return "", true
+			}
 		}
 	}
 

--- a/v2/cmd/asoctl/internal/importing/resource_import_result.go
+++ b/v2/cmd/asoctl/internal/importing/resource_import_result.go
@@ -140,7 +140,7 @@ func (*ResourceImportResult) writeTo(resources []genruntime.MetaObject, destinat
 			return errors.Wrap(err, "unable to save to writer")
 		}
 
-		data = redactStatus(data)
+		data = redact(data)
 
 		_, err = buf.Write(data)
 		if err != nil {
@@ -156,12 +156,11 @@ func (*ResourceImportResult) writeTo(resources []genruntime.MetaObject, destinat
 	return nil
 }
 
-// redactStatus removes any empty `status { }` blocks from the yaml.
-// If we start redacting other things, we should rename this method
-// and possibly consider using a more general purpose technique,
-// such as a yaml parser.
-func redactStatus(data []byte) []byte {
+// redact removes any selected information that shouldn't be included,
+// starting with empty `status { }` blocks from the yaml.
+func redact(data []byte) []byte {
 	content := string(data)
 	content = strings.Replace(content, "status: {}", "", -1)
+	content = strings.TrimSuffix(content, "\n")
 	return []byte(content)
 }

--- a/v2/cmd/asoctl/internal/importing/resource_importer.go
+++ b/v2/cmd/asoctl/internal/importing/resource_importer.go
@@ -304,7 +304,7 @@ func (ri *ResourceImporter) createProgressBar(
 		mpb.PrependDecorators(
 			decor.Name(name, decor.WCSyncSpaceR)),
 		mpb.AppendDecorators(
-			decor.Percentage(decor.WC{W: 5})))
+			decor.CountersNoUnit("%d/%d", decor.WCSyncSpaceR)))
 
 	// Monitor for progress updates
 	go func() {
@@ -345,7 +345,8 @@ func (ri *ResourceImporter) createSubProgressBar(
 		mpb.BarRemoveOnComplete(),
 		mpb.PrependDecorators(
 			decor.Name(name, decor.WCSyncSpaceR)),
-		mpb.AppendDecorators(decor.Percentage(decor.WC{W: 5})))
+		mpb.AppendDecorators(
+			decor.CountersNoUnit("%d/%d", decor.WCSyncSpaceR)))
 
 	// Monitor for progress updates
 	go func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug where attempts to list the extension resource `kubernetestconfiguration/extension` will fail, aborting the import.

Closes #3852 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2lzNDVoczVzNmdzNGYzcTRsMHhpNnpmMTBpa3k4bzB6dzVsZDY4OCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/FnF7vgz2oON3i/giphy.gif)

