### PR TITLE
Update Swagger submodule to latest

### DIFF
--- a/v2/api/containerservice/v1api20230315preview/fleets_update_run_spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20230315preview/fleets_update_run_spec_arm_types_gen.go
@@ -65,9 +65,7 @@ type ManagedClusterUpgradeSpec_ARM struct {
 	// KubernetesVersion: The Kubernetes version to upgrade the member clusters to.
 	KubernetesVersion *string `json:"kubernetesVersion,omitempty"`
 
-	// Type: The upgrade type.
-	// Full requires the KubernetesVersion property to be set.
-	// NodeImageOnly requires the KubernetesVersion property not to be set.
+	// Type: ManagedClusterUpgradeType is the type of upgrade to be applied.
 	Type *ManagedClusterUpgradeType `json:"type,omitempty"`
 }
 

--- a/v2/api/containerservice/v1api20230315preview/fleets_update_run_status_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20230315preview/fleets_update_run_status_arm_types_gen.go
@@ -80,9 +80,7 @@ type ManagedClusterUpgradeSpec_STATUS_ARM struct {
 	// KubernetesVersion: The Kubernetes version to upgrade the member clusters to.
 	KubernetesVersion *string `json:"kubernetesVersion,omitempty"`
 
-	// Type: The upgrade type.
-	// Full requires the KubernetesVersion property to be set.
-	// NodeImageOnly requires the KubernetesVersion property not to be set.
+	// Type: ManagedClusterUpgradeType is the type of upgrade to be applied.
 	Type *ManagedClusterUpgradeType_STATUS `json:"type,omitempty"`
 }
 

--- a/v2/api/containerservice/v1api20230315preview/fleets_update_run_types_gen.go
+++ b/v2/api/containerservice/v1api20230315preview/fleets_update_run_types_gen.go
@@ -1586,9 +1586,7 @@ type ManagedClusterUpgradeSpec struct {
 	KubernetesVersion *string `json:"kubernetesVersion,omitempty"`
 
 	// +kubebuilder:validation:Required
-	// Type: The upgrade type.
-	// Full requires the KubernetesVersion property to be set.
-	// NodeImageOnly requires the KubernetesVersion property not to be set.
+	// Type: ManagedClusterUpgradeType is the type of upgrade to be applied.
 	Type *ManagedClusterUpgradeType `json:"type,omitempty"`
 }
 
@@ -1712,9 +1710,7 @@ type ManagedClusterUpgradeSpec_STATUS struct {
 	// KubernetesVersion: The Kubernetes version to upgrade the member clusters to.
 	KubernetesVersion *string `json:"kubernetesVersion,omitempty"`
 
-	// Type: The upgrade type.
-	// Full requires the KubernetesVersion property to be set.
-	// NodeImageOnly requires the KubernetesVersion property not to be set.
+	// Type: ManagedClusterUpgradeType is the type of upgrade to be applied.
 	Type *ManagedClusterUpgradeType_STATUS `json:"type,omitempty"`
 }
 

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -145,7 +145,7 @@ func createAllPipelineStages(
 
 		// Strip out redundant type aliases
 		pipeline.RemoveTypeAliases(),
-		pipeline.CollapseCrossGroupReferences(),
+		pipeline.CollapseCrossGroupReferences(idFactory),
 		pipeline.StripUnreferencedTypeDefinitions(),
 		pipeline.AssertTypesCollectionValid(),
 


### PR DESCRIPTION
Fix a bug where Fleet + AKS had a type name with a different shape that collided.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
