### PR TITLE
Eliminate panic in InterfaceImplementer AsDeclarations()

### DIFF
--- a/v2/tools/generator/internal/astbuilder/builder.go
+++ b/v2/tools/generator/internal/astbuilder/builder.go
@@ -438,22 +438,6 @@ func NotEmpty(x dst.Expr) *dst.BinaryExpr {
 	}
 }
 
-// StatementBlock generates a block containing the supplied statements
-// If we're given a single statement that's already a block, we won't double wrap it
-func StatementBlock(statements ...dst.Stmt) *dst.BlockStmt {
-	stmts := Statements(statements)
-
-	if len(stmts) == 1 {
-		if block, ok := stmts[0].(*dst.BlockStmt); ok {
-			return block
-		}
-	}
-
-	return &dst.BlockStmt{
-		List: stmts,
-	}
-}
-
 func BinaryExpr(lhs dst.Expr, op token.Token, rhs dst.Expr) *dst.BinaryExpr {
 	return &dst.BinaryExpr{
 		X:  dst.Clone(lhs).(dst.Expr),

--- a/v2/tools/generator/internal/astbuilder/declarations.go
+++ b/v2/tools/generator/internal/astbuilder/declarations.go
@@ -11,8 +11,28 @@ import (
 	"github.com/dave/dst"
 )
 
+// Declarations constructs a slice of dst.Decl by combining the given declarations.
+// Pass any combination of dst.Decl and []dst.Decl as arguments; anything else will
+// result in a runtime panic.
 func Declarations(declarations ...any) []dst.Decl {
-	decls := make([]dst.Decl, 0, len(declarations))
+	// Calculate the final size required
+	size := 0
+	for _, d := range declarations {
+		switch d := d.(type) {
+		case nil:
+			// Skip nils
+			continue
+		case dst.Decl:
+			size++
+		case []dst.Decl:
+			size += len(d)
+		default:
+			panic(fmt.Sprintf("expected dst.Decl or []dst.Decl, but found %T", d))
+		}
+	}
+
+	// Flatten the declarations into a single slice
+	decls := make([]dst.Decl, 0, size)
 	for _, d := range declarations {
 		switch d := d.(type) {
 		case nil:
@@ -29,6 +49,7 @@ func Declarations(declarations ...any) []dst.Decl {
 		}
 	}
 
+	// Clone everything to avoid sharing nodes
 	result := make([]dst.Decl, 0, len(decls))
 	for _, d := range decls {
 		result = append(result, dst.Clone(d).(dst.Decl))

--- a/v2/tools/generator/internal/astbuilder/declarations.go
+++ b/v2/tools/generator/internal/astbuilder/declarations.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astbuilder
+
+import (
+	"fmt"
+
+	"github.com/dave/dst"
+)
+
+func Declarations(declarations ...any) []dst.Decl {
+	decls := make([]dst.Decl, 0, len(declarations))
+	for _, d := range declarations {
+		switch d := d.(type) {
+		case nil:
+			// Skip nils
+			continue
+		case dst.Decl:
+			// Add a single declaration
+			decls = append(decls, d)
+		case []dst.Decl:
+			// Add many declarations
+			decls = append(decls, d...)
+		default:
+			panic(fmt.Sprintf("expected dst.Decl or []dst.Decl, but found %T", d))
+		}
+	}
+
+	result := make([]dst.Decl, 0, len(decls))
+	for _, d := range decls {
+		result = append(result, dst.Clone(d).(dst.Decl))
+	}
+
+	return result
+}

--- a/v2/tools/generator/internal/astbuilder/statements.go
+++ b/v2/tools/generator/internal/astbuilder/statements.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astbuilder
+
+import (
+	"fmt"
+	"github.com/dave/dst"
+)
+
+// Statements creates a slice of dst.Stmt by combining the given statements.
+// Pass any combination of dst.Stmt and []dst.Stmt as arguments; anything else will
+// result in a runtime panic.
+func Statements(statements ...any) []dst.Stmt {
+	// Calculate the final size required
+	size := 0
+	for _, s := range statements {
+		switch s := s.(type) {
+		case nil:
+			// Skip nils
+			continue
+		case dst.Stmt:
+			size++
+		case []dst.Stmt:
+			size += len(s)
+		default:
+			panic(fmt.Sprintf("expected dst.Stmt or []dst.Stmt, but found %T", s))
+		}
+	}
+
+	// Flatten the statements into a single slice
+	stmts := make([]dst.Stmt, 0, size)
+	for _, s := range statements {
+		switch s := s.(type) {
+		case nil:
+			// Skip nils
+			continue
+		case dst.Stmt:
+			// Add a single statement
+			stmts = append(stmts, s)
+		case []dst.Stmt:
+			// Add many statements
+			stmts = append(stmts, s...)
+		default:
+			panic(fmt.Sprintf("expected dst.Stmt or []dst.Stmt, but found %T", s))
+		}
+	}
+
+	// Clone everything to avoid sharing nodes
+	result := make([]dst.Stmt, 0, len(stmts))
+	for _, st := range stmts {
+		result = append(result, dst.Clone(st).(dst.Stmt))
+	}
+
+	return result
+}
+
+// StatementBlock generates a block containing the supplied statements
+// If we're given a single statement that's already a block, we won't double wrap it
+func StatementBlock(statements ...dst.Stmt) *dst.BlockStmt {
+	stmts := Statements(statements)
+
+	if len(stmts) == 1 {
+		if block, ok := stmts[0].(*dst.BlockStmt); ok {
+			return block
+		}
+	}
+
+	return &dst.BlockStmt{
+		List: stmts,
+	}
+}

--- a/v2/tools/generator/internal/astmodel/object_type.go
+++ b/v2/tools/generator/internal/astmodel/object_type.go
@@ -87,15 +87,21 @@ func (objectType *ObjectType) AsDeclarations(
 	astbuilder.AddUnwrappedComments(&declaration.Decs.Start, declContext.Description)
 	AddValidationComments(&declaration.Decs.Start, declContext.Validations)
 
-	result := []dst.Decl{declaration}
-	result = append(result, objectType.InterfaceImplementer.AsDeclarations(codeGenerationContext, declContext.Name, nil)...)
+	interfaceDeclarations, err := objectType.InterfaceImplementer.AsDeclarations(codeGenerationContext, declContext.Name, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "generating interface declarations for %s", declContext.Name)
+	}
 
-	decls, err := objectType.generateMethodDecls(codeGenerationContext, declContext.Name)
+	methodDeclarations, err := objectType.generateMethodDecls(codeGenerationContext, declContext.Name)
 	if err != nil {
 		return nil, errors.Wrapf(err, "generating method declarations for %s", declContext.Name)
 	}
 
-	result = append(result, decls...)
+	result := astbuilder.Declarations(
+		declaration,
+		interfaceDeclarations,
+		methodDeclarations)
+
 	return result, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The method `InterfaceImplementer.AsDeclarations()` had a panic stemming from the fact that we previously couldn't return the error; thanks to other tech-debt cleanup, we now can.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/UTBKwwtB1FuWG1UOYL/giphy.gif?cid=790b76113irzf9zvpsp2860w6nipjyubweotho5giwa8jtiy&ep=v1_gifs_search&rid=giphy.gif&ct=g)

**CoPilot Summary**

This pull request includes changes to the `v2/tools/generator/internal/astmodel` package to enhance error handling and code readability. The most important changes include the addition of a new `Declarations` function, modification of the `import` statement, changes to the `AsDeclarations` function in multiple files to include error returns and use the new `Declarations` function, and improvements in error messages.

Addition of new function:

* [`v2/tools/generator/internal/astbuilder/declarations.go`](diffhunk://#diff-dab59b17308e211e7d474b2f135f1fee11dcdeb111fcf26e60c0823f507f520dR1-R38): Added a new function `Declarations` to handle the creation of declarations. This function takes in a variable number of declarations and returns a slice of `dst.Decl`. It also handles the cloning of declarations.

Import modifications:

* [`v2/tools/generator/internal/astmodel/interface_implementer.go`](diffhunk://#diff-9f21fd6a6e93c53549e97d1798f1a45b7e25ad774da2f7b6fb4543a694ad34c7R15): Added `github.com/pkg/errors` to the import statement.

Changes to `AsDeclarations` function:

* [`v2/tools/generator/internal/astmodel/interface_implementer.go`](diffhunk://#diff-9f21fd6a6e93c53549e97d1798f1a45b7e25ad774da2f7b6fb4543a694ad34c7L69-R70): Modified `AsDeclarations` function to return an error along with the slice of `dst.Decl`. Removed the panic statement and replaced it with an error return. [[1]](diffhunk://#diff-9f21fd6a6e93c53549e97d1798f1a45b7e25ad774da2f7b6fb4543a694ad34c7L69-R70) [[2]](diffhunk://#diff-9f21fd6a6e93c53549e97d1798f1a45b7e25ad774da2f7b6fb4543a694ad34c7L102-R111)
* [`v2/tools/generator/internal/astmodel/object_type.go`](diffhunk://#diff-b25232595a331fd1356dfadde169dc7b170d668f0e1c6c8aec143d585eb0b991L90-R104): Updated `AsDeclarations` function to use the new `Declarations` function from `astbuilder` and to return an error. Improved error messages for better clarity.
* [`v2/tools/generator/internal/astmodel/resource_type.go`](diffhunk://#diff-e3db31ffb34a3a08788d32627dcf044d1ee98e0af562653dcf8a9f79a0614fd6L669-R686): Updated `AsDeclarations` function to use the new `Declarations` function from `astbuilder` and to return an error. Improved error messages for better clarity.