### PR TITLE
Improve/astype signature

### DIFF
--- a/v2/tools/generator/internal/armconversion/arm_conversion_function.go
+++ b/v2/tools/generator/internal/armconversion/arm_conversion_function.go
@@ -92,11 +92,17 @@ func (c *PopulateFromARMFunction) AsFunc(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	receiver astmodel.InternalTypeName,
 ) (*dst.FuncDecl, error) {
-	builder := newConvertFromARMFunctionBuilder(
+	builder, err := newConvertFromARMFunctionBuilder(
 		&c.ARMConversionFunction,
 		codeGenerationContext,
 		receiver,
 		c.Name())
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"error creating ConvertFromARM function for %s",
+			receiver.Name())
+	}
 
 	decl, err := builder.functionDeclaration()
 	if err != nil {

--- a/v2/tools/generator/internal/armconversion/arm_conversion_function.go
+++ b/v2/tools/generator/internal/armconversion/arm_conversion_function.go
@@ -71,11 +71,17 @@ func (c *ConvertToARMFunction) AsFunc(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	receiver astmodel.InternalTypeName,
 ) (*dst.FuncDecl, error) {
-	builder := newConvertToARMFunctionBuilder(
+	builder, err := newConvertToARMFunctionBuilder(
 		&c.ARMConversionFunction,
 		codeGenerationContext,
 		receiver,
 		c.Name())
+	if err != nil {
+		return nil, errors.Wrapf(
+			err,
+			"error creating ConvertToARM function for %s",
+			receiver.Name())
+	}
 
 	decl, err := builder.functionDeclaration()
 	if err != nil {

--- a/v2/tools/generator/internal/armconversion/arm_spec_interface.go
+++ b/v2/tools/generator/internal/armconversion/arm_spec_interface.go
@@ -84,7 +84,10 @@ func armSpecInterfaceSimpleGetFunction(
 	castToString bool,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := fn.IdFactory().CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", receiver.Name())
+	}
 
 	var result dst.Expr = astbuilder.Selector(dst.NewIdent(receiverIdent), propertyName)
 

--- a/v2/tools/generator/internal/armconversion/arm_spec_interface.go
+++ b/v2/tools/generator/internal/armconversion/arm_spec_interface.go
@@ -84,7 +84,7 @@ func armSpecInterfaceSimpleGetFunction(
 	castToString bool,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := fn.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	var result dst.Expr = astbuilder.Selector(dst.NewIdent(receiverIdent), propertyName)
 
@@ -100,7 +100,7 @@ func armSpecInterfaceSimpleGetFunction(
 	details := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.Dereference(receiverType),
+		ReceiverType:  astbuilder.Dereference(receiverExpr),
 		Body:          astbuilder.Statements(retResult),
 	}
 

--- a/v2/tools/generator/internal/armconversion/arm_spec_interface.go
+++ b/v2/tools/generator/internal/armconversion/arm_spec_interface.go
@@ -84,7 +84,7 @@ func armSpecInterfaceSimpleGetFunction(
 	castToString bool,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := fn.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	var result dst.Expr = astbuilder.Selector(dst.NewIdent(receiverIdent), propertyName)
 

--- a/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
@@ -30,8 +30,12 @@ func newConvertFromARMFunctionBuilder(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	receiver astmodel.InternalTypeName,
 	methodName string,
-) *convertFromARMBuilder {
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+) (*convertFromARMBuilder, error) {
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+	}
+
 	result := &convertFromARMBuilder{
 		// Note: If we have a property with these names we will have a compilation issue in the generated
 		// code. Right now that doesn't seem to be the case anywhere but if it does happen we may need
@@ -82,7 +86,7 @@ func newConvertFromARMFunctionBuilder(
 		result.propertiesByNameHandler,
 	}
 
-	return result
+	return result, nil
 }
 
 func (builder *convertFromARMBuilder) functionDeclaration() (*dst.FuncDecl, error) {
@@ -286,7 +290,7 @@ func (builder *convertFromARMBuilder) ownerPropertyHandler(
 			return notHandled,
 				errors.Wrapf(err, "creating known resource reference type expression for %s", ownerProp)
 		}
-		
+
 		compositeLit := astbuilder.NewCompositeLiteralBuilder(knownResourceReferenceExpr)
 		compositeLit.AddField("Name", astbuilder.Selector(dst.NewIdent(ownerParameter), "Name"))
 		compositeLit.AddField("ARMID", astbuilder.Selector(dst.NewIdent(ownerParameter), "ARMID"))

--- a/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_from_arm_function_builder.go
@@ -45,7 +45,7 @@ func newConvertFromARMFunctionBuilder(
 			destinationType:       getReceiverObjectType(codeGenerationContext, receiver),
 			destinationTypeName:   c.kubeTypeName,
 			receiverIdent:         c.idFactory.CreateReceiver(receiver.Name()),
-			receiverTypeExpr:      receiver.AsType(codeGenerationContext),
+			receiverTypeExpr:      receiver.AsTypeExpr(codeGenerationContext),
 			idFactory:             c.idFactory,
 			typeKind:              c.typeKind,
 			codeGenerationContext: codeGenerationContext,
@@ -100,7 +100,7 @@ func (builder *convertFromARMBuilder) functionDeclaration() (*dst.FuncDecl, erro
 	fn.AddComments("populates a Kubernetes CRD object from an Azure ARM object")
 	fn.AddParameter(
 		builder.idFactory.CreateIdentifier(astmodel.OwnerProperty, astmodel.NotExported),
-		astmodel.ArbitraryOwnerReference.AsType(builder.codeGenerationContext))
+		astmodel.ArbitraryOwnerReference.AsTypeExpr(builder.codeGenerationContext))
 
 	fn.AddParameter(builder.inputIdent, dst.NewIdent("interface{}"))
 	fn.AddReturns("error")
@@ -275,7 +275,7 @@ func (builder *convertFromARMBuilder) ownerPropertyHandler(
 
 	var convertedOwner dst.Expr
 	if ownerNameType == astmodel.KnownResourceReferenceType {
-		compositeLit := astbuilder.NewCompositeLiteralBuilder(astmodel.KnownResourceReferenceType.AsType(builder.codeGenerationContext))
+		compositeLit := astbuilder.NewCompositeLiteralBuilder(astmodel.KnownResourceReferenceType.AsTypeExpr(builder.codeGenerationContext))
 		compositeLit.AddField("Name", astbuilder.Selector(dst.NewIdent(ownerParameter), "Name"))
 		compositeLit.AddField("ARMID", astbuilder.Selector(dst.NewIdent(ownerParameter), "ARMID"))
 		convertedOwner = astbuilder.AddrOf(compositeLit.Build())

--- a/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
@@ -32,8 +32,12 @@ func newConvertToARMFunctionBuilder(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	receiver astmodel.InternalTypeName,
 	methodName string,
-) *convertToARMBuilder {
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+) (*convertToARMBuilder, error) {
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+	}
+
 	result := &convertToARMBuilder{
 		conversionBuilder: conversionBuilder{
 			methodName:            methodName,
@@ -80,7 +84,7 @@ func newConvertToARMFunctionBuilder(
 		result.propertiesByNameHandler,
 	}
 
-	return result
+	return result, nil
 }
 
 func (builder *convertToARMBuilder) functionDeclaration() (*dst.FuncDecl, error) {

--- a/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
@@ -41,7 +41,7 @@ func newConvertToARMFunctionBuilder(
 			destinationType:       c.armType,
 			destinationTypeName:   c.armTypeName,
 			receiverIdent:         c.idFactory.CreateReceiver(receiver.Name()),
-			receiverTypeExpr:      receiver.AsType(codeGenerationContext),
+			receiverTypeExpr:      receiver.AsTypeExpr(codeGenerationContext),
 			idFactory:             c.idFactory,
 			typeKind:              c.typeKind,
 			codeGenerationContext: codeGenerationContext,
@@ -95,7 +95,7 @@ func (builder *convertToARMBuilder) functionDeclaration() (*dst.FuncDecl, error)
 		Body:          body,
 	}
 
-	fn.AddParameter(resolvedParameterString, astmodel.ConvertToARMResolvedDetailsType.AsType(builder.codeGenerationContext))
+	fn.AddParameter(resolvedParameterString, astmodel.ConvertToARMResolvedDetailsType.AsTypeExpr(builder.codeGenerationContext))
 	fn.AddReturns("interface{}", "error")
 	fn.AddComments("converts from a Kubernetes CRD object to an ARM object")
 
@@ -516,7 +516,7 @@ func (builder *convertToARMBuilder) buildToPropInitializer(
 	// build (x || y || …)
 	cond := astbuilder.JoinOr(conditions...)
 
-	literal := astbuilder.NewCompositeLiteralBuilder(toPropTypeName.AsType(builder.codeGenerationContext))
+	literal := astbuilder.NewCompositeLiteralBuilder(toPropTypeName.AsTypeExpr(builder.codeGenerationContext))
 
 	// build if (conditions…) { target.prop = &TargetType{} }
 	return &dst.IfStmt{
@@ -629,8 +629,8 @@ func (builder *convertToARMBuilder) convertUserAssignedIdentitiesCollection(
 	locals := params.Locals.Clone()
 
 	itemIdent := locals.CreateLocal("ident")
-	keyTypeAst := destinationType.KeyType().AsType(conversionBuilder.CodeGenerationContext)
-	valueTypeAst := destinationType.ValueType().AsType(conversionBuilder.CodeGenerationContext)
+	keyTypeAst := destinationType.KeyType().AsTypeExpr(conversionBuilder.CodeGenerationContext)
+	valueTypeAst := destinationType.ValueType().AsTypeExpr(conversionBuilder.CodeGenerationContext)
 
 	makeMapStatement := astbuilder.AssignmentStatement(
 		params.Destination,

--- a/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
@@ -652,18 +652,18 @@ func (builder *convertToARMBuilder) convertUserAssignedIdentitiesCollection(
 	locals := params.Locals.Clone()
 
 	itemIdent := locals.CreateLocal("ident")
-	keyTypeExpr, kerr := destinationType.KeyType().AsTypeExpr(conversionBuilder.CodeGenerationContext)
-	if kerr != nil {
+	keyTypeExpr, err := destinationType.KeyType().AsTypeExpr(conversionBuilder.CodeGenerationContext)
+	if err != nil {
 		return nil,
-			errors.Wrapf(kerr,
+			errors.Wrapf(err,
 				"creating type expression for key type %s",
 				destinationType.KeyType())
 	}
 
-	valueTypeExpr, verr := destinationType.ValueType().AsTypeExpr(conversionBuilder.CodeGenerationContext)
-	if verr != nil {
+	valueTypeExpr, err := destinationType.ValueType().AsTypeExpr(conversionBuilder.CodeGenerationContext)
+	if err != nil {
 		return nil,
-			errors.Wrapf(verr,
+			errors.Wrapf(err,
 				"creating type expression for value type %s",
 				destinationType.ValueType())
 	}

--- a/v2/tools/generator/internal/astmodel/allof_type.go
+++ b/v2/tools/generator/internal/astmodel/allof_type.go
@@ -109,7 +109,7 @@ var allOfFailureMsg = "AllOfType should have been replaced by generation time by
 
 // AsType always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (allOf *AllOfType) AsType(_ *CodeGenerationContext) dst.Expr {
+func (allOf *AllOfType) AsTypeExpr(_ *CodeGenerationContext) dst.Expr {
 	panic(errors.New(allOfFailureMsg))
 }
 

--- a/v2/tools/generator/internal/astmodel/allof_type.go
+++ b/v2/tools/generator/internal/astmodel/allof_type.go
@@ -109,7 +109,7 @@ var allOfFailureMsg = "AllOfType should have been replaced by generation time by
 
 // AsType always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (allOf *AllOfType) AsTypeExpr(_ *CodeGenerationContext) dst.Expr {
+func (allOf *AllOfType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	panic(errors.New(allOfFailureMsg))
 }
 

--- a/v2/tools/generator/internal/astmodel/allof_type_test.go
+++ b/v2/tools/generator/internal/astmodel/allof_type_test.go
@@ -99,7 +99,7 @@ func TestAllOfAsTypePanics(t *testing.T) {
 
 	x := AllOfType{}
 	g.Expect(func() {
-		x.AsType(&CodeGenerationContext{})
+		x.AsTypeExpr(&CodeGenerationContext{})
 	}).To(PanicWith(MatchError(expectedAllOfPanic)))
 }
 

--- a/v2/tools/generator/internal/astmodel/allof_type_test.go
+++ b/v2/tools/generator/internal/astmodel/allof_type_test.go
@@ -99,7 +99,8 @@ func TestAllOfAsTypePanics(t *testing.T) {
 
 	x := AllOfType{}
 	g.Expect(func() {
-		x.AsTypeExpr(&CodeGenerationContext{})
+		_, err := x.AsTypeExpr(&CodeGenerationContext{})
+		g.Expect(err).To(BeNil()) // Unreachable, but keeps lint happy
 	}).To(PanicWith(MatchError(expectedAllOfPanic)))
 }
 

--- a/v2/tools/generator/internal/astmodel/array_type.go
+++ b/v2/tools/generator/internal/astmodel/array_type.go
@@ -7,10 +7,10 @@ package astmodel
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 )

--- a/v2/tools/generator/internal/astmodel/array_type.go
+++ b/v2/tools/generator/internal/astmodel/array_type.go
@@ -47,7 +47,7 @@ func (array *ArrayType) WithElement(t Type) *ArrayType {
 var _ Type = (*ArrayType)(nil)
 
 func (array *ArrayType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
-	return AsSimpleDeclarations(codeGenerationContext, declContext, array), nil
+	return AsSimpleDeclarations(codeGenerationContext, declContext, array)
 }
 
 // AsType renders the Go abstract syntax tree for an array type

--- a/v2/tools/generator/internal/astmodel/array_type.go
+++ b/v2/tools/generator/internal/astmodel/array_type.go
@@ -51,8 +51,9 @@ func (array *ArrayType) AsDeclarations(codeGenerationContext *CodeGenerationCont
 
 // AsType renders the Go abstract syntax tree for an array type
 func (array *ArrayType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
+	elementExpr := array.element.AsTypeExpr(codeGenerationContext)
 	return &dst.ArrayType{
-		Elt: array.element.AsTypeExpr(codeGenerationContext),
+		Elt: elementExpr,
 	}
 }
 

--- a/v2/tools/generator/internal/astmodel/array_type.go
+++ b/v2/tools/generator/internal/astmodel/array_type.go
@@ -7,6 +7,7 @@ package astmodel
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/dave/dst"
@@ -50,11 +51,15 @@ func (array *ArrayType) AsDeclarations(codeGenerationContext *CodeGenerationCont
 }
 
 // AsType renders the Go abstract syntax tree for an array type
-func (array *ArrayType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
-	elementExpr := array.element.AsTypeExpr(codeGenerationContext)
+func (array *ArrayType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
+	elementExpr, err := array.element.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating array element type")
+	}
+
 	return &dst.ArrayType{
 		Elt: elementExpr,
-	}
+	}, nil
 }
 
 // AsZero renders an expression for the "zero" value of the array by calling make()

--- a/v2/tools/generator/internal/astmodel/array_type.go
+++ b/v2/tools/generator/internal/astmodel/array_type.go
@@ -50,9 +50,9 @@ func (array *ArrayType) AsDeclarations(codeGenerationContext *CodeGenerationCont
 }
 
 // AsType renders the Go abstract syntax tree for an array type
-func (array *ArrayType) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr {
+func (array *ArrayType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
 	return &dst.ArrayType{
-		Elt: array.element.AsType(codeGenerationContext),
+		Elt: array.element.AsTypeExpr(codeGenerationContext),
 	}
 }
 

--- a/v2/tools/generator/internal/astmodel/conversion_function_builder.go
+++ b/v2/tools/generator/internal/astmodel/conversion_function_builder.go
@@ -417,14 +417,14 @@ func IdentityConvertComplexMapProperty(
 		return astbuilder.InsertMap(lhs, dst.NewIdent(keyIdent), rhs)
 	}
 
-	keyTypeExpr, kerr := destinationType.KeyType().AsTypeExpr(builder.CodeGenerationContext)
-	if kerr != nil {
-		return nil, errors.Wrap(kerr, "creating key type expression")
+	keyTypeExpr, err := destinationType.KeyType().AsTypeExpr(builder.CodeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating key type expression")
 	}
 
-	valueTypeExpr, verr := destinationType.ValueType().AsTypeExpr(builder.CodeGenerationContext)
-	if verr != nil {
-		return nil, errors.Wrap(verr, "creating value type expression")
+	valueTypeExpr, err := destinationType.ValueType().AsTypeExpr(builder.CodeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating value type expression")
 	}
 
 	makeMapStatement := astbuilder.AssignmentStatement(

--- a/v2/tools/generator/internal/astmodel/conversion_function_builder.go
+++ b/v2/tools/generator/internal/astmodel/conversion_function_builder.go
@@ -296,7 +296,7 @@ func IdentityConvertComplexArrayProperty(
 			results,
 			astbuilder.LocalVariableDeclaration(
 				innerDestinationIdent,
-				destinationType.AsType(builder.CodeGenerationContext),
+				destinationType.AsTypeExpr(builder.CodeGenerationContext),
 				""))
 	}
 
@@ -336,7 +336,7 @@ func IdentityConvertComplexArrayProperty(
 	// If we must forcibly construct empty collections, check if the destination is nil and if so, construct an empty collection
 	// This only applies for top-level collections (we don't forcibly construct nested collections)
 	if depth == 0 && builder.ShouldInitializeCollectionToEmpty(params.SourceProperty) {
-		emptySlice := astbuilder.SliceLiteral(destinationType.Element().AsType(builder.CodeGenerationContext))
+		emptySlice := astbuilder.SliceLiteral(destinationType.Element().AsTypeExpr(builder.CodeGenerationContext))
 		assignEmpty := astbuilder.SimpleAssignment(params.GetDestination(), emptySlice)
 		astbuilder.AddComments(
 			&assignEmpty.Decs.Start,
@@ -407,8 +407,8 @@ func IdentityConvertComplexMapProperty(
 		return astbuilder.InsertMap(lhs, dst.NewIdent(keyIdent), rhs)
 	}
 
-	keyTypeAst := destinationType.KeyType().AsType(builder.CodeGenerationContext)
-	valueTypeAst := destinationType.ValueType().AsType(builder.CodeGenerationContext)
+	keyTypeAst := destinationType.KeyType().AsTypeExpr(builder.CodeGenerationContext)
+	valueTypeAst := destinationType.ValueType().AsTypeExpr(builder.CodeGenerationContext)
 
 	makeMapStatement := astbuilder.AssignmentStatement(
 		destination,
@@ -581,7 +581,7 @@ func AssignToOptional(
 	}
 
 	return astbuilder.Statements(
-		astbuilder.LocalVariableDeclaration(tmpLocal, dstType.AsType(builder.CodeGenerationContext), ""),
+		astbuilder.LocalVariableDeclaration(tmpLocal, dstType.AsTypeExpr(builder.CodeGenerationContext), ""),
 		conversion,
 		params.AssignmentHandlerOrDefault()(
 			params.GetDestination(),
@@ -644,7 +644,7 @@ func AssignFromOptional(
 	}
 
 	var result []dst.Stmt
-	result = append(result, astbuilder.LocalVariableDeclaration(tmpLocal, params.DestinationType.AsType(builder.CodeGenerationContext), ""))
+	result = append(result, astbuilder.LocalVariableDeclaration(tmpLocal, params.DestinationType.AsTypeExpr(builder.CodeGenerationContext), ""))
 	result = append(result, conversion...)
 	result = append(result, params.AssignmentHandlerOrDefault()(params.GetDestination(), dst.NewIdent(tmpLocal)))
 

--- a/v2/tools/generator/internal/astmodel/conversion_function_builder.go
+++ b/v2/tools/generator/internal/astmodel/conversion_function_builder.go
@@ -292,11 +292,12 @@ func IdentityConvertComplexArrayProperty(
 		// TODO: The suffix here should maybe be configurable on the function builder?
 		innerDestinationIdent := locals.CreateLocal(params.NameHint, "Temp")
 		destination = dst.NewIdent(innerDestinationIdent)
+		destinationTypeExpr := destinationType.AsTypeExpr(builder.CodeGenerationContext)
 		results = append(
 			results,
 			astbuilder.LocalVariableDeclaration(
 				innerDestinationIdent,
-				destinationType.AsTypeExpr(builder.CodeGenerationContext),
+				destinationTypeExpr,
 				""))
 	}
 
@@ -336,7 +337,8 @@ func IdentityConvertComplexArrayProperty(
 	// If we must forcibly construct empty collections, check if the destination is nil and if so, construct an empty collection
 	// This only applies for top-level collections (we don't forcibly construct nested collections)
 	if depth == 0 && builder.ShouldInitializeCollectionToEmpty(params.SourceProperty) {
-		emptySlice := astbuilder.SliceLiteral(destinationType.Element().AsTypeExpr(builder.CodeGenerationContext))
+		destinationTypeExpr := destinationType.Element().AsTypeExpr(builder.CodeGenerationContext)
+		emptySlice := astbuilder.SliceLiteral(destinationTypeExpr)
 		assignEmpty := astbuilder.SimpleAssignment(params.GetDestination(), emptySlice)
 		astbuilder.AddComments(
 			&assignEmpty.Decs.Start,
@@ -407,13 +409,13 @@ func IdentityConvertComplexMapProperty(
 		return astbuilder.InsertMap(lhs, dst.NewIdent(keyIdent), rhs)
 	}
 
-	keyTypeAst := destinationType.KeyType().AsTypeExpr(builder.CodeGenerationContext)
-	valueTypeAst := destinationType.ValueType().AsTypeExpr(builder.CodeGenerationContext)
+	keyTypeExpr := destinationType.KeyType().AsTypeExpr(builder.CodeGenerationContext)
+	valueTypeExpr := destinationType.ValueType().AsTypeExpr(builder.CodeGenerationContext)
 
 	makeMapStatement := astbuilder.AssignmentStatement(
 		destination,
 		makeMapToken,
-		astbuilder.MakeMapWithCapacity(keyTypeAst, valueTypeAst,
+		astbuilder.MakeMapWithCapacity(keyTypeExpr, valueTypeExpr,
 			astbuilder.CallFunc("len", params.GetSource())))
 
 	conversion, err := builder.BuildConversion(
@@ -445,7 +447,7 @@ func IdentityConvertComplexMapProperty(
 	// This only applies for top-level collections (we don't forcibly construct nested collections)
 	var result *dst.IfStmt
 	if depth == 0 && builder.ShouldInitializeCollectionToEmpty(params.SourceProperty) {
-		emptyMap := astbuilder.MakeMap(keyTypeAst, valueTypeAst)
+		emptyMap := astbuilder.MakeMap(keyTypeExpr, valueTypeExpr)
 
 		assignEmpty := astbuilder.SimpleAssignment(params.GetDestination(), emptyMap)
 		astbuilder.AddComments(
@@ -580,8 +582,9 @@ func AssignToOptional(
 		return nil, nil // unable to build inner conversion
 	}
 
+	destinationTypeExpr := dstType.AsTypeExpr(builder.CodeGenerationContext)
 	return astbuilder.Statements(
-		astbuilder.LocalVariableDeclaration(tmpLocal, dstType.AsTypeExpr(builder.CodeGenerationContext), ""),
+		astbuilder.LocalVariableDeclaration(tmpLocal, destinationTypeExpr, ""),
 		conversion,
 		params.AssignmentHandlerOrDefault()(
 			params.GetDestination(),
@@ -644,7 +647,8 @@ func AssignFromOptional(
 	}
 
 	var result []dst.Stmt
-	result = append(result, astbuilder.LocalVariableDeclaration(tmpLocal, params.DestinationType.AsTypeExpr(builder.CodeGenerationContext), ""))
+	destinationTypeExpr := params.DestinationType.AsTypeExpr(builder.CodeGenerationContext)
+	result = append(result, astbuilder.LocalVariableDeclaration(tmpLocal, destinationTypeExpr, ""))
 	result = append(result, conversion...)
 	result = append(result, params.AssignmentHandlerOrDefault()(params.GetDestination(), dst.NewIdent(tmpLocal)))
 

--- a/v2/tools/generator/internal/astmodel/enum_type.go
+++ b/v2/tools/generator/internal/astmodel/enum_type.go
@@ -115,7 +115,7 @@ func (enum *EnumType) createBaseDeclaration(
 ) dst.Decl {
 	typeSpecification := &dst.TypeSpec{
 		Name: dst.NewIdent(name.Name()),
-		Type: enum.baseType.AsType(codeGenerationContext),
+		Type: enum.baseType.AsTypeExpr(codeGenerationContext),
 	}
 
 	declaration := &dst.GenDecl{
@@ -204,7 +204,7 @@ func (enum *EnumType) createValueDeclaration(name TypeName, value EnumValue) dst
 }
 
 // AsType implements Type for EnumType
-func (enum *EnumType) AsType(_ *CodeGenerationContext) dst.Expr {
+func (enum *EnumType) AsTypeExpr(_ *CodeGenerationContext) dst.Expr {
 	// this should "never" happen as we name all enums; panic if it does
 	panic(errors.New("Emitting unnamed enum, something’s awry"))
 }

--- a/v2/tools/generator/internal/astmodel/enum_type.go
+++ b/v2/tools/generator/internal/astmodel/enum_type.go
@@ -113,9 +113,10 @@ func (enum *EnumType) createBaseDeclaration(
 	description []string,
 	validations []KubeBuilderValidation,
 ) dst.Decl {
+	baseTypeExpr := enum.baseType.AsTypeExpr(codeGenerationContext)
 	typeSpecification := &dst.TypeSpec{
 		Name: dst.NewIdent(name.Name()),
-		Type: enum.baseType.AsTypeExpr(codeGenerationContext),
+		Type: baseTypeExpr,
 	}
 
 	declaration := &dst.GenDecl{

--- a/v2/tools/generator/internal/astmodel/enum_type.go
+++ b/v2/tools/generator/internal/astmodel/enum_type.go
@@ -182,7 +182,7 @@ func (enum *EnumType) createMappingDeclaration(
 	if err != nil {
 		return nil, errors.Wrap(err, "creating name expression")
 	}
-	
+
 	literal := astbuilder.NewMapLiteral(
 		baseTypeExpr,
 		nameExpr)

--- a/v2/tools/generator/internal/astmodel/enum_type.go
+++ b/v2/tools/generator/internal/astmodel/enum_type.go
@@ -98,7 +98,10 @@ func (enum *EnumType) AsDeclarations(
 		declContext.Validations)
 
 	valuesDeclaration := enum.createValuesDeclaration(declContext)
-	mapperDeclaration := enum.createMappingDeclaration(declContext.Name, codeGenerationContext)
+	mapperDeclaration, err := enum.createMappingDeclaration(declContext.Name, codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating mapping declaration")
+	}
 
 	return astbuilder.Declarations(
 		declareEnum,
@@ -113,7 +116,7 @@ func (enum *EnumType) createBaseDeclaration(
 	description []string,
 	validations []KubeBuilderValidation,
 ) dst.Decl {
-	baseTypeExpr := enum.baseType.AsTypeExpr(codeGenerationContext)
+	baseTypeExpr, _ := enum.baseType.AsTypeExpr(codeGenerationContext)
 	typeSpecification := &dst.TypeSpec{
 		Name: dst.NewIdent(name.Name()),
 		Type: baseTypeExpr,
@@ -164,15 +167,25 @@ func (enum *EnumType) createValuesDeclaration(
 func (enum *EnumType) createMappingDeclaration(
 	name InternalTypeName,
 	codeGenerationContext *CodeGenerationContext,
-) dst.Decl {
+) (dst.Decl, error) {
 	if !enum.NeedsMappingConversion(name) {
 		// We don't need a mapping conversion map for this enum
-		return nil
+		return nil, nil
 	}
 
+	baseTypeExpr, err := enum.baseType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating base type expression")
+	}
+
+	nameExpr, err := name.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating name expression")
+	}
+	
 	literal := astbuilder.NewMapLiteral(
-		enum.baseType.AsType(codeGenerationContext),
-		name.AsType(codeGenerationContext))
+		baseTypeExpr,
+		nameExpr)
 
 	for _, v := range enum.options {
 		key := astbuilder.TextLiteral(strings.ToLower(v.Value))
@@ -190,7 +203,7 @@ func (enum *EnumType) createMappingDeclaration(
 		decl.Decorations().Start,
 		fmt.Sprintf("// Mapping from string to %s", name.Name()))
 
-	return decl
+	return decl, nil
 }
 
 func (enum *EnumType) createValueDeclaration(name TypeName, value EnumValue) dst.Spec {
@@ -205,7 +218,7 @@ func (enum *EnumType) createValueDeclaration(name TypeName, value EnumValue) dst
 }
 
 // AsType implements Type for EnumType
-func (enum *EnumType) AsTypeExpr(_ *CodeGenerationContext) dst.Expr {
+func (enum *EnumType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	// this should "never" happen as we name all enums; panic if it does
 	panic(errors.New("Emitting unnamed enum, something’s awry"))
 }

--- a/v2/tools/generator/internal/astmodel/errored_type.go
+++ b/v2/tools/generator/internal/astmodel/errored_type.go
@@ -162,16 +162,21 @@ func (e *ErroredType) AsDeclarations(
 	return e.inner.AsDeclarations(codeGenerationContext, declContext)
 }
 
-func (e *ErroredType) AsTypeExpr(cgc *CodeGenerationContext) dst.Expr {
+func (e *ErroredType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	if err := e.checkForWarningsAndErrors(); err != nil {
 		// Temporary hack until we change AsTypeExpr to return an error
 		panic(err)
 	}
 	if e.inner == nil {
-		return nil
+		return nil, nil
 	}
 
-	return e.inner.AsTypeExpr(cgc)
+	result, err := e.inner.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating inner type expression for errored type")
+	}
+
+	return result, nil
 }
 
 // AsZero renders an expression for the "zero" value of the type

--- a/v2/tools/generator/internal/astmodel/errored_type.go
+++ b/v2/tools/generator/internal/astmodel/errored_type.go
@@ -162,16 +162,16 @@ func (e *ErroredType) AsDeclarations(
 	return e.inner.AsDeclarations(codeGenerationContext, declContext)
 }
 
-func (e *ErroredType) AsType(cgc *CodeGenerationContext) dst.Expr {
+func (e *ErroredType) AsTypeExpr(cgc *CodeGenerationContext) dst.Expr {
 	if err := e.checkForWarningsAndErrors(); err != nil {
-		// Temporary hack until we change AsType to return an error
+		// Temporary hack until we change AsTypeExpr to return an error
 		panic(err)
 	}
 	if e.inner == nil {
 		return nil
 	}
 
-	return e.inner.AsType(cgc)
+	return e.inner.AsTypeExpr(cgc)
 }
 
 // AsZero renders an expression for the "zero" value of the type

--- a/v2/tools/generator/internal/astmodel/external_type_name.go
+++ b/v2/tools/generator/internal/astmodel/external_type_name.go
@@ -48,7 +48,7 @@ func (tn ExternalTypeName) AsDeclarations(codeGenerationContext *CodeGenerationC
 }
 
 // AsType implements Type for TypeName
-func (tn ExternalTypeName) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr {
+func (tn ExternalTypeName) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
 	// Need to ensure we include a selector for our external reference
 	packageName := codeGenerationContext.MustGetImportedPackageName(tn.packageReference)
 	return astbuilder.Selector(dst.NewIdent(packageName), tn.Name())

--- a/v2/tools/generator/internal/astmodel/external_type_name.go
+++ b/v2/tools/generator/internal/astmodel/external_type_name.go
@@ -44,7 +44,7 @@ func (tn ExternalTypeName) PackageReference() PackageReference {
 }
 
 func (tn ExternalTypeName) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
-	return AsSimpleDeclarations(codeGenerationContext, declContext, tn), nil
+	return AsSimpleDeclarations(codeGenerationContext, declContext, tn)
 }
 
 // AsType implements Type for TypeName

--- a/v2/tools/generator/internal/astmodel/external_type_name.go
+++ b/v2/tools/generator/internal/astmodel/external_type_name.go
@@ -48,10 +48,10 @@ func (tn ExternalTypeName) AsDeclarations(codeGenerationContext *CodeGenerationC
 }
 
 // AsType implements Type for TypeName
-func (tn ExternalTypeName) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
+func (tn ExternalTypeName) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	// Need to ensure we include a selector for our external reference
 	packageName := codeGenerationContext.MustGetImportedPackageName(tn.packageReference)
-	return astbuilder.Selector(dst.NewIdent(packageName), tn.Name())
+	return astbuilder.Selector(dst.NewIdent(packageName), tn.Name()), nil
 }
 
 // AsZero renders an expression for the "zero" value of the type.

--- a/v2/tools/generator/internal/astmodel/file_definition.go
+++ b/v2/tools/generator/internal/astmodel/file_definition.go
@@ -6,7 +6,6 @@
 package astmodel
 
 import (
-	"github.com/pkg/errors"
 	"go/token"
 	"sort"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 )

--- a/v2/tools/generator/internal/astmodel/file_definition.go
+++ b/v2/tools/generator/internal/astmodel/file_definition.go
@@ -207,7 +207,7 @@ func (file *FileDefinition) AsAst() (result *dst.File, err error) {
 	for _, defn := range file.definitions {
 		if resource, ok := defn.Type().(*ResourceType); ok {
 			for _, t := range resource.SchemeTypes(defn.Name()) {
-				literal := astbuilder.NewCompositeLiteralBuilder(t.AsType(codeGenContext))
+				literal := astbuilder.NewCompositeLiteralBuilder(t.AsTypeExpr(codeGenContext))
 				exprs = append(exprs, astbuilder.AddrOf(literal.Build()))
 			}
 		}

--- a/v2/tools/generator/internal/astmodel/file_definition.go
+++ b/v2/tools/generator/internal/astmodel/file_definition.go
@@ -207,7 +207,8 @@ func (file *FileDefinition) AsAst() (result *dst.File, err error) {
 	for _, defn := range file.definitions {
 		if resource, ok := defn.Type().(*ResourceType); ok {
 			for _, t := range resource.SchemeTypes(defn.Name()) {
-				literal := astbuilder.NewCompositeLiteralBuilder(t.AsTypeExpr(codeGenContext))
+				tExpr := t.AsTypeExpr(codeGenContext)
+				literal := astbuilder.NewCompositeLiteralBuilder(tExpr)
 				exprs = append(exprs, astbuilder.AddrOf(literal.Build()))
 			}
 		}

--- a/v2/tools/generator/internal/astmodel/file_definition.go
+++ b/v2/tools/generator/internal/astmodel/file_definition.go
@@ -6,6 +6,7 @@
 package astmodel
 
 import (
+	"github.com/pkg/errors"
 	"go/token"
 	"sort"
 	"strings"
@@ -207,7 +208,11 @@ func (file *FileDefinition) AsAst() (result *dst.File, err error) {
 	for _, defn := range file.definitions {
 		if resource, ok := defn.Type().(*ResourceType); ok {
 			for _, t := range resource.SchemeTypes(defn.Name()) {
-				tExpr := t.AsTypeExpr(codeGenContext)
+				tExpr, err := t.AsTypeExpr(codeGenContext)
+				if err != nil {
+					return nil, errors.Wrapf(err, "creating type expression for %s", t.Name())
+				}
+
 				literal := astbuilder.NewCompositeLiteralBuilder(tExpr)
 				exprs = append(exprs, astbuilder.AddrOf(literal.Build()))
 			}

--- a/v2/tools/generator/internal/astmodel/flagged_type.go
+++ b/v2/tools/generator/internal/astmodel/flagged_type.go
@@ -6,10 +6,10 @@
 package astmodel
 
 import (
-	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
 )

--- a/v2/tools/generator/internal/astmodel/flagged_type.go
+++ b/v2/tools/generator/internal/astmodel/flagged_type.go
@@ -102,8 +102,8 @@ func (ft *FlaggedType) References() TypeNameSet {
 
 // AsType renders as a Go abstract syntax tree for a type
 // (yes this says ast.Expr but that is what the Go 'dst' package uses for types)
-func (ft *FlaggedType) AsType(ctx *CodeGenerationContext) dst.Expr {
-	return ft.element.AsType(ctx)
+func (ft *FlaggedType) AsTypeExpr(ctx *CodeGenerationContext) dst.Expr {
+	return ft.element.AsTypeExpr(ctx)
 }
 
 // AsDeclarations renders as a Go abstract syntax tree for a declaration

--- a/v2/tools/generator/internal/astmodel/flagged_type.go
+++ b/v2/tools/generator/internal/astmodel/flagged_type.go
@@ -6,6 +6,7 @@
 package astmodel
 
 import (
+	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/dave/dst"
@@ -102,8 +103,13 @@ func (ft *FlaggedType) References() TypeNameSet {
 
 // AsType renders as a Go abstract syntax tree for a type
 // (yes this says ast.Expr but that is what the Go 'dst' package uses for types)
-func (ft *FlaggedType) AsTypeExpr(ctx *CodeGenerationContext) dst.Expr {
-	return ft.element.AsTypeExpr(ctx)
+func (ft *FlaggedType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
+	result, err := ft.element.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating inner expression for flagged type")
+	}
+
+	return result, nil
 }
 
 // AsDeclarations renders as a Go abstract syntax tree for a declaration

--- a/v2/tools/generator/internal/astmodel/interface_type.go
+++ b/v2/tools/generator/internal/astmodel/interface_type.go
@@ -79,7 +79,7 @@ func (i *InterfaceType) References() TypeNameSet {
 }
 
 // AsType renders the Go abstract syntax tree for the interface type
-func (i *InterfaceType) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr {
+func (i *InterfaceType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
 	fields := make([]*dst.Field, 0, i.functions.Len())
 
 	functions := i.functions.Values()
@@ -100,7 +100,7 @@ func (i *InterfaceType) AsType(codeGenerationContext *CodeGenerationContext) dst
 	}
 
 	if len(errs) > 0 {
-		// Temporarily panic until we modify the signature for AsType resolving #2970
+		// Temporarily panic until we modify the signature for AsTypeExpr resolving #2970
 		panic(kerrors.NewAggregate(errs))
 	}
 
@@ -123,7 +123,7 @@ func (i *InterfaceType) AsDeclarations(codeGenerationContext *CodeGenerationCont
 		Specs: []dst.Spec{
 			&dst.TypeSpec{
 				Name: dst.NewIdent(declContext.Name.Name()),
-				Type: i.AsType(codeGenerationContext),
+				Type: i.AsTypeExpr(codeGenerationContext),
 			},
 		},
 	}

--- a/v2/tools/generator/internal/astmodel/interface_type.go
+++ b/v2/tools/generator/internal/astmodel/interface_type.go
@@ -79,7 +79,7 @@ func (i *InterfaceType) References() TypeNameSet {
 }
 
 // AsType renders the Go abstract syntax tree for the interface type
-func (i *InterfaceType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
+func (i *InterfaceType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	fields := make([]*dst.Field, 0, i.functions.Len())
 
 	functions := i.functions.Values()
@@ -108,11 +108,18 @@ func (i *InterfaceType) AsTypeExpr(codeGenerationContext *CodeGenerationContext)
 		Methods: &dst.FieldList{
 			List: fields,
 		},
-	}
+	}, nil
 }
 
-func (i *InterfaceType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
-	iExpr := i.AsTypeExpr(codeGenerationContext)
+func (i *InterfaceType) AsDeclarations(
+	codeGenerationContext *CodeGenerationContext,
+	declContext DeclarationContext,
+) ([]dst.Decl, error) {
+	iExpr, err := i.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for interface %s", declContext.Name)
+	}
+
 	declaration := &dst.GenDecl{
 		Decs: dst.GenDeclDecorations{
 			NodeDecs: dst.NodeDecs{

--- a/v2/tools/generator/internal/astmodel/interface_type.go
+++ b/v2/tools/generator/internal/astmodel/interface_type.go
@@ -112,6 +112,7 @@ func (i *InterfaceType) AsTypeExpr(codeGenerationContext *CodeGenerationContext)
 }
 
 func (i *InterfaceType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
+	iExpr := i.AsTypeExpr(codeGenerationContext)
 	declaration := &dst.GenDecl{
 		Decs: dst.GenDeclDecorations{
 			NodeDecs: dst.NodeDecs{
@@ -123,7 +124,7 @@ func (i *InterfaceType) AsDeclarations(codeGenerationContext *CodeGenerationCont
 		Specs: []dst.Spec{
 			&dst.TypeSpec{
 				Name: dst.NewIdent(declContext.Name.Name()),
-				Type: i.AsTypeExpr(codeGenerationContext),
+				Type: iExpr,
 			},
 		},
 	}

--- a/v2/tools/generator/internal/astmodel/internal_type_name.go
+++ b/v2/tools/generator/internal/astmodel/internal_type_name.go
@@ -59,7 +59,7 @@ func (tn InternalTypeName) WithPackageReference(ref InternalPackageReference) In
 var _ Type = InternalTypeName{}
 
 func (tn InternalTypeName) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
-	return AsSimpleDeclarations(codeGenerationContext, declContext, tn), nil
+	return AsSimpleDeclarations(codeGenerationContext, declContext, tn)
 }
 
 // AsType implements Type for TypeName

--- a/v2/tools/generator/internal/astmodel/internal_type_name.go
+++ b/v2/tools/generator/internal/astmodel/internal_type_name.go
@@ -63,7 +63,7 @@ func (tn InternalTypeName) AsDeclarations(codeGenerationContext *CodeGenerationC
 }
 
 // AsType implements Type for TypeName
-func (tn InternalTypeName) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr {
+func (tn InternalTypeName) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
 	// If our name is in the current package, we don't need to qualify it
 	if codeGenerationContext.currentPackage.Equals(tn.packageReference) {
 		return dst.NewIdent(tn.name)

--- a/v2/tools/generator/internal/astmodel/internal_type_name.go
+++ b/v2/tools/generator/internal/astmodel/internal_type_name.go
@@ -63,10 +63,10 @@ func (tn InternalTypeName) AsDeclarations(codeGenerationContext *CodeGenerationC
 }
 
 // AsType implements Type for TypeName
-func (tn InternalTypeName) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
+func (tn InternalTypeName) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	// If our name is in the current package, we don't need to qualify it
 	if codeGenerationContext.currentPackage.Equals(tn.packageReference) {
-		return dst.NewIdent(tn.name)
+		return dst.NewIdent(tn.name), nil
 	}
 
 	// Need to ensure we include a selector for that reference
@@ -79,7 +79,7 @@ func (tn InternalTypeName) AsTypeExpr(codeGenerationContext *CodeGenerationConte
 			codeGenerationContext.currentPackage))
 	}
 
-	return astbuilder.Selector(dst.NewIdent(packageName), tn.Name())
+	return astbuilder.Selector(dst.NewIdent(packageName), tn.Name()), nil
 }
 
 // AsZero renders an expression for the "zero" value of the type.

--- a/v2/tools/generator/internal/astmodel/map_type.go
+++ b/v2/tools/generator/internal/astmodel/map_type.go
@@ -7,10 +7,10 @@ package astmodel
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 )

--- a/v2/tools/generator/internal/astmodel/map_type.go
+++ b/v2/tools/generator/internal/astmodel/map_type.go
@@ -7,6 +7,7 @@ package astmodel
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/dave/dst"
@@ -68,13 +69,21 @@ func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, d
 }
 
 // AsType implements Type for MapType to create the abstract syntax tree for a map
-func (m *MapType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
-	keyExpr := m.key.AsTypeExpr(codeGenerationContext)
-	valueExpr := m.value.AsTypeExpr(codeGenerationContext)
+func (m *MapType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
+	keyExpr, kerr := m.key.AsTypeExpr(codeGenerationContext)
+	if kerr != nil {
+		return nil, errors.Wrap(kerr, "creating map key type")
+	}
+
+	valueExpr, verr := m.value.AsTypeExpr(codeGenerationContext)
+	if verr != nil {
+		return nil, errors.Wrap(verr, "creating map value type")
+	}
+
 	return &dst.MapType{
 		Key:   keyExpr,
 		Value: valueExpr,
-	}
+	}, nil
 }
 
 // AsZero renders an expression for the "zero" value of a map by calling make()

--- a/v2/tools/generator/internal/astmodel/map_type.go
+++ b/v2/tools/generator/internal/astmodel/map_type.go
@@ -68,10 +68,10 @@ func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, d
 }
 
 // AsType implements Type for MapType to create the abstract syntax tree for a map
-func (m *MapType) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr {
+func (m *MapType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
 	return &dst.MapType{
-		Key:   m.key.AsType(codeGenerationContext),
-		Value: m.value.AsType(codeGenerationContext),
+		Key:   m.key.AsTypeExpr(codeGenerationContext),
+		Value: m.value.AsTypeExpr(codeGenerationContext),
 	}
 }
 

--- a/v2/tools/generator/internal/astmodel/map_type.go
+++ b/v2/tools/generator/internal/astmodel/map_type.go
@@ -65,7 +65,7 @@ func NewStringMapType(value Type) *MapType {
 var _ Type = (*MapType)(nil)
 
 func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
-	return AsSimpleDeclarations(codeGenerationContext, declContext, m), nil
+	return AsSimpleDeclarations(codeGenerationContext, declContext, m)
 }
 
 // AsType implements Type for MapType to create the abstract syntax tree for a map

--- a/v2/tools/generator/internal/astmodel/map_type.go
+++ b/v2/tools/generator/internal/astmodel/map_type.go
@@ -70,14 +70,14 @@ func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, d
 
 // AsType implements Type for MapType to create the abstract syntax tree for a map
 func (m *MapType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
-	keyExpr, kerr := m.key.AsTypeExpr(codeGenerationContext)
-	if kerr != nil {
-		return nil, errors.Wrap(kerr, "creating map key type")
+	keyExpr, err := m.key.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating map key type")
 	}
 
-	valueExpr, verr := m.value.AsTypeExpr(codeGenerationContext)
-	if verr != nil {
-		return nil, errors.Wrap(verr, "creating map value type")
+	valueExpr, err := m.value.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating map value type")
 	}
 
 	return &dst.MapType{

--- a/v2/tools/generator/internal/astmodel/map_type.go
+++ b/v2/tools/generator/internal/astmodel/map_type.go
@@ -69,9 +69,11 @@ func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, d
 
 // AsType implements Type for MapType to create the abstract syntax tree for a map
 func (m *MapType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
+	keyExpr := m.key.AsTypeExpr(codeGenerationContext)
+	valueExpr := m.value.AsTypeExpr(codeGenerationContext)
 	return &dst.MapType{
-		Key:   m.key.AsTypeExpr(codeGenerationContext),
-		Value: m.value.AsTypeExpr(codeGenerationContext),
+		Key:   keyExpr,
+		Value: valueExpr,
 	}
 }
 

--- a/v2/tools/generator/internal/astmodel/object_type.go
+++ b/v2/tools/generator/internal/astmodel/object_type.go
@@ -68,7 +68,11 @@ func (objectType *ObjectType) AsDeclarations(
 	codeGenerationContext *CodeGenerationContext,
 	declContext DeclarationContext,
 ) ([]dst.Decl, error) {
-	objectTypeExpr := objectType.AsTypeExpr(codeGenerationContext)
+	objectTypeExpr, err := objectType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating object type expression for %s", declContext.Name)
+	}
+
 	declaration := &dst.GenDecl{
 		Decs: dst.GenDeclDecorations{
 			NodeDecs: dst.NodeDecs{
@@ -242,7 +246,7 @@ func (objectType *ObjectType) HasFunctionWithName(name string) bool {
 }
 
 // AsType implements Type for ObjectType
-func (objectType *ObjectType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
+func (objectType *ObjectType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	embedded := objectType.EmbeddedProperties()
 	fields := make([]*dst.Field, 0, len(embedded))
 	for _, f := range embedded {
@@ -263,7 +267,7 @@ func (objectType *ObjectType) AsTypeExpr(codeGenerationContext *CodeGenerationCo
 		Fields: &dst.FieldList{
 			List: fields,
 		},
-	}
+	}, nil
 }
 
 // AsZero renders an expression for the "zero" value of the type

--- a/v2/tools/generator/internal/astmodel/object_type.go
+++ b/v2/tools/generator/internal/astmodel/object_type.go
@@ -68,6 +68,7 @@ func (objectType *ObjectType) AsDeclarations(
 	codeGenerationContext *CodeGenerationContext,
 	declContext DeclarationContext,
 ) ([]dst.Decl, error) {
+	objectTypeExpr := objectType.AsTypeExpr(codeGenerationContext)
 	declaration := &dst.GenDecl{
 		Decs: dst.GenDeclDecorations{
 			NodeDecs: dst.NodeDecs{
@@ -79,7 +80,7 @@ func (objectType *ObjectType) AsDeclarations(
 		Specs: []dst.Spec{
 			&dst.TypeSpec{
 				Name: dst.NewIdent(declContext.Name.Name()),
-				Type: objectType.AsTypeExpr(codeGenerationContext),
+				Type: objectTypeExpr,
 			},
 		},
 	}

--- a/v2/tools/generator/internal/astmodel/object_type.go
+++ b/v2/tools/generator/internal/astmodel/object_type.go
@@ -79,7 +79,7 @@ func (objectType *ObjectType) AsDeclarations(
 		Specs: []dst.Spec{
 			&dst.TypeSpec{
 				Name: dst.NewIdent(declContext.Name.Name()),
-				Type: objectType.AsType(codeGenerationContext),
+				Type: objectType.AsTypeExpr(codeGenerationContext),
 			},
 		},
 	}
@@ -241,7 +241,7 @@ func (objectType *ObjectType) HasFunctionWithName(name string) bool {
 }
 
 // AsType implements Type for ObjectType
-func (objectType *ObjectType) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr {
+func (objectType *ObjectType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
 	embedded := objectType.EmbeddedProperties()
 	fields := make([]*dst.Field, 0, len(embedded))
 	for _, f := range embedded {

--- a/v2/tools/generator/internal/astmodel/oneof_type.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type.go
@@ -153,7 +153,7 @@ var oneOFailureMsg = "OneOfType should have been replaced by generation time by 
 
 // AsType always panics; OneOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (oneOf *OneOfType) AsType(_ *CodeGenerationContext) dst.Expr {
+func (oneOf *OneOfType) AsTypeExpr(_ *CodeGenerationContext) dst.Expr {
 	panic(errors.New(oneOFailureMsg))
 }
 

--- a/v2/tools/generator/internal/astmodel/oneof_type.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type.go
@@ -153,7 +153,7 @@ var oneOFailureMsg = "OneOfType should have been replaced by generation time by 
 
 // AsType always panics; OneOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (oneOf *OneOfType) AsTypeExpr(_ *CodeGenerationContext) dst.Expr {
+func (oneOf *OneOfType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	panic(errors.New(oneOFailureMsg))
 }
 

--- a/v2/tools/generator/internal/astmodel/oneof_type_test.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type_test.go
@@ -52,7 +52,7 @@ func TestOneOfAsTypePanics(t *testing.T) {
 
 	x := OneOfType{}
 	g.Expect(func() {
-		x.AsType(&CodeGenerationContext{})
+		x.AsTypeExpr(&CodeGenerationContext{})
 	}).To(PanicWith(MatchError(expectedOneOfPanic)))
 }
 

--- a/v2/tools/generator/internal/astmodel/oneof_type_test.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type_test.go
@@ -52,7 +52,8 @@ func TestOneOfAsTypePanics(t *testing.T) {
 
 	x := OneOfType{}
 	g.Expect(func() {
-		x.AsTypeExpr(&CodeGenerationContext{})
+		_, err := x.AsTypeExpr(&CodeGenerationContext{})
+		g.Expect(err).To(HaveOccurred()) // Unreachable, but keeps lint happy
 	}).To(PanicWith(MatchError(expectedOneOfPanic)))
 }
 

--- a/v2/tools/generator/internal/astmodel/optional_type.go
+++ b/v2/tools/generator/internal/astmodel/optional_type.go
@@ -7,10 +7,10 @@ package astmodel
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 )

--- a/v2/tools/generator/internal/astmodel/optional_type.go
+++ b/v2/tools/generator/internal/astmodel/optional_type.go
@@ -127,11 +127,12 @@ func (optional *OptionalType) AsDeclarations(codeGenerationContext *CodeGenerati
 // AsType renders the Go abstract syntax tree for an optional type
 func (optional *OptionalType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
 	// Special case interface{} as it shouldn't be a pointer
+	elementExpr := optional.element.AsTypeExpr(codeGenerationContext)
 	if optional.element == AnyType {
-		return optional.element.AsTypeExpr(codeGenerationContext)
+		return elementExpr
 	}
 
-	return astbuilder.PointerTo(optional.element.AsTypeExpr(codeGenerationContext))
+	return astbuilder.PointerTo(elementExpr)
 }
 
 // AsZero renders an expression for the "zero" value of the type

--- a/v2/tools/generator/internal/astmodel/optional_type.go
+++ b/v2/tools/generator/internal/astmodel/optional_type.go
@@ -122,7 +122,7 @@ func (optional *OptionalType) WithElement(t Type) Type {
 }
 
 func (optional *OptionalType) AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error) {
-	return AsSimpleDeclarations(codeGenerationContext, declContext, optional), nil
+	return AsSimpleDeclarations(codeGenerationContext, declContext, optional)
 }
 
 // AsType renders the Go abstract syntax tree for an optional type

--- a/v2/tools/generator/internal/astmodel/optional_type.go
+++ b/v2/tools/generator/internal/astmodel/optional_type.go
@@ -125,13 +125,13 @@ func (optional *OptionalType) AsDeclarations(codeGenerationContext *CodeGenerati
 }
 
 // AsType renders the Go abstract syntax tree for an optional type
-func (optional *OptionalType) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr {
+func (optional *OptionalType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr {
 	// Special case interface{} as it shouldn't be a pointer
 	if optional.element == AnyType {
-		return optional.element.AsType(codeGenerationContext)
+		return optional.element.AsTypeExpr(codeGenerationContext)
 	}
 
-	return astbuilder.PointerTo(optional.element.AsType(codeGenerationContext))
+	return astbuilder.PointerTo(optional.element.AsTypeExpr(codeGenerationContext))
 }
 
 // AsZero renders an expression for the "zero" value of the type

--- a/v2/tools/generator/internal/astmodel/primitive_type.go
+++ b/v2/tools/generator/internal/astmodel/primitive_type.go
@@ -56,7 +56,7 @@ func (prim *PrimitiveType) AsDeclarations(
 	codeGenerationContext *CodeGenerationContext,
 	declContext DeclarationContext,
 ) ([]dst.Decl, error) {
-	return AsSimpleDeclarations(codeGenerationContext, declContext, prim), nil
+	return AsSimpleDeclarations(codeGenerationContext, declContext, prim)
 }
 
 // RequiredPackageReferences returns a list of package required by this

--- a/v2/tools/generator/internal/astmodel/primitive_type.go
+++ b/v2/tools/generator/internal/astmodel/primitive_type.go
@@ -48,7 +48,7 @@ var ErrorType = &PrimitiveType{"error", "nil"}
 var _ Type = (*PrimitiveType)(nil)
 
 // AsType implements Type for PrimitiveType returning an abstract syntax tree
-func (prim *PrimitiveType) AsType(_ *CodeGenerationContext) dst.Expr {
+func (prim *PrimitiveType) AsTypeExpr(_ *CodeGenerationContext) dst.Expr {
 	return dst.NewIdent(prim.name)
 }
 

--- a/v2/tools/generator/internal/astmodel/primitive_type.go
+++ b/v2/tools/generator/internal/astmodel/primitive_type.go
@@ -48,8 +48,8 @@ var ErrorType = &PrimitiveType{"error", "nil"}
 var _ Type = (*PrimitiveType)(nil)
 
 // AsType implements Type for PrimitiveType returning an abstract syntax tree
-func (prim *PrimitiveType) AsTypeExpr(_ *CodeGenerationContext) dst.Expr {
-	return dst.NewIdent(prim.name)
+func (prim *PrimitiveType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
+	return dst.NewIdent(prim.name), nil
 }
 
 func (prim *PrimitiveType) AsDeclarations(

--- a/v2/tools/generator/internal/astmodel/property_definition.go
+++ b/v2/tools/generator/internal/astmodel/property_definition.go
@@ -7,11 +7,11 @@ package astmodel
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"sort"
 	"strings"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 	"golang.org/x/exp/slices"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"

--- a/v2/tools/generator/internal/astmodel/property_definition.go
+++ b/v2/tools/generator/internal/astmodel/property_definition.go
@@ -431,8 +431,9 @@ func (property *PropertyDefinition) AsField(codeGenerationContext *CodeGeneratio
 	}
 
 	// Some types opt out of codegen by returning nil
-	typeDeclaration := propType.AsTypeExpr(codeGenerationContext)
-	if typeDeclaration == nil {
+	propTypeExpr := propType.AsTypeExpr(codeGenerationContext)
+	typeExpr := propTypeExpr
+	if typeExpr == nil {
 		return nil
 	}
 
@@ -450,7 +451,7 @@ func (property *PropertyDefinition) AsField(codeGenerationContext *CodeGeneratio
 			},
 		},
 		Names: names,
-		Type:  propType.AsTypeExpr(codeGenerationContext),
+		Type:  propTypeExpr,
 		Tag:   astbuilder.TextLiteralf("`%s`", tags),
 	}
 

--- a/v2/tools/generator/internal/astmodel/property_definition.go
+++ b/v2/tools/generator/internal/astmodel/property_definition.go
@@ -431,7 +431,7 @@ func (property *PropertyDefinition) AsField(codeGenerationContext *CodeGeneratio
 	}
 
 	// Some types opt out of codegen by returning nil
-	typeDeclaration := propType.AsType(codeGenerationContext)
+	typeDeclaration := propType.AsTypeExpr(codeGenerationContext)
 	if typeDeclaration == nil {
 		return nil
 	}
@@ -450,7 +450,7 @@ func (property *PropertyDefinition) AsField(codeGenerationContext *CodeGeneratio
 			},
 		},
 		Names: names,
-		Type:  propType.AsType(codeGenerationContext),
+		Type:  propType.AsTypeExpr(codeGenerationContext),
 		Tag:   astbuilder.TextLiteralf("`%s`", tags),
 	}
 

--- a/v2/tools/generator/internal/astmodel/property_definition.go
+++ b/v2/tools/generator/internal/astmodel/property_definition.go
@@ -7,6 +7,7 @@ package astmodel
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"sort"
 	"strings"
 
@@ -173,9 +174,11 @@ func (property *PropertyDefinition) Description() string {
 }
 
 // WithType clones the property and returns it with a new type
-func (property *PropertyDefinition) WithType(newType Type) *PropertyDefinition {
+func (property *PropertyDefinition) WithType(
+	newType Type,
+) *PropertyDefinition {
 	if newType == nil {
-		panic("nil type provided to WithType")
+		panic(errors.New("nil type provided to WithType"))
 	}
 
 	if TypeEquals(property.propertyType, newType) {
@@ -283,7 +286,7 @@ func (property *PropertyDefinition) MakeRequired() *PropertyDefinition {
 	}
 
 	if !isTypeOptional(property.PropertyType()) {
-		panic(fmt.Sprintf(
+		panic(errors.Errorf(
 			"property %s with non-optional type %T cannot be marked kubebuilder:validation:Required.",
 			property.PropertyName(),
 			property.PropertyType()))
@@ -406,9 +409,11 @@ func (property *PropertyDefinition) renderedTags() string {
 }
 
 // AsField generates a Go AST field node representing this property definition
-func (property *PropertyDefinition) AsField(codeGenerationContext *CodeGenerationContext) *dst.Field {
+func (property *PropertyDefinition) AsField(
+	codeGenerationContext *CodeGenerationContext,
+) (*dst.Field, error) {
 	if property.flatten {
-		panic(fmt.Sprintf("property %s marked for flattening was not flattened", property.propertyName))
+		return nil, errors.Errorf("property %s marked for flattening was not flattened", property.propertyName)
 	}
 
 	tags := property.renderedTags()
@@ -431,10 +436,14 @@ func (property *PropertyDefinition) AsField(codeGenerationContext *CodeGeneratio
 	}
 
 	// Some types opt out of codegen by returning nil
-	propTypeExpr := propType.AsTypeExpr(codeGenerationContext)
+	propTypeExpr, err := propType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to generate field for property %s", property.propertyName)
+	}
+
 	typeExpr := propTypeExpr
 	if typeExpr == nil {
-		return nil
+		return nil, nil
 	}
 
 	before := dst.NewLine
@@ -461,7 +470,7 @@ func (property *PropertyDefinition) AsField(codeGenerationContext *CodeGeneratio
 		astbuilder.AddWrappedComment(&result.Decs.Start, fmt.Sprintf("%s: %s", property.propertyName, property.description))
 	}
 
-	return result
+	return result, nil
 }
 
 func (property *PropertyDefinition) tagsEqual(f *PropertyDefinition) bool {

--- a/v2/tools/generator/internal/astmodel/property_definition_test.go
+++ b/v2/tools/generator/internal/astmodel/property_definition_test.go
@@ -518,7 +518,7 @@ func Test_PropertyDefinitionAsAst_GivenValidField_ReturnsNonNilResult(t *testing
 		WithDescription(propertyDescription)
 
 	node, err := original.AsField(nil)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(node).NotTo(BeNil())
 }
 

--- a/v2/tools/generator/internal/astmodel/property_definition_test.go
+++ b/v2/tools/generator/internal/astmodel/property_definition_test.go
@@ -515,8 +515,8 @@ func Test_PropertyDefinitionAsAst_GivenValidField_ReturnsNonNilResult(t *testing
 		MakeRequired().
 		WithDescription(propertyDescription)
 
-	node := original.AsField(nil)
-
+	node, err := original.AsField(nil)
+	g.Expect(err).To(BeNil())
 	g.Expect(node).NotTo(BeNil())
 }
 

--- a/v2/tools/generator/internal/astmodel/property_definition_test.go
+++ b/v2/tools/generator/internal/astmodel/property_definition_test.go
@@ -314,8 +314,10 @@ func Test_PropertyDefinitionMakeRequired_WhenTypeIsOptional_Panics(t *testing.T)
 
 	original := NewPropertyDefinition(propertyName, propertyJsonName, propertyType).MakeTypeRequired()
 	g.Expect(func() { original.MakeRequired() }).To(
-		PanicWith(fmt.Sprintf("property %s with non-optional type *astmodel.PrimitiveType cannot be marked kubebuilder:validation:Required.",
-			propertyName)))
+		PanicWith(
+			MatchError(
+				fmt.Sprintf("property %s with non-optional type *astmodel.PrimitiveType cannot be marked kubebuilder:validation:Required.",
+					propertyName))))
 }
 
 /*

--- a/v2/tools/generator/internal/astmodel/resource_type.go
+++ b/v2/tools/generator/internal/astmodel/resource_type.go
@@ -343,7 +343,7 @@ func (resource *ResourceType) TestCases() []TestCase {
 }
 
 // AsType always panics because a resource has no direct AST representation
-func (resource *ResourceType) AsType(_ *CodeGenerationContext) dst.Expr {
+func (resource *ResourceType) AsTypeExpr(_ *CodeGenerationContext) dst.Expr {
 	panic("a resource cannot be used directly as a type")
 }
 
@@ -730,7 +730,7 @@ func (resource *ResourceType) resourceListTypeDecls(
 	fields := []*dst.Field{
 		typeMetaField,
 		objectMetaField,
-		defineField("Items", items.AsType(codeGenerationContext), "`json:\"items\"`"),
+		defineField("Items", items.AsTypeExpr(codeGenerationContext), "`json:\"items\"`"),
 	}
 
 	resourceTypeSpec := &dst.TypeSpec{

--- a/v2/tools/generator/internal/astmodel/resource_type.go
+++ b/v2/tools/generator/internal/astmodel/resource_type.go
@@ -727,10 +727,11 @@ func (resource *ResourceType) resourceListTypeDecls(
 	// We need an array of items
 	items := NewArrayType(resourceTypeName)
 
+	itemTypeExpr := items.AsTypeExpr(codeGenerationContext)
 	fields := []*dst.Field{
 		typeMetaField,
 		objectMetaField,
-		defineField("Items", items.AsTypeExpr(codeGenerationContext), "`json:\"items\"`"),
+		defineField("Items", itemTypeExpr, "`json:\"items\"`"),
 	}
 
 	resourceTypeSpec := &dst.TypeSpec{

--- a/v2/tools/generator/internal/astmodel/resource_type.go
+++ b/v2/tools/generator/internal/astmodel/resource_type.go
@@ -343,7 +343,7 @@ func (resource *ResourceType) TestCases() []TestCase {
 }
 
 // AsType always panics because a resource has no direct AST representation
-func (resource *ResourceType) AsTypeExpr(_ *CodeGenerationContext) dst.Expr {
+func (resource *ResourceType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	panic("a resource cannot be used directly as a type")
 }
 

--- a/v2/tools/generator/internal/astmodel/type.go
+++ b/v2/tools/generator/internal/astmodel/type.go
@@ -22,9 +22,10 @@ type Type interface {
 	// Person.
 	References() TypeNameSet
 
-	// AsType renders as a Go abstract syntax tree for a type
-	// (yes this says dst.Expr but that is what the Go 'dst' package uses for types)
-	AsType(codeGenerationContext *CodeGenerationContext) dst.Expr
+	// AsTypeExpr renders as the Go abstract syntax tree to reference this type
+	// (Yes, this returns dst.Expr but that is what the Go 'dst' package uses
+	// for type references).
+	AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr
 
 	// AsDeclarations renders as a Go abstract syntax tree for a declaration
 	AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error)

--- a/v2/tools/generator/internal/astmodel/type.go
+++ b/v2/tools/generator/internal/astmodel/type.go
@@ -25,7 +25,7 @@ type Type interface {
 	// AsTypeExpr renders as the Go abstract syntax tree to reference this type
 	// (Yes, this returns dst.Expr but that is what the Go 'dst' package uses
 	// for type references).
-	AsTypeExpr(codeGenerationContext *CodeGenerationContext) dst.Expr
+	AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error)
 
 	// AsDeclarations renders as a Go abstract syntax tree for a declaration
 	AsDeclarations(codeGenerationContext *CodeGenerationContext, declContext DeclarationContext) ([]dst.Decl, error)

--- a/v2/tools/generator/internal/astmodel/type_definition.go
+++ b/v2/tools/generator/internal/astmodel/type_definition.go
@@ -106,7 +106,7 @@ func AsSimpleDeclarations(
 		Specs: []dst.Spec{
 			&dst.TypeSpec{
 				Name: dst.NewIdent(declContext.Name.Name()),
-				Type: theType.AsType(codeGenerationContext),
+				Type: theType.AsTypeExpr(codeGenerationContext),
 			},
 		},
 	}

--- a/v2/tools/generator/internal/astmodel/type_definition.go
+++ b/v2/tools/generator/internal/astmodel/type_definition.go
@@ -95,6 +95,7 @@ func AsSimpleDeclarations(
 
 	AddValidationComments(&docComments, declContext.Validations)
 
+	theTypeExpr := theType.AsTypeExpr(codeGenerationContext)
 	result := &dst.GenDecl{
 		Decs: dst.GenDeclDecorations{
 			NodeDecs: dst.NodeDecs{
@@ -106,7 +107,7 @@ func AsSimpleDeclarations(
 		Specs: []dst.Spec{
 			&dst.TypeSpec{
 				Name: dst.NewIdent(declContext.Name.Name()),
-				Type: theType.AsTypeExpr(codeGenerationContext),
+				Type: theTypeExpr,
 			},
 		},
 	}

--- a/v2/tools/generator/internal/astmodel/type_definition.go
+++ b/v2/tools/generator/internal/astmodel/type_definition.go
@@ -87,7 +87,7 @@ func AsSimpleDeclarations(
 	codeGenerationContext *CodeGenerationContext,
 	declContext DeclarationContext,
 	theType Type,
-) []dst.Decl {
+) ([]dst.Decl, error) {
 	var docComments dst.Decorations
 	if len(declContext.Description) > 0 {
 		astbuilder.AddWrappedComments(&docComments, declContext.Description)
@@ -95,7 +95,11 @@ func AsSimpleDeclarations(
 
 	AddValidationComments(&docComments, declContext.Validations)
 
-	theTypeExpr := theType.AsTypeExpr(codeGenerationContext)
+	theTypeExpr, err := theType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating simple declaration")
+	}
+
 	result := &dst.GenDecl{
 		Decs: dst.GenDeclDecorations{
 			NodeDecs: dst.NodeDecs{
@@ -112,7 +116,7 @@ func AsSimpleDeclarations(
 		},
 	}
 
-	return []dst.Decl{result}
+	return astbuilder.Declarations(result), nil
 }
 
 // RequiredPackageReferences returns a list of packages required by this type

--- a/v2/tools/generator/internal/astmodel/validated_type.go
+++ b/v2/tools/generator/internal/astmodel/validated_type.go
@@ -176,7 +176,7 @@ func (v *ValidatedType) AsDeclarations(
 }
 
 // AsType panics because validated types should always be named
-func (v *ValidatedType) AsTypeExpr(_ *CodeGenerationContext) dst.Expr {
+func (v *ValidatedType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	panic("Should never happen: validated types must either be named (handled by 'name types for CRDs' pipeline stage) or be directly under properties (handled by PropertyDefinition.AsField)")
 }
 

--- a/v2/tools/generator/internal/astmodel/validated_type.go
+++ b/v2/tools/generator/internal/astmodel/validated_type.go
@@ -176,7 +176,7 @@ func (v *ValidatedType) AsDeclarations(
 }
 
 // AsType panics because validated types should always be named
-func (v *ValidatedType) AsType(_ *CodeGenerationContext) dst.Expr {
+func (v *ValidatedType) AsTypeExpr(_ *CodeGenerationContext) dst.Expr {
 	panic("Should never happen: validated types must either be named (handled by 'name types for CRDs' pipeline stage) or be directly under properties (handled by PropertyDefinition.AsField)")
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
@@ -183,7 +183,10 @@ func validateSecretDestinations(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating receiver expression")
+	}
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
@@ -221,7 +224,10 @@ func validateConfigMapDestinations(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating receiver expression")
+	}
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,

--- a/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
@@ -183,7 +183,7 @@ func validateSecretDestinations(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
@@ -221,7 +221,7 @@ func validateConfigMapDestinations(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
@@ -295,7 +295,7 @@ func validateOperatorSpecSliceBody(
 	//     ...
 	// }
 	sliceBuilder := astbuilder.NewSliceLiteralBuilder(
-		validateType.AsType(codeGenerationContext),
+		validateType.AsTypeExpr(codeGenerationContext),
 		true)
 	for _, prop := range operatorSpecPropertyObj.Properties().AsSlice() {
 		propSelector := astbuilder.Selector(specPropertySelector, prop.PropertyName().String())

--- a/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
@@ -183,12 +183,12 @@ func validateSecretDestinations(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body: validateOperatorSpecSliceBody(
 			codeGenerationContext,
 			k.Resource(),
@@ -221,12 +221,12 @@ func validateConfigMapDestinations(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body: validateOperatorSpecSliceBody(
 			codeGenerationContext,
 			k.Resource(),
@@ -294,9 +294,8 @@ func validateOperatorSpecSliceBody(
 	//     account.Spec.OperatorSpec.Secrets.SecondaryReadonlyMasterKey,
 	//     ...
 	// }
-	sliceBuilder := astbuilder.NewSliceLiteralBuilder(
-		validateType.AsTypeExpr(codeGenerationContext),
-		true)
+	validateTypeExpr := validateType.AsTypeExpr(codeGenerationContext)
+	sliceBuilder := astbuilder.NewSliceLiteralBuilder(validateTypeExpr, true)
 	for _, prop := range operatorSpecPropertyObj.Properties().AsSlice() {
 		propSelector := astbuilder.Selector(specPropertySelector, prop.PropertyName().String())
 		sliceBuilder.AddElement(propSelector)

--- a/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
@@ -193,7 +193,8 @@ func createAssignPropertiesOverrideStub(
 		funcDetails := &astbuilder.FuncDetails{
 			Name: methodName,
 		}
-		funcDetails.AddParameter(paramName, paramType.AsTypeExpr(codeGenerationContext))
+		paramTypeExpr := paramType.AsTypeExpr(codeGenerationContext)
+		funcDetails.AddParameter(paramName, paramTypeExpr)
 		funcDetails.AddReturn(dst.NewIdent("error"))
 
 		return funcDetails.DefineFuncHeader(), nil

--- a/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
@@ -193,7 +193,11 @@ func createAssignPropertiesOverrideStub(
 		funcDetails := &astbuilder.FuncDetails{
 			Name: methodName,
 		}
-		paramTypeExpr := paramType.AsTypeExpr(codeGenerationContext)
+		paramTypeExpr, err := paramType.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating parameter type expression for %s", paramName)
+		}
+
 		funcDetails.AddParameter(paramName, paramTypeExpr)
 		funcDetails.AddReturn(dst.NewIdent("error"))
 

--- a/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
@@ -193,7 +193,7 @@ func createAssignPropertiesOverrideStub(
 		funcDetails := &astbuilder.FuncDetails{
 			Name: methodName,
 		}
-		funcDetails.AddParameter(paramName, paramType.AsType(codeGenerationContext))
+		funcDetails.AddParameter(paramName, paramType.AsTypeExpr(codeGenerationContext))
 		funcDetails.AddReturn(dst.NewIdent("error"))
 
 		return funcDetails.DefineFuncHeader(), nil

--- a/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
@@ -224,7 +224,11 @@ func createGetKnownTypesFunc(
 			batch = batch[:0]
 		}
 
-		typeNameExpr := typeName.AsTypeExpr(codeGenerationContext)
+		typeNameExpr, err := typeName.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating type expression for %s", typeName.Name())
+		}
+
 		batch = append(batch, astbuilder.CallFunc("new", typeNameExpr))
 		lastPkg = typeName.PackageReference()
 	}

--- a/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
@@ -82,7 +82,11 @@ func (r *ResourceRegistrationFile) AsAst() (*dst.File, error) {
 	}
 
 	// getKnownStorageTypes() function
-	knownStorageTypes := r.createGetKnownStorageTypesFunc(codeGenContext)
+	knownStorageTypes, err := r.createGetKnownStorageTypesFunc(codeGenContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating %s function", "getKnownStorageTypes")
+	}
+
 	decls = append(decls, knownStorageTypes)
 
 	// getKnownTypes() function
@@ -95,12 +99,17 @@ func (r *ResourceRegistrationFile) AsAst() (*dst.File, error) {
 	// createScheme() function
 	createSchemeFunc, err := r.createCreateSchemeFunc(codeGenContext)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "creating getKnownResourceExtensions function")
 	}
+
 	decls = append(decls, createSchemeFunc)
 
 	// Create Resource Extensions
-	resourceExtensionTypes := r.createGetResourceExtensions(codeGenContext)
+	resourceExtensionTypes, err := r.createGetResourceExtensions(codeGenContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating getKnownResourceExtensions function")
+	}
+
 	decls = append(decls, resourceExtensionTypes)
 
 	// All the index functions
@@ -278,7 +287,7 @@ func createGetKnownTypesFunc(
 //	}
 func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 	codeGenerationContext *astmodel.CodeGenerationContext,
-) dst.Decl {
+) (dst.Decl, error) {
 	funcName := "getKnownStorageTypes"
 	funcComment := "returns the list of storage types which can be reconciled."
 
@@ -286,7 +295,11 @@ func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 	resultType := astmodel.NewArrayType(
 		astmodel.NewOptionalType(
 			astmodel.StorageTypeRegistrationType))
-	resultTypeExpr := resultType.AsTypeExpr(codeGenerationContext)
+	resultTypeExpr, err := resultType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating type expression for StorageTypeRegistrationType")
+	}
+
 	resultVar := astbuilder.LocalVariableDeclaration(
 		resultIdent.String(),
 		resultTypeExpr,
@@ -296,9 +309,16 @@ func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 
 	resourceAppendStatements := make([]dst.Stmt, 0, len(r.storageVersionResources))
 	for _, typeName := range r.storageVersionResources {
-		typeNameExpr := typeName.AsTypeExpr(codeGenerationContext)
+		typeNameExpr, err := typeName.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating type expression for %s", typeName.Name())
+		}
 
-		registrationTypeExpr := astmodel.StorageTypeRegistrationType.AsTypeExpr(codeGenerationContext)
+		registrationTypeExpr, err := astmodel.StorageTypeRegistrationType.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating type expression for StorageTypeRegistrationType")
+		}
+
 		newStorageTypeBuilder := astbuilder.NewCompositeLiteralBuilder(registrationTypeExpr)
 		newStorageTypeBuilder.AddField("Obj", astbuilder.CallFunc("new", typeNameExpr))
 
@@ -310,7 +330,12 @@ func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 		//		}
 		//	}
 		if indexFuncs, ok := r.indexFunctions[typeName]; ok {
-			indexRegistrationTypeExpr := astmodel.IndexRegistrationType.AsTypeExpr(codeGenerationContext)
+			var indexRegistrationTypeExpr dst.Expr
+			indexRegistrationTypeExpr, err = astmodel.IndexRegistrationType.AsTypeExpr(codeGenerationContext)
+			if err != nil {
+				return nil, errors.Wrap(err, "creating type expression for IndexRegistrationType")
+			}
+
 			sliceBuilder := astbuilder.NewSliceLiteralBuilder(indexRegistrationTypeExpr, true)
 			sort.Slice(indexFuncs, orderByFunctionName(indexFuncs))
 			if len(indexFuncs) > 0 {
@@ -332,7 +357,11 @@ func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 		//			MakeEventHandler: <func>,
 		//		}
 		//	}
-		watches := r.makeWatchesExpr(typeName, codeGenerationContext)
+		watches, err := r.makeWatchesExpr(typeName, codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating watches expression for %s", typeName.Name())
+		}
+
 		if watches != nil {
 			newStorageTypeBuilder.AddField("Watches", watches)
 		}
@@ -360,17 +389,23 @@ func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 		resultTypeExpr)
 	f.AddComments(funcComment)
 
-	return f.DefineFunc()
+	return f.DefineFunc(), nil
 }
 
-func (r *ResourceRegistrationFile) createGetResourceExtensions(context *astmodel.CodeGenerationContext) dst.Decl {
+func (r *ResourceRegistrationFile) createGetResourceExtensions(
+	context *astmodel.CodeGenerationContext,
+) (dst.Decl, error) {
 	funcName := "getResourceExtensions"
 	funcComment := "returns a list of resource extensions"
 
 	sort.Slice(r.resourceExtensions, orderByImportedTypeName(context, r.resourceExtensions))
 	resultIdent := dst.NewIdent("result")
 	resultType := astmodel.NewArrayType(astmodel.ResourceExtensionType)
-	resultTypeExpr := resultType.AsTypeExpr(context)
+	resultTypeExpr, err := resultType.AsTypeExpr(context)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating type expression for ResourceExtensionType")
+	}
+
 	resultVar := astbuilder.LocalVariableDeclaration(
 		resultIdent.String(),
 		resultTypeExpr,
@@ -378,7 +413,11 @@ func (r *ResourceRegistrationFile) createGetResourceExtensions(context *astmodel
 
 	resourceAppendStatements := make([]dst.Stmt, 0, len(r.resourceExtensions))
 	for _, typeName := range r.resourceExtensions {
-		typeNameExpr := typeName.AsTypeExpr(context)
+		typeNameExpr, err := typeName.AsTypeExpr(context)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating type expression for %s", typeName.Name())
+		}
+
 		literalExpr := astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(typeNameExpr).Build())
 		appendStmt := astbuilder.AppendItemToSlice(
 			resultIdent,
@@ -399,7 +438,7 @@ func (r *ResourceRegistrationFile) createGetResourceExtensions(context *astmodel
 	f.AddReturn(resultTypeExpr)
 	f.AddComments(funcComment)
 
-	return f.DefineFunc()
+	return f.DefineFunc(), nil
 }
 
 // createCreateSchemeFunc creates a createScheme() function like:
@@ -512,25 +551,36 @@ func (r *ResourceRegistrationFile) getImportedPackages() map[astmodel.PackageRef
 func (r *ResourceRegistrationFile) makeWatchesExpr(
 	typeName astmodel.InternalTypeName,
 	codeGenerationContext *astmodel.CodeGenerationContext,
-) dst.Expr {
-	secretWatchesExpr := r.makeSimpleWatchesExpr(
+) (dst.Expr, error) {
+	secretWatchesExpr, err := r.makeSimpleWatchesExpr(
 		typeName,
 		astmodel.SecretType,
 		"watchSecretsFactory",
 		r.secretPropertyKeys,
 		codeGenerationContext)
-	configMapWatchesExpr := r.makeSimpleWatchesExpr(
+	if err != nil {
+		return nil, errors.Wrap(err, "creating watches expression for secrets")
+	}
+
+	configMapWatchesExpr, err := r.makeSimpleWatchesExpr(
 		typeName,
 		astmodel.ConfigMapType,
 		"watchConfigMapsFactory",
 		r.configMapPropertyKeys,
 		codeGenerationContext)
-
-	if secretWatchesExpr == nil && configMapWatchesExpr == nil {
-		return nil
+	if err != nil {
+		return nil, errors.Wrap(err, "creating watches expression for configmaps")
 	}
 
-	watchRegistrationTypeExpr := astmodel.WatchRegistrationType.AsTypeExpr(codeGenerationContext)
+	if secretWatchesExpr == nil && configMapWatchesExpr == nil {
+		return nil, nil
+	}
+
+	watchRegistrationTypeExpr, err := astmodel.WatchRegistrationType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating type expression for WatchRegistrationType")
+	}
+
 	sliceBuilder := astbuilder.NewSliceLiteralBuilder(watchRegistrationTypeExpr, true)
 	if secretWatchesExpr != nil {
 		sliceBuilder.AddElement(secretWatchesExpr)
@@ -538,7 +588,8 @@ func (r *ResourceRegistrationFile) makeWatchesExpr(
 	if configMapWatchesExpr != nil {
 		sliceBuilder.AddElement(configMapWatchesExpr)
 	}
-	return sliceBuilder.Build()
+
+	return sliceBuilder.Build(), nil
 }
 
 // makeSimpleWatchesExpr generates code for a Watches expression:
@@ -553,21 +604,29 @@ func (r *ResourceRegistrationFile) makeSimpleWatchesExpr(
 	watchHelperFuncName string,
 	typeNameKeys map[astmodel.InternalTypeName][]string,
 	codeGenerationContext *astmodel.CodeGenerationContext,
-) dst.Expr {
+) (dst.Expr, error) {
 	keys, ok := typeNameKeys[typeName]
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	if len(keys) == 0 {
-		return nil
+		return nil, nil
 	}
 
-	watchRegistrationTypeExpr := astmodel.WatchRegistrationType.AsTypeExpr(codeGenerationContext)
+	watchRegistrationTypeExpr, err := astmodel.WatchRegistrationType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating type expression for WatchRegistrationType")
+	}
+
 	newWatchBuilder := astbuilder.NewCompositeLiteralBuilder(watchRegistrationTypeExpr)
 	sort.Strings(keys)
 
-	fieldTypeExpr := fieldType.AsTypeExpr(codeGenerationContext)
+	fieldTypeExpr, err := fieldType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", fieldType.Name())
+	}
+
 	objectType := astbuilder.AddrOf(&dst.CompositeLit{
 		Type: fieldTypeExpr,
 	})
@@ -579,7 +638,10 @@ func (r *ResourceRegistrationFile) makeSimpleWatchesExpr(
 	}
 
 	listType := typeName.WithName(typeName.Name() + "List")
-	listTypeExpr := listType.AsTypeExpr(codeGenerationContext)
+	listTypeExpr, err := listType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", listType.Name())
+	}
 
 	eventHandler := astbuilder.CallFunc(
 		watchHelperFuncName,
@@ -587,5 +649,5 @@ func (r *ResourceRegistrationFile) makeSimpleWatchesExpr(
 		astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(listTypeExpr).Build()))
 	newWatchBuilder.AddField("MakeEventHandler", eventHandler)
 
-	return newWatchBuilder.Build()
+	return newWatchBuilder.Build(), nil
 }

--- a/v2/tools/generator/internal/conversions/property_bag_member_type.go
+++ b/v2/tools/generator/internal/conversions/property_bag_member_type.go
@@ -6,11 +6,11 @@
 package conversions
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -61,8 +61,13 @@ func (b *PropertyBagMemberType) References() astmodel.TypeNameSet {
 }
 
 // AsType renders as our contained type
-func (b *PropertyBagMemberType) AsTypeExpr(ctx *astmodel.CodeGenerationContext) dst.Expr {
-	return b.element.AsTypeExpr(ctx)
+func (b *PropertyBagMemberType) AsTypeExpr(codeGenerationContext *astmodel.CodeGenerationContext) (dst.Expr, error) {
+	result, err := b.element.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating inner expression for property bag type")
+	}
+
+	return result, nil
 }
 
 // AsDeclarations panics because this is a metatype that will never be rendered

--- a/v2/tools/generator/internal/conversions/property_bag_member_type.go
+++ b/v2/tools/generator/internal/conversions/property_bag_member_type.go
@@ -61,8 +61,8 @@ func (b *PropertyBagMemberType) References() astmodel.TypeNameSet {
 }
 
 // AsType renders as our contained type
-func (b *PropertyBagMemberType) AsType(ctx *astmodel.CodeGenerationContext) dst.Expr {
-	return b.element.AsType(ctx)
+func (b *PropertyBagMemberType) AsTypeExpr(ctx *astmodel.CodeGenerationContext) dst.Expr {
+	return b.element.AsTypeExpr(ctx)
 }
 
 // AsDeclarations panics because this is a metatype that will never be rendered

--- a/v2/tools/generator/internal/conversions/property_conversions.go
+++ b/v2/tools/generator/internal/conversions/property_conversions.go
@@ -1474,18 +1474,18 @@ func assignMapFromMap(
 		itemId := loopLocals.CreateSingularLocal(sourceEndpoint.Name(), "Value")
 		keyId := loopLocals.CreateSingularLocal(sourceEndpoint.Name(), "Key")
 
-		keyTypeExpr, kerr := destinationMap.KeyType().AsTypeExpr(generationContext)
-		if kerr != nil {
+		keyTypeExpr, err := destinationMap.KeyType().AsTypeExpr(generationContext)
+		if err != nil {
 			return nil, errors.Wrapf(
-				kerr,
+				err,
 				"creating map key type expression for %s",
 				astmodel.DebugDescription(destinationMap.KeyType()))
 		}
 
-		valueTypeExpr, verr := destinationMap.ValueType().AsTypeExpr(generationContext)
-		if verr != nil {
+		valueTypeExpr, err := destinationMap.ValueType().AsTypeExpr(generationContext)
+		if err != nil {
 			return nil, errors.Wrapf(
-				verr,
+				err,
 				"creating map value type expression for %s",
 				astmodel.DebugDescription(destinationMap.ValueType()))
 		}

--- a/v2/tools/generator/internal/conversions/property_conversions.go
+++ b/v2/tools/generator/internal/conversions/property_conversions.go
@@ -522,7 +522,7 @@ func pullFromBagItem(
 		// var <local> <sourceBagItemType>
 		declare := astbuilder.NewVariableWithType(
 			local,
-			sourceBagItem.AsType(generationContext))
+			sourceBagItem.AsTypeExpr(generationContext))
 
 		// We're wrapping the conversion in a nested block, so any locals are independent
 		knownLocals = knownLocals.Clone()
@@ -790,7 +790,7 @@ func assignToEnumeration(
 		// Otherwise we just do a direct cast
 		castingWriter := func(expr dst.Expr) []dst.Stmt {
 			cast := &dst.CallExpr{
-				Fun:  dstName.AsType(generationContext),
+				Fun:  dstName.AsTypeExpr(generationContext),
 				Args: []dst.Expr{expr},
 			}
 			return writer(cast)
@@ -894,7 +894,7 @@ func assignAliasedPrimitiveFromAliasedPrimitive(
 		generationContext *astmodel.CodeGenerationContext,
 	) ([]dst.Stmt, error) {
 		return writer(&dst.CallExpr{
-			Fun:  destinationName.AsType(generationContext),
+			Fun:  destinationName.AsTypeExpr(generationContext),
 			Args: []dst.Expr{reader},
 		}), nil
 	}, nil
@@ -947,7 +947,7 @@ func assignFromAliasedType(
 		generationContext *astmodel.CodeGenerationContext,
 	) ([]dst.Stmt, error) {
 		actualReader := &dst.CallExpr{
-			Fun:  sourceType.AsType(generationContext),
+			Fun:  sourceType.AsTypeExpr(generationContext),
 			Args: []dst.Expr{reader},
 		}
 
@@ -1005,7 +1005,7 @@ func assignToAliasedType(
 	) ([]dst.Stmt, error) {
 		actualWriter := func(expr dst.Expr) []dst.Stmt {
 			castToAlias := &dst.CallExpr{
-				Fun:  destinationName.AsType(generationContext),
+				Fun:  destinationName.AsTypeExpr(generationContext),
 				Args: []dst.Expr{expr},
 			}
 
@@ -1291,7 +1291,7 @@ func assignArrayFromArray(
 
 		declaration := astbuilder.ShortDeclaration(
 			tempId,
-			astbuilder.MakeSlice(destinationArray.AsType(generationContext), astbuilder.CallFunc("len", actualReader)))
+			astbuilder.MakeSlice(destinationArray.AsTypeExpr(generationContext), astbuilder.CallFunc("len", actualReader)))
 
 		writeToElement := func(expr dst.Expr) []dst.Stmt {
 			return []dst.Stmt{
@@ -1435,8 +1435,8 @@ func assignMapFromMap(
 		declaration := astbuilder.ShortDeclaration(
 			tempId,
 			astbuilder.MakeMapWithCapacity(
-				destinationMap.KeyType().AsType(generationContext),
-				destinationMap.ValueType().AsType(generationContext),
+				destinationMap.KeyType().AsTypeExpr(generationContext),
+				destinationMap.ValueType().AsTypeExpr(generationContext),
 				astbuilder.CallFunc("len", actualReader)))
 
 		assignToItem := func(expr dst.Expr) []dst.Stmt {
@@ -1562,13 +1562,13 @@ func assignUserAssignedIdentityMapFromArray(
 		tempId := knownLocals.CreateSingularLocal(sourceEndpoint.Name(), "List")
 		declaration := astbuilder.ShortDeclaration(
 			tempId,
-			astbuilder.MakeEmptySlice(destinationArray.AsType(generationContext), astbuilder.CallFunc("len", reader)))
+			astbuilder.MakeEmptySlice(destinationArray.AsTypeExpr(generationContext), astbuilder.CallFunc("len", reader)))
 
 		loopLocals := knownLocals.Clone()
 		keyID := loopLocals.CreateLocal(sourceEndpoint.Name(), "Key")
 
 		intermediateDestination := loopLocals.CreateLocal(destinationEndpoint.Name(), "Ref")
-		uaiBuilder := astbuilder.NewCompositeLiteralBuilder(destinationElement.AsType(generationContext))
+		uaiBuilder := astbuilder.NewCompositeLiteralBuilder(destinationElement.AsTypeExpr(generationContext))
 		uaiBuilder.AddField("Reference", dst.NewIdent(intermediateDestination))
 
 		writeToElement := func(expr dst.Expr) []dst.Stmt {

--- a/v2/tools/generator/internal/functions/chained_conversion_function.go
+++ b/v2/tools/generator/internal/functions/chained_conversion_function.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
@@ -145,7 +146,7 @@ func (fn *ChainedConversionFunction) AsFunc(
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating parameter type expression for %s", parameterName)
 	}
-	
+
 	funcDetails.AddParameter(parameterName, parameterTypeExpr)
 
 	funcDetails.AddReturns("error")

--- a/v2/tools/generator/internal/functions/chained_conversion_function.go
+++ b/v2/tools/generator/internal/functions/chained_conversion_function.go
@@ -128,16 +128,17 @@ func (fn *ChainedConversionFunction) AsFunc(
 	receiverName := fn.idFactory.CreateReceiver(receiver.Name())
 
 	// We always use a pointer receiver, so we can modify it
-	receiverType := astmodel.NewOptionalType(receiver).AsTypeExpr(codeGenerationContext)
+	receiverExpr := astmodel.NewOptionalType(receiver).AsTypeExpr(codeGenerationContext)
 
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
-		ReceiverType:  receiverType,
+		ReceiverType:  receiverExpr,
 		Name:          fn.Name(),
 	}
 
 	parameterName := fn.direction.SelectString("source", "destination")
-	funcDetails.AddParameter(parameterName, fn.parameterType.AsTypeExpr(codeGenerationContext))
+	parameterTypeExpr := fn.parameterType.AsTypeExpr(codeGenerationContext)
+	funcDetails.AddParameter(parameterName, parameterTypeExpr)
 
 	funcDetails.AddReturns("error")
 	funcDetails.AddComments(fn.declarationDocComment(receiver, parameterName))

--- a/v2/tools/generator/internal/functions/chained_conversion_function.go
+++ b/v2/tools/generator/internal/functions/chained_conversion_function.go
@@ -128,7 +128,7 @@ func (fn *ChainedConversionFunction) AsFunc(
 	receiverName := fn.idFactory.CreateReceiver(receiver.Name())
 
 	// We always use a pointer receiver, so we can modify it
-	receiverType := astmodel.NewOptionalType(receiver).AsType(codeGenerationContext)
+	receiverType := astmodel.NewOptionalType(receiver).AsTypeExpr(codeGenerationContext)
 
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
@@ -137,7 +137,7 @@ func (fn *ChainedConversionFunction) AsFunc(
 	}
 
 	parameterName := fn.direction.SelectString("source", "destination")
-	funcDetails.AddParameter(parameterName, fn.parameterType.AsType(codeGenerationContext))
+	funcDetails.AddParameter(parameterName, fn.parameterType.AsTypeExpr(codeGenerationContext))
 
 	funcDetails.AddReturns("error")
 	funcDetails.AddComments(fn.declarationDocComment(receiver, parameterName))
@@ -178,7 +178,7 @@ func (fn *ChainedConversionFunction) bodyForConvert(
 	local := dst.NewIdent(fn.localVariableId())
 	errIdent := dst.NewIdent("err")
 
-	intermediateType := fn.propertyAssignmentParameterType.AsType(generationContext)
+	intermediateType := fn.propertyAssignmentParameterType.AsTypeExpr(generationContext)
 
 	// <local>, ok := <parameter>.(<intermediateType>)
 	typeAssert := astbuilder.TypeAssert(local, parameter, astbuilder.Dereference(intermediateType))

--- a/v2/tools/generator/internal/functions/common.go
+++ b/v2/tools/generator/internal/functions/common.go
@@ -47,16 +47,18 @@ func createBodyReturningValue(
 			receiverType = receiver
 		}
 
+		receiverExpr := receiverType.AsTypeExpr(codeGenerationContext)
 		fn := &astbuilder.FuncDetails{
 			Name:          methodName,
 			ReceiverIdent: receiverIdent,
-			ReceiverType:  receiverType.AsTypeExpr(codeGenerationContext),
+			ReceiverType:  receiverExpr,
 			Params:        nil,
 			Body:          astbuilder.Statements(astbuilder.Returns(result)),
 		}
 
 		fn.AddComments(comment)
-		fn.AddReturn(returnType.AsTypeExpr(codeGenerationContext))
+		returnTypeExpr := returnType.AsTypeExpr(codeGenerationContext)
+		fn.AddReturn(returnTypeExpr)
 
 		return fn.DefineFunc(), nil
 	}

--- a/v2/tools/generator/internal/functions/common.go
+++ b/v2/tools/generator/internal/functions/common.go
@@ -50,13 +50,13 @@ func createBodyReturningValue(
 		fn := &astbuilder.FuncDetails{
 			Name:          methodName,
 			ReceiverIdent: receiverIdent,
-			ReceiverType:  receiverType.AsType(codeGenerationContext),
+			ReceiverType:  receiverType.AsTypeExpr(codeGenerationContext),
 			Params:        nil,
 			Body:          astbuilder.Statements(astbuilder.Returns(result)),
 		}
 
 		fn.AddComments(comment)
-		fn.AddReturn(returnType.AsType(codeGenerationContext))
+		fn.AddReturn(returnType.AsTypeExpr(codeGenerationContext))
 
 		return fn.DefineFunc(), nil
 	}

--- a/v2/tools/generator/internal/functions/common.go
+++ b/v2/tools/generator/internal/functions/common.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -47,7 +48,11 @@ func createBodyReturningValue(
 			receiverType = receiver
 		}
 
-		receiverExpr := receiverType.AsTypeExpr(codeGenerationContext)
+		receiverExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating receiver expression for %s", receiverType)
+		}
+
 		fn := &astbuilder.FuncDetails{
 			Name:          methodName,
 			ReceiverIdent: receiverIdent,
@@ -57,7 +62,11 @@ func createBodyReturningValue(
 		}
 
 		fn.AddComments(comment)
-		returnTypeExpr := returnType.AsTypeExpr(codeGenerationContext)
+		returnTypeExpr, err := returnType.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating type expression for %s", returnType)
+		}
+
 		fn.AddReturn(returnTypeExpr)
 
 		return fn.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/conditions_functions.go
+++ b/v2/tools/generator/internal/functions/conditions_functions.go
@@ -6,8 +6,9 @@
 package functions
 
 import (
-	"github.com/pkg/errors"
 	"go/token"
+
+	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
 
@@ -48,7 +49,7 @@ func GetConditionsFunction(
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating type expression for %s", astmodel.ConditionsType)
 	}
-	
+
 	fn.AddReturn(conditionsTypeExpr)
 
 	return fn.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/conditions_functions.go
+++ b/v2/tools/generator/internal/functions/conditions_functions.go
@@ -26,21 +26,22 @@ func GetConditionsFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	status := astbuilder.Selector(dst.NewIdent(receiverIdent), "Status")
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body: []dst.Stmt{
 			astbuilder.Returns(astbuilder.Selector(status, astmodel.ConditionsProperty)),
 		},
 	}
 
 	fn.AddComments("returns the conditions of the resource")
-	fn.AddReturn(astmodel.ConditionsType.AsTypeExpr(codeGenerationContext))
+	conditionsTypeExpr := astmodel.ConditionsType.AsTypeExpr(codeGenerationContext)
+	fn.AddReturn(conditionsTypeExpr)
 
 	return fn.DefineFunc(), nil
 }
@@ -59,21 +60,22 @@ func SetConditionsFunction(
 	conditionsParameterName := k.IdFactory().CreateIdentifier(astmodel.ConditionsProperty, astmodel.NotExported)
 
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 	status := astbuilder.Selector(dst.NewIdent(receiverIdent), "Status")
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body: []dst.Stmt{
 			astbuilder.QualifiedAssignment(status, "Conditions", token.ASSIGN, dst.NewIdent(conditionsParameterName)),
 		},
 	}
 
+	conditionsTypeExpr := astmodel.ConditionsType.AsTypeExpr(codeGenerationContext)
 	fn.AddParameter(
 		conditionsParameterName,
-		astmodel.ConditionsType.AsTypeExpr(codeGenerationContext))
+		conditionsTypeExpr)
 	fn.AddComments("sets the conditions on the resource status")
 
 	return fn.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/conditions_functions.go
+++ b/v2/tools/generator/internal/functions/conditions_functions.go
@@ -8,9 +8,8 @@ package functions
 import (
 	"go/token"
 
-	"github.com/pkg/errors"
-
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"

--- a/v2/tools/generator/internal/functions/conditions_functions.go
+++ b/v2/tools/generator/internal/functions/conditions_functions.go
@@ -26,7 +26,7 @@ func GetConditionsFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	status := astbuilder.Selector(dst.NewIdent(receiverIdent), "Status")
 
@@ -40,7 +40,7 @@ func GetConditionsFunction(
 	}
 
 	fn.AddComments("returns the conditions of the resource")
-	fn.AddReturn(astmodel.ConditionsType.AsType(codeGenerationContext))
+	fn.AddReturn(astmodel.ConditionsType.AsTypeExpr(codeGenerationContext))
 
 	return fn.DefineFunc(), nil
 }
@@ -59,7 +59,7 @@ func SetConditionsFunction(
 	conditionsParameterName := k.IdFactory().CreateIdentifier(astmodel.ConditionsProperty, astmodel.NotExported)
 
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 	status := astbuilder.Selector(dst.NewIdent(receiverIdent), "Status")
 
 	fn := &astbuilder.FuncDetails{
@@ -73,7 +73,7 @@ func SetConditionsFunction(
 
 	fn.AddParameter(
 		conditionsParameterName,
-		astmodel.ConditionsType.AsType(codeGenerationContext))
+		astmodel.ConditionsType.AsTypeExpr(codeGenerationContext))
 	fn.AddComments("sets the conditions on the resource status")
 
 	return fn.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/conditions_functions.go
+++ b/v2/tools/generator/internal/functions/conditions_functions.go
@@ -6,6 +6,7 @@
 package functions
 
 import (
+	"github.com/pkg/errors"
 	"go/token"
 
 	"github.com/dave/dst"
@@ -26,7 +27,10 @@ func GetConditionsFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+	}
 
 	status := astbuilder.Selector(dst.NewIdent(receiverIdent), "Status")
 
@@ -40,7 +44,11 @@ func GetConditionsFunction(
 	}
 
 	fn.AddComments("returns the conditions of the resource")
-	conditionsTypeExpr := astmodel.ConditionsType.AsTypeExpr(codeGenerationContext)
+	conditionsTypeExpr, err := astmodel.ConditionsType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", astmodel.ConditionsType)
+	}
+	
 	fn.AddReturn(conditionsTypeExpr)
 
 	return fn.DefineFunc(), nil
@@ -60,7 +68,11 @@ func SetConditionsFunction(
 	conditionsParameterName := k.IdFactory().CreateIdentifier(astmodel.ConditionsProperty, astmodel.NotExported)
 
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+	}
+
 	status := astbuilder.Selector(dst.NewIdent(receiverIdent), "Status")
 
 	fn := &astbuilder.FuncDetails{
@@ -72,7 +84,11 @@ func SetConditionsFunction(
 		},
 	}
 
-	conditionsTypeExpr := astmodel.ConditionsType.AsTypeExpr(codeGenerationContext)
+	conditionsTypeExpr, err := astmodel.ConditionsType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to render type expression for %s", astmodel.ConditionsType)
+	}
+
 	fn.AddParameter(
 		conditionsParameterName,
 		conditionsTypeExpr)

--- a/v2/tools/generator/internal/functions/empty_status_function.go
+++ b/v2/tools/generator/internal/functions/empty_status_function.go
@@ -34,6 +34,7 @@ func createNewEmptyStatusFunction(
 	return func(f *ObjectFunction, genContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, _ string) (*dst.FuncDecl, error) {
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 		receiverType := astmodel.NewOptionalType(receiver)
+		receiverTypeExpr := receiverType.AsTypeExpr(genContext)
 
 		// When Storage variants are created from resources, any existing functions are copied across - which means
 		// the statusType we've been passed in above may be from the wrong package. We always want to use the status
@@ -44,14 +45,15 @@ func createNewEmptyStatusFunction(
 
 		fn := &astbuilder.FuncDetails{
 			ReceiverIdent: receiverIdent,
-			ReceiverType:  receiverType.AsTypeExpr(genContext),
+			ReceiverType:  receiverTypeExpr,
 			Name:          "NewEmptyStatus",
 			Body: astbuilder.Statements(
 				astbuilder.Returns(
 					astbuilder.AddrOf(literal))),
 		}
 
-		fn.AddReturn(astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(genContext))
+		convertibleStatusInterfaceExpr := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(genContext)
+		fn.AddReturn(convertibleStatusInterfaceExpr)
 		fn.AddComments("returns a new empty (blank) status")
 
 		return fn.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/empty_status_function.go
+++ b/v2/tools/generator/internal/functions/empty_status_function.go
@@ -44,14 +44,14 @@ func createNewEmptyStatusFunction(
 
 		fn := &astbuilder.FuncDetails{
 			ReceiverIdent: receiverIdent,
-			ReceiverType:  receiverType.AsType(genContext),
+			ReceiverType:  receiverType.AsTypeExpr(genContext),
 			Name:          "NewEmptyStatus",
 			Body: astbuilder.Statements(
 				astbuilder.Returns(
 					astbuilder.AddrOf(literal))),
 		}
 
-		fn.AddReturn(astmodel.ConvertibleStatusInterfaceType.AsType(genContext))
+		fn.AddReturn(astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(genContext))
 		fn.AddComments("returns a new empty (blank) status")
 
 		return fn.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/get_extended_resources_function.go
+++ b/v2/tools/generator/internal/functions/get_extended_resources_function.go
@@ -101,16 +101,18 @@ func (ext *GetExtendedResourcesFunction) AsFunc(
 
 	// Iterate through the resourceType versions and add them to the KubernetesResource literal slice
 	for _, resource := range ext.resources {
-		expr := astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(resource.AsTypeExpr(codeGenerationContext)).Build())
+		resourceExpr := resource.AsTypeExpr(codeGenerationContext)
+		expr := astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(resourceExpr).Build())
 		expr.Decs.Before = dst.NewLine
 		krLiteral.Elts = append(krLiteral.Elts, expr)
 	}
 
 	receiverName := ext.idFactory.CreateReceiver(receiver.Name())
-
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
-		ReceiverType:  astbuilder.PointerTo(receiver.AsTypeExpr(codeGenerationContext)),
+		ReceiverType:  astbuilder.PointerTo(receiverType),
 		Name:          ExtendedResourcesFunctionName,
 		Body:          astbuilder.Statements(astbuilder.Returns(krLiteral)),
 	}

--- a/v2/tools/generator/internal/functions/get_extended_resources_function.go
+++ b/v2/tools/generator/internal/functions/get_extended_resources_function.go
@@ -6,8 +6,9 @@
 package functions
 
 import (
-	"github.com/pkg/errors"
 	"reflect"
+
+	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
 	"golang.org/x/exp/slices"
@@ -106,7 +107,8 @@ func (ext *GetExtendedResourcesFunction) AsFunc(
 
 	// Iterate through the resourceType versions and add them to the KubernetesResource literal slice
 	for _, resource := range ext.resources {
-		resourceExpr, err := resource.AsTypeExpr(codeGenerationContext)
+		var resourceExpr dst.Expr
+		resourceExpr, err = resource.AsTypeExpr(codeGenerationContext)
 		if err != nil {
 			return nil, errors.Wrapf(err, "creating type expression for %s", resource)
 		}

--- a/v2/tools/generator/internal/functions/get_extended_resources_function.go
+++ b/v2/tools/generator/internal/functions/get_extended_resources_function.go
@@ -6,6 +6,7 @@
 package functions
 
 import (
+	"github.com/pkg/errors"
 	"reflect"
 
 	"github.com/dave/dst"
@@ -96,20 +97,31 @@ func (ext *GetExtendedResourcesFunction) AsFunc(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	receiver astmodel.InternalTypeName,
 ) (*dst.FuncDecl, error) {
-	krType := astmodel.NewArrayType(astmodel.KubernetesResourceType).AsTypeExpr(codeGenerationContext)
+	krType, err := astmodel.NewArrayType(astmodel.KubernetesResourceType).AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", astmodel.KubernetesResourceType)
+	}
+
 	krLiteral := astbuilder.NewCompositeLiteralBuilder(krType).Build()
 
 	// Iterate through the resourceType versions and add them to the KubernetesResource literal slice
 	for _, resource := range ext.resources {
-		resourceExpr := resource.AsTypeExpr(codeGenerationContext)
+		resourceExpr, err := resource.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating type expression for %s", resource)
+		}
+
 		expr := astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(resourceExpr).Build())
 		expr.Decs.Before = dst.NewLine
 		krLiteral.Elts = append(krLiteral.Elts, expr)
 	}
 
 	receiverName := ext.idFactory.CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
-	
+	receiverType, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+	}
+
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
 		ReceiverType:  astbuilder.PointerTo(receiverType),

--- a/v2/tools/generator/internal/functions/get_extended_resources_function.go
+++ b/v2/tools/generator/internal/functions/get_extended_resources_function.go
@@ -96,12 +96,12 @@ func (ext *GetExtendedResourcesFunction) AsFunc(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	receiver astmodel.InternalTypeName,
 ) (*dst.FuncDecl, error) {
-	krType := astmodel.NewArrayType(astmodel.KubernetesResourceType).AsType(codeGenerationContext)
+	krType := astmodel.NewArrayType(astmodel.KubernetesResourceType).AsTypeExpr(codeGenerationContext)
 	krLiteral := astbuilder.NewCompositeLiteralBuilder(krType).Build()
 
 	// Iterate through the resourceType versions and add them to the KubernetesResource literal slice
 	for _, resource := range ext.resources {
-		expr := astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(resource.AsType(codeGenerationContext)).Build())
+		expr := astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(resource.AsTypeExpr(codeGenerationContext)).Build())
 		expr.Decs.Before = dst.NewLine
 		krLiteral.Elts = append(krLiteral.Elts, expr)
 	}
@@ -110,7 +110,7 @@ func (ext *GetExtendedResourcesFunction) AsFunc(
 
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
-		ReceiverType:  astbuilder.PointerTo(receiver.AsType(codeGenerationContext)),
+		ReceiverType:  astbuilder.PointerTo(receiver.AsTypeExpr(codeGenerationContext)),
 		Name:          ExtendedResourcesFunctionName,
 		Body:          astbuilder.Statements(astbuilder.Returns(krLiteral)),
 	}

--- a/v2/tools/generator/internal/functions/get_spec_function.go
+++ b/v2/tools/generator/internal/functions/get_spec_function.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -27,7 +28,10 @@ func createGetSpecFunction(
 ) (*dst.FuncDecl, error) {
 	receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
-	receiverTypeExpr := receiverType.AsTypeExpr(genContext)
+	receiverTypeExpr, err := receiverType.AsTypeExpr(genContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	ret := astbuilder.Returns(astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec")))
 
@@ -38,7 +42,11 @@ func createGetSpecFunction(
 		Body:          astbuilder.Statements(ret),
 	}
 
-	convertibleSpecInterfaceExpr := astmodel.ConvertibleSpecInterfaceType.AsTypeExpr(genContext)
+	convertibleSpecInterfaceExpr, err := astmodel.ConvertibleSpecInterfaceType.AsTypeExpr(genContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating type expression for ConvertibleSpecInterface")
+	}
+	
 	fn.AddReturn(convertibleSpecInterfaceExpr)
 	fn.AddComments("returns the specification of this resource")
 

--- a/v2/tools/generator/internal/functions/get_spec_function.go
+++ b/v2/tools/generator/internal/functions/get_spec_function.go
@@ -27,17 +27,19 @@ func createGetSpecFunction(
 ) (*dst.FuncDecl, error) {
 	receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
+	receiverTypeExpr := receiverType.AsTypeExpr(genContext)
 
 	ret := astbuilder.Returns(astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec")))
 
 	fn := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  receiverType.AsTypeExpr(genContext),
+		ReceiverType:  receiverTypeExpr,
 		Name:          "GetSpec",
 		Body:          astbuilder.Statements(ret),
 	}
 
-	fn.AddReturn(astmodel.ConvertibleSpecInterfaceType.AsTypeExpr(genContext))
+	convertibleSpecInterfaceExpr := astmodel.ConvertibleSpecInterfaceType.AsTypeExpr(genContext)
+	fn.AddReturn(convertibleSpecInterfaceExpr)
 	fn.AddComments("returns the specification of this resource")
 
 	return fn.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/get_spec_function.go
+++ b/v2/tools/generator/internal/functions/get_spec_function.go
@@ -46,7 +46,7 @@ func createGetSpecFunction(
 	if err != nil {
 		return nil, errors.Wrap(err, "creating type expression for ConvertibleSpecInterface")
 	}
-	
+
 	fn.AddReturn(convertibleSpecInterfaceExpr)
 	fn.AddComments("returns the specification of this resource")
 

--- a/v2/tools/generator/internal/functions/get_spec_function.go
+++ b/v2/tools/generator/internal/functions/get_spec_function.go
@@ -32,12 +32,12 @@ func createGetSpecFunction(
 
 	fn := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  receiverType.AsType(genContext),
+		ReceiverType:  receiverType.AsTypeExpr(genContext),
 		Name:          "GetSpec",
 		Body:          astbuilder.Statements(ret),
 	}
 
-	fn.AddReturn(astmodel.ConvertibleSpecInterfaceType.AsType(genContext))
+	fn.AddReturn(astmodel.ConvertibleSpecInterfaceType.AsTypeExpr(genContext))
 	fn.AddComments("returns the specification of this resource")
 
 	return fn.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/get_status_function.go
+++ b/v2/tools/generator/internal/functions/get_status_function.go
@@ -30,14 +30,14 @@ func createGetStatusFunction(
 
 	fn := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  receiverType.AsType(genContext),
+		ReceiverType:  receiverType.AsTypeExpr(genContext),
 		Name:          "GetStatus",
 		Body: astbuilder.Statements(
 			astbuilder.Returns(
 				astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(receiverIdent), "Status")))),
 	}
 
-	fn.AddReturn(astmodel.ConvertibleStatusInterfaceType.AsType(genContext))
+	fn.AddReturn(astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(genContext))
 	fn.AddComments("returns the status of this resource")
 
 	return fn.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/get_status_function.go
+++ b/v2/tools/generator/internal/functions/get_status_function.go
@@ -27,17 +27,19 @@ func createGetStatusFunction(
 ) (*dst.FuncDecl, error) {
 	receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
+	receiverTypeExpr := receiverType.AsTypeExpr(genContext)
 
 	fn := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  receiverType.AsTypeExpr(genContext),
+		ReceiverType:  receiverTypeExpr,
 		Name:          "GetStatus",
 		Body: astbuilder.Statements(
 			astbuilder.Returns(
 				astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(receiverIdent), "Status")))),
 	}
 
-	fn.AddReturn(astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(genContext))
+	convertibleStatusInterfaceExpr := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(genContext)
+	fn.AddReturn(convertibleStatusInterfaceExpr)
 	fn.AddComments("returns the status of this resource")
 
 	return fn.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/get_status_function.go
+++ b/v2/tools/generator/internal/functions/get_status_function.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -27,7 +28,10 @@ func createGetStatusFunction(
 ) (*dst.FuncDecl, error) {
 	receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
-	receiverTypeExpr := receiverType.AsTypeExpr(genContext)
+	receiverTypeExpr, err := receiverType.AsTypeExpr(genContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	fn := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverIdent,
@@ -38,7 +42,11 @@ func createGetStatusFunction(
 				astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(receiverIdent), "Status")))),
 	}
 
-	convertibleStatusInterfaceExpr := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(genContext)
+	convertibleStatusInterfaceExpr, err := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(genContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating type expression for ConvertibleStatusInterface")
+	}
+
 	fn.AddReturn(convertibleStatusInterfaceExpr)
 	fn.AddComments("returns the status of this resource")
 

--- a/v2/tools/generator/internal/functions/hub_function.go
+++ b/v2/tools/generator/internal/functions/hub_function.go
@@ -7,9 +7,9 @@ package functions
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"

--- a/v2/tools/generator/internal/functions/hub_function.go
+++ b/v2/tools/generator/internal/functions/hub_function.go
@@ -34,7 +34,7 @@ func createHubFunctionBody(
 	receiverName := fn.IdFactory().CreateReceiver(receiver.Name())
 
 	// We always use a pointer receiver
-	receiverType := astmodel.NewOptionalType(receiver).AsType(genContext)
+	receiverType := astmodel.NewOptionalType(receiver).AsTypeExpr(genContext)
 
 	details := astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,

--- a/v2/tools/generator/internal/functions/hub_function.go
+++ b/v2/tools/generator/internal/functions/hub_function.go
@@ -34,11 +34,12 @@ func createHubFunctionBody(
 	receiverName := fn.IdFactory().CreateReceiver(receiver.Name())
 
 	// We always use a pointer receiver
-	receiverType := astmodel.NewOptionalType(receiver).AsTypeExpr(genContext)
+	receiverType := astmodel.NewOptionalType(receiver)
+	receiverTypeExpr := receiverType.AsTypeExpr(genContext)
 
 	details := astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
-		ReceiverType:  receiverType,
+		ReceiverType:  receiverTypeExpr,
 		Name:          methodName,
 		Body:          []dst.Stmt{}, // empty body
 	}

--- a/v2/tools/generator/internal/functions/hub_function.go
+++ b/v2/tools/generator/internal/functions/hub_function.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
 
@@ -35,7 +36,10 @@ func createHubFunctionBody(
 
 	// We always use a pointer receiver
 	receiverType := astmodel.NewOptionalType(receiver)
-	receiverTypeExpr := receiverType.AsTypeExpr(genContext)
+	receiverTypeExpr, err := receiverType.AsTypeExpr(genContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	details := astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,

--- a/v2/tools/generator/internal/functions/index_registration_function.go
+++ b/v2/tools/generator/internal/functions/index_registration_function.go
@@ -86,7 +86,11 @@ func (f *IndexRegistrationFunction) AsFunc(
 	objName := "obj"
 
 	// obj, ok := rawObj.(*<type>)
-	resourceTypeNameExpr := f.resourceTypeName.AsTypeExpr(codeGenerationContext)
+	resourceTypeNameExpr, err := f.resourceTypeName.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", f.resourceTypeName)
+	}
+	
 	cast := astbuilder.TypeAssert(
 		dst.NewIdent(objName),
 		dst.NewIdent(rawObjName),
@@ -115,7 +119,11 @@ func (f *IndexRegistrationFunction) AsFunc(
 			stmts),
 	}
 
-	controllerRuntimeObjectExpr := astmodel.ControllerRuntimeObjectType.AsTypeExpr(codeGenerationContext)
+	controllerRuntimeObjectExpr, err := astmodel.ControllerRuntimeObjectType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating type expression for index registration function")
+	}
+
 	fn.AddParameter(rawObjName, controllerRuntimeObjectExpr)
 
 	fn.AddReturn(&dst.ArrayType{Elt: dst.NewIdent("string")})

--- a/v2/tools/generator/internal/functions/index_registration_function.go
+++ b/v2/tools/generator/internal/functions/index_registration_function.go
@@ -90,7 +90,7 @@ func (f *IndexRegistrationFunction) AsFunc(
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating type expression for %s", f.resourceTypeName)
 	}
-	
+
 	cast := astbuilder.TypeAssert(
 		dst.NewIdent(objName),
 		dst.NewIdent(rawObjName),
@@ -104,7 +104,6 @@ func (f *IndexRegistrationFunction) AsFunc(
 	if f.isIndexSingleValue() {
 		stmts = f.singleValue(specSelector)
 	} else {
-		var err error
 		stmts, err = f.multipleValues(specSelector)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to generate multiple value index registration function for %s", f.resourceTypeName)

--- a/v2/tools/generator/internal/functions/index_registration_function.go
+++ b/v2/tools/generator/internal/functions/index_registration_function.go
@@ -86,10 +86,11 @@ func (f *IndexRegistrationFunction) AsFunc(
 	objName := "obj"
 
 	// obj, ok := rawObj.(*<type>)
+	resourceTypeNameExpr := f.resourceTypeName.AsTypeExpr(codeGenerationContext)
 	cast := astbuilder.TypeAssert(
 		dst.NewIdent(objName),
 		dst.NewIdent(rawObjName),
-		astbuilder.PointerTo(f.resourceTypeName.AsTypeExpr(codeGenerationContext)))
+		astbuilder.PointerTo(resourceTypeNameExpr))
 
 	// if !ok { return nil }
 	checkAssert := astbuilder.ReturnIfNotOk(astbuilder.Nil())
@@ -114,7 +115,8 @@ func (f *IndexRegistrationFunction) AsFunc(
 			stmts),
 	}
 
-	fn.AddParameter(rawObjName, astmodel.ControllerRuntimeObjectType.AsTypeExpr(codeGenerationContext))
+	controllerRuntimeObjectExpr := astmodel.ControllerRuntimeObjectType.AsTypeExpr(codeGenerationContext)
+	fn.AddParameter(rawObjName, controllerRuntimeObjectExpr)
 
 	fn.AddReturn(&dst.ArrayType{Elt: dst.NewIdent("string")})
 

--- a/v2/tools/generator/internal/functions/index_registration_function.go
+++ b/v2/tools/generator/internal/functions/index_registration_function.go
@@ -89,7 +89,7 @@ func (f *IndexRegistrationFunction) AsFunc(
 	cast := astbuilder.TypeAssert(
 		dst.NewIdent(objName),
 		dst.NewIdent(rawObjName),
-		astbuilder.PointerTo(f.resourceTypeName.AsType(codeGenerationContext)))
+		astbuilder.PointerTo(f.resourceTypeName.AsTypeExpr(codeGenerationContext)))
 
 	// if !ok { return nil }
 	checkAssert := astbuilder.ReturnIfNotOk(astbuilder.Nil())
@@ -114,7 +114,7 @@ func (f *IndexRegistrationFunction) AsFunc(
 			stmts),
 	}
 
-	fn.AddParameter(rawObjName, astmodel.ControllerRuntimeObjectType.AsType(codeGenerationContext))
+	fn.AddParameter(rawObjName, astmodel.ControllerRuntimeObjectType.AsTypeExpr(codeGenerationContext))
 
 	fn.AddReturn(&dst.ArrayType{Elt: dst.NewIdent("string")})
 

--- a/v2/tools/generator/internal/functions/initialize_spec_function.go
+++ b/v2/tools/generator/internal/functions/initialize_spec_function.go
@@ -48,7 +48,11 @@ func NewInitializeSpecFunction(
 	) (*dst.FuncDecl, error) {
 		fmtPackage := codeGenerationContext.MustGetImportedPackageName(astmodel.FmtReference)
 
-		receiverType := receiver.AsTypeExpr(codeGenerationContext)
+		receiverType, err := receiver.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+		}
+
 		receiverName := idFactory.CreateReceiver(receiver.Name())
 
 		knownLocals := astmodel.NewKnownLocalsSet(idFactory)
@@ -67,7 +71,11 @@ func NewInitializeSpecFunction(
 		// if s, ok := fromStatus.(<type of status>); ok {
 		//   return receiver.Spec.InitializeFromStatus(s)
 		// }
-		statusTypeExpr := statusType.AsTypeExpr(codeGenerationContext)
+		statusTypeExpr, err := statusType.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating type expression for status %s", statusType)
+		}
+
 		initialize := astbuilder.IfType(
 			dst.NewIdent(statusParam),
 			astbuilder.Dereference(statusTypeExpr),
@@ -92,7 +100,11 @@ func NewInitializeSpecFunction(
 		}
 
 		funcDetails.AddComments("initializes the spec for this resource from the given status")
-		convertibleStatusInterfaceExpr := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(codeGenerationContext)
+		convertibleStatusInterfaceExpr, err := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrapf(err, "creating type expression for %s", astmodel.ConvertibleStatusInterfaceType)
+		}
+
 		funcDetails.AddParameter(statusParam, convertibleStatusInterfaceExpr)
 		funcDetails.AddReturns("error")
 

--- a/v2/tools/generator/internal/functions/initialize_spec_function.go
+++ b/v2/tools/generator/internal/functions/initialize_spec_function.go
@@ -67,9 +67,10 @@ func NewInitializeSpecFunction(
 		// if s, ok := fromStatus.(<type of status>); ok {
 		//   return receiver.Spec.InitializeFromStatus(s)
 		// }
+		statusTypeExpr := statusType.AsTypeExpr(codeGenerationContext)
 		initialize := astbuilder.IfType(
 			dst.NewIdent(statusParam),
-			astbuilder.Dereference(statusType.AsTypeExpr(codeGenerationContext)),
+			astbuilder.Dereference(statusTypeExpr),
 			statusLocal,
 			returnConversion)
 
@@ -91,7 +92,8 @@ func NewInitializeSpecFunction(
 		}
 
 		funcDetails.AddComments("initializes the spec for this resource from the given status")
-		funcDetails.AddParameter(statusParam, astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(codeGenerationContext))
+		convertibleStatusInterfaceExpr := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(codeGenerationContext)
+		funcDetails.AddParameter(statusParam, convertibleStatusInterfaceExpr)
 		funcDetails.AddReturns("error")
 
 		return funcDetails.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/initialize_spec_function.go
+++ b/v2/tools/generator/internal/functions/initialize_spec_function.go
@@ -48,7 +48,7 @@ func NewInitializeSpecFunction(
 	) (*dst.FuncDecl, error) {
 		fmtPackage := codeGenerationContext.MustGetImportedPackageName(astmodel.FmtReference)
 
-		receiverType := receiver.AsType(codeGenerationContext)
+		receiverType := receiver.AsTypeExpr(codeGenerationContext)
 		receiverName := idFactory.CreateReceiver(receiver.Name())
 
 		knownLocals := astmodel.NewKnownLocalsSet(idFactory)
@@ -69,7 +69,7 @@ func NewInitializeSpecFunction(
 		// }
 		initialize := astbuilder.IfType(
 			dst.NewIdent(statusParam),
-			astbuilder.Dereference(statusType.AsType(codeGenerationContext)),
+			astbuilder.Dereference(statusType.AsTypeExpr(codeGenerationContext)),
 			statusLocal,
 			returnConversion)
 
@@ -91,7 +91,7 @@ func NewInitializeSpecFunction(
 		}
 
 		funcDetails.AddComments("initializes the spec for this resource from the given status")
-		funcDetails.AddParameter(statusParam, astmodel.ConvertibleStatusInterfaceType.AsType(codeGenerationContext))
+		funcDetails.AddParameter(statusParam, astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(codeGenerationContext))
 		funcDetails.AddReturns("error")
 
 		return funcDetails.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
@@ -7,10 +7,10 @@ package functions
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
@@ -112,7 +112,7 @@ func (d *DefaulterBuilder) localDefault(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	defaults := make([]dst.Stmt, 0, len(d.defaults))
 	for _, def := range d.defaults {
@@ -124,7 +124,7 @@ func (d *DefaulterBuilder) localDefault(
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body:          defaults,
 	}
 

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
@@ -112,7 +112,7 @@ func (d *DefaulterBuilder) localDefault(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	defaults := make([]dst.Stmt, 0, len(d.defaults))
 	for _, def := range d.defaults {
@@ -139,11 +139,11 @@ func (d *DefaulterBuilder) defaultFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 	tempVarIdent := "temp"
 	runtimeDefaulterIdent := "runtimeDefaulter"
 
-	overrideInterfaceType := astmodel.GenRuntimeDefaulterInterfaceName.AsType(codeGenerationContext)
+	overrideInterfaceType := astmodel.GenRuntimeDefaulterInterfaceName.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/dave/dst"
@@ -112,7 +113,10 @@ func (d *DefaulterBuilder) localDefault(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	defaults := make([]dst.Stmt, 0, len(d.defaults))
 	for _, def := range d.defaults {
@@ -139,11 +143,18 @@ func (d *DefaulterBuilder) defaultFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverType, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
+
 	tempVarIdent := "temp"
 	runtimeDefaulterIdent := "runtimeDefaulter"
 
-	overrideInterfaceType := astmodel.GenRuntimeDefaulterInterfaceName.AsTypeExpr(codeGenerationContext)
+	overrideInterfaceType, err := astmodel.GenRuntimeDefaulterInterfaceName.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating runtime defaulter interface type expression for method %s", methodName)
+	}
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaults.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaults.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -31,7 +32,10 @@ func defaultAzureNameFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	azureNameProp := astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec", astmodel.AzureNameProperty)
 	nameProp := astbuilder.Selector(dst.NewIdent(receiverIdent), "Name")

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaults.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaults.go
@@ -31,7 +31,7 @@ func defaultAzureNameFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	azureNameProp := astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec", astmodel.AzureNameProperty)
 	nameProp := astbuilder.Selector(dst.NewIdent(receiverIdent), "Name")
@@ -39,7 +39,7 @@ func defaultAzureNameFunction(
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body: astbuilder.Statements(
 			astbuilder.IfEqual(
 				azureNameProp,

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaults.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaults.go
@@ -31,7 +31,7 @@ func defaultAzureNameFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	azureNameProp := astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec", astmodel.AzureNameProperty)
 	nameProp := astbuilder.Selector(dst.NewIdent(receiverIdent), "Name")

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
@@ -6,6 +6,7 @@
 package functions
 
 import (
+	"github.com/pkg/errors"
 	"go/token"
 
 	"github.com/dave/dst"
@@ -57,7 +58,10 @@ func validateResourceReferences(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
@@ -113,7 +117,10 @@ func validateOwnerReferences(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating receiver type expression for %s", receiver)
+	}
 
 	admissionPkg := codeGenerationContext.MustGetImportedPackageName(astmodel.ControllerRuntimeAdmission)
 
@@ -156,7 +163,10 @@ func validateWriteOncePropertiesFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := resourceFn.IdFactory().CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating receiver type expression for %s", receiver)
+	}
 
 	runtimePackage := codeGenerationContext.MustGetImportedPackageName(astmodel.APIMachineryRuntimeReference)
 
@@ -213,7 +223,10 @@ func validateOptionalConfigMapReferences(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
@@ -57,7 +57,7 @@ func validateResourceReferences(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
@@ -113,7 +113,7 @@ func validateOwnerReferences(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	admissionPkg := codeGenerationContext.MustGetImportedPackageName(astmodel.ControllerRuntimeAdmission)
 
@@ -156,7 +156,7 @@ func validateWriteOncePropertiesFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := resourceFn.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	runtimePackage := codeGenerationContext.MustGetImportedPackageName(astmodel.APIMachineryRuntimeReference)
 
@@ -188,7 +188,7 @@ func validateWriteOncePropertiesFunctionBody(receiver astmodel.TypeName, codeGen
 
 	obj := dst.NewIdent("oldObj")
 
-	cast := astbuilder.TypeAssert(obj, dst.NewIdent("old"), astbuilder.PointerTo(receiver.AsType(codeGenerationContext)))
+	cast := astbuilder.TypeAssert(obj, dst.NewIdent("old"), astbuilder.PointerTo(receiver.AsTypeExpr(codeGenerationContext)))
 	checkAssert := astbuilder.ReturnIfNotOk(astbuilder.Nil(), astbuilder.Nil())
 
 	returnStmt := astbuilder.Returns(
@@ -212,7 +212,7 @@ func validateOptionalConfigMapReferences(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
@@ -6,10 +6,10 @@
 package functions
 
 import (
-	"github.com/pkg/errors"
 	"go/token"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
@@ -57,12 +57,12 @@ func validateResourceReferences(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body:          validateResourceReferencesBody(codeGenerationContext, receiverIdent),
 	}
 
@@ -113,14 +113,14 @@ func validateOwnerReferences(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	admissionPkg := codeGenerationContext.MustGetImportedPackageName(astmodel.ControllerRuntimeAdmission)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body:          validateOwnerReferencesBody(codeGenerationContext, receiverIdent),
 	}
 
@@ -156,14 +156,14 @@ func validateWriteOncePropertiesFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := resourceFn.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	runtimePackage := codeGenerationContext.MustGetImportedPackageName(astmodel.APIMachineryRuntimeReference)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body:          validateWriteOncePropertiesFunctionBody(receiver, codeGenerationContext, receiverIdent),
 	}
 
@@ -188,7 +188,8 @@ func validateWriteOncePropertiesFunctionBody(receiver astmodel.TypeName, codeGen
 
 	obj := dst.NewIdent("oldObj")
 
-	cast := astbuilder.TypeAssert(obj, dst.NewIdent("old"), astbuilder.PointerTo(receiver.AsTypeExpr(codeGenerationContext)))
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	cast := astbuilder.TypeAssert(obj, dst.NewIdent("old"), astbuilder.PointerTo(receiverExpr))
 	checkAssert := astbuilder.ReturnIfNotOk(astbuilder.Nil(), astbuilder.Nil())
 
 	returnStmt := astbuilder.Returns(
@@ -212,12 +213,12 @@ func validateOptionalConfigMapReferences(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body:          validateOptionalConfigMapReferencesBody(codeGenerationContext, receiverIdent),
 	}
 

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
@@ -157,7 +157,7 @@ func (v *ValidatorBuilder) validateCreate(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
@@ -186,7 +186,7 @@ func (v *ValidatorBuilder) validateUpdate(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	retType := getValidationFuncType(ValidationKindUpdate, codeGenerationContext)
 
@@ -217,7 +217,7 @@ func (v *ValidatorBuilder) validateDelete(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
@@ -256,7 +256,7 @@ func (v *ValidatorBuilder) validateBody(
 	validationFunctionName string,
 	funcParamIdent string,
 ) []dst.Stmt {
-	overrideInterfaceType := astmodel.GenRuntimeValidatorInterfaceName.AsType(codeGenerationContext)
+	overrideInterfaceType := astmodel.GenRuntimeValidatorInterfaceName.AsTypeExpr(codeGenerationContext)
 
 	validationsIdent := "validations"
 	tempVarIdent := "temp"
@@ -346,7 +346,7 @@ func (v *ValidatorBuilder) makeLocalValidationFuncDetails(
 	methodName string,
 ) (*astbuilder.FuncDetails, error) {
 	receiverIdent := v.idFactory.CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	body, err := v.localValidationFuncBody(kind, codeGenerationContext, receiver)
 	if err != nil {

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
@@ -162,17 +162,22 @@ func (v *ValidatorBuilder) validateCreate(
 		return nil, errors.Wrap(err, "creating receiver type expression")
 	}
 
+	body, err := v.validateBody(
+		codeGenerationContext,
+		receiverIdent,
+		"createValidations",
+		"CreateValidations",
+		"ValidateCreate",
+		"")
+	if err != nil {
+		return nil, errors.Wrap(err, "creating validation body")
+	}
+
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
 		ReceiverType:  astbuilder.PointerTo(receiverExpr),
-		Body: v.validateBody(
-			codeGenerationContext,
-			receiverIdent,
-			"createValidations",
-			"CreateValidations",
-			"ValidateCreate",
-			""),
+		Body:          body,
 	}
 
 	fn.AddReturn(astbuilder.QualifiedTypeName(codeGenerationContext.MustGetImportedPackageName(astmodel.ControllerRuntimeAdmission), "Warnings"))
@@ -196,19 +201,24 @@ func (v *ValidatorBuilder) validateUpdate(
 
 	retType := getValidationFuncType(ValidationKindUpdate, codeGenerationContext)
 
+	body, err := v.validateBody(
+		codeGenerationContext,
+		receiverIdent,
+		"updateValidations",
+		"UpdateValidations",
+		"ValidateUpdate",
+		"old")
+	if err != nil {
+		return nil, errors.Wrap(err, "creating validation body")
+	}
+
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		Params:        retType.Params.List,
 		ReceiverIdent: receiverIdent,
 		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Returns:       retType.Results.List,
-		Body: v.validateBody(
-			codeGenerationContext,
-			receiverIdent,
-			"updateValidations",
-			"UpdateValidations",
-			"ValidateUpdate",
-			"old"),
+		Body:          body,
 	}
 
 	fn.AddComments("validates an update of the resource")
@@ -228,17 +238,22 @@ func (v *ValidatorBuilder) validateDelete(
 		return nil, errors.Wrap(err, "creating receiver type expression")
 	}
 
+	body, err := v.validateBody(
+		codeGenerationContext,
+		receiverIdent,
+		"deleteValidations",
+		"DeleteValidations",
+		"ValidateDelete",
+		"")
+	if err != nil {
+		return nil, errors.Wrap(err, "creating validation body")
+	}
+
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
 		ReceiverType:  astbuilder.PointerTo(receiverExpr),
-		Body: v.validateBody(
-			codeGenerationContext,
-			receiverIdent,
-			"deleteValidations",
-			"DeleteValidations",
-			"ValidateDelete",
-			""),
+		Body:          body,
 	}
 
 	fn.AddReturn(astbuilder.QualifiedTypeName(codeGenerationContext.MustGetImportedPackageName(astmodel.ControllerRuntimeAdmission), "Warnings"))
@@ -264,8 +279,11 @@ func (v *ValidatorBuilder) validateBody(
 	overrideFunctionName string,
 	validationFunctionName string,
 	funcParamIdent string,
-) []dst.Stmt {
-	overrideInterfaceType := astmodel.GenRuntimeValidatorInterfaceName.AsTypeExpr(codeGenerationContext)
+) ([]dst.Stmt, error) {
+	overrideInterfaceType, err := astmodel.GenRuntimeValidatorInterfaceName.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", astmodel.GenRuntimeValidatorInterfaceName)
+	}
 
 	validationsIdent := "validations"
 	tempVarIdent := "temp"
@@ -297,7 +315,7 @@ func (v *ValidatorBuilder) validateBody(
 		astbuilder.Returns(astbuilder.CallQualifiedFunc(astmodel.GenRuntimeReference.PackageName(), validationFunctionName, args...)),
 	)
 
-	return body
+	return body, nil
 }
 
 func (v *ValidatorBuilder) localCreateValidations(
@@ -382,7 +400,7 @@ func (v *ValidatorBuilder) makeLocalValidationFuncDetails(
 
 // localValidationFuncBody returns the body of the local (code generated) validation functions:
 //
-//	return []func() error{
+//	return []func() error {
 //		<receiver>.<validationFunc1>,
 //		<receiver>.<validationFunc2>,
 //		...

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
@@ -157,7 +157,10 @@ func (v *ValidatorBuilder) validateCreate(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
@@ -186,7 +189,10 @@ func (v *ValidatorBuilder) validateUpdate(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	retType := getValidationFuncType(ValidationKindUpdate, codeGenerationContext)
 
@@ -217,7 +223,10 @@ func (v *ValidatorBuilder) validateDelete(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
@@ -346,7 +355,10 @@ func (v *ValidatorBuilder) makeLocalValidationFuncDetails(
 	methodName string,
 ) (*astbuilder.FuncDetails, error) {
 	receiverIdent := v.idFactory.CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	body, err := v.localValidationFuncBody(kind, codeGenerationContext, receiver)
 	if err != nil {

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
@@ -157,12 +157,12 @@ func (v *ValidatorBuilder) validateCreate(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body: v.validateBody(
 			codeGenerationContext,
 			receiverIdent,
@@ -186,7 +186,7 @@ func (v *ValidatorBuilder) validateUpdate(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	retType := getValidationFuncType(ValidationKindUpdate, codeGenerationContext)
 
@@ -194,7 +194,7 @@ func (v *ValidatorBuilder) validateUpdate(
 		Name:          methodName,
 		Params:        retType.Params.List,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Returns:       retType.Results.List,
 		Body: v.validateBody(
 			codeGenerationContext,
@@ -217,12 +217,12 @@ func (v *ValidatorBuilder) validateDelete(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body: v.validateBody(
 			codeGenerationContext,
 			receiverIdent,
@@ -346,7 +346,7 @@ func (v *ValidatorBuilder) makeLocalValidationFuncDetails(
 	methodName string,
 ) (*astbuilder.FuncDetails, error) {
 	receiverIdent := v.idFactory.CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	body, err := v.localValidationFuncBody(kind, codeGenerationContext, receiver)
 	if err != nil {
@@ -356,7 +356,7 @@ func (v *ValidatorBuilder) makeLocalValidationFuncDetails(
 	return &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Returns: []*dst.Field{
 			{
 				Type: &dst.ArrayType{

--- a/v2/tools/generator/internal/functions/kubernetes_exporter_function.go
+++ b/v2/tools/generator/internal/functions/kubernetes_exporter_function.go
@@ -87,7 +87,10 @@ func (d *KubernetesExporterBuilder) exportKubernetesResources(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	configMapsReference := codeGenerationContext.MustGetImportedPackageName(astmodel.GenRuntimeConfigMapsReference)
 
@@ -207,20 +210,40 @@ func (d *KubernetesExporterBuilder) exportKubernetesResources(
 			sliceToClientObjectSlice),
 	}
 
-	contextTypeExpr := astmodel.ContextType.AsTypeExpr(codeGenerationContext)
+	contextTypeExpr, err := astmodel.ContextType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating context type expression")
+	}
+
 	fn.AddParameter("_", contextTypeExpr)
 
-	metaObjectTypeExpr := astmodel.GenRuntimeMetaObjectType.AsTypeExpr(codeGenerationContext)
+	metaObjectTypeExpr, err := astmodel.GenRuntimeMetaObjectType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating meta object type expression")
+	}
+
 	fn.AddParameter("_", metaObjectTypeExpr)
 
-	clientTypeExpr := astmodel.NewOptionalType(astmodel.GenericClientType).AsTypeExpr(codeGenerationContext)
+	clientTypeExpr, err := astmodel.NewOptionalType(astmodel.GenericClientType).AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating client type expression")
+	}
+
 	fn.AddParameter("_", clientTypeExpr)
 
-	logrTypeExpr := astmodel.LogrType.AsTypeExpr(codeGenerationContext)
+	logrTypeExpr, err := astmodel.LogrType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating logr type expression")
+	}
+
 	fn.AddParameter("_", logrTypeExpr)
 
-	objectArrayType := astmodel.NewArrayType(astmodel.ControllerRuntimeObjectType).
+	objectArrayType, err := astmodel.NewArrayType(astmodel.ControllerRuntimeObjectType).
 		AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating object array type expression")
+	}
+
 	fn.AddReturn(objectArrayType)
 	fn.AddReturn(dst.NewIdent("error"))
 

--- a/v2/tools/generator/internal/functions/kubernetes_exporter_function.go
+++ b/v2/tools/generator/internal/functions/kubernetes_exporter_function.go
@@ -87,7 +87,7 @@ func (d *KubernetesExporterBuilder) exportKubernetesResources(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	configMapsReference := codeGenerationContext.MustGetImportedPackageName(astmodel.GenRuntimeConfigMapsReference)
 
@@ -207,12 +207,12 @@ func (d *KubernetesExporterBuilder) exportKubernetesResources(
 			sliceToClientObjectSlice),
 	}
 
-	fn.AddParameter("_", astmodel.ContextType.AsType(codeGenerationContext))
-	fn.AddParameter("_", astmodel.GenRuntimeMetaObjectType.AsType(codeGenerationContext))
-	fn.AddParameter("_", astmodel.NewOptionalType(astmodel.GenericClientType).AsType(codeGenerationContext))
-	fn.AddParameter("_", astmodel.LogrType.AsType(codeGenerationContext))
+	fn.AddParameter("_", astmodel.ContextType.AsTypeExpr(codeGenerationContext))
+	fn.AddParameter("_", astmodel.GenRuntimeMetaObjectType.AsTypeExpr(codeGenerationContext))
+	fn.AddParameter("_", astmodel.NewOptionalType(astmodel.GenericClientType).AsTypeExpr(codeGenerationContext))
+	fn.AddParameter("_", astmodel.LogrType.AsTypeExpr(codeGenerationContext))
 
-	fn.AddReturn(&dst.ArrayType{Elt: astmodel.ControllerRuntimeObjectType.AsType(codeGenerationContext)})
+	fn.AddReturn(&dst.ArrayType{Elt: astmodel.ControllerRuntimeObjectType.AsTypeExpr(codeGenerationContext)})
 	fn.AddReturn(dst.NewIdent("error"))
 
 	fn.AddComments("defines a resource which can create other resources in Kubernetes.")

--- a/v2/tools/generator/internal/functions/locatable_resource_function.go
+++ b/v2/tools/generator/internal/functions/locatable_resource_function.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -34,7 +35,10 @@ func locatableResourceLocationFunc(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	locationSelector := astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec", "Location")
 	returnIfLocationNil := astbuilder.ReturnIfNil(locationSelector, astbuilder.StringLiteral(""))
@@ -53,7 +57,11 @@ func locatableResourceLocationFunc(
 
 	fn.AddComments("returns the location of the resource")
 
-	stringTypeExpr := astmodel.StringType.AsTypeExpr(codeGenerationContext)
+	stringTypeExpr, err := astmodel.StringType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating string type expression")
+	}
+
 	fn.AddReturn(stringTypeExpr)
 
 	return fn.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/locatable_resource_function.go
+++ b/v2/tools/generator/internal/functions/locatable_resource_function.go
@@ -34,7 +34,7 @@ func locatableResourceLocationFunc(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	locationSelector := astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec", "Location")
 	returnIfLocationNil := astbuilder.ReturnIfNil(locationSelector, astbuilder.StringLiteral(""))
@@ -52,6 +52,6 @@ func locatableResourceLocationFunc(
 	}
 
 	fn.AddComments("returns the location of the resource")
-	fn.AddReturn(astmodel.StringType.AsType(codeGenerationContext))
+	fn.AddReturn(astmodel.StringType.AsTypeExpr(codeGenerationContext))
 	return fn.DefineFunc(), nil
 }

--- a/v2/tools/generator/internal/functions/locatable_resource_function.go
+++ b/v2/tools/generator/internal/functions/locatable_resource_function.go
@@ -34,7 +34,7 @@ func locatableResourceLocationFunc(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
-	receiverType := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	locationSelector := astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec", "Location")
 	returnIfLocationNil := astbuilder.ReturnIfNil(locationSelector, astbuilder.StringLiteral(""))
@@ -47,11 +47,14 @@ func locatableResourceLocationFunc(
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiverType),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body:          body,
 	}
 
 	fn.AddComments("returns the location of the resource")
-	fn.AddReturn(astmodel.StringType.AsTypeExpr(codeGenerationContext))
+
+	stringTypeExpr := astmodel.StringType.AsTypeExpr(codeGenerationContext)
+	fn.AddReturn(stringTypeExpr)
+
 	return fn.DefineFunc(), nil
 }

--- a/v2/tools/generator/internal/functions/new_empty_arm_value_function.go
+++ b/v2/tools/generator/internal/functions/new_empty_arm_value_function.go
@@ -34,7 +34,7 @@ func newEmptyARMValueBody(instanceType astmodel.TypeName) ObjectFunctionHandler 
 		methodName string,
 	) (*dst.FuncDecl, error) {
 		receiverName := fn.IdFactory().CreateReceiver(receiver.Name())
-		receiverType := astbuilder.PointerTo(receiver.AsType(genContext))
+		receiverType := astbuilder.PointerTo(receiver.AsTypeExpr(genContext))
 		instance := astbuilder.NewCompositeLiteralBuilder(dst.NewIdent(instanceType.Name()))
 		returnInstance := astbuilder.Returns(astbuilder.AddrOf(instance.Build()))
 		details := &astbuilder.FuncDetails{
@@ -44,7 +44,7 @@ func newEmptyARMValueBody(instanceType astmodel.TypeName) ObjectFunctionHandler 
 			Body:          astbuilder.Statements(returnInstance),
 		}
 
-		details.AddReturn(astmodel.ARMResourceStatusType.AsType(genContext))
+		details.AddReturn(astmodel.ARMResourceStatusType.AsTypeExpr(genContext))
 		details.AddComments("returns an empty ARM value suitable for deserializing into")
 
 		return details.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/new_empty_arm_value_function.go
+++ b/v2/tools/generator/internal/functions/new_empty_arm_value_function.go
@@ -39,7 +39,7 @@ func newEmptyARMValueBody(instanceType astmodel.TypeName) ObjectFunctionHandler 
 		if err != nil {
 			return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
 		}
-		
+
 		receiverTypeExpr := astbuilder.PointerTo(receiverType)
 
 		instance := astbuilder.NewCompositeLiteralBuilder(dst.NewIdent(instanceType.Name()))

--- a/v2/tools/generator/internal/functions/new_empty_arm_value_function.go
+++ b/v2/tools/generator/internal/functions/new_empty_arm_value_function.go
@@ -34,17 +34,20 @@ func newEmptyARMValueBody(instanceType astmodel.TypeName) ObjectFunctionHandler 
 		methodName string,
 	) (*dst.FuncDecl, error) {
 		receiverName := fn.IdFactory().CreateReceiver(receiver.Name())
-		receiverType := astbuilder.PointerTo(receiver.AsTypeExpr(genContext))
+		receiverType := receiver.AsTypeExpr(genContext)
+		receiverTypeExpr := astbuilder.PointerTo(receiverType)
+
 		instance := astbuilder.NewCompositeLiteralBuilder(dst.NewIdent(instanceType.Name()))
 		returnInstance := astbuilder.Returns(astbuilder.AddrOf(instance.Build()))
 		details := &astbuilder.FuncDetails{
 			Name:          "NewEmptyARMValue",
 			ReceiverIdent: receiverName,
-			ReceiverType:  receiverType,
+			ReceiverType:  receiverTypeExpr,
 			Body:          astbuilder.Statements(returnInstance),
 		}
 
-		details.AddReturn(astmodel.ARMResourceStatusType.AsTypeExpr(genContext))
+		armResourceStatusTypeExpr := astmodel.ARMResourceStatusType.AsTypeExpr(genContext)
+		details.AddReturn(armResourceStatusTypeExpr)
 		details.AddComments("returns an empty ARM value suitable for deserializing into")
 
 		return details.DefineFunc(), nil

--- a/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
+++ b/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
@@ -7,9 +7,9 @@ package functions
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"

--- a/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
+++ b/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
@@ -84,7 +84,7 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 	fn := &astbuilder.FuncDetails{
 		Name:          f.Name(),
 		ReceiverIdent: receiverName,
-		ReceiverType:  receiver.AsType(codeGenerationContext),
+		ReceiverType:  receiver.AsTypeExpr(codeGenerationContext),
 		Body:          statements,
 	}
 

--- a/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
+++ b/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
 
@@ -59,7 +60,10 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 	jsonPackage := codeGenerationContext.MustGetImportedPackageName(astmodel.JsonReference)
 
 	receiverName := f.idFactory.CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+	}
 
 	props := f.oneOfObject.Properties().AsSlice()
 	statements := make([]dst.Stmt, 0, len(props))

--- a/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
+++ b/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
@@ -59,6 +59,7 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 	jsonPackage := codeGenerationContext.MustGetImportedPackageName(astmodel.JsonReference)
 
 	receiverName := f.idFactory.CreateReceiver(receiver.Name())
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	props := f.oneOfObject.Properties().AsSlice()
 	statements := make([]dst.Stmt, 0, len(props))
@@ -84,7 +85,7 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 	fn := &astbuilder.FuncDetails{
 		Name:          f.Name(),
 		ReceiverIdent: receiverName,
-		ReceiverType:  receiver.AsTypeExpr(codeGenerationContext),
+		ReceiverType:  receiverExpr,
 		Body:          statements,
 	}
 

--- a/v2/tools/generator/internal/functions/one_of_json_unmarshal_function.go
+++ b/v2/tools/generator/internal/functions/one_of_json_unmarshal_function.go
@@ -113,7 +113,7 @@ func (f *OneOfJSONUnmarshalFunction) AsFunc(
 	fn := &astbuilder.FuncDetails{
 		Name:          f.Name(),
 		ReceiverIdent: receiverName,
-		ReceiverType:  astbuilder.PointerTo(receiver.AsType(codeGenerationContext)),
+		ReceiverType:  astbuilder.PointerTo(receiver.AsTypeExpr(codeGenerationContext)),
 		Body:          statements,
 	}
 	fn.AddParameter(paramName, &dst.ArrayType{Elt: dst.NewIdent("byte")})

--- a/v2/tools/generator/internal/functions/one_of_json_unmarshal_function.go
+++ b/v2/tools/generator/internal/functions/one_of_json_unmarshal_function.go
@@ -61,7 +61,10 @@ func (f *OneOfJSONUnmarshalFunction) AsFunc(
 ) (*dst.FuncDecl, error) {
 	jsonPackage := codeGenerationContext.MustGetImportedPackageName(astmodel.JsonReference)
 	receiverName := f.idFactory.CreateReceiver(receiver.Name())
-	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+	}
 
 	allDefinitions := codeGenerationContext.GetAllReachableDefinitions()
 	discrimJSONName, valuesMapping, err := astmodel.DetermineDiscriminantAndValues(f.oneOfObject, allDefinitions)

--- a/v2/tools/generator/internal/functions/one_of_json_unmarshal_function.go
+++ b/v2/tools/generator/internal/functions/one_of_json_unmarshal_function.go
@@ -61,6 +61,7 @@ func (f *OneOfJSONUnmarshalFunction) AsFunc(
 ) (*dst.FuncDecl, error) {
 	jsonPackage := codeGenerationContext.MustGetImportedPackageName(astmodel.JsonReference)
 	receiverName := f.idFactory.CreateReceiver(receiver.Name())
+	receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	allDefinitions := codeGenerationContext.GetAllReachableDefinitions()
 	discrimJSONName, valuesMapping, err := astmodel.DetermineDiscriminantAndValues(f.oneOfObject, allDefinitions)
@@ -113,7 +114,7 @@ func (f *OneOfJSONUnmarshalFunction) AsFunc(
 	fn := &astbuilder.FuncDetails{
 		Name:          f.Name(),
 		ReceiverIdent: receiverName,
-		ReceiverType:  astbuilder.PointerTo(receiver.AsTypeExpr(codeGenerationContext)),
+		ReceiverType:  astbuilder.PointerTo(receiverExpr),
 		Body:          statements,
 	}
 	fn.AddParameter(paramName, &dst.ArrayType{Elt: dst.NewIdent("byte")})

--- a/v2/tools/generator/internal/functions/original_gvk_function.go
+++ b/v2/tools/generator/internal/functions/original_gvk_function.go
@@ -71,7 +71,7 @@ func (o *OriginalGVKFunction) AsFunc(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	receiver astmodel.InternalTypeName,
 ) (*dst.FuncDecl, error) {
-	gvkType := astmodel.GroupVersionKindType.AsType(codeGenerationContext)
+	gvkType := astmodel.GroupVersionKindType.AsTypeExpr(codeGenerationContext)
 	groupVersionPackageGlobal := dst.NewIdent("GroupVersion")
 
 	receiverName := o.idFactory.CreateReceiver(receiver.Name())
@@ -92,7 +92,7 @@ func (o *OriginalGVKFunction) AsFunc(
 
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
-		ReceiverType:  astbuilder.PointerTo(receiver.AsType(codeGenerationContext)),
+		ReceiverType:  astbuilder.PointerTo(receiver.AsTypeExpr(codeGenerationContext)),
 		Name:          o.Name(),
 		Body:          astbuilder.Statements(astbuilder.Returns(astbuilder.AddrOf(initGVK))),
 	}

--- a/v2/tools/generator/internal/functions/original_gvk_function.go
+++ b/v2/tools/generator/internal/functions/original_gvk_function.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -71,11 +72,18 @@ func (o *OriginalGVKFunction) AsFunc(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	receiver astmodel.InternalTypeName,
 ) (*dst.FuncDecl, error) {
-	gvkType := astmodel.GroupVersionKindType.AsTypeExpr(codeGenerationContext)
+	gvkType, err := astmodel.GroupVersionKindType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", astmodel.GroupVersionKindType)
+	}
+
 	groupVersionPackageGlobal := dst.NewIdent("GroupVersion")
 
 	receiverName := o.idFactory.CreateReceiver(receiver.Name())
-	receiverTypeExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverTypeExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+	}
 
 	spec := astbuilder.Selector(dst.NewIdent(receiverName), "Spec")
 

--- a/v2/tools/generator/internal/functions/original_gvk_function.go
+++ b/v2/tools/generator/internal/functions/original_gvk_function.go
@@ -75,6 +75,7 @@ func (o *OriginalGVKFunction) AsFunc(
 	groupVersionPackageGlobal := dst.NewIdent("GroupVersion")
 
 	receiverName := o.idFactory.CreateReceiver(receiver.Name())
+	receiverTypeExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	spec := astbuilder.Selector(dst.NewIdent(receiverName), "Spec")
 
@@ -92,7 +93,7 @@ func (o *OriginalGVKFunction) AsFunc(
 
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
-		ReceiverType:  astbuilder.PointerTo(receiver.AsTypeExpr(codeGenerationContext)),
+		ReceiverType:  astbuilder.PointerTo(receiverTypeExpr),
 		Name:          o.Name(),
 		Body:          astbuilder.Statements(astbuilder.Returns(astbuilder.AddrOf(initGVK))),
 	}

--- a/v2/tools/generator/internal/functions/original_version_function.go
+++ b/v2/tools/generator/internal/functions/original_version_function.go
@@ -62,7 +62,7 @@ func (o *OriginalVersionFunction) AsFunc(
 
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
-		ReceiverType:  astbuilder.PointerTo(receiver.AsType(codeGenerationContext)),
+		ReceiverType:  astbuilder.PointerTo(receiver.AsTypeExpr(codeGenerationContext)),
 		Name:          o.Name(),
 		Body:          astbuilder.Statements(returnVersion),
 	}

--- a/v2/tools/generator/internal/functions/original_version_function.go
+++ b/v2/tools/generator/internal/functions/original_version_function.go
@@ -56,13 +56,14 @@ func (o *OriginalVersionFunction) AsFunc(
 	groupVersionPackageGlobal := dst.NewIdent("GroupVersion")
 
 	receiverName := o.idFactory.CreateReceiver(receiver.Name())
+	receiverTypeExpr := receiver.AsTypeExpr(codeGenerationContext)
 
 	returnVersion := astbuilder.Returns(
 		astbuilder.Selector(groupVersionPackageGlobal, "Version"))
 
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
-		ReceiverType:  astbuilder.PointerTo(receiver.AsTypeExpr(codeGenerationContext)),
+		ReceiverType:  astbuilder.PointerTo(receiverTypeExpr),
 		Name:          o.Name(),
 		Body:          astbuilder.Statements(returnVersion),
 	}

--- a/v2/tools/generator/internal/functions/original_version_function.go
+++ b/v2/tools/generator/internal/functions/original_version_function.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -56,7 +57,10 @@ func (o *OriginalVersionFunction) AsFunc(
 	groupVersionPackageGlobal := dst.NewIdent("GroupVersion")
 
 	receiverName := o.idFactory.CreateReceiver(receiver.Name())
-	receiverTypeExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverTypeExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+	}
 
 	returnVersion := astbuilder.Returns(
 		astbuilder.Selector(groupVersionPackageGlobal, "Version"))

--- a/v2/tools/generator/internal/functions/pivot_conversion_function.go
+++ b/v2/tools/generator/internal/functions/pivot_conversion_function.go
@@ -141,16 +141,18 @@ func (fn *PivotConversionFunction) AsFunc(
 	receiverName := fn.idFactory.CreateReceiver(receiver.Name())
 
 	// We always use a pointer receiver, so we can modify it
-	receiverType := astmodel.NewOptionalType(receiver).AsTypeExpr(codeGenerationContext)
+	receiverType := astmodel.NewOptionalType(receiver)
+	receiverTypeExpr := receiverType.AsTypeExpr(codeGenerationContext)
 
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
-		ReceiverType:  receiverType,
+		ReceiverType:  receiverTypeExpr,
 		Name:          fn.Name(),
 	}
 
 	parameterName := fn.direction.SelectString("source", "destination")
-	funcDetails.AddParameter(parameterName, fn.parameterType.AsTypeExpr(codeGenerationContext))
+	parameterTypeExpr := fn.parameterType.AsTypeExpr(codeGenerationContext)
+	funcDetails.AddParameter(parameterName, parameterTypeExpr)
 
 	funcDetails.AddReturns("error")
 	funcDetails.AddComments(fn.declarationDocComment(receiver, parameterName))

--- a/v2/tools/generator/internal/functions/pivot_conversion_function.go
+++ b/v2/tools/generator/internal/functions/pivot_conversion_function.go
@@ -7,9 +7,9 @@ package functions
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"

--- a/v2/tools/generator/internal/functions/pivot_conversion_function.go
+++ b/v2/tools/generator/internal/functions/pivot_conversion_function.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
 
@@ -142,7 +143,10 @@ func (fn *PivotConversionFunction) AsFunc(
 
 	// We always use a pointer receiver, so we can modify it
 	receiverType := astmodel.NewOptionalType(receiver)
-	receiverTypeExpr := receiverType.AsTypeExpr(codeGenerationContext)
+	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
@@ -151,7 +155,11 @@ func (fn *PivotConversionFunction) AsFunc(
 	}
 
 	parameterName := fn.direction.SelectString("source", "destination")
-	parameterTypeExpr := fn.parameterType.AsTypeExpr(codeGenerationContext)
+	parameterTypeExpr, err := fn.parameterType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating parameter type expression")
+	}
+
 	funcDetails.AddParameter(parameterName, parameterTypeExpr)
 
 	funcDetails.AddReturns("error")

--- a/v2/tools/generator/internal/functions/pivot_conversion_function.go
+++ b/v2/tools/generator/internal/functions/pivot_conversion_function.go
@@ -141,7 +141,7 @@ func (fn *PivotConversionFunction) AsFunc(
 	receiverName := fn.idFactory.CreateReceiver(receiver.Name())
 
 	// We always use a pointer receiver, so we can modify it
-	receiverType := astmodel.NewOptionalType(receiver).AsType(codeGenerationContext)
+	receiverType := astmodel.NewOptionalType(receiver).AsTypeExpr(codeGenerationContext)
 
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
@@ -150,7 +150,7 @@ func (fn *PivotConversionFunction) AsFunc(
 	}
 
 	parameterName := fn.direction.SelectString("source", "destination")
-	funcDetails.AddParameter(parameterName, fn.parameterType.AsType(codeGenerationContext))
+	funcDetails.AddParameter(parameterName, fn.parameterType.AsTypeExpr(codeGenerationContext))
 
 	funcDetails.AddReturns("error")
 	funcDetails.AddComments(fn.declarationDocComment(receiver, parameterName))

--- a/v2/tools/generator/internal/functions/property_assignment_function.go
+++ b/v2/tools/generator/internal/functions/property_assignment_function.go
@@ -137,7 +137,10 @@ func (fn *PropertyAssignmentFunction) AsFunc(
 
 	// We always use a pointer receiver, so we can modify it
 	receiverType := astmodel.NewOptionalType(receiver)
-	receiverTypeExpr := receiverType.AsTypeExpr(codeGenerationContext)
+	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	body, err := fn.generateBody(fn.receiverName, fn.parameterName, codeGenerationContext)
 	if err != nil {
@@ -151,8 +154,12 @@ func (fn *PropertyAssignmentFunction) AsFunc(
 		Body:          body,
 	}
 
-	parameterTypeExpr := astmodel.NewOptionalType(fn.ParameterType()).
+	parameterTypeExpr, err := astmodel.NewOptionalType(fn.ParameterType()).
 		AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating parameter type expression")
+	}
+	
 	funcDetails.AddParameter(fn.parameterName, parameterTypeExpr)
 
 	funcDetails.AddReturns("error")

--- a/v2/tools/generator/internal/functions/property_assignment_function.go
+++ b/v2/tools/generator/internal/functions/property_assignment_function.go
@@ -136,7 +136,7 @@ func (fn *PropertyAssignmentFunction) AsFunc(
 		fmt.Sprintf("populates the provided destination %s from our %s", fn.ParameterType().Name(), receiver.Name()))
 
 	// We always use a pointer receiver, so we can modify it
-	receiverType := astmodel.NewOptionalType(receiver).AsType(codeGenerationContext)
+	receiverType := astmodel.NewOptionalType(receiver).AsTypeExpr(codeGenerationContext)
 
 	body, err := fn.generateBody(fn.receiverName, fn.parameterName, codeGenerationContext)
 	if err != nil {
@@ -152,7 +152,7 @@ func (fn *PropertyAssignmentFunction) AsFunc(
 
 	funcDetails.AddParameter(
 		fn.parameterName,
-		astbuilder.PointerTo(fn.ParameterType().AsType(codeGenerationContext)))
+		astbuilder.PointerTo(fn.ParameterType().AsTypeExpr(codeGenerationContext)))
 
 	funcDetails.AddReturns("error")
 	funcDetails.AddComments(description)
@@ -304,7 +304,7 @@ func (fn *PropertyAssignmentFunction) handleAugmentationInterface(
 		return nil
 	}
 
-	overrideInterface := fn.augmentationInterface.AsType(generationContext)
+	overrideInterface := fn.augmentationInterface.AsTypeExpr(generationContext)
 	receiverAsAnyIdent := knownLocals.CreateLocal(receiver + "AsAny")
 
 	sourceAsAny := astbuilder.NewVariableAssignmentWithType(receiverAsAnyIdent, dst.NewIdent("any"), dst.NewIdent(receiver))

--- a/v2/tools/generator/internal/functions/resource_conversion_function.go
+++ b/v2/tools/generator/internal/functions/resource_conversion_function.go
@@ -59,7 +59,7 @@ var _ astmodel.Function = &ResourceConversionFunction{}
 
 // NewResourceConversionFunction creates a conversion function that populates our hub type from the current instance
 // hub is the TypeName of our hub type
-// propertyFuntion is the function we use to copy properties across
+// propertyFunction is the function we use to copy properties across
 func NewResourceConversionFunction(
 	hub astmodel.InternalTypeName,
 	propertyFunction *PropertyAssignmentFunction,

--- a/v2/tools/generator/internal/functions/resource_conversion_function.go
+++ b/v2/tools/generator/internal/functions/resource_conversion_function.go
@@ -7,9 +7,9 @@ package functions
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"

--- a/v2/tools/generator/internal/functions/resource_conversion_function.go
+++ b/v2/tools/generator/internal/functions/resource_conversion_function.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
 
@@ -104,7 +105,10 @@ func (fn *ResourceConversionFunction) AsFunc(
 
 	// We always use a pointer receiver, so we can modify it
 	receiverType := astmodel.NewOptionalType(receiver)
-	receiverTypeExpr := receiverType.AsTypeExpr(codeGenerationContext)
+	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,

--- a/v2/tools/generator/internal/functions/resource_conversion_function.go
+++ b/v2/tools/generator/internal/functions/resource_conversion_function.go
@@ -103,7 +103,7 @@ func (fn *ResourceConversionFunction) AsFunc(
 	receiverName := fn.idFactory.CreateReceiver(receiver.Name())
 
 	// We always use a pointer receiver, so we can modify it
-	receiverType := astmodel.NewOptionalType(receiver).AsType(codeGenerationContext)
+	receiverType := astmodel.NewOptionalType(receiver).AsTypeExpr(codeGenerationContext)
 
 	funcDetails := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
@@ -161,7 +161,7 @@ func (fn *ResourceConversionFunction) directConversion(
 	assignLocal := astbuilder.TypeAssert(
 		localIdent,
 		hubIdent,
-		astbuilder.PointerTo(fn.hub.AsType(generationContext)))
+		astbuilder.PointerTo(fn.hub.AsTypeExpr(generationContext)))
 
 	checkAssert := astbuilder.ReturnIfNotOk(
 		astbuilder.FormatError(
@@ -206,7 +206,7 @@ func (fn *ResourceConversionFunction) indirectConversionFromHub(
 	intermediateType := fn.propertyFunction.ParameterType()
 
 	declareLocal := astbuilder.LocalVariableDeclaration(
-		localId, intermediateType.AsType(generationContext), "// intermediate variable for conversion")
+		localId, intermediateType.AsTypeExpr(generationContext), "// intermediate variable for conversion")
 	declareLocal.Decorations().Before = dst.NewLine
 
 	populateLocalFromHub := astbuilder.ShortDeclaration(
@@ -266,7 +266,7 @@ func (fn *ResourceConversionFunction) indirectConversionToHub(
 	intermediateType := fn.propertyFunction.ParameterType()
 
 	declareLocal := astbuilder.LocalVariableDeclaration(
-		localId, intermediateType.AsType(generationContext), "// intermediate variable for conversion")
+		localId, intermediateType.AsTypeExpr(generationContext), "// intermediate variable for conversion")
 	declareLocal.Decorations().Before = dst.NewLine
 
 	populateLocalFromReceiver := astbuilder.ShortDeclaration(

--- a/v2/tools/generator/internal/functions/resource_status_setter_function.go
+++ b/v2/tools/generator/internal/functions/resource_status_setter_function.go
@@ -62,6 +62,7 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 ) (*dst.FuncDecl, error) {
 	receiverIdent := fn.idFactory.CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
+	receiverTypeExpr := receiverType.AsTypeExpr(codeGenerationContext)
 
 	statusLocal := "st"
 	statusParameter := "status"
@@ -113,7 +114,7 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 
 	builder := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  receiverType.AsTypeExpr(codeGenerationContext),
+		ReceiverType:  receiverTypeExpr,
 		Name:          "SetStatus",
 		Body: astbuilder.Statements(
 			simplePath,
@@ -124,8 +125,11 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 			returnNil),
 	}
 
-	builder.AddParameter(statusParameter, astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(codeGenerationContext))
-	builder.AddReturn(astmodel.ErrorType.AsTypeExpr(codeGenerationContext))
+	convertibleStatusInterfaceTypeExpr := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(codeGenerationContext)
+	builder.AddParameter(statusParameter, convertibleStatusInterfaceTypeExpr)
+
+	errorTypeExpr := astmodel.ErrorType.AsTypeExpr(codeGenerationContext)
+	builder.AddReturn(errorTypeExpr)
 
 	builder.AddComments("sets the status of this resource")
 

--- a/v2/tools/generator/internal/functions/resource_status_setter_function.go
+++ b/v2/tools/generator/internal/functions/resource_status_setter_function.go
@@ -7,9 +7,9 @@ package functions
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"

--- a/v2/tools/generator/internal/functions/resource_status_setter_function.go
+++ b/v2/tools/generator/internal/functions/resource_status_setter_function.go
@@ -113,7 +113,7 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 
 	builder := &astbuilder.FuncDetails{
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  receiverType.AsType(codeGenerationContext),
+		ReceiverType:  receiverType.AsTypeExpr(codeGenerationContext),
 		Name:          "SetStatus",
 		Body: astbuilder.Statements(
 			simplePath,
@@ -124,8 +124,8 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 			returnNil),
 	}
 
-	builder.AddParameter(statusParameter, astmodel.ConvertibleStatusInterfaceType.AsType(codeGenerationContext))
-	builder.AddReturn(astmodel.ErrorType.AsType(codeGenerationContext))
+	builder.AddParameter(statusParameter, astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(codeGenerationContext))
+	builder.AddReturn(astmodel.ErrorType.AsTypeExpr(codeGenerationContext))
 
 	builder.AddComments("sets the status of this resource")
 

--- a/v2/tools/generator/internal/functions/resource_status_setter_function.go
+++ b/v2/tools/generator/internal/functions/resource_status_setter_function.go
@@ -7,6 +7,7 @@ package functions
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/dave/dst"
 
@@ -62,7 +63,10 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 ) (*dst.FuncDecl, error) {
 	receiverIdent := fn.idFactory.CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
-	receiverTypeExpr := receiverType.AsTypeExpr(codeGenerationContext)
+	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	statusLocal := "st"
 	statusParameter := "status"
@@ -125,10 +129,18 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 			returnNil),
 	}
 
-	convertibleStatusInterfaceTypeExpr := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(codeGenerationContext)
+	convertibleStatusInterfaceTypeExpr, err := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating convertible status interface type expression")
+	}
+
 	builder.AddParameter(statusParameter, convertibleStatusInterfaceTypeExpr)
 
-	errorTypeExpr := astmodel.ErrorType.AsTypeExpr(codeGenerationContext)
+	errorTypeExpr, err := astmodel.ErrorType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating error type expression")
+	}
+
 	builder.AddReturn(errorTypeExpr)
 
 	builder.AddComments("sets the status of this resource")

--- a/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
@@ -229,7 +229,7 @@ func getEnumAzureNameFunction(enumType astmodel.TypeName) functions.ObjectFuncti
 		methodName string,
 	) (*dst.FuncDecl, error) {
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
-		receiverType := receiver.AsType(codeGenerationContext)
+		receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 		fn := &astbuilder.FuncDetails{
 			Name:          methodName,
@@ -256,7 +256,7 @@ func setEnumAzureNameFunction(enumType astmodel.TypeName) functions.ObjectFuncti
 		methodName string,
 	) (*dst.FuncDecl, error) {
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
-		receiverType := receiver.AsType(codeGenerationContext)
+		receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 		azureNameProp := astbuilder.Selector(dst.NewIdent(receiverIdent), astmodel.AzureNameProperty)
 
@@ -295,7 +295,7 @@ func fixedValueGetAzureNameFunction(fixedValue string) functions.ObjectFunctionH
 		methodName string,
 	) (*dst.FuncDecl, error) {
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
-		receiverType := receiver.AsType(codeGenerationContext)
+		receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 		fn := &astbuilder.FuncDetails{
 			Name:          methodName,
@@ -337,10 +337,10 @@ func getOwnerFunction(
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  astbuilder.PointerTo(receiver.AsType(codeGenerationContext)),
+		ReceiverType:  astbuilder.PointerTo(receiver.AsTypeExpr(codeGenerationContext)),
 		Params:        nil,
 	}
-	fn.AddReturn(astbuilder.Dereference(astmodel.ResourceReferenceType.AsType(codeGenerationContext)))
+	fn.AddReturn(astbuilder.Dereference(astmodel.ResourceReferenceType.AsTypeExpr(codeGenerationContext)))
 
 	groupLocal := "group"
 	kindLocal := "kind"
@@ -408,7 +408,7 @@ func getResourceScopeFunction(
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  receiverType.AsType(codeGenerationContext),
+		ReceiverType:  receiverType.AsTypeExpr(codeGenerationContext),
 		Params:        nil,
 		Body: astbuilder.Statements(
 			astbuilder.Returns(
@@ -416,7 +416,7 @@ func getResourceScopeFunction(
 	}
 
 	fn.AddComments("returns the scope of the resource")
-	fn.AddReturn(astmodel.ResourceScopeType.AsType(codeGenerationContext))
+	fn.AddReturn(astmodel.ResourceScopeType.AsTypeExpr(codeGenerationContext))
 
 	return fn.DefineFunc(), nil
 }
@@ -459,7 +459,7 @@ func getSupportedOperationsFunction(
 		idents = append(idents, astbuilder.Selector(dst.NewIdent(genruntimePackage), genruntimeOpName))
 	}
 
-	sliceBuilder := astbuilder.NewSliceLiteralBuilder(astmodel.ResourceOperationType.AsType(codeGenerationContext), true)
+	sliceBuilder := astbuilder.NewSliceLiteralBuilder(astmodel.ResourceOperationType.AsTypeExpr(codeGenerationContext), true)
 	for _, id := range idents {
 		sliceBuilder.AddElement(id)
 	}
@@ -467,7 +467,7 @@ func getSupportedOperationsFunction(
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		ReceiverType:  receiverType.AsType(codeGenerationContext),
+		ReceiverType:  receiverType.AsTypeExpr(codeGenerationContext),
 		Params:        nil,
 		Body: astbuilder.Statements(
 			astbuilder.Returns(sliceBuilder.Build()),
@@ -475,7 +475,7 @@ func getSupportedOperationsFunction(
 	}
 
 	fn.AddComments("returns the operations supported by the resource")
-	fn.AddReturn(astmodel.ResourceOperationTypeArray.AsType(codeGenerationContext))
+	fn.AddReturn(astmodel.ResourceOperationTypeArray.AsTypeExpr(codeGenerationContext))
 
 	return fn.DefineFunc(), nil
 }
@@ -523,7 +523,7 @@ func setStringAzureNameFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
@@ -551,7 +551,7 @@ func getStringAzureNameFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverType := receiver.AsType(codeGenerationContext)
+	receiverType := receiver.AsTypeExpr(codeGenerationContext)
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,

--- a/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
@@ -229,7 +229,10 @@ func getEnumAzureNameFunction(enumType astmodel.TypeName) functions.ObjectFuncti
 		methodName string,
 	) (*dst.FuncDecl, error) {
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
-		receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+		receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating receiver type expression")
+		}
 
 		fn := &astbuilder.FuncDetails{
 			Name:          methodName,
@@ -256,7 +259,10 @@ func setEnumAzureNameFunction(enumType astmodel.TypeName) functions.ObjectFuncti
 		methodName string,
 	) (*dst.FuncDecl, error) {
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
-		receiverTypeExpr := receiver.AsTypeExpr(codeGenerationContext)
+		receiverTypeExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating receiver type expression")
+		}
 
 		azureNameProp := astbuilder.Selector(dst.NewIdent(receiverIdent), astmodel.AzureNameProperty)
 
@@ -295,7 +301,10 @@ func fixedValueGetAzureNameFunction(fixedValue string) functions.ObjectFunctionH
 		methodName string,
 	) (*dst.FuncDecl, error) {
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
-		receiverExpr := receiver.AsTypeExpr(codeGenerationContext)
+		receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating receiver type expression")
+		}
 
 		fn := &astbuilder.FuncDetails{
 			Name:          methodName,
@@ -333,7 +342,10 @@ func getOwnerFunction(
 ) (*dst.FuncDecl, error) {
 	receiverIdent := r.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
-	receiverTypeExpr := receiverType.AsTypeExpr(codeGenerationContext)
+	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	specSelector := astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec")
 	fn := &astbuilder.FuncDetails{
@@ -342,7 +354,11 @@ func getOwnerFunction(
 		ReceiverType:  receiverTypeExpr,
 		Params:        nil,
 	}
-	resourceReferenceTypeExpr := astmodel.ResourceReferenceType.AsTypeExpr(codeGenerationContext)
+	resourceReferenceTypeExpr, err := astmodel.ResourceReferenceType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating resource reference type expression")
+	}
+
 	fn.AddReturn(astbuilder.Dereference(resourceReferenceTypeExpr))
 
 	groupLocal := "group"
@@ -393,7 +409,10 @@ func getResourceScopeFunction(
 ) (*dst.FuncDecl, error) {
 	receiverIdent := r.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
-	receiverTypeExpr := receiverType.AsTypeExpr(codeGenerationContext)
+	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	var resourceScope string
 	switch r.Resource().Scope() {
@@ -420,7 +439,11 @@ func getResourceScopeFunction(
 	}
 
 	fn.AddComments("returns the scope of the resource")
-	resourceScopeTypeExpr := astmodel.ResourceScopeType.AsTypeExpr(codeGenerationContext)
+	resourceScopeTypeExpr, err := astmodel.ResourceScopeType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating resource scope type expression")
+	}
+
 	fn.AddReturn(resourceScopeTypeExpr)
 
 	return fn.DefineFunc(), nil
@@ -443,7 +466,10 @@ func getSupportedOperationsFunction(
 ) (*dst.FuncDecl, error) {
 	receiverIdent := r.IdFactory().CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
-	receiverTypeExpr := receiverType.AsTypeExpr(codeGenerationContext)
+	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	genruntimePackage := codeGenerationContext.MustGetImportedPackageName(astmodel.GenRuntimeReference)
 	supportedOperations := set.AsSortedSlice(r.Resource().SupportedOperations()) // Sorted to ensure ordered codegen
@@ -465,7 +491,11 @@ func getSupportedOperationsFunction(
 		idents = append(idents, astbuilder.Selector(dst.NewIdent(genruntimePackage), genruntimeOpName))
 	}
 
-	resourceOperationTypeExpr := astmodel.ResourceOperationType.AsTypeExpr(codeGenerationContext)
+	resourceOperationTypeExpr, err := astmodel.ResourceOperationType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating resource operation type expression")
+	}
+
 	sliceBuilder := astbuilder.NewSliceLiteralBuilder(resourceOperationTypeExpr, true)
 	for _, id := range idents {
 		sliceBuilder.AddElement(id)
@@ -482,7 +512,11 @@ func getSupportedOperationsFunction(
 	}
 
 	fn.AddComments("returns the operations supported by the resource")
-	resourceOperationTypeArrayExpr := astmodel.ResourceOperationTypeArray.AsTypeExpr(codeGenerationContext)
+	resourceOperationTypeArrayExpr, err := astmodel.ResourceOperationTypeArray.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating resource operation type array expression")
+	}
+
 	fn.AddReturn(resourceOperationTypeArrayExpr)
 
 	return fn.DefineFunc(), nil
@@ -531,7 +565,10 @@ func setStringAzureNameFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverTypeExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverTypeExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,
@@ -559,7 +596,10 @@ func getStringAzureNameFunction(
 	methodName string,
 ) (*dst.FuncDecl, error) {
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
-	receiverTypeExpr := receiver.AsTypeExpr(codeGenerationContext)
+	receiverTypeExpr, err := receiver.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	fn := &astbuilder.FuncDetails{
 		Name:          methodName,

--- a/v2/tools/generator/internal/test/fake_function.go
+++ b/v2/tools/generator/internal/test/fake_function.go
@@ -7,6 +7,7 @@ package test
 
 import (
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -55,7 +56,10 @@ func (fake *FakeFunction) AsFunc(
 ) (*dst.FuncDecl, error) {
 	receiverName := fake.idFactory.CreateReceiver(receiver.Name())
 	receiverType := astmodel.NewOptionalType(receiver)
-	receiverTypeExpr := receiverType.AsTypeExpr(codeGenerationContext)
+	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating receiver type expression")
+	}
 
 	details := astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
@@ -64,7 +68,11 @@ func (fake *FakeFunction) AsFunc(
 	}
 
 	if fake.TypeReturned != nil {
-		typeReturnedExpr := fake.TypeReturned.AsTypeExpr(codeGenerationContext)
+		typeReturnedExpr, err := fake.TypeReturned.AsTypeExpr(codeGenerationContext)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating type returned expression")
+		}
+
 		details.AddReturn(typeReturnedExpr)
 	}
 

--- a/v2/tools/generator/internal/test/fake_function.go
+++ b/v2/tools/generator/internal/test/fake_function.go
@@ -56,12 +56,12 @@ func (fake *FakeFunction) AsFunc(
 	receiverName := fake.idFactory.CreateReceiver(receiver.Name())
 	details := astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
-		ReceiverType:  astmodel.NewOptionalType(receiver).AsType(codeGenerationContext),
+		ReceiverType:  astmodel.NewOptionalType(receiver).AsTypeExpr(codeGenerationContext),
 		Name:          fake.name,
 	}
 
 	if fake.TypeReturned != nil {
-		details.AddReturn(fake.TypeReturned.AsType(codeGenerationContext))
+		details.AddReturn(fake.TypeReturned.AsTypeExpr(codeGenerationContext))
 	}
 
 	return details.DefineFunc(), nil

--- a/v2/tools/generator/internal/test/fake_function.go
+++ b/v2/tools/generator/internal/test/fake_function.go
@@ -54,14 +54,18 @@ func (fake *FakeFunction) AsFunc(
 	receiver astmodel.InternalTypeName,
 ) (*dst.FuncDecl, error) {
 	receiverName := fake.idFactory.CreateReceiver(receiver.Name())
+	receiverType := astmodel.NewOptionalType(receiver)
+	receiverTypeExpr := receiverType.AsTypeExpr(codeGenerationContext)
+
 	details := astbuilder.FuncDetails{
 		ReceiverIdent: receiverName,
-		ReceiverType:  astmodel.NewOptionalType(receiver).AsTypeExpr(codeGenerationContext),
+		ReceiverType:  receiverTypeExpr,
 		Name:          fake.name,
 	}
 
 	if fake.TypeReturned != nil {
-		details.AddReturn(fake.TypeReturned.AsTypeExpr(codeGenerationContext))
+		typeReturnedExpr := fake.TypeReturned.AsTypeExpr(codeGenerationContext)
+		details.AddReturn(typeReturnedExpr)
 	}
 
 	return details.DefineFunc(), nil

--- a/v2/tools/generator/internal/testcases/property_assignment_test_case.go
+++ b/v2/tools/generator/internal/testcases/property_assignment_test_case.go
@@ -254,9 +254,10 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 	astbuilder.AddComment(&assignCopied.Decorations().Start, "// Copy subject to make sure assignment doesn't modify it")
 
 	// var other OtherType
+	parameterTypeExpr := p.toFn.ParameterType().AsTypeExpr(codegenContext)
 	declareOther := astbuilder.LocalVariableDeclaration(
 		otherId,
-		p.toFn.ParameterType().AsTypeExpr(codegenContext),
+		parameterTypeExpr,
 		"// Use AssignPropertiesTo() for the first stage of conversion")
 	declareOther.Decorations().Before = dst.EmptyLine
 
@@ -274,9 +275,10 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 		astbuilder.CallQualifiedFunc("err", "Error"))
 
 	// var result OurType
+	subjectExpr := subject.AsTypeExpr(codegenContext)
 	declareResult := astbuilder.LocalVariableDeclaration(
 		actualId,
-		subject.AsTypeExpr(codegenContext),
+		subjectExpr,
 		"// Use AssignPropertiesFrom() to convert back to our original type")
 	declareResult.Decorations().Before = dst.EmptyLine
 
@@ -354,7 +356,8 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 			ret),
 	}
 
-	fn.AddParameter("subject", p.subject.AsTypeExpr(codegenContext))
+	subjectExpr = p.subject.AsTypeExpr(codegenContext)
+	fn.AddParameter("subject", subjectExpr)
 	fn.AddComments(fmt.Sprintf(
 		"tests if a specific instance of %s can be assigned to %s and back losslessly",
 		p.subject.Name(),

--- a/v2/tools/generator/internal/testcases/property_assignment_test_case.go
+++ b/v2/tools/generator/internal/testcases/property_assignment_test_case.go
@@ -7,11 +7,11 @@ package testcases
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"go/token"
 	"strings"
 
 	"github.com/dave/dst"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"

--- a/v2/tools/generator/internal/testcases/property_assignment_test_case.go
+++ b/v2/tools/generator/internal/testcases/property_assignment_test_case.go
@@ -256,7 +256,7 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 	// var other OtherType
 	declareOther := astbuilder.LocalVariableDeclaration(
 		otherId,
-		p.toFn.ParameterType().AsType(codegenContext),
+		p.toFn.ParameterType().AsTypeExpr(codegenContext),
 		"// Use AssignPropertiesTo() for the first stage of conversion")
 	declareOther.Decorations().Before = dst.EmptyLine
 
@@ -276,7 +276,7 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 	// var result OurType
 	declareResult := astbuilder.LocalVariableDeclaration(
 		actualId,
-		subject.AsType(codegenContext),
+		subject.AsTypeExpr(codegenContext),
 		"// Use AssignPropertiesFrom() to convert back to our original type")
 	declareResult.Decorations().Before = dst.EmptyLine
 
@@ -354,7 +354,7 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 			ret),
 	}
 
-	fn.AddParameter("subject", p.subject.AsType(codegenContext))
+	fn.AddParameter("subject", p.subject.AsTypeExpr(codegenContext))
 	fn.AddComments(fmt.Sprintf(
 		"tests if a specific instance of %s can be assigned to %s and back losslessly",
 		p.subject.Name(),

--- a/v2/tools/generator/internal/testcases/resource_conversion_test_case.go
+++ b/v2/tools/generator/internal/testcases/resource_conversion_test_case.go
@@ -291,9 +291,10 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 	astbuilder.AddComment(&assignCopied.Decorations().Start, "// Copy subject to make sure conversion doesn't modify it")
 
 	// var hub OtherType
+	hubExpr := tc.toFn.Hub().AsTypeExpr(codegenContext)
 	declareOther := astbuilder.LocalVariableDeclaration(
 		hubId,
-		tc.toFn.Hub().AsTypeExpr(codegenContext),
+		hubExpr,
 		"// Convert to our hub version")
 	declareOther.Decorations().Before = dst.EmptyLine
 
@@ -311,9 +312,10 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 		astbuilder.CallQualifiedFunc("err", "Error"))
 
 	// var result OurType
+	subjectExpr := subject.AsTypeExpr(codegenContext)
 	declareResult := astbuilder.LocalVariableDeclaration(
 		actualId,
-		subject.AsTypeExpr(codegenContext),
+		subjectExpr,
 		"// Convert from our hub version")
 	declareResult.Decorations().Before = dst.EmptyLine
 
@@ -390,7 +392,8 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 			ret),
 	}
 
-	fn.AddParameter("subject", tc.subject.AsTypeExpr(codegenContext))
+	subjectExpr = tc.subject.AsTypeExpr(codegenContext)
+	fn.AddParameter("subject", subjectExpr)
 	fn.AddComments(fmt.Sprintf(
 		"tests if a specific instance of %s round trips to the hub storage version and back losslessly",
 		tc.subject.Name()))

--- a/v2/tools/generator/internal/testcases/resource_conversion_test_case.go
+++ b/v2/tools/generator/internal/testcases/resource_conversion_test_case.go
@@ -293,7 +293,7 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 	// var hub OtherType
 	declareOther := astbuilder.LocalVariableDeclaration(
 		hubId,
-		tc.toFn.Hub().AsType(codegenContext),
+		tc.toFn.Hub().AsTypeExpr(codegenContext),
 		"// Convert to our hub version")
 	declareOther.Decorations().Before = dst.EmptyLine
 
@@ -313,7 +313,7 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 	// var result OurType
 	declareResult := astbuilder.LocalVariableDeclaration(
 		actualId,
-		subject.AsType(codegenContext),
+		subject.AsTypeExpr(codegenContext),
 		"// Convert from our hub version")
 	declareResult.Decorations().Before = dst.EmptyLine
 
@@ -390,7 +390,7 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 			ret),
 	}
 
-	fn.AddParameter("subject", tc.subject.AsType(codegenContext))
+	fn.AddParameter("subject", tc.subject.AsTypeExpr(codegenContext))
 	fn.AddComments(fmt.Sprintf(
 		"tests if a specific instance of %s round trips to the hub storage version and back losslessly",
 		tc.subject.Name()))


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the signature of the `AsTypeExpr` method (formerly `AsType`), allowing it to return errors instead of forcing implementations to panic. 

Closes #2970 

**Special notes for your reviewer**:

The `AsTypeExpr` method is used in a lot of places!

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/1d5Qn4RM2O90RVG8wX/giphy.gif)