### PR TITLE
Exclude `v2` and `docs` paths from ADO pipeline PR trigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,6 @@ pr:
     exclude:
       - docs/
       - v2/
-      - azure-pipelines.yml
 
 resources:
 - repo: self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,7 @@ trigger:
     exclude:
       - docs
       - v2
+      - azure-pipelines.yml
 
 # PR Section describes what happens on PR
 pr:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,10 @@ trigger:
   branches:
     # Run automatically ONLY on GitHub Merge Queue branches
     include: [ 'gh-readonly-queue/*' ]
+  paths:
+    exclude:
+      - docs/*
+      - v2
 
 # PR Section describes what happens on PR
 pr:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ trigger:
     include: [ 'gh-readonly-queue/*' ]
   paths:
     exclude:
-      - docs/*
+      - docs
       - v2
 
 # PR Section describes what happens on PR

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,17 +4,17 @@ trigger:
   branches:
     # Run automatically ONLY on GitHub Merge Queue branches
     include: [ 'gh-readonly-queue/*' ]
-  paths:
-    exclude:
-      - docs
-      - v2
-      - azure-pipelines.yml
 
 # PR Section describes what happens on PR
 pr:
   branches:
     include:
     - main
+  paths:
+    exclude:
+      - docs/
+      - v2/
+      - azure-pipelines.yml
 
 resources:
 - repo: self


### PR DESCRIPTION
Excluding `v2` and `docs` path for ADO pipeline trigger on PRs. 

Tested out on commit [6ad7510](https://github.com/Azure/azure-service-operator/pull/3927/commits/6ad7510f3ac28459e274d9cf3bd7162874f2748c): 
![image](https://github.com/Azure/azure-service-operator/assets/38904804/2b9865b2-3cd2-4792-90d3-8ed4c3bd4878)
