### PR TITLE
Group updates from all 3 packages into a single dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,78 +6,9 @@
 version: 2
 updates:
   # ASO v2 controller 
-  - package-ecosystem: "gomod" 
-    directory: "/v2" 
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-    groups:
-      # Group updates together, so that they are all applied in a single PR.
-      # Grouped updates are currently in beta and is subject to change.
-      # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
-      k8s-go-deps:
-        applies-to: version-updates
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-      go-deps:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-      # Group security updates too
-      k8s-go-deps-sec:
-        applies-to: security-updates
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-      go-deps-sec:
-        applies-to: security-updates
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-  # ASO v2 asoctl
-  - package-ecosystem: "gomod" 
-    directory: "/v2/cmd/asoctl" 
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-    groups:
-      # Group updates together, so that they are all applied in a single PR.
-      # Grouped updates are currently in beta and is subject to change.
-      # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
-      k8s-go-deps:
-        applies-to: version-updates
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-      go-deps:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-      # Group security updates too
-      k8s-go-deps-sec:
-        applies-to: security-updates
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-      go-deps-sec:
-        applies-to: security-updates
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-  # ASO v2 generator
-  - package-ecosystem: "gomod" 
-    directory: "/v2/tools/generator" 
+  - package-ecosystem: "gomod"
+    directories:
+      - "/v2/*"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"


### PR DESCRIPTION
This should avoid the issues we've had in the past with dependencies between /v2 and /v2/cmd/asoctl requiring merges in a certain order.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
