### PR TITLE
Fix panic in asoctl

### DIFF
--- a/v2/cmd/asoctl/internal/importing/find_group_kind.go
+++ b/v2/cmd/asoctl/internal/importing/find_group_kind.go
@@ -6,11 +6,13 @@
 package importing
 
 import (
+	"strings"
 	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/Azure/azure-service-operator/v2/api"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var (
@@ -23,8 +25,14 @@ func FindGroupKindForResourceType(t string) (schema.GroupKind, bool) {
 		resourceTypeGK = createTypeToGKMap()
 	})
 
+	t = canonicalizeAzureTypeString(t)
 	gk, ok := resourceTypeGK[t]
 	return gk, ok
+}
+
+func canonicalizeAzureTypeString(t string) string {
+	// ToLower the type, as Azure type names are not case-sensitive
+	return strings.ToLower(t)
 }
 
 func createTypeToGKMap() map[string]schema.GroupKind {
@@ -43,7 +51,8 @@ func createTypeToGKMap() map[string]schema.GroupKind {
 			continue
 		}
 
-		result[rsrc.GetType()] = gvk.GroupKind()
+		typeStr := canonicalizeAzureTypeString(rsrc.GetType())
+		result[typeStr] = gvk.GroupKind()
 	}
 
 	return result

--- a/v2/cmd/asoctl/internal/importing/importable_arm_resource.go
+++ b/v2/cmd/asoctl/internal/importing/importable_arm_resource.go
@@ -383,12 +383,12 @@ func (i *importableARMResource) createImportableObjectFromID(
 
 	gvk, gvkErr := i.groupVersionKindFromID(armID)
 	if gvkErr != nil {
-		return nil, errors.Wrap(err, "unable to determine GVK of resource")
+		return nil, errors.Wrap(gvkErr, "unable to determine GVK of resource")
 	}
 
 	obj, objErr := i.createBlankObjectFromGVK(gvk)
 	if objErr != nil {
-		return nil, errors.Wrap(err, "unable to create blank resource")
+		return nil, errors.Wrap(objErr, "unable to create blank resource")
 	}
 
 	importable, ok := obj.(genruntime.ImportableARMResource)

--- a/v2/cmd/asoctl/internal/importing/importable_arm_resource_test.go
+++ b/v2/cmd/asoctl/internal/importing/importable_arm_resource_test.go
@@ -53,6 +53,18 @@ func Test_ARMResourceImporter_GroupKindFromARMID(t *testing.T) {
 			expectedGroup: "containerservice.azure.com",
 			expectedKind:  "ManagedCluster",
 		},
+		{
+			name:          "Redis cache",
+			armId:         "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aso-rg/providers/Microsoft.Cache/redis/my-cache",
+			expectedGroup: "cache.azure.com",
+			expectedKind:  "Redis",
+		},
+		{
+			name:          "Redis cache different case",
+			armId:         "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aso-rg/providers/Microsoft.Cache/REDIS/my-cache",
+			expectedGroup: "cache.azure.com",
+			expectedKind:  "Redis",
+		},
 		//{
 		//	"VMSS Instance",
 		//	"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aso-rg/providers/Microsoft.Compute/virtualMachineScaleSets/aso-scaleset/virtualMachines/0",
@@ -112,6 +124,20 @@ func Test_ARMResourceImporter_GroupVersionKindFromARMID(t *testing.T) {
 			expectedGroup:   "containerservice.azure.com",
 			expectedKind:    "ManagedCluster",
 			expectedVersion: "v1api20231001",
+		},
+		{
+			name:            "Redis cache",
+			armId:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aso-rg/providers/Microsoft.Cache/redis/my-cache",
+			expectedGroup:   "cache.azure.com",
+			expectedKind:    "Redis",
+			expectedVersion: "v1api20230401",
+		},
+		{
+			name:            "Redis cache different case",
+			armId:           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aso-rg/providers/Microsoft.Cache/REDIS/my-cache",
+			expectedGroup:   "cache.azure.com",
+			expectedKind:    "Redis",
+			expectedVersion: "v1api20230401",
 		},
 	}
 


### PR DESCRIPTION
Caused by case-mismatch in Azure reported resource type.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
