### PR TITLE
Use NPM from standard source

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,14 +9,9 @@ ARG TARGETARCH
 # APT dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends bash-completion software-properties-common lsb-release graphviz zip \
+    && apt-get -y install --no-install-recommends bash-completion software-properties-common lsb-release graphviz zip nodejs npm \
     # install az-cli
     && curl -sL https://aka.ms/InstallAzureCLIDeb | bash -
-
-# For Hugo we need a newer version of NodeJS than the v12.22.12 available via the standard sources
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x -o /tmp/nodesource-setup.sh \
-    && sudo bash /tmp/nodesource-setup.sh \
-    && apt-get -y install nodejs
 
 # install docker
 # - not yet needed?


### PR DESCRIPTION
**What this PR does / why we need it**:

We previously were manually making node v18 available because only v12 was available from standard sources; we now have v18 directly available, so the prior workaround is not required.

**Special notes for your reviewer**:

I suspect this may have been the underlying cause of the problems I was experiencing with reloads of the devcontainer.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/ErlEYuTRAmOmQ/giphy.gif?cid=ecf05e47kqm95mf3bh41wa2hsaagv19gols08yv41bperwy5&ep=v1_gifs_search&rid=giphy.gif&ct=g)
