### PR TITLE
Update Go version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.137.0/containers/go/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/devcontainers/images/blob/main/src/go/.devcontainer/Dockerfile
 
 # This is pinned to a particular version of go:
-FROM mcr.microsoft.com/vscode/devcontainers/go:0-1.20
+FROM mcr.microsoft.com/devcontainers/go:1.22
 
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 ARG TARGETARCH

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -94,7 +94,7 @@ fi
 
 # Ensure we have the right version of GO
 
-#doc# | Go | 1.20 | https://golang.org/doc/install #
+#doc# | Go | 1.22 | https://golang.org/doc/install #
 if ! command -v go > /dev/null 2>&1; then
     write-error "Go must be installed manually; see https://golang.org/doc/install"
     exit 1
@@ -104,7 +104,7 @@ GOVER=$(go version)
 write-info "Go version: ${GOVER[*]}"
 
 GOVERREGEX=".*go1.([0-9]+).([0-9]+).*"
-GOVERREQUIRED="go1.20.*"
+GOVERREQUIRED="go1.22.*"
 GOVERACTUAL=$(go version | { read _ _ ver _; echo "$ver"; })
 
 if ! [[ $GOVERACTUAL =~ $GOVERREGEX ]]; then
@@ -113,7 +113,7 @@ if ! [[ $GOVERACTUAL =~ $GOVERREGEX ]]; then
 fi
 
 GOMINORVER="${BASH_REMATCH[1]}"
-GOMINORREQUIRED=20
+GOMINORREQUIRED=22
 
 # We allow for Go versions above the min version, but prevent versions below. This is safe given Go's back-compat guarantees
 if ! [[ $GOMINORVER -ge $GOMINORREQUIRED ]]; then
@@ -179,11 +179,11 @@ go-install() {
     fi
 }
 
-#doc# | conversion-gen | v0.28.0 | https://pkg.go.dev/k8s.io/code-generator/cmd/conversion-gen |
-go-install conversion-gen k8s.io/code-generator/cmd/conversion-gen@v0.28.0
+#doc# | conversion-gen | v0.28.8 | https://pkg.go.dev/k8s.io/code-generator/cmd/conversion-gen |
+go-install conversion-gen k8s.io/code-generator/cmd/conversion-gen@v0.28.8
 
-#doc# | controller-gen | v0.13.0 | https://book.kubebuilder.io/reference/controller-gen |
-go-install controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen@v0.13.0
+#doc# | controller-gen | v0.14.0 | https://book.kubebuilder.io/reference/controller-gen |
+go-install controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
 
 #doc# | kind | v0.20.0 | https://kind.sigs.k8s.io/ |
 go-install kind sigs.k8s.io/kind@v0.20.0

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -153,9 +153,20 @@ jobs:
           if-no-files-found: error
         if: steps.check-changes.outputs.code-changed == 'true'
 
+      # Workaround for getting "Permission denied" errors when trying to perform code coverage upload
+      - name: Take Ownership
+        run: sudo chown -R $USER:$USER .
+
+      # We were using bash upload previously, but it's unsupported since 2022 and
+      # seems to hang forever now. There seems to be significant throttling of tokenless requests (from forks)
+      # errors like: Upload failed: {"detail":"Tokenless has reached GitHub rate limit. Please upload using a token:
+      # https://docs.codecov.com/docs/adding-the-codecov-token. Expected available in 395 seconds."}
+      # Unfortunately I don't see another choice for this so for now we'll live with it
       - name: Upload code coverage to Codecov
-        run: bash <(curl -s https://codecov.io/bash)
-        if: steps.check-changes.outputs.code-changed == 'true'
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 
   # TODO: Changing this name requires changing the github API calls in pr-validation-fork.yml
   integration-tests:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.22 as builder
 
 # need jq for running the Makefile
 RUN curl -L -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x /usr/local/bin/jq

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -91,7 +91,7 @@ tasks:
     desc: Ensure all code is formatted
     dir: v2
     cmds:
-      - gofumpt -l -s -w .
+      - gofumpt -l -w .
 
   build-docs-site:
     cmds:
@@ -620,7 +620,7 @@ tasks:
       - if [ -d "{{.CONTROLLER_OUTPUT}}/crd/generated/patches" ]; then find "{{.CONTROLLER_OUTPUT}}/crd/generated/patches" -type f -delete; fi
       - cd v2/api && controller-gen {{.OBJECT_OPTIONS}} paths=./...
       - cd v2/api && controller-gen {{.CRD_OPTIONS}} {{.WEBHOOK_OPTIONS}} {{.RBAC_OPTIONS}} paths=./...
-      - cd v2/api && gofumpt -l -s -w . # format all generated code
+      - cd v2/api && gofumpt -l -w . # format all generated code
     vars:
       OBJECT_OPTIONS: object:headerFile={{.HEADER_FILE}}
       CRD_OPTIONS: crd:crdVersions=v1,allowDangerousTypes=true output:crd:artifacts:config={{.CONTROLLER_OUTPUT}}/crd/generated/bases
@@ -1040,7 +1040,7 @@ tasks:
       - if [ -d "{{.CROSSPLANE_OUTPUT}}/crd/patches" ]; then find "{{.CROSSPLANE_OUTPUT}}/crd/patches" -type f -delete; fi
       - cd apis && controller-gen {{.OBJECT_OPTIONS}} paths=./...
       - cd apis && controller-gen {{.CRD_OPTIONS}} {{.WEBHOOK_OPTIONS}} {{.RBAC_OPTIONS}} paths=./...
-      - cd apis && gofumpt -l -s -w . # format all generated code
+      - cd apis && gofumpt -l -w . # format all generated code
     vars:
       OBJECT_OPTIONS: object:headerFile={{.HEADER_FILE}}
       CRD_OPTIONS: crd:crdVersions=v1,allowDangerousTypes=true output:crd:artifacts:config={{.CROSSPLANE_OUTPUT}}/crd/bases

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,7 @@ jobs:
       displayName: 'Validate Source'
       continueOnError: 'false'
 
-
+    # TODO: Tried to update to Go 1.22 but failed, see https://github.com/microsoft/azure-pipelines-tasks/issues/19690
     - task: GoTool@0
       displayName: Get Go 1.20
       condition: or(eq(variables['check_changes.SOURCE_CODE_CHANGED'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))

--- a/docs/hugo/content/contributing/dependencies.md
+++ b/docs/hugo/content/contributing/dependencies.md
@@ -12,10 +12,10 @@ If you prefer to install those dependencies manually (instead of using the `.dev
 | AZWI | v1.2.0 | https://github.com/Azure/azure-workload-identity |
 | BuildX | v0.11.2 | https://github.com/docker/buildx |
 | cmctl | latest | https://cert-manager.io/docs/reference/cmctl |
-| controller-gen | v0.13.0 | https://book.kubebuilder.io/reference/controller-gen |
-| conversion-gen | v0.28.0 | https://pkg.go.dev/k8s.io/code-generator/cmd/conversion-gen |
+| controller-gen | v0.14.0 | https://book.kubebuilder.io/reference/controller-gen |
+| conversion-gen | v0.28.8 | https://pkg.go.dev/k8s.io/code-generator/cmd/conversion-gen |
 | gen-crd-api-reference-docs | 11fe95cb | https://github.com/ahmetb/gen-crd-api-reference-docs |
-| Go | 1.20 | https://golang.org/doc/install #
+| Go | 1.22 | https://golang.org/doc/install #
 | gofumpt | latest | https://pkg.go.dev/mvdan.cc/gofumpt |
 | golangci-lint | 1.51.2 | https://github.com/golangci/golangci-lint |
 | Helm | v3.8.0 | https://helm.sh/ |

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -2,7 +2,7 @@
 ARG VERSION_FLAGS
 
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.22 as builder
 ARG VERSION_FLAGS
 
 WORKDIR /workspace/

--- a/v2/cmd/asoctl/go.mod
+++ b/v2/cmd/asoctl/go.mod
@@ -1,6 +1,8 @@
 module github.com/Azure/azure-service-operator/v2/cmd/asoctl
 
-go 1.20
+go 1.21
+
+toolchain go1.21.8
 
 replace github.com/Azure/azure-service-operator/v2 => ../../
 

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,6 +1,8 @@
 module github.com/Azure/azure-service-operator/v2
 
-go 1.20
+go 1.21
+
+toolchain go1.21.8
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0

--- a/v2/tools/generator/go.mod
+++ b/v2/tools/generator/go.mod
@@ -1,6 +1,8 @@
 module github.com/Azure/azure-service-operator/v2/tools/generator
 
-go 1.20
+go 1.21
+
+toolchain go1.21.8
 
 // Needed to reference shared version numbering:
 replace github.com/Azure/azure-service-operator/v2 => ../../

--- a/v2/tools/generator/internal/astbuilder/statements.go
+++ b/v2/tools/generator/internal/astbuilder/statements.go
@@ -7,6 +7,7 @@ package astbuilder
 
 import (
 	"fmt"
+
 	"github.com/dave/dst"
 )
 


### PR DESCRIPTION
This was required as setup-envtest@latest no longer works with Go versions less than 1.22.

controller-tools was also updated as it panics if 0.13.0 is used with Go 1.22. 0.14.0 must be used instead.

Go version also moved to 1.21 to comply with new mod shape.
