### PR TITLE
Fix v3 recording infrastructure

### DIFF
--- a/v2/internal/testcommon/creds/creds.go
+++ b/v2/internal/testcommon/creds/creds.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,6 +66,14 @@ func GetCreds() (azcore.TokenCredential, AzureIDs, error) {
 	cachedCreds = creds
 	cachedIds = ids
 	return creds, ids, nil
+}
+
+func DummyAzureIDs() AzureIDs {
+	return AzureIDs{
+		SubscriptionID:   uuid.Nil.String(),
+		TenantID:         uuid.Nil.String(),
+		BillingInvoiceID: DummyBillingId,
+	}
 }
 
 // newScopedCredentialSecret is the internal factory used to create credential secrets

--- a/v2/internal/testcommon/vcr/v1/error_translating_roundtripper.go
+++ b/v2/internal/testcommon/vcr/v1/error_translating_roundtripper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
+	"github.com/Azure/azure-service-operator/v2/internal/testcommon/creds"
 	"github.com/Azure/azure-service-operator/v2/internal/testcommon/vcr"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 )
@@ -81,7 +82,7 @@ func (w errorTranslation) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		// Apply the same body filtering that we do in recordings so that the diffs don't show things
 		// that we've just removed
-		sentBodyString = vcr.HideRecordingData(string(bodyBytes))
+		sentBodyString = vcr.HideRecordingData(creds.DummyAzureIDs(), string(bodyBytes))
 	}
 
 	// find all request bodies for the specified method/URL combination

--- a/v2/internal/testcommon/vcr/v1/test_replayer.go
+++ b/v2/internal/testcommon/vcr/v1/test_replayer.go
@@ -91,7 +91,7 @@ func NewTestPlayer(
 		}
 
 		r.Body = io.NopCloser(&b)
-		return b.String() == "" || vcr.HideRecordingData(b.String()) == i.Body
+		return b.String() == "" || vcr.HideRecordingData(creds.DummyAzureIDs(), b.String()) == i.Body
 	})
 
 	return &player{

--- a/v2/internal/testcommon/vcr/v3/error_translating_roundtripper.go
+++ b/v2/internal/testcommon/vcr/v3/error_translating_roundtripper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/dnaeon/go-vcr.v3/cassette"
 
+	"github.com/Azure/azure-service-operator/v2/internal/testcommon/creds"
 	"github.com/Azure/azure-service-operator/v2/internal/testcommon/vcr"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 )
@@ -74,7 +75,7 @@ func (w errorTranslation) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		// Apply the same body filtering that we do in recordings so that the diffs don't show things
 		// that we've just removed
-		sentBodyString = vcr.HideRecordingData(string(bodyBytes))
+		sentBodyString = vcr.HideRecordingData(creds.DummyAzureIDs(), string(bodyBytes))
 	}
 
 	// find all request bodies for the specified method/URL combination
@@ -125,7 +126,7 @@ func (w errorTranslation) findMatchingBodies(r *http.Request) []string {
 	urlString := r.URL.String()
 	var result []string
 	for _, interaction := range w.ensureCassette().Interactions {
-		if urlString == interaction.Request.RequestURI && r.Method == interaction.Request.Method &&
+		if urlString == interaction.Request.URL && r.Method == interaction.Request.Method &&
 			r.Header.Get(COUNT_HEADER) == interaction.Request.Headers.Get(COUNT_HEADER) {
 			result = append(result, interaction.Request.Body)
 		}

--- a/v2/internal/testcommon/vcr/v3/replay_roundtripper.go
+++ b/v2/internal/testcommon/vcr/v3/replay_roundtripper.go
@@ -14,9 +14,11 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/Azure/azure-service-operator/v2/internal/testcommon/vcr"
 	"github.com/go-logr/logr"
 	"gopkg.in/dnaeon/go-vcr.v3/cassette"
+
+	"github.com/Azure/azure-service-operator/v2/internal/testcommon/creds"
+	"github.com/Azure/azure-service-operator/v2/internal/testcommon/vcr"
 )
 
 // replayRoundTripper wraps an inner round tripper and replays requests in order to improve the resilience of ASO tests.
@@ -141,7 +143,7 @@ func (replayer *replayRoundTripper) hashOfBody(request *http.Request) string {
 	}
 
 	// Apply the same body filtering that we do in recordings so that the hash is consistent
-	bodyString := vcr.HideRecordingData(string(body.Bytes()))
+	bodyString := vcr.HideRecordingData(creds.DummyAzureIDs(), string(body.Bytes()))
 
 	// Calculate a hash based on body string
 	hash := sha256.Sum256([]byte(bodyString))

--- a/v2/internal/testcommon/vcr/v3/replay_roundtripper_test.go
+++ b/v2/internal/testcommon/vcr/v3/replay_roundtripper_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	"github.com/Azure/azure-service-operator/v2/internal/testcommon/creds"
 	"github.com/Azure/azure-service-operator/v2/internal/testcommon/vcr"
 )
 
@@ -162,6 +163,7 @@ func Test_ReplayRoundTripper_WhenCombinedWithTrackingRoundTripper_GivesDesiredRe
 
 	// Act
 	replayer := AddTrackingHeaders(
+		creds.DummyAzureIDs(),
 		NewReplayRoundTripper(fake, logr.Discard()))
 
 	// Assert - first PUT to create the resource works


### PR DESCRIPTION
Fix bug where interaction.Request.RequestURI was used when interaction.Request.URL should have been used. RequestURI seems to always be empty.

Fix bug where body hashes were computed before subscriptionID and other Azure IDs were redacted, resulting in a hash that doesn't match the body that was eventually recorded (that body had these values redacted).
This issue only showed up for requests that contained ARM IDs in the body which is why we didn't notice it before.
The issue here was that there are two contexts that use the vcr/redact.go helpers, one during replay and one
during recording. For replay, there's no need to redact subID because we set it to 0000's, but during recording (such as when we compute the body hash header) we need to redact the subids first.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
