### PR TITLE
Fix a few small test issues

### DIFF
--- a/v2/internal/controllers/edge_case_test.go
+++ b/v2/internal/controllers/edge_case_test.go
@@ -53,8 +53,7 @@ func storageAccountAndResourceGroupProvisionedOutOfOrderHelper(t *testing.T, wai
 	waitHelper(tc, acct)
 
 	// The resource group should be created successfully
-	_, err := tc.CreateResourceGroup(rg)
-	tc.Expect(err).ToNot(HaveOccurred())
+	tc.CreateResource(rg)
 
 	// The storage account should also be created successfully
 	tc.Eventually(acct).Should(tc.Match.BeProvisioned(0))

--- a/v2/internal/controllers/operatormode_test.go
+++ b/v2/internal/controllers/operatormode_test.go
@@ -32,8 +32,7 @@ func TestOperatorMode_Webhooks(t *testing.T) {
 	}
 	tc.Expect(rg.Spec.AzureName).To(Equal(""))
 
-	_, err := tc.CreateResourceGroup(&rg)
-	tc.Expect(err).ToNot(HaveOccurred())
+	tc.CreateResource(&rg)
 	// AzureName should have been defaulted on the group on the
 	// way in (it doesn't require waiting for a reconcile).
 	tc.Expect(rg.Spec.AzureName).To(Equal(rg.ObjectMeta.Name))
@@ -60,7 +59,7 @@ func TestOperatorMode_Watchers(t *testing.T) {
 	}
 	tc.Expect(rg.Spec.AzureName).To(Equal(""))
 
-	_, err := tc.CreateResourceGroup(&rg)
+	err := tc.CreateResourceExpectRequestFailure(&rg)
 	// We should fail because the webhook isn't registered (in a real
 	// multi-operator deployment it would be routed to a different
 	// operator running in webhook-only mode).
@@ -89,8 +88,7 @@ func TestOperatorMode_Both(t *testing.T) {
 	}
 	tc.Expect(rg.Spec.AzureName).To(Equal(""))
 
-	_, err := tc.CreateResourceGroup(&rg)
-	tc.Expect(err).NotTo(HaveOccurred())
+	tc.CreateResource(&rg)
 
 	// AzureName should have been defaulted on the group on the
 	// way in (it doesn't require waiting for a reconcile).

--- a/v2/internal/controllers/targetnamespace_test.go
+++ b/v2/internal/controllers/targetnamespace_test.go
@@ -52,7 +52,7 @@ func TestTargetNamespaces(t *testing.T) {
 		},
 		Spec: standardSpec,
 	}
-	tc.CreateResourceGroupAndWait(&rgDefault)
+	tc.CreateResourceAndWait(&rgDefault)
 	// Check that the instance is annotated with the operator namespace.
 	checkNamespaceAnnotation(tc, &rgDefault, podNamespace)
 
@@ -64,7 +64,7 @@ func TestTargetNamespaces(t *testing.T) {
 		},
 		Spec: standardSpec,
 	}
-	tc.CreateResourceGroupAndWait(&rgWatched)
+	tc.CreateResourceAndWait(&rgWatched)
 	checkNamespaceAnnotation(tc, &rgWatched, podNamespace)
 
 	// But the unwatched namespace isn't...
@@ -77,8 +77,7 @@ func TestTargetNamespaces(t *testing.T) {
 		},
 		Spec: standardSpec,
 	}
-	_, err = tc.CreateResourceGroup(&rgUnwatched)
-	tc.Expect(err).ToNot(HaveOccurred())
+	tc.CreateResource(&rgUnwatched)
 
 	// We can tell that the resource isn't being reconciled if it
 	// never gets a finalizer.
@@ -169,8 +168,7 @@ func TestOperatorNamespacePreventsReconciling(t *testing.T) {
 			Tags:     testcommon.CreateTestResourceGroupDefaultTags(),
 		},
 	}
-	_, err := tc.CreateResourceGroup(&notMine)
-	tc.Expect(err).NotTo(HaveOccurred())
+	tc.CreateResource(&notMine)
 
 	checkNeverGetsFinalizer(tc, &notMine, "instance claimed by some other operator got finalizer")
 
@@ -201,5 +199,5 @@ func TestOperatorNamespacePreventsReconciling(t *testing.T) {
 			Tags:     testcommon.CreateTestResourceGroupDefaultTags(),
 		},
 	}
-	tc.CreateResourceGroupAndWait(&mine)
+	tc.CreateResourceAndWait(&mine)
 }

--- a/v2/internal/controllers/to_azure_configmaps_test.go
+++ b/v2/internal/controllers/to_azure_configmaps_test.go
@@ -193,7 +193,7 @@ func Test_ConfigMapInDifferentNamespace_ConfigMapNotFound(t *testing.T) {
 
 	configMap := &v1.ConfigMap{
 		ObjectMeta: ctrl.ObjectMeta{
-			Namespace: tc.Namespace,
+			Namespace: namespaceName,
 			Name:      configMapName,
 		},
 		Data: map[string]string{
@@ -248,11 +248,11 @@ func Test_UserConfigMapInDifferentNamespace_ShouldNotTriggerReconcile(t *testing
 
 	rg := tc.NewTestResourceGroup()
 	rg.Namespace = ns1
-	tc.CreateResourceGroupAndWait(rg)
+	tc.CreateResourceAndWait(rg)
 
 	rg2 := tc.NewTestResourceGroup()
 	rg2.Namespace = ns2
-	tc.CreateResourceGroupAndWait(rg2)
+	tc.CreateResourceAndWait(rg2)
 
 	mi := &managedidentity.UserAssignedIdentity{
 		ObjectMeta: metav1.ObjectMeta{

--- a/v2/internal/controllers/to_azure_secrets_test.go
+++ b/v2/internal/controllers/to_azure_secrets_test.go
@@ -149,11 +149,11 @@ func Test_UserSecretInDifferentNamespace_ShouldNotTriggerReconcile(t *testing.T)
 
 	rg := tc.NewTestResourceGroup()
 	rg.Namespace = ns1
-	tc.CreateResourceGroupAndWait(rg)
+	tc.CreateResourceAndWait(rg)
 
 	rg2 := tc.NewTestResourceGroup()
 	rg2.Namespace = ns2
-	tc.CreateResourceGroupAndWait(rg2)
+	tc.CreateResourceAndWait(rg2)
 
 	// VM1 with same secret name in ns1
 	vm1 := createNamespacedVM(tc, rg, ns1, ns1Secret)


### PR DESCRIPTION
- Remove unneeded CreateResourceGroup test helpers in favor of the existing CreateResource helpers (which are identical).
- Fix test to actually use the namespace it created.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
