### PR TITLE
Use "never" rather than "" to mean "don't sync" for AZURE_SYNC_PERIOD.

### DIFF
--- a/docs/hugo/content/guide/aso-controller-settings-options.md
+++ b/docs/hugo/content/guide/aso-controller-settings-options.md
@@ -71,6 +71,8 @@ This sync exists to detect and correct changes that happened in Azure that Kuber
 BE VERY CAREFUL setting this value low - even a modest number of resources can cause
 subscription level throttling if they are re-synced frequently. If nil or empty (`""`), sync period defaults to `1h`.
 
+Specify the special value `"never"` to stop syncing.
+
 **Format:** `duration string`
 
 **Example:** `"1h"`, `"15m"`, or `"60s"`. See [ParseDuration](https://pkg.go.dev/time#ParseDuration) for more details.

--- a/v2/charts/azure-service-operator/values.yaml
+++ b/v2/charts/azure-service-operator/values.yaml
@@ -31,8 +31,8 @@ aadPodIdentity:
 # exists to detect and correct changes that happened in Azure that Kubernetes is not
 # aware about. BE VERY CAREFUL setting this value low - even a modest number of resources
 # can cause subscription level throttling if they are re-synced frequently.
-# If nil, no sync is performed. Durations are specified as "1h", "15m", or "60s". See
-# https://pkg.go.dev/time#ParseDuration for more details.
+# Durations are specified as "1h", "15m", or "60s". Specify the special value "never" to prevent
+# syncing. See https://pkg.go.dev/time#ParseDuration for more details.
 azureSyncPeriod: ""
 
 # useWorkloadIdentityAuth can be set to use workload identity authentication

--- a/v2/internal/config/vars.go
+++ b/v2/internal/config/vars.go
@@ -61,8 +61,7 @@ type Values struct {
 	// If nil, no sync is performed. Durations are specified as "1h", "15m", or "60s". See
 	// https://pkg.go.dev/time#ParseDuration for more details.
 	//
-	// This can be set to nil by specifying empty string for AZURE_SYNC_PERIOD explicitly in
-	// the config.
+	// Specify the special value "never" for AZURE_SYNC_PERIOD to prevent syncing.
 	SyncPeriod *time.Duration
 
 	// ResourceManagerEndpoint is the Azure Resource Manager endpoint.
@@ -232,7 +231,7 @@ func parseTargetNamespaces(fromEnv string) []string {
 // parseSyncPeriod parses the sync period from the environment
 func parseSyncPeriod() (*time.Duration, error) {
 	syncPeriodStr := envOrDefault(config.SyncPeriod, "1h")
-	if syncPeriodStr == "" {
+	if syncPeriodStr == "never" { // magical string that means no sync
 		return nil, nil
 	}
 
@@ -248,6 +247,9 @@ func parseSyncPeriod() (*time.Duration, error) {
 func envOrDefault(env string, def string) string {
 	result, specified := os.LookupEnv(env)
 	if !specified {
+		return def
+	}
+	if result == "" {
 		return def
 	}
 

--- a/v2/internal/config/vars_internal_test.go
+++ b/v2/internal/config/vars_internal_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-service-operator/v2/pkg/common/config"
+)
+
+//nolint:paralleltest
+func Test_ParseSyncPeriod_ReturnsNever(t *testing.T) {
+	g := NewGomegaWithT(t)
+	t.Setenv(config.SyncPeriod, "never") // Can't run in parallel
+
+	dur, err := parseSyncPeriod()
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(dur).To(BeNil()) // Nil means no sync
+}
+
+//nolint:paralleltest
+func Test_ParseSyncPeriod_ReturnsDefaultWhenEmpty(t *testing.T) {
+	g := NewGomegaWithT(t)
+	t.Setenv(config.SyncPeriod, "") // Can't run in parallel
+
+	dur, err := parseSyncPeriod()
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(dur).ToNot(BeNil())
+	g.Expect(*dur).To(Equal(1 * time.Hour))
+}
+
+//nolint:paralleltest
+func Test_ParseSyncPeriod_ReturnsValue(t *testing.T) {
+	g := NewGomegaWithT(t)
+	t.Setenv(config.SyncPeriod, "21m") // Can't run in parallel
+
+	dur, err := parseSyncPeriod()
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(dur).ToNot(BeNil())
+	g.Expect(*dur).To(Equal(21 * time.Minute))
+}

--- a/v2/pkg/common/config/config.go
+++ b/v2/pkg/common/config/config.go
@@ -32,8 +32,8 @@ const (
 	// exists to detect and correct changes that happened in Azure that Kubernetes is not
 	// aware about. BE VERY CAREFUL setting this value low - even a modest number of resources
 	// can cause subscription level throttling if they are re-synced frequently.
-	// If nil, no sync is performed. Durations are specified as "1h", "15m", or "60s". See
-	// https://pkg.go.dev/time#ParseDuration for more details.
+	// Durations are specified as "1h", "15m", or "60s". Specify the special value "never" to prevent
+	// syncing. See https://pkg.go.dev/time#ParseDuration for more details.
 	SyncPeriod = "AZURE_SYNC_PERIOD"
 	// ResourceManagerEndpoint is the Azure Resource Manager endpoint.
 	// If not specified, the default is the Public cloud resource manager endpoint.


### PR DESCRIPTION
This fixes #3965.

This is technically breaking but seems unlikely to break many folks.

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
