### PR TITLE
Order numeric enums by magnitude

### DIFF
--- a/v2/api/operationalinsights/v1api20210601/structure.txt
+++ b/v2/api/operationalinsights/v1api20210601/structure.txt
@@ -37,12 +37,12 @@ github.com/Azure/azure-service-operator/v2/api/operationalinsights/v1api20210601
 │   │   ├── Sku: *Object (2 properties)
 │   │   │   ├── CapacityReservationLevel: *Enum (8 values)
 │   │   │   │   ├── 100
-│   │   │   │   ├── 1000
 │   │   │   │   ├── 200
-│   │   │   │   ├── 2000
 │   │   │   │   ├── 300
 │   │   │   │   ├── 400
 │   │   │   │   ├── 500
+│   │   │   │   ├── 1000
+│   │   │   │   ├── 2000
 │   │   │   │   └── 5000
 │   │   │   └── Name: *Enum (8 values)
 │   │   │       ├── "CapacityReservation"
@@ -93,12 +93,12 @@ github.com/Azure/azure-service-operator/v2/api/operationalinsights/v1api20210601
 │       ├── Sku: *Object (3 properties)
 │       │   ├── CapacityReservationLevel: *Enum (8 values)
 │       │   │   ├── 100
-│       │   │   ├── 1000
 │       │   │   ├── 200
-│       │   │   ├── 2000
 │       │   │   ├── 300
 │       │   │   ├── 400
 │       │   │   ├── 500
+│       │   │   ├── 1000
+│       │   │   ├── 2000
 │       │   │   └── 5000
 │       │   ├── LastSkuUpdate: *string
 │       │   └── Name: *Enum (8 values)
@@ -159,12 +159,12 @@ github.com/Azure/azure-service-operator/v2/api/operationalinsights/v1api20210601
 │   │   ├── Sku: *Object (3 properties)
 │   │   │   ├── CapacityReservationLevel: *Enum (8 values)
 │   │   │   │   ├── 100
-│   │   │   │   ├── 1000
 │   │   │   │   ├── 200
-│   │   │   │   ├── 2000
 │   │   │   │   ├── 300
 │   │   │   │   ├── 400
 │   │   │   │   ├── 500
+│   │   │   │   ├── 1000
+│   │   │   │   ├── 2000
 │   │   │   │   └── 5000
 │   │   │   ├── LastSkuUpdate: *string
 │   │   │   └── Name: *Enum (8 values)
@@ -218,12 +218,12 @@ github.com/Azure/azure-service-operator/v2/api/operationalinsights/v1api20210601
     │   ├── Sku: *Object (2 properties)
     │   │   ├── CapacityReservationLevel: *Enum (8 values)
     │   │   │   ├── 100
-    │   │   │   ├── 1000
     │   │   │   ├── 200
-    │   │   │   ├── 2000
     │   │   │   ├── 300
     │   │   │   ├── 400
     │   │   │   ├── 500
+    │   │   │   ├── 1000
+    │   │   │   ├── 2000
     │   │   │   └── 5000
     │   │   └── Name: *Enum (8 values)
     │   │       ├── "CapacityReservation"

--- a/v2/api/operationalinsights/v1api20210601/workspace_spec_arm_types_gen_test.go
+++ b/v2/api/operationalinsights/v1api20210601/workspace_spec_arm_types_gen_test.go
@@ -367,12 +367,12 @@ func WorkspaceSku_ARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForWorkspaceSku_ARM(gens map[string]gopter.Gen) {
 	gens["CapacityReservationLevel"] = gen.PtrOf(gen.OneConstOf(
 		WorkspaceSku_CapacityReservationLevel_100,
-		WorkspaceSku_CapacityReservationLevel_1000,
 		WorkspaceSku_CapacityReservationLevel_200,
-		WorkspaceSku_CapacityReservationLevel_2000,
 		WorkspaceSku_CapacityReservationLevel_300,
 		WorkspaceSku_CapacityReservationLevel_400,
 		WorkspaceSku_CapacityReservationLevel_500,
+		WorkspaceSku_CapacityReservationLevel_1000,
+		WorkspaceSku_CapacityReservationLevel_2000,
 		WorkspaceSku_CapacityReservationLevel_5000))
 	gens["Name"] = gen.PtrOf(gen.OneConstOf(
 		WorkspaceSku_Name_CapacityReservation,

--- a/v2/api/operationalinsights/v1api20210601/workspace_status_arm_types_gen_test.go
+++ b/v2/api/operationalinsights/v1api20210601/workspace_status_arm_types_gen_test.go
@@ -445,12 +445,12 @@ func WorkspaceSku_STATUS_ARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForWorkspaceSku_STATUS_ARM(gens map[string]gopter.Gen) {
 	gens["CapacityReservationLevel"] = gen.PtrOf(gen.OneConstOf(
 		WorkspaceSku_CapacityReservationLevel_STATUS_100,
-		WorkspaceSku_CapacityReservationLevel_STATUS_1000,
 		WorkspaceSku_CapacityReservationLevel_STATUS_200,
-		WorkspaceSku_CapacityReservationLevel_STATUS_2000,
 		WorkspaceSku_CapacityReservationLevel_STATUS_300,
 		WorkspaceSku_CapacityReservationLevel_STATUS_400,
 		WorkspaceSku_CapacityReservationLevel_STATUS_500,
+		WorkspaceSku_CapacityReservationLevel_STATUS_1000,
+		WorkspaceSku_CapacityReservationLevel_STATUS_2000,
 		WorkspaceSku_CapacityReservationLevel_STATUS_5000))
 	gens["LastSkuUpdate"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.OneConstOf(

--- a/v2/api/operationalinsights/v1api20210601/workspace_types_gen.go
+++ b/v2/api/operationalinsights/v1api20210601/workspace_types_gen.go
@@ -2511,17 +2511,17 @@ const (
 	WorkspaceCapping_DataIngestionStatus_STATUS_SubscriptionSuspended = WorkspaceCapping_DataIngestionStatus_STATUS("SubscriptionSuspended")
 )
 
-// +kubebuilder:validation:Enum={100,1000,200,2000,300,400,500,5000}
+// +kubebuilder:validation:Enum={100,200,300,400,500,1000,2000,5000}
 type WorkspaceSku_CapacityReservationLevel int
 
 const (
 	WorkspaceSku_CapacityReservationLevel_100  = WorkspaceSku_CapacityReservationLevel(100)
-	WorkspaceSku_CapacityReservationLevel_1000 = WorkspaceSku_CapacityReservationLevel(1000)
 	WorkspaceSku_CapacityReservationLevel_200  = WorkspaceSku_CapacityReservationLevel(200)
-	WorkspaceSku_CapacityReservationLevel_2000 = WorkspaceSku_CapacityReservationLevel(2000)
 	WorkspaceSku_CapacityReservationLevel_300  = WorkspaceSku_CapacityReservationLevel(300)
 	WorkspaceSku_CapacityReservationLevel_400  = WorkspaceSku_CapacityReservationLevel(400)
 	WorkspaceSku_CapacityReservationLevel_500  = WorkspaceSku_CapacityReservationLevel(500)
+	WorkspaceSku_CapacityReservationLevel_1000 = WorkspaceSku_CapacityReservationLevel(1000)
+	WorkspaceSku_CapacityReservationLevel_2000 = WorkspaceSku_CapacityReservationLevel(2000)
 	WorkspaceSku_CapacityReservationLevel_5000 = WorkspaceSku_CapacityReservationLevel(5000)
 )
 
@@ -2529,12 +2529,12 @@ type WorkspaceSku_CapacityReservationLevel_STATUS int
 
 const (
 	WorkspaceSku_CapacityReservationLevel_STATUS_100  = WorkspaceSku_CapacityReservationLevel_STATUS(100)
-	WorkspaceSku_CapacityReservationLevel_STATUS_1000 = WorkspaceSku_CapacityReservationLevel_STATUS(1000)
 	WorkspaceSku_CapacityReservationLevel_STATUS_200  = WorkspaceSku_CapacityReservationLevel_STATUS(200)
-	WorkspaceSku_CapacityReservationLevel_STATUS_2000 = WorkspaceSku_CapacityReservationLevel_STATUS(2000)
 	WorkspaceSku_CapacityReservationLevel_STATUS_300  = WorkspaceSku_CapacityReservationLevel_STATUS(300)
 	WorkspaceSku_CapacityReservationLevel_STATUS_400  = WorkspaceSku_CapacityReservationLevel_STATUS(400)
 	WorkspaceSku_CapacityReservationLevel_STATUS_500  = WorkspaceSku_CapacityReservationLevel_STATUS(500)
+	WorkspaceSku_CapacityReservationLevel_STATUS_1000 = WorkspaceSku_CapacityReservationLevel_STATUS(1000)
+	WorkspaceSku_CapacityReservationLevel_STATUS_2000 = WorkspaceSku_CapacityReservationLevel_STATUS(2000)
 	WorkspaceSku_CapacityReservationLevel_STATUS_5000 = WorkspaceSku_CapacityReservationLevel_STATUS(5000)
 )
 

--- a/v2/api/operationalinsights/v1api20210601/workspace_types_gen_test.go
+++ b/v2/api/operationalinsights/v1api20210601/workspace_types_gen_test.go
@@ -1066,12 +1066,12 @@ func WorkspaceSkuGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForWorkspaceSku(gens map[string]gopter.Gen) {
 	gens["CapacityReservationLevel"] = gen.PtrOf(gen.OneConstOf(
 		WorkspaceSku_CapacityReservationLevel_100,
-		WorkspaceSku_CapacityReservationLevel_1000,
 		WorkspaceSku_CapacityReservationLevel_200,
-		WorkspaceSku_CapacityReservationLevel_2000,
 		WorkspaceSku_CapacityReservationLevel_300,
 		WorkspaceSku_CapacityReservationLevel_400,
 		WorkspaceSku_CapacityReservationLevel_500,
+		WorkspaceSku_CapacityReservationLevel_1000,
+		WorkspaceSku_CapacityReservationLevel_2000,
 		WorkspaceSku_CapacityReservationLevel_5000))
 	gens["Name"] = gen.PtrOf(gen.OneConstOf(
 		WorkspaceSku_Name_CapacityReservation,
@@ -1186,12 +1186,12 @@ func WorkspaceSku_STATUSGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForWorkspaceSku_STATUS(gens map[string]gopter.Gen) {
 	gens["CapacityReservationLevel"] = gen.PtrOf(gen.OneConstOf(
 		WorkspaceSku_CapacityReservationLevel_STATUS_100,
-		WorkspaceSku_CapacityReservationLevel_STATUS_1000,
 		WorkspaceSku_CapacityReservationLevel_STATUS_200,
-		WorkspaceSku_CapacityReservationLevel_STATUS_2000,
 		WorkspaceSku_CapacityReservationLevel_STATUS_300,
 		WorkspaceSku_CapacityReservationLevel_STATUS_400,
 		WorkspaceSku_CapacityReservationLevel_STATUS_500,
+		WorkspaceSku_CapacityReservationLevel_STATUS_1000,
+		WorkspaceSku_CapacityReservationLevel_STATUS_2000,
 		WorkspaceSku_CapacityReservationLevel_STATUS_5000))
 	gens["LastSkuUpdate"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.OneConstOf(

--- a/v2/tools/generator/internal/astmodel/enum_type.go
+++ b/v2/tools/generator/internal/astmodel/enum_type.go
@@ -8,7 +8,7 @@ package astmodel
 import (
 	"fmt"
 	"go/token"
-	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -40,9 +40,28 @@ func NewEnumType(baseType *PrimitiveType, options ...EnumValue) *EnumType {
 		panic("baseType must be provided")
 	}
 
-	sort.Slice(options, func(left int, right int) bool {
-		return options[left].Identifier < options[right].Identifier
-	})
+	slices.SortFunc(
+		options,
+		func(left EnumValue, right EnumValue) int {
+			if baseType == IntType {
+				// Compare integers as numbers if we can
+				l, lOk := strconv.Atoi(left.Identifier)
+				r, rOk := strconv.Atoi(right.Identifier)
+				if lOk == nil && rOk == nil {
+					return l - r
+				}
+
+				if lOk == nil && rOk != nil {
+					return -1 // put the int first
+				}
+
+				if lOk != nil && rOk == nil {
+					return 1 // put the int first
+				}
+			}
+
+			return strings.Compare(left.Identifier, right.Identifier)
+		})
 
 	return &EnumType{
 		baseType:       baseType,


### PR DESCRIPTION
**What this PR does / why we need it**:

Ordering tweak for declarations of enumerations with an integer base, listing them in order of magnitude instead of alphabetically.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/WjAkQjz7h9ESA/giphy.gif?cid=790b7611owcxwundljgmrzzogbqd8ufvi28bh1vks2dd6ymz&ep=v1_gifs_search&rid=giphy.gif&ct=g)
