### PR TITLE
Fix pre-release-test task target

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -374,7 +374,7 @@ tasks:
     dir: "{{.CONTROLLER_ROOT}}"
     cmds:
       - task: controller:docker-push-local
-      - task: controller:gen-helm-manifest
+      - task: controller:package-helm-manifest
       - task: controller:install-helm-wi
         vars:
           AZURE_MI_CLIENT_ID:

--- a/scripts/v2/create-kind-wi-storage.sh
+++ b/scripts/v2/create-kind-wi-storage.sh
@@ -52,7 +52,7 @@ openssl rsa -in "$DIR/sa.key" -pubout -out "$DIR/sa.pub"
 
 az group create -l westus -n "${RESOURCE_GROUP}" --tags "CreatedAt=$(date --utc +"%Y-%m-%dT%H:%M:%SZ")"
 
-az storage account create --resource-group "${RESOURCE_GROUP}" --name "${AZURE_STORAGE_ACCOUNT}"
+az storage account create --resource-group "${RESOURCE_GROUP}" --name "${AZURE_STORAGE_ACCOUNT}" --allow-blob-public-access false
 # Enable static website serving
 az storage blob service-properties update --account-name "${AZURE_STORAGE_ACCOUNT}" --static-website
 az storage container create --account-name "${AZURE_STORAGE_ACCOUNT}" --name "${AZURE_STORAGE_CONTAINER}"


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR fixes the TaskFile's `controller:test-upgrade-apply-prerelease-chart` target to replace the old target `controller:gen-helm-manifest` to `controller:package-helm-manifest`

Also, fixes `create-kind-wi-storage.sh` to set --allow-blob-public-access==false for StorageAccount creation.

