### PR TITLE
Fix issue with aks-create Taskfile target failing due to no specified DOCKER_REGISTRY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 
 # need jq for running the Makefile
 RUN curl -L -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x /usr/local/bin/jq

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -456,7 +456,9 @@ tasks:
     desc: Builds, tags and pushes the multi architecture controller container image to repository
     deps:
       - controller:bundle-crds
-      - docker-login
+      - task: docker-login
+        vars:
+          DOCKER_REGISTRY: "{{.DOCKER_REGISTRY}}"
     dir: "{{.CONTROLLER_ROOT}}"
     run: always
     cmds:
@@ -846,7 +848,7 @@ tasks:
     vars:
       DIR: "{{default .KIND_WORKLOAD_IDENTITY_PATH .DIR}}"
       RESOURCE_GROUP_FILE:
-        sh: "cat ./{{.DIR}}/azure/rg.txt"
+        sh: "cat ./{{.DIR}}/azure/rg.txt || echo ''"
       RESOURCE_GROUP: "{{default .RESOURCE_GROUP_FILE .RESOURCE_GROUP}}"
       ISSUER_FILE:
         sh: "cat ./{{.DIR}}/azure/saissuer.txt"
@@ -891,11 +893,11 @@ tasks:
           DIR: "{{.AKS_WORKLOAD_IDENTITY_PATH}}"
           RESOURCE_GROUP: "{{.HOSTNAME}}-aso-rg"
       - task: controller:install-cert-manager
-      - "az acr login --name {{.ACR_NAME}}"
       - task: controller:docker-push-multiarch
         vars:
           PLATFORMS: "{{OS}}/{{ARCH}}" # Just push to one platform for now
           DOCKER_PUSH_TARGET: "{{.ACR_NAME}}.azurecr.io"
+          DOCKER_REGISTRY: "{{.ACR_NAME}}"
       - task: controller:package-helm-manifest
       # We need the below to wait until cert-manager is up, otherwise the subsequent installation of webhooks fails. See https://cert-manager.io/next-docs/installation/verify/
       - "cmctl check api --wait=2m"

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -2,7 +2,7 @@
 ARG VERSION_FLAGS
 
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 ARG VERSION_FLAGS
 
 WORKDIR /workspace/


### PR DESCRIPTION
Also fix unrelated warning from Dockerfiles for using FROM and as with different cases.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
