### PR TITLE
Add RoleAssignment UUID Generation ADR

### DIFF
--- a/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
+++ b/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
@@ -11,7 +11,7 @@ The aim for above approach was to:
 - include the owner group, kind, and name to avoid collisions between resources with the same name in different clusters that actually point to different Azure resources.
 
 However, the case where users have multiple ASO instances in multiple clusters with resources in the same namespace, in each cluster having the same name and pointing to different Azure resource is not supported without the user manually giving each RoleAssignment its own UUID.
-The above issue can still be avoided by overriding the AzureName property with random uuids, however it's not consistent and user-friendly.
+The above issue can be avoided by defaulting the AzureName property to a random UUID, however it will cause issues if the RoleAssignment is ever deleted and recreated (or migrated between clusters) as the old UUID will be orphaned.
 
 Issue: [RoleAssignment UUID clashes](https://github.com/Azure/azure-service-operator/issues/3637)
 

--- a/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
+++ b/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
@@ -21,12 +21,12 @@ Add a new property on RoleAssignment spec to control this behaviour.
 
 To use random uuid: 
 ```yaml
-uuidGeneration: Random
+uuidGeneration: random
 ```
 
 To use deterministic uuid(default)
 ```yaml
-uuidGeneration: Default
+uuidGeneration: stable
 ```
 
 **Pro**: Backward compatible
@@ -37,16 +37,17 @@ uuidGeneration: Default
 
 ### Option 2: Using annotations
 
-We can use annotation below to control the name generation behaviour
+We can use annotation below to control the name generation behaviour. 
+In this case, If user does not specify any annotation and does not specify AzureName, ASO sets the default annotation below and follows the default behaviour of stable UUID generation.  
 
 To use random uuid:
 ```yaml
-serviceoperator.azure.com/uuid-generation: Random 
+serviceoperator.azure.com/uuid-generation: random 
 ```
 
 To use deterministic uuid(default)
 ```yaml
-serviceoperator.azure.com/uuid-generation: Default
+serviceoperator.azure.com/uuid-generation: stable
 ```
 
 **Pro**: Backward compatible

--- a/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
+++ b/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
@@ -10,8 +10,7 @@ The aim for above approach was to:
 - include the group and kind to ensure that different kinds of resources get different UUIDs. This isn't entirely required by Azure, but it makes sense to avoid collisions between two resources of different types even if they have the same namespace and name.
 - include the owner group, kind, and name to avoid collisions between resources with the same name in different clusters that actually point to different Azure resources.
 
-However, the case where users have multiple ASO instances in multiple clusters with resources in the same namespace, in each cluster having the same name and pointing to different Azure resource is not supported without the user manually giving each RoleAssignment its own UUID.
-The above issue can be avoided by defaulting the AzureName property to a random UUID, however it will cause issues if the RoleAssignment is ever deleted and recreated (or migrated between clusters) as the old UUID will be orphaned.
+In scenarios where users have multiple ASO instances across different clusters, resources within the identical namespaces, and each cluster has resources with identical names pointing to distinct Azure resources, there is no native support for this configuration. To work around this limitation, users must manually assign a unique UUID to each RoleAssignment. Alternatively, setting the AzureName property to a random UUID by default can prevent the issue, but it may lead to complications if a RoleAssignment is ever deleted and then recreated (or migrated between clusters), as the old UUID would become orphaned.
 
 Issue: [RoleAssignment UUID clashes](https://github.com/Azure/azure-service-operator/issues/3637)
 
@@ -66,11 +65,26 @@ Adding subscriptionId as a seed string would make the resource names distinct ac
 **Con**: Moving resource with same name between older to newer ASO version would require a workaround
 **Con**: Webhooks don't have information about subscriptionID
 
+### Option 4: Use custom OperatorSpec property
+
+Adding an OperatorSpec property to the RoleAssignment resource. Which would enable users to choose the generation type within operatorSpec while resource creation.
+
+``` yaml
+  operatorSpec:
+    generationType: random/default
+```
+
+**Pro**: Backward compatible
+**Pro**: Ease of use
+**Pro**: Decoupled from annotations and resource spec
+
+**Con**: Users will have to manage the AzureName by themselves while exporting/importing if they use Random generation
+
 ## Decision
 
-Recommendation: Option 2 - Using annotations
+Recommendation: Option 4 - Using OperatorSpec properties
 
-We retain how the resource shape looks like and suggest using annotation for the users running into the edge case. 
+We retain how the resource shape looks like and suggest using OperatorSpec property for the users running into the edge case. 
 
 ## Status
 

--- a/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
+++ b/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
@@ -4,7 +4,7 @@ title: '2024-04: RoleAssignments UUID Generation'
 
 ## Context
 
-In ASO, we have made several improvements on making the RoleAssignment's name user-friendly by auto-generating the UUID using UUIDv5 with a seed string based on the group, kind, namespace and name. 
+In ASO, we made several improvements to make RoleAssignment user-friendly by auto-generating their AzureName (which must be a UUID) using UUIDv5 with a seed string based on group, kind, namespace, and name. 
 The aim for above approach was to:
 - include the namespace and name to ensure no two RoleAssignments in the same cluster can end up with the same UUID.
 - include the group and kind to ensure that different kinds of resources get different UUIDs. This isn't entirely required by Azure, but it makes sense to avoid collisions between two resources of different types even if they have the same namespace and name.

--- a/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
+++ b/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
@@ -10,7 +10,7 @@ The aim for above approach was to:
 - include the group and kind to ensure that different kinds of resources get different UUIDs. This isn't entirely required by Azure, but it makes sense to avoid collisions between two resources of different types even if they have the same namespace and name.
 - include the owner group, kind, and name to avoid collisions between resources with the same name in different clusters that actually point to different Azure resources.
 
-However, the case where users have multiple clusters with resources in the same namespace, in each cluster having the same name and pointing to the same Azure resource was skipped.
+However, the case where users have multiple ASO instances in multiple clusters with resources in the same namespace, in each cluster having the same name and pointing to different Azure resource is not supported without the user manually giving each RoleAssignment its own UUID.
 The above issue can still be avoided by overriding the AzureName property with random uuids, however it's not consistent and user-friendly.
 
 Issue: [RoleAssignment UUID clashes](https://github.com/Azure/azure-service-operator/issues/3637)

--- a/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
+++ b/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
@@ -54,6 +54,8 @@ serviceoperator.azure.com/uuid-generation: stable
 **Pro**: Ease of use
 
 **Con**: Users will have to manage the AzureName by themselves while exporting/importing
+**Con**: Pushes a crucial part of the resource definition into an annotation; the spec is no longer a complete definition of the resource.
+**Con**: Annotations are far more easily modified by other tooling, which may have unexpected flow on effects.
 
 ### Option 3: Using subscription ID as seed
 

--- a/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
+++ b/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
@@ -1,0 +1,80 @@
+---
+title: '2024-04: RoleAssignments UUID Generation'
+---
+
+## Context
+
+In ASO, we have made several improvements on making the RoleAssignment's name user-friendly by auto-generating the UUID using UUIDv5 with a seed string based on the group, kind, namespace and name. 
+The aim for above approach was to:
+- include the namespace and name to ensure no two RoleAssignments in the same cluster can end up with the same UUID.
+- include the group and kind to ensure that different kinds of resources get different UUIDs. This isn't entirely required by Azure, but it makes sense to avoid collisions between two resources of different types even if they have the same namespace and name.
+- include the owner group, kind, and name to avoid collisions between resources with the same name in different clusters that actually point to different Azure resources.
+
+However, the case where users have multiple clusters with resources in the same namespace, in each cluster having the same name and pointing to the same Azure resource was skipped.
+The above issue can still be avoided by overriding the AzureName property with random uuids, however it's not consistent and user-friendly.
+
+Issue: [RoleAssignment UUID clashes](https://github.com/Azure/azure-service-operator/issues/3637)
+
+### Option 1: Adding a new property
+
+Add a new property on RoleAssignment spec to control this behaviour. 
+
+To use random uuid: 
+```yaml
+uuidGeneration: Random
+```
+
+To use deterministic uuid(default)
+```yaml
+uuidGeneration: Default
+```
+
+**Pro**: Backward compatible
+**Pro**: Ease of use
+
+**Con**: Need to implement infrastructure to add a new property
+**Con**: Users will have to manage the AzureName by themselves while exporting/importing
+
+### Option 2: Using annotations
+
+We can use annotation below to control the name generation behaviour
+
+To use random uuid:
+```yaml
+serviceoperator.azure.com/uuid-generation: random 
+```
+
+To use deterministic uuid(default)
+```yaml
+serviceoperator.azure.com/uuid-generation: Default
+```
+
+**Pro**: Backward compatible
+**Pro**: Ease of use
+
+**Con**: Users will have to manage the AzureName by themselves while exporting/importing
+
+### Option 3: Using subscription ID as seed
+
+Adding subscriptionId as a seed string would make the resource names distinct across subscriptions
+
+**Pro**: User does not have to do anything
+
+**Con**: Moving resource with same name between multiple ASO instances would require a workaround
+**Con**: Webhooks don't have information about subscriptionID
+
+## Status
+
+Proposed.
+
+## Consequences
+
+TBC
+
+## Experience Report
+
+TBC
+
+## References
+
+None

--- a/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
+++ b/docs/hugo/content/design/ADR-2024-04-RoleAssignment-UUID-Generation.md
@@ -41,7 +41,7 @@ We can use annotation below to control the name generation behaviour
 
 To use random uuid:
 ```yaml
-serviceoperator.azure.com/uuid-generation: random 
+serviceoperator.azure.com/uuid-generation: Random 
 ```
 
 To use deterministic uuid(default)
@@ -60,8 +60,14 @@ Adding subscriptionId as a seed string would make the resource names distinct ac
 
 **Pro**: User does not have to do anything
 
-**Con**: Moving resource with same name between multiple ASO instances would require a workaround
+**Con**: Moving resource with same name between older to newer ASO version would require a workaround
 **Con**: Webhooks don't have information about subscriptionID
+
+## Decision
+
+Recommendation: Option 2 - Using annotations
+
+We retain how the resource shape looks like and suggest using annotation for the users running into the edge case. 
 
 ## Status
 


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR adds ADR for RoleAssignment UUID clashes. ADR discusses about the issue with UUID clashes for RoleAssignment mentioned in #3637. 

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
