### PR TITLE
fix AZURE_USER_AGENT_SUFFIX not getting set

### DIFF
--- a/v2/config/manager/manager_image_patch.yaml
+++ b/v2/config/manager/manager_image_patch.yaml
@@ -88,6 +88,12 @@ spec:
                   key: USE_WORKLOAD_IDENTITY_AUTH
                   name: aso-controller-settings
                   optional: true
+            - name: AZURE_USER_AGENT_SUFFIX
+              valueFrom:
+                secretKeyRef:
+                  key: AZURE_USER_AGENT_SUFFIX
+                  name: aso-controller-settings
+                  optional: true
             # Used for setting the operator-namespace annotation (and
             # for aad-pod-identity once we support it).
             - name: POD_NAMESPACE


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Closes #[issue number]

**What this PR does / why we need it**:

The `AZURE_USER_AGENT_SUFFIX` field in the aso-controller-settings Secret added in #3650 was not being read because the controller Pod wasn't setting the environment variable for it in its definition.

**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://giphy.com/)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
