### PR TITLE
Catalog all known resources, regardless of whether ASO exports them

### DIFF
--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -151,6 +151,8 @@ func createAllPipelineStages(
 
 		pipeline.RemoveEmbeddedResources(configuration, log).UsedFor(pipeline.ARMTarget),
 
+		pipeline.CatalogKnownResources(),
+
 		// Apply export filters before generating
 		// ARM types for resources etc:
 		pipeline.ApplyExportFilters(configuration, log),

--- a/v2/tools/generator/internal/codegen/pipeline/add_kubernetes_exporter.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_kubernetes_exporter.go
@@ -24,9 +24,9 @@ func AddKubernetesExporter(idFactory astmodel.IdentifierFactory) *Stage {
 			defs := state.Definitions()
 			updatedDefs := make(astmodel.TypeDefinitionSet)
 
-			mappings, ok := GetStateInfo[*ExportedTypeNameProperties](state, ExportedConfigMaps)
-			if !ok {
-				return nil, errors.New("exported config maps not found")
+			mappings, err := GetStateInfo[*ExportedTypeNameProperties](state, ExportedConfigMaps)
+			if err != nil {
+				return nil, errors.Wrapf(err, "couldn't find exported config maps")
 			}
 
 			for _, def := range astmodel.FindResourceDefinitions(defs) {

--- a/v2/tools/generator/internal/codegen/pipeline/add_kubernetes_exporter.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_kubernetes_exporter.go
@@ -24,7 +24,10 @@ func AddKubernetesExporter(idFactory astmodel.IdentifierFactory) *Stage {
 			defs := state.Definitions()
 			updatedDefs := make(astmodel.TypeDefinitionSet)
 
-			mappings := state.GeneratedConfigMaps()
+			mappings, ok := GetStateInfo[*ExportedTypeNameProperties](state, ExportedConfigMaps)
+			if !ok {
+				return nil, errors.New("exported config maps not found")
+			}
 
 			for _, def := range astmodel.FindResourceDefinitions(defs) {
 				resourceType, ok := astmodel.AsResourceType(def.Type())

--- a/v2/tools/generator/internal/codegen/pipeline/add_kubernetes_exporter.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_kubernetes_exporter.go
@@ -24,7 +24,7 @@ func AddKubernetesExporter(idFactory astmodel.IdentifierFactory) *Stage {
 			defs := state.Definitions()
 			updatedDefs := make(astmodel.TypeDefinitionSet)
 
-			mappings, err := GetStateInfo[*ExportedTypeNameProperties](state, ExportedConfigMaps)
+			mappings, err := GetStateData[*ExportedTypeNameProperties](state, ExportedConfigMaps)
 			if err != nil {
 				return nil, errors.Wrapf(err, "couldn't find exported config maps")
 			}

--- a/v2/tools/generator/internal/codegen/pipeline/add_operator_spec.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_operator_spec.go
@@ -55,7 +55,7 @@ func AddOperatorSpec(configuration *config.Configuration, idFactory astmodel.Ide
 				return nil, err
 			}
 
-			return StateWithInfo(
+			return StateWithData(
 				state.WithOverlaidDefinitions(result),
 				ExportedConfigMaps,
 				exportedTypeNameConfigMaps), nil

--- a/v2/tools/generator/internal/codegen/pipeline/add_operator_spec.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_operator_spec.go
@@ -55,7 +55,10 @@ func AddOperatorSpec(configuration *config.Configuration, idFactory astmodel.Ide
 				return nil, err
 			}
 
-			return state.WithOverlaidDefinitions(result).WithGeneratedConfigMaps(exportedTypeNameConfigMaps), nil
+			return StateWithInfo(
+				state.WithOverlaidDefinitions(result),
+				ExportedConfigMaps,
+				exportedTypeNameConfigMaps), nil
 		})
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/catalog_known_resources.go
+++ b/v2/tools/generator/internal/codegen/pipeline/catalog_known_resources.go
@@ -34,7 +34,7 @@ func CatalogKnownResources() *Stage {
 				rsrcsInGroup.Add(rsrc.Name())
 			}
 
-			return StateWithInfo(state, AllKnownResources, catalog), nil
+			return StateWithData(state, AllKnownResources, catalog), nil
 		})
 
 	// We're cataloging all known resources, so we have to do this before we reduce the set of

--- a/v2/tools/generator/internal/codegen/pipeline/catalog_known_resources.go
+++ b/v2/tools/generator/internal/codegen/pipeline/catalog_known_resources.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package pipeline
+
+import (
+	"context"
+
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+)
+
+// CatalogKnownResourcesStageID is the unique identifier for this pipeline stage
+const CatalogKnownResourcesStageID = "catalogKnownResources"
+
+func CatalogKnownResources() *Stage {
+	stage := NewStage(
+		CatalogKnownResourcesStageID,
+		"Catalog known resources",
+		func(ctx context.Context, state *State) (*State, error) {
+			rsrcs := astmodel.FindResourceDefinitions(state.Definitions())
+
+			// catalog contains a set of all known resources for each group
+			catalog := make(map[string]astmodel.TypeNameSet)
+			for _, rsrc := range rsrcs {
+				group := rsrc.Name().InternalPackageReference().Group()
+				rsrcsInGroup, ok := catalog[group]
+				if !ok {
+					rsrcsInGroup = make(astmodel.TypeNameSet)
+					catalog[group] = rsrcsInGroup
+				}
+
+				rsrcsInGroup.Add(rsrc.Name())
+			}
+
+			return StateWithInfo(state, AllKnownResources, catalog), nil
+		})
+
+	// We're cataloging all known resources, so we have to do this before we reduce the set of
+	// resources we're processing by applying the export filters.
+	stage.RequiresPostrequisiteStages(ApplyExportFiltersStageID)
+
+	return stage
+}

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
@@ -62,14 +62,14 @@ func CreateConversionGraph(
 }
 
 func exportConversionGraph(settings *DebugSettings, index int, state *State) error {
-	graph, ok := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
-	if !ok {
-		return errors.New("no conversion graph available")
+	graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+	if err != nil {
+		return errors.Wrapf(err, "conversion graph not found")
 	}
 
 	// Create our output folder
 	outputFolder := settings.CreateFileName(fmt.Sprintf("conversion-graph-%d", index))
-	err := os.Mkdir(outputFolder, 0o700)
+	err = os.Mkdir(outputFolder, 0o700)
 	if err != nil {
 		return errors.Wrapf(err, "creating output folder for conversion graph diagnostic")
 	}

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
@@ -52,7 +52,7 @@ func CreateConversionGraph(
 				return nil, errors.Wrapf(err, "creating conversion graph")
 			}
 
-			return StateWithInfo(state, ConversionGraphInfo, graph), nil
+			return StateWithData(state, ConversionGraphInfo, graph), nil
 		})
 
 	stage.AddDiagnostic(exportConversionGraph)
@@ -62,7 +62,7 @@ func CreateConversionGraph(
 }
 
 func exportConversionGraph(settings *DebugSettings, index int, state *State) error {
-	graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+	graph, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo)
 	if err != nil {
 		return errors.Wrapf(err, "conversion graph not found")
 	}

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
@@ -52,7 +52,7 @@ func CreateConversionGraph(
 				return nil, errors.Wrapf(err, "creating conversion graph")
 			}
 
-			return state.WithConversionGraph(graph), nil
+			return StateWithInfo(state, ConversionGraphInfo, graph), nil
 		})
 
 	stage.AddDiagnostic(exportConversionGraph)
@@ -62,8 +62,8 @@ func CreateConversionGraph(
 }
 
 func exportConversionGraph(settings *DebugSettings, index int, state *State) error {
-	graph := state.ConversionGraph()
-	if graph == nil {
+	graph, ok := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+	if !ok {
 		return errors.New("no conversion graph available")
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph_test.go
@@ -41,7 +41,7 @@ func TestCreateConversionGraph(t *testing.T) {
 
 	g.Expect(finalState.Definitions()).To(HaveLen(6))
 
-	graph, err := GetStateInfo[*storage.ConversionGraph](finalState, ConversionGraphInfo)
+	graph, err := GetStateData[*storage.ConversionGraph](finalState, ConversionGraphInfo)
 	g.Expect(graph).NotTo(BeNil())
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph_test.go
@@ -41,9 +41,9 @@ func TestCreateConversionGraph(t *testing.T) {
 
 	g.Expect(finalState.Definitions()).To(HaveLen(6))
 
-	graph, ok := GetStateInfo[*storage.ConversionGraph](finalState, ConversionGraphInfo)
+	graph, err := GetStateInfo[*storage.ConversionGraph](finalState, ConversionGraphInfo)
 	g.Expect(graph).NotTo(BeNil())
-	g.Expect(ok).To(BeTrue())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	// Expect to have a link from Pkg2020 to a matching storage version
 	storage2020 := graph.LookupTransition(person2020.Name())

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph_test.go
@@ -6,8 +6,9 @@
 package pipeline
 
 import (
-	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/storage"
 	"testing"
+
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/storage"
 
 	. "github.com/onsi/gomega"
 

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph_test.go
@@ -6,6 +6,7 @@
 package pipeline
 
 import (
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/storage"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -39,9 +40,10 @@ func TestCreateConversionGraph(t *testing.T) {
 	g.Expect(err).To(Succeed())
 
 	g.Expect(finalState.Definitions()).To(HaveLen(6))
-	g.Expect(finalState.ConversionGraph()).NotTo(BeNil())
 
-	graph := finalState.ConversionGraph()
+	graph, ok := GetStateInfo[*storage.ConversionGraph](finalState, ConversionGraphInfo)
+	g.Expect(graph).NotTo(BeNil())
+	g.Expect(ok).To(BeTrue())
 
 	// Expect to have a link from Pkg2020 to a matching storage version
 	storage2020 := graph.LookupTransition(person2020.Name())

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
@@ -29,9 +29,9 @@ func ImplementConvertibleInterface(idFactory astmodel.IdentifierFactory) *Stage 
 
 			modifiedTypes, err := astmodel.FindResourceDefinitions(state.Definitions()).Process(
 				func(def astmodel.TypeDefinition) (*astmodel.TypeDefinition, error) {
-					graph, ok := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
-					if !ok {
-						return nil, errors.New("conversion graph not found")
+					graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+					if err != nil {
+						return nil, errors.Wrapf(err, "couldn't find conversion graph")
 					}
 
 					hub, err := graph.FindHub(def.Name(), state.Definitions())

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
@@ -29,7 +29,7 @@ func ImplementConvertibleInterface(idFactory astmodel.IdentifierFactory) *Stage 
 
 			modifiedTypes, err := astmodel.FindResourceDefinitions(state.Definitions()).Process(
 				func(def astmodel.TypeDefinition) (*astmodel.TypeDefinition, error) {
-					graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+					graph, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo)
 					if err != nil {
 						return nil, errors.Wrapf(err, "couldn't find conversion graph")
 					}

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
@@ -7,6 +7,7 @@ package pipeline
 
 import (
 	"context"
+
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/storage"
 
 	"github.com/pkg/errors"

--- a/v2/tools/generator/internal/codegen/pipeline/implement_importable_resource_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_importable_resource_interface.go
@@ -7,8 +7,9 @@ package pipeline
 
 import (
 	"context"
-	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/storage"
 	"strings"
+
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/storage"
 
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/v2/tools/generator/internal/codegen/pipeline/implement_importable_resource_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_importable_resource_interface.go
@@ -30,7 +30,7 @@ func ImplementImportableResourceInterface(
 		"Implement the ImportableResource interface for resources that support import via asoctl",
 		func(ctx context.Context, state *State) (*State, error) {
 			// Scan for the resources requiring the ImportableResource interface injected
-			graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			graph, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo)
 			if err != nil {
 				return nil, errors.Wrapf(err, "couldn't find conversion graph")
 			}

--- a/v2/tools/generator/internal/codegen/pipeline/implement_importable_resource_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_importable_resource_interface.go
@@ -7,6 +7,7 @@ package pipeline
 
 import (
 	"context"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/storage"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -29,7 +30,12 @@ func ImplementImportableResourceInterface(
 		"Implement the ImportableResource interface for resources that support import via asoctl",
 		func(ctx context.Context, state *State) (*State, error) {
 			// Scan for the resources requiring the ImportableResource interface injected
-			scanner := newSpecInitializationScanner(state.Definitions(), state.ConversionGraph(), configuration)
+			graph, ok := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			if !ok {
+				return nil, errors.New("conversion graph not found")
+			}
+
+			scanner := newSpecInitializationScanner(state.Definitions(), graph, configuration)
 			rsrcs, err := scanner.findResources()
 			if err != nil {
 				return nil, errors.Wrapf(err, "unable to find resources that support import")

--- a/v2/tools/generator/internal/codegen/pipeline/implement_importable_resource_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_importable_resource_interface.go
@@ -30,9 +30,9 @@ func ImplementImportableResourceInterface(
 		"Implement the ImportableResource interface for resources that support import via asoctl",
 		func(ctx context.Context, state *State) (*State, error) {
 			// Scan for the resources requiring the ImportableResource interface injected
-			graph, ok := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
-			if !ok {
-				return nil, errors.New("conversion graph not found")
+			graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			if err != nil {
+				return nil, errors.Wrapf(err, "couldn't find conversion graph")
 			}
 
 			scanner := newSpecInitializationScanner(state.Definitions(), graph, configuration)

--- a/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
@@ -35,9 +35,14 @@ func InjectPropertyAssignmentFunctions(
 		InjectPropertyAssignmentFunctionsStageID,
 		"Inject property assignment functions AssignFrom() and AssignTo() into resources and objects",
 		func(ctx context.Context, state *State) (*State, error) {
+			graph, ok := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			if !ok {
+				return nil, errors.New("conversion graph not found")
+			}
+
 			defs := state.Definitions()
 			result := defs.Copy()
-			factory := newPropertyAssignmentFunctionsFactory(state.ConversionGraph(), idFactory, configuration, defs)
+			factory := newPropertyAssignmentFunctionsFactory(graph, idFactory, configuration, defs)
 
 			for name, def := range defs {
 				_, ok := astmodel.AsFunctionContainer(def.Type())
@@ -50,7 +55,7 @@ func InjectPropertyAssignmentFunctions(
 				}
 
 				// Find the definition we want to convert to/from
-				nextName, err := state.ConversionGraph().FindNextType(name, state.Definitions())
+				nextName, err := graph.FindNextType(name, state.Definitions())
 				if err != nil {
 					return nil, errors.Wrapf(err, "finding next type after %s", name)
 				}

--- a/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
@@ -35,9 +35,9 @@ func InjectPropertyAssignmentFunctions(
 		InjectPropertyAssignmentFunctionsStageID,
 		"Inject property assignment functions AssignFrom() and AssignTo() into resources and objects",
 		func(ctx context.Context, state *State) (*State, error) {
-			graph, ok := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
-			if !ok {
-				return nil, errors.New("conversion graph not found")
+			graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			if err != nil {
+				return nil, errors.Wrapf(err, "couldn't find conversion graph")
 			}
 
 			defs := state.Definitions()

--- a/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
@@ -35,7 +35,7 @@ func InjectPropertyAssignmentFunctions(
 		InjectPropertyAssignmentFunctionsStageID,
 		"Inject property assignment functions AssignFrom() and AssignTo() into resources and objects",
 		func(ctx context.Context, state *State) (*State, error) {
-			graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			graph, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo)
 			if err != nil {
 				return nil, errors.Wrapf(err, "couldn't find conversion graph")
 			}

--- a/v2/tools/generator/internal/codegen/pipeline/inject_spec_initialization_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_spec_initialization_functions.go
@@ -34,9 +34,9 @@ func InjectSpecInitializationFunctions(
 		func(ctx context.Context, state *State) (*State, error) {
 			defs := state.Definitions()
 
-			graph, ok := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
-			if !ok {
-				return nil, errors.New("conversion graph not found")
+			graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			if err != nil {
+				return nil, errors.Wrapf(err, "couldn't find conversion graph")
 			}
 
 			// Scan for the object definitions that need spec initialization functions injected

--- a/v2/tools/generator/internal/codegen/pipeline/inject_spec_initialization_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_spec_initialization_functions.go
@@ -34,7 +34,7 @@ func InjectSpecInitializationFunctions(
 		func(ctx context.Context, state *State) (*State, error) {
 			defs := state.Definitions()
 
-			graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			graph, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo)
 			if err != nil {
 				return nil, errors.Wrapf(err, "couldn't find conversion graph")
 			}

--- a/v2/tools/generator/internal/codegen/pipeline/inject_spec_initialization_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_spec_initialization_functions.go
@@ -34,8 +34,13 @@ func InjectSpecInitializationFunctions(
 		func(ctx context.Context, state *State) (*State, error) {
 			defs := state.Definitions()
 
+			graph, ok := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			if !ok {
+				return nil, errors.New("conversion graph not found")
+			}
+
 			// Scan for the object definitions that need spec initialization functions injected
-			scanner := newSpecInitializationScanner(state.Definitions(), state.ConversionGraph(), configuration)
+			scanner := newSpecInitializationScanner(state.Definitions(), graph, configuration)
 			mappings, err := scanner.scanResources()
 			if err != nil {
 				return nil, errors.Wrap(err, "scanning for spec/status mappings")

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
@@ -24,9 +24,9 @@ func MarkLatestStorageVariantAsHubVersion() *Stage {
 		MarkLatestStorageVariantAsHubVersionID,
 		"Mark the latest GA storage variant of each resource as the hub version",
 		func(ctx context.Context, state *State) (*State, error) {
-			graph, ok := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
-			if !ok {
-				return nil, errors.New("conversion graph not found")
+			graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			if err != nil {
+				return nil, errors.Wrapf(err, "couldn't find conversion graph")
 			}
 
 			updatedDefs, err := astmodel.FindResourceDefinitions(state.Definitions()).Process(

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
@@ -24,7 +24,7 @@ func MarkLatestStorageVariantAsHubVersion() *Stage {
 		MarkLatestStorageVariantAsHubVersionID,
 		"Mark the latest GA storage variant of each resource as the hub version",
 		func(ctx context.Context, state *State) (*State, error) {
-			graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			graph, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo)
 			if err != nil {
 				return nil, errors.Wrapf(err, "couldn't find conversion graph")
 			}

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
@@ -7,6 +7,7 @@ package pipeline
 
 import (
 	"context"
+
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/storage"
 
 	"github.com/pkg/errors"
@@ -24,9 +25,11 @@ func MarkLatestStorageVariantAsHubVersion() *Stage {
 		MarkLatestStorageVariantAsHubVersionID,
 		"Mark the latest GA storage variant of each resource as the hub version",
 		func(ctx context.Context, state *State) (*State, error) {
-			graph, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo)
-			if err != nil {
+			var graph *storage.ConversionGraph
+			if g, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo); err != nil {
 				return nil, errors.Wrapf(err, "couldn't find conversion graph")
+			} else {
+				graph = g
 			}
 
 			updatedDefs, err := astmodel.FindResourceDefinitions(state.Definitions()).Process(

--- a/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties.go
@@ -49,9 +49,9 @@ func RepairSkippingProperties() *Stage {
 		RepairSkippingPropertiesStageID,
 		"Repair property bag serialization for properties that skip resource or object versions",
 		func(ctx context.Context, state *State) (*State, error) {
-			graph, ok := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
-			if !ok {
-				return nil, errors.New("conversion graph not found")
+			graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			if err != nil {
+				return nil, errors.Wrapf(err, "couldn't find conversion graph")
 			}
 
 			repairer := newSkippingPropertyRepairer(state.Definitions(), graph)

--- a/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties.go
@@ -49,7 +49,7 @@ func RepairSkippingProperties() *Stage {
 		RepairSkippingPropertiesStageID,
 		"Repair property bag serialization for properties that skip resource or object versions",
 		func(ctx context.Context, state *State) (*State, error) {
-			graph, err := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			graph, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo)
 			if err != nil {
 				return nil, errors.Wrapf(err, "couldn't find conversion graph")
 			}

--- a/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties.go
@@ -49,9 +49,11 @@ func RepairSkippingProperties() *Stage {
 		RepairSkippingPropertiesStageID,
 		"Repair property bag serialization for properties that skip resource or object versions",
 		func(ctx context.Context, state *State) (*State, error) {
-			graph, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo)
-			if err != nil {
+			var graph *storage.ConversionGraph
+			if g, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo); err != nil {
 				return nil, errors.Wrapf(err, "couldn't find conversion graph")
+			} else {
+				graph = g
 			}
 
 			repairer := newSkippingPropertyRepairer(state.Definitions(), graph)

--- a/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties.go
@@ -49,7 +49,12 @@ func RepairSkippingProperties() *Stage {
 		RepairSkippingPropertiesStageID,
 		"Repair property bag serialization for properties that skip resource or object versions",
 		func(ctx context.Context, state *State) (*State, error) {
-			repairer := newSkippingPropertyRepairer(state.Definitions(), state.ConversionGraph())
+			graph, ok := GetStateInfo[*storage.ConversionGraph](state, ConversionGraphInfo)
+			if !ok {
+				return nil, errors.New("conversion graph not found")
+			}
+
+			repairer := newSkippingPropertyRepairer(state.Definitions(), graph)
 
 			// Add resources and objects to the graph
 			for _, def := range state.Definitions() {

--- a/v2/tools/generator/internal/codegen/pipeline/state.go
+++ b/v2/tools/generator/internal/codegen/pipeline/state.go
@@ -16,11 +16,10 @@ import (
 
 // State is an immutable instance that captures the information being passed along the pipeline
 type State struct {
-	definitions        astmodel.TypeDefinitionSet // set of type definitions generated so far
-	exportedConfigMaps *ExportedTypeNameProperties
-	stagesSeen         set.Set[string]            // set of ids of the stages already run
-	stagesExpected     map[string]set.Set[string] // set of ids of expected stages, each with a set of ids for the stages expecting them
-	stateInfo          map[StateInfo]any          // map of state information
+	definitions    astmodel.TypeDefinitionSet // set of type definitions generated so far
+	stagesSeen     set.Set[string]            // set of ids of the stages already run
+	stagesExpected map[string]set.Set[string] // set of ids of expected stages, each with a set of ids for the stages expecting them
+	stateInfo      map[StateInfo]any          // map of state information
 }
 
 /*
@@ -67,17 +66,6 @@ func (s *State) WithOverlaidDefinitions(definitions astmodel.TypeDefinitionSet) 
 	return result
 }
 
-// WithGeneratedConfigMaps returns a new independent State with the given generated config maps
-func (s *State) WithGeneratedConfigMaps(exportedConfigMaps *ExportedTypeNameProperties) *State {
-	if s.exportedConfigMaps != nil {
-		panic("may only set the generated config mappings once")
-	}
-
-	result := s.copy()
-	result.exportedConfigMaps = exportedConfigMaps
-	return result
-}
-
 // WithSeenStage records that the passed stage has been seen
 func (s *State) WithSeenStage(id string) *State {
 	result := s.copy()
@@ -105,11 +93,6 @@ func (s *State) Definitions() astmodel.TypeDefinitionSet {
 	return s.definitions
 }
 
-// GeneratedConfigMaps returns the set of generated config maps
-func (s *State) GeneratedConfigMaps() *ExportedTypeNameProperties {
-	return s.exportedConfigMaps
-}
-
 // CheckFinalState checks that our final state is valid, returning an error if not
 func (s *State) CheckFinalState() error {
 	var errs []error
@@ -125,11 +108,10 @@ func (s *State) CheckFinalState() error {
 // copy creates a new independent copy of the state
 func (s *State) copy() *State {
 	return &State{
-		definitions:        s.definitions.Copy(),
-		exportedConfigMaps: s.exportedConfigMaps.Copy(),
-		stagesSeen:         s.stagesSeen,
-		stagesExpected:     s.stagesExpected,
-		stateInfo:          maps.Clone(s.stateInfo),
+		definitions:    s.definitions.Copy(),
+		stagesSeen:     s.stagesSeen,
+		stagesExpected: s.stagesExpected,
+		stateInfo:      maps.Clone(s.stateInfo),
 	}
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/state.go
+++ b/v2/tools/generator/internal/codegen/pipeline/state.go
@@ -133,12 +133,28 @@ func StateWithInfo[I any](
 func GetStateInfo[I any](
 	state *State,
 	key StateInfo,
-) (I, bool) {
+) (I, error) {
 	if state.stateInfo == nil {
-		var result I
-		return result, false
+		var zero I
+		return zero, errors.Errorf("no state information available")
 	}
 
-	info, ok := state.stateInfo[key].(I)
-	return info, ok
+	value, ok := state.stateInfo[key]
+	if !ok {
+		var zero I
+		return zero, errors.Errorf("no state information found for key %s", key)
+	}
+
+	info, ok := value.(I)
+	if !ok {
+		var zero I
+		return zero,
+			errors.Errorf(
+				"state information found for key %s of type %T, expected %T",
+				key,
+				value,
+				zero)
+	}
+
+	return info, nil
 }

--- a/v2/tools/generator/internal/codegen/pipeline/state.go
+++ b/v2/tools/generator/internal/codegen/pipeline/state.go
@@ -7,6 +7,7 @@ package pipeline
 
 import (
 	"github.com/pkg/errors"
+	"golang.org/x/exp/maps"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
@@ -35,6 +36,7 @@ type StateInfo string
 
 const (
 	ConversionGraphInfo StateInfo = "ConversionGraph"
+	ExportedConfigMaps  StateInfo = "ExportedConfigMaps"
 )
 
 // NewState returns a new empty state
@@ -143,6 +145,7 @@ func (s *State) copy() *State {
 		exportedConfigMaps: s.exportedConfigMaps.Copy(),
 		stagesSeen:         s.stagesSeen,
 		stagesExpected:     s.stagesExpected,
+		stateInfo:          maps.Clone(s.stateInfo),
 	}
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/state.go
+++ b/v2/tools/generator/internal/codegen/pipeline/state.go
@@ -22,13 +22,6 @@ type State struct {
 	stateInfo      map[StateInfo]any          // map of state information
 }
 
-/*
- *  TODO: Future extension (suggested by @matthchr):
- *  Instead of hard coding specific knowledge in the state type, implement a generic solution where stages can stash
- *  information in a map indexed by their unique identifier; later stages can then retrieve that information using
- *  that identifier.
- */
-
 type StateInfo string
 
 const (

--- a/v2/tools/generator/internal/codegen/pipeline/state.go
+++ b/v2/tools/generator/internal/codegen/pipeline/state.go
@@ -19,15 +19,17 @@ type State struct {
 	definitions    astmodel.TypeDefinitionSet // set of type definitions generated so far
 	stagesSeen     set.Set[string]            // set of ids of the stages already run
 	stagesExpected map[string]set.Set[string] // set of ids of expected stages, each with a set of ids for the stages expecting them
-	stateInfo      map[StateInfo]any          // map of state information
+	stateInfo      map[StateDataKey]any       // map of state information
 }
 
-type StateInfo string
+// StateDataKey defines a unique key used to store/recall information in the pipeline state.
+// This allows one stage to store information for consumption by another later stage.
+type StateDataKey string
 
 const (
-	AllKnownResources   StateInfo = "AllKnownResources"
-	ConversionGraphInfo StateInfo = "ConversionGraph"
-	ExportedConfigMaps  StateInfo = "ExportedConfigMaps"
+	AllKnownResources   StateDataKey = "AllKnownResources"
+	ConversionGraphInfo StateDataKey = "ConversionGraph"
+	ExportedConfigMaps  StateDataKey = "ExportedConfigMaps"
 )
 
 // NewState returns a new empty state
@@ -109,30 +111,30 @@ func (s *State) copy() *State {
 	}
 }
 
-// StateWithInfo returns a new state with the given information included.
+// StateWithData returns a new state with the given information included.
 // Any existing information with the same key is replaced.
 // Has to be written as a standalone function because methods can't introduce new generic variation.
-func StateWithInfo[I any](
+func StateWithData[I any](
 	state *State,
-	key StateInfo,
+	key StateDataKey,
 	info I,
 ) *State {
 	result := state.copy()
 	if result.stateInfo == nil {
-		result.stateInfo = make(map[StateInfo]any)
+		result.stateInfo = make(map[StateDataKey]any)
 	}
 
 	result.stateInfo[key] = info
 	return result
 }
 
-// GetStateInfo returns the information stored in the state under the given key.
+// GetStateData returns the information stored in the state under the given key.
 // If no information is stored under the key, or if it doesn't have the expected type, the second
 // return value is false.
 // Has to be written as a standalone function because methods can't introduce new generic variation.
-func GetStateInfo[I any](
+func GetStateData[I any](
 	state *State,
-	key StateInfo,
+	key StateDataKey,
 ) (I, error) {
 	if state.stateInfo == nil {
 		var zero I

--- a/v2/tools/generator/internal/codegen/pipeline/state.go
+++ b/v2/tools/generator/internal/codegen/pipeline/state.go
@@ -32,6 +32,7 @@ type State struct {
 type StateInfo string
 
 const (
+	AllKnownResources   StateInfo = "AllKnownResources"
 	ConversionGraphInfo StateInfo = "ConversionGraph"
 	ExportedConfigMaps  StateInfo = "ExportedConfigMaps"
 )

--- a/v2/tools/generator/internal/codegen/pipeline/state.go
+++ b/v2/tools/generator/internal/codegen/pipeline/state.go
@@ -131,7 +131,7 @@ func StateWithData[I any](
 // GetStateData returns the information stored in the state under the given key.
 // If no information is stored under the key, or if it doesn't have the expected type, the second
 // return value is false.
-// Has to be written as a standalone function because methods can't introduce new generic variation.
+// Has to be written as a standalone function because methods can't introduce new generic variables.
 func GetStateData[I any](
 	state *State,
 	key StateDataKey,

--- a/v2/tools/generator/internal/codegen/pipeline/state_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/state_test.go
@@ -46,3 +46,26 @@ func TestStateCheckFinalState_WhenExpectationNotSatisfied_ReturnsExpectedError(t
 	g.Expect(err.Error()).To(ContainSubstring(firstStageId))
 	g.Expect(err.Error()).To(ContainSubstring(lastStageId))
 }
+
+func TestStateInfo_WhenValueStored_CanBeRetrieved(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	state := NewState()
+	state = StateWithInfo(state, ConversionGraphInfo, 42)
+
+	value, ok := GetStateInfo[int](state, ConversionGraphInfo)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(value).To(Equal(42))
+}
+
+func TestStateInfo_WhenValueStored_CannotBeRetrievedWithWrongType(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	state := NewState()
+	state = StateWithInfo(state, ConversionGraphInfo, 42)
+
+	_, ok := GetStateInfo[string](state, ConversionGraphInfo)
+	g.Expect(ok).To(BeFalse())
+}

--- a/v2/tools/generator/internal/codegen/pipeline/state_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/state_test.go
@@ -52,9 +52,9 @@ func TestStateInfo_WhenValueStored_CanBeRetrieved(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	state := NewState()
-	state = StateWithInfo(state, ConversionGraphInfo, 42)
+	state = StateWithData(state, ConversionGraphInfo, 42)
 
-	value, err := GetStateInfo[int](state, ConversionGraphInfo)
+	value, err := GetStateData[int](state, ConversionGraphInfo)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(value).To(Equal(42))
 }
@@ -64,9 +64,9 @@ func TestStateInfo_WhenValueStored_CannotBeRetrievedWithWrongType(t *testing.T) 
 	g := NewGomegaWithT(t)
 
 	state := NewState()
-	state = StateWithInfo(state, ConversionGraphInfo, 42)
+	state = StateWithData(state, ConversionGraphInfo, 42)
 
-	_, err := GetStateInfo[string](state, ConversionGraphInfo)
+	_, err := GetStateData[string](state, ConversionGraphInfo)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("expected string"))
 }
@@ -76,14 +76,14 @@ func TestStateInfo_CanStoreAndRecallMultipleValues(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	state := NewState()
-	state = StateWithInfo(state, ConversionGraphInfo, 42)
-	state = StateWithInfo(state, ExportedConfigMaps, "hello")
+	state = StateWithData(state, ConversionGraphInfo, 42)
+	state = StateWithData(state, ExportedConfigMaps, "hello")
 
-	graphInfo, err := GetStateInfo[int](state, ConversionGraphInfo)
+	graphInfo, err := GetStateData[int](state, ConversionGraphInfo)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(graphInfo).To(Equal(42))
 
-	configMaps, err := GetStateInfo[string](state, ExportedConfigMaps)
+	configMaps, err := GetStateData[string](state, ExportedConfigMaps)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(configMaps).To(Equal("hello"))
 }

--- a/v2/tools/generator/internal/codegen/pipeline/state_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/state_test.go
@@ -54,8 +54,8 @@ func TestStateInfo_WhenValueStored_CanBeRetrieved(t *testing.T) {
 	state := NewState()
 	state = StateWithInfo(state, ConversionGraphInfo, 42)
 
-	value, ok := GetStateInfo[int](state, ConversionGraphInfo)
-	g.Expect(ok).To(BeTrue())
+	value, err := GetStateInfo[int](state, ConversionGraphInfo)
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(value).To(Equal(42))
 }
 
@@ -66,8 +66,9 @@ func TestStateInfo_WhenValueStored_CannotBeRetrievedWithWrongType(t *testing.T) 
 	state := NewState()
 	state = StateWithInfo(state, ConversionGraphInfo, 42)
 
-	_, ok := GetStateInfo[string](state, ConversionGraphInfo)
-	g.Expect(ok).To(BeFalse())
+	_, err := GetStateInfo[string](state, ConversionGraphInfo)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("expected string"))
 }
 
 func TestStateInfo_CanStoreAndRecallMultipleValues(t *testing.T) {
@@ -78,11 +79,11 @@ func TestStateInfo_CanStoreAndRecallMultipleValues(t *testing.T) {
 	state = StateWithInfo(state, ConversionGraphInfo, 42)
 	state = StateWithInfo(state, ExportedConfigMaps, "hello")
 
-	graphInfo, ok := GetStateInfo[int](state, ConversionGraphInfo)
-	g.Expect(ok).To(BeTrue())
+	graphInfo, err := GetStateInfo[int](state, ConversionGraphInfo)
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(graphInfo).To(Equal(42))
 
-	configMaps, ok := GetStateInfo[string](state, ExportedConfigMaps)
-	g.Expect(ok).To(BeTrue())
+	configMaps, err := GetStateInfo[string](state, ExportedConfigMaps)
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(configMaps).To(Equal("hello"))
 }

--- a/v2/tools/generator/internal/codegen/pipeline/state_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/state_test.go
@@ -69,3 +69,20 @@ func TestStateInfo_WhenValueStored_CannotBeRetrievedWithWrongType(t *testing.T) 
 	_, ok := GetStateInfo[string](state, ConversionGraphInfo)
 	g.Expect(ok).To(BeFalse())
 }
+
+func TestStateInfo_CanStoreAndRecallMultipleValues(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	state := NewState()
+	state = StateWithInfo(state, ConversionGraphInfo, 42)
+	state = StateWithInfo(state, ExportedConfigMaps, "hello")
+
+	graphInfo, ok := GetStateInfo[int](state, ConversionGraphInfo)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(graphInfo).To(Equal(42))
+
+	configMaps, ok := GetStateInfo[string](state, ExportedConfigMaps)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(configMaps).To(Equal("hello"))
+}

--- a/v2/tools/generator/internal/codegen/testdata/TestGolden_NewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/v2/tools/generator/internal/codegen/testdata/TestGolden_NewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -19,6 +19,7 @@ collapseCrossGroupReferences                                 Find and remove cro
 stripUnreferenced                                            Strip unreferenced types
 assertTypesStructureValid                                    Verify that all local TypeNames refer to a type
 removeEmbeddedResources                           azure      Remove properties that point to embedded resources.
+catalogKnownResources                                        Catalog known resources
 filterTypes                                                  Apply export filters to reduce the number of generated types
 add-api-version-enums                                        Add enums for API Versions in each package
 removeAliases                                                Remove type aliases

--- a/v2/tools/generator/internal/codegen/testdata/TestGolden_NewCrossplaneCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/v2/tools/generator/internal/codegen/testdata/TestGolden_NewCrossplaneCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -18,6 +18,7 @@ removeAliases                                           Remove type aliases
 collapseCrossGroupReferences                            Find and remove cross group references
 stripUnreferenced                                       Strip unreferenced types
 assertTypesStructureValid                               Verify that all local TypeNames refer to a type
+catalogKnownResources                                   Catalog known resources
 filterTypes                                             Apply export filters to reduce the number of generated types
 add-api-version-enums                                   Add enums for API Versions in each package
 removeAliases                                           Remove type aliases

--- a/v2/tools/generator/internal/codegen/testdata/TestGolden_NewTestCodeGeneratorCreatesRightPipeline.golden
+++ b/v2/tools/generator/internal/codegen/testdata/TestGolden_NewTestCodeGeneratorCreatesRightPipeline.golden
@@ -17,6 +17,7 @@ determineResourceOwnership                            Determine ARM resource rel
 removeAliases                                         Remove type aliases
 stripUnused                                           Strip unused types for test
 assertTypesStructureValid                             Verify that all local TypeNames refer to a type
+catalogKnownResources                                 Catalog known resources
 add-api-version-enums                                 Add enums for API Versions in each package
 removeAliases                                         Remove type aliases
 makeStatusPropertiesOptional                          Force all status properties to be optional


### PR DESCRIPTION
**What this PR does / why we need it**:

To produce a report listing supported resources that need upgrading, we first need to have a catalog of all known resources.

In this PR we add that catalog to our pipeline state, unblocking the future report.

**Special notes for your reviewer**:

As this is the _third_ piece of specialized (non-global) data that we need to store in the state, I've switched up the storage to a more generic approach where we don't need to make extensive customizations to `State` as new data needs are identified.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExd2Jld2Fwam12aWJkcjU1MGtwcGU4aXo0N3o4MXkxdG56NTAwdmM1MyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Y34nuiC606Pc0Me4DZ/giphy.gif)
