### PR TITLE
Fix replay bug with go-vcr v3

### DIFF
--- a/v2/internal/testcommon/vcr/v3/test_recorder.go
+++ b/v2/internal/testcommon/vcr/v3/test_recorder.go
@@ -84,14 +84,18 @@ func NewTestRecorder(
 
 		// verify custom request count header matches, if present
 		if header := r.Header.Get(COUNT_HEADER); header != "" {
-			if header != i.Headers.Get(COUNT_HEADER) {
+			interactionHeader := i.Headers.Get(COUNT_HEADER)
+			if header != interactionHeader {
+				log.Info("Request count header mismatch", COUNT_HEADER, header, "interaction", interactionHeader)
 				return false
 			}
 		}
 
 		// verify custom body hash header matches, if present
 		if header := r.Header.Get(HASH_HEADER); header != "" {
-			if header != i.Headers.Get(HASH_HEADER) {
+			interactionHeader := i.Headers.Get(HASH_HEADER)
+			if header != interactionHeader {
+				log.Info("Request body hash header mismatch", HASH_HEADER, header, "interaction", interactionHeader)
 				return false
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use of the replaying-roundtripper was consuming attempt numbers, causing mismatches where an interaction in the recording file wouldn't be picked up because it didn't have the expected attempt header (e.g. the recording had an unused _attempt 2_ header, when the matcher was looking for an _attempt 3_ header.)

This seems to only impact on PUT request recordings.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbDh1bmw4dDd1MTA1d2Z0ZjZkd3BobHR5MXIxMWJvdHllenlxYzdldSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3o72FhxujRMcOqUm8o/giphy.gif)

