### PR TITLE
Fix bug where 'none' crd-management mode blocked pod start

### DIFF
--- a/v2/cmd/controller/app/setup.go
+++ b/v2/cmd/controller/app/setup.go
@@ -163,11 +163,9 @@ func SetupControllerManager(ctx context.Context, setupLog logr.Logger, flgs Flag
 		os.Exit(1)
 	}
 
-	// By default, assume the existing CRDs are the goal CRDs. If CRD management is enabled, we will
-	// load the goal CRDs from disk and apply them.
-	goalCRDs := existingCRDs
 	switch flgs.CRDManagementMode {
 	case "auto":
+		var goalCRDs []apiextensions.CustomResourceDefinition
 		goalCRDs, err = crdManager.LoadOperatorCRDs(crdmanagement.CRDLocation, cfg.PodNamespace)
 		if err != nil {
 			setupLog.Error(err, "failed to load CRDs from disk")
@@ -190,6 +188,7 @@ func SetupControllerManager(ctx context.Context, setupLog logr.Logger, flgs Flag
 				os.Exit(1)
 			}
 
+			// Note that this step will restart the pod when it succeeds
 			err = crdManager.ApplyCRDs(ctx, installationInstructions)
 			if err != nil {
 				setupLog.Error(err, "failed to apply CRDs")
@@ -203,13 +202,24 @@ func SetupControllerManager(ctx context.Context, setupLog logr.Logger, flgs Flag
 		os.Exit(1)
 	}
 
-	// Of all the resources we know of, find any that aren't ready. We will use this collection
-	// to skip watching of these not-ready resources.
-	nonReadyResources := crdmanagement.GetNonReadyCRDs(cfg, crdManager, goalCRDs, existingCRDs)
+	// There are 3 possibilities once we reach here:
+	// 1. Webhooks mode + crd-management-mode=auto: existingCRDs will be up to date (upgraded, crd-pattern applied, etc)
+	//    by the time we get here as the pod will keep exiting until it is so (see crdManager.ApplyCRDs above).
+	// 2. Non-webhooks mode + auto: As outlined in https://azure.github.io/azure-service-operator/guide/authentication/multitenant-deployment/#upgrading
+	//    the webhooks mode pod must be upgraded first, so there's not really much practical difference between this and
+	//    crd-management-mode=none (see below).
+	// 3. crd-management-mode=none: existingCRDs is the set of CRDs that are installed and we can't do anything else but
+	//    trust that they are correct.
+	//    TODO: This is not quite true as if we wanted we could still read the CRDs from the filesystem and
+	//    TODO: just exit if what we see remotely doesn't match what we have locally, the downside of this is we pay
+	//    TODO: the nontrivial startup cost of reading the local copy of CRDs into memory. Since "none" is
+	//    TODO: us approximating the standard operator experience we don't perform this assertion currently as most
+	//    TODO: operators don't.
+	readyResources := crdmanagement.MakeCRDMap(existingCRDs)
 
 	if cfg.OperatorMode.IncludesWatchers() {
 		//nolint:contextcheck
-		err = initializeWatchers(nonReadyResources, cfg, mgr, clients)
+		err = initializeWatchers(readyResources, cfg, mgr, clients)
 		if err != nil {
 			setupLog.Error(err, "failed to initialize watchers")
 			os.Exit(1)
@@ -219,7 +229,7 @@ func SetupControllerManager(ctx context.Context, setupLog logr.Logger, flgs Flag
 	if cfg.OperatorMode.IncludesWebhooks() {
 		objs := controllers.GetKnownTypes()
 
-		objs, err = crdmanagement.FilterKnownTypesByReadyCRDs(clients.log, scheme, nonReadyResources, objs)
+		objs, err = crdmanagement.FilterKnownTypesByReadyCRDs(clients.log, scheme, readyResources, objs)
 		if err != nil {
 			setupLog.Error(err, "failed to filter known types by ready CRDs")
 			os.Exit(1)
@@ -385,7 +395,7 @@ func initializeClients(cfg config.Values, mgr ctrl.Manager) (*clients, error) {
 	}, nil
 }
 
-func initializeWatchers(nonReadyResources map[string]apiextensions.CustomResourceDefinition, cfg config.Values, mgr ctrl.Manager, clients *clients) error {
+func initializeWatchers(readyResources map[string]apiextensions.CustomResourceDefinition, cfg config.Values, mgr ctrl.Manager, clients *clients) error {
 	clients.log.V(Status).Info("Configuration details", "config", cfg.String())
 
 	objs, err := controllers.GetKnownStorageTypes(
@@ -400,7 +410,7 @@ func initializeWatchers(nonReadyResources map[string]apiextensions.CustomResourc
 	}
 
 	// Filter the types to register
-	objs, err = crdmanagement.FilterStorageTypesByReadyCRDs(clients.log, mgr.GetScheme(), nonReadyResources, objs)
+	objs, err = crdmanagement.FilterStorageTypesByReadyCRDs(clients.log, mgr.GetScheme(), readyResources, objs)
 	if err != nil {
 		return errors.Wrap(err, "failed to filter storage types by ready CRDs")
 	}

--- a/v2/internal/crdmanagement/helpers.go
+++ b/v2/internal/crdmanagement/helpers.go
@@ -15,39 +15,31 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
-	"github.com/Azure/azure-service-operator/v2/internal/config"
 	"github.com/Azure/azure-service-operator/v2/internal/set"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/registration"
 )
 
-func GetNonReadyCRDs(
-	cfg config.Values,
-	crdManager *Manager,
-	goalCRDs []apiextensions.CustomResourceDefinition,
-	existingCRDs []apiextensions.CustomResourceDefinition,
+func MakeCRDMap(
+	crds []apiextensions.CustomResourceDefinition,
 ) map[string]apiextensions.CustomResourceDefinition {
-	equalityCheck := SpecEqual
-	// If we're not the webhooks install, we're in multitenant mode and we expect that the CRD webhook points to a different
-	// namespace than ours. We don't actually know what the right namespace is though so we can't verify it - we just have to trust it's right.
-	if !cfg.OperatorMode.IncludesWebhooks() {
-		equalityCheck = SpecEqualIgnoreConversionWebhook
+	// Build a map so lookup is faster
+	result := make(map[string]apiextensions.CustomResourceDefinition, len(crds))
+	for _, crd := range crds {
+		result[crd.Name] = crd
 	}
-
-	nonReadyResources := crdManager.FindNonMatchingCRDs(existingCRDs, goalCRDs, equalityCheck)
-
-	return nonReadyResources
+	return result
 }
 
 func FilterStorageTypesByReadyCRDs(
 	logger logr.Logger,
 	scheme *runtime.Scheme,
-	skip map[string]apiextensions.CustomResourceDefinition,
+	include map[string]apiextensions.CustomResourceDefinition,
 	storageTypes []*registration.StorageType,
 ) ([]*registration.StorageType, error) {
-	// skip map key is by CRD name, but we need it to be by kind
-	skipKinds := set.Make[schema.GroupKind]()
-	for _, crd := range skip {
-		skipKinds.Add(schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind})
+	// include map key is by CRD name, but we need it to be by kind
+	includeKinds := set.Make[schema.GroupKind]()
+	for _, crd := range include {
+		includeKinds.Add(schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind})
 	}
 
 	result := make([]*registration.StorageType, 0, len(storageTypes))
@@ -59,8 +51,10 @@ func FilterStorageTypesByReadyCRDs(
 			return nil, errors.Wrapf(err, "creating GVK for obj %T", storageType.Obj)
 		}
 
-		if skipKinds.Contains(gvk.GroupKind()) {
-			logger.V(0).Info("Skipping reconciliation of resource because CRD was not installed", "groupKind", gvk.GroupKind().String())
+		if !includeKinds.Contains(gvk.GroupKind()) {
+			logger.V(0).Info(
+				"Skipping reconciliation of resource because CRD was not installed or did not match the expected shape",
+				"groupKind", gvk.GroupKind().String())
 			continue
 		}
 
@@ -73,13 +67,13 @@ func FilterStorageTypesByReadyCRDs(
 func FilterKnownTypesByReadyCRDs(
 	logger logr.Logger,
 	scheme *runtime.Scheme,
-	skip map[string]apiextensions.CustomResourceDefinition,
+	include map[string]apiextensions.CustomResourceDefinition,
 	knownTypes []client.Object,
 ) ([]client.Object, error) {
-	// skip map key is by CRD name, but we need it to be by kind
-	skipKinds := set.Make[schema.GroupKind]()
-	for _, crd := range skip {
-		skipKinds.Add(schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind})
+	// include map key is by CRD name, but we need it to be by kind
+	includeKinds := set.Make[schema.GroupKind]()
+	for _, crd := range include {
+		includeKinds.Add(schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind})
 	}
 
 	result := make([]client.Object, 0, len(knownTypes))
@@ -89,8 +83,10 @@ func FilterKnownTypesByReadyCRDs(
 		if err != nil {
 			return nil, errors.Wrapf(err, "creating GVK for obj %T", knownType)
 		}
-		if skipKinds.Contains(gvk.GroupKind()) {
-			logger.V(0).Info("Skipping webhooks of resource because CRD was not installed", "groupKind", gvk.GroupKind().String())
+		if !includeKinds.Contains(gvk.GroupKind()) {
+			logger.V(0).Info(
+				"Skipping webhooks of resource because CRD was not installed or did not match the expected shape",
+				"groupKind", gvk.GroupKind().String())
 			continue
 		}
 

--- a/v2/internal/crdmanagement/helpers_test.go
+++ b/v2/internal/crdmanagement/helpers_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package crdmanagement_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/Azure/azure-service-operator/v2/api"
+	"github.com/Azure/azure-service-operator/v2/internal/config"
+	"github.com/Azure/azure-service-operator/v2/internal/controllers"
+	"github.com/Azure/azure-service-operator/v2/internal/crdmanagement"
+	"github.com/Azure/azure-service-operator/v2/internal/reconcilers/arm"
+	"github.com/Azure/azure-service-operator/v2/internal/reconcilers/generic"
+	"github.com/Azure/azure-service-operator/v2/internal/testcommon"
+	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/registration"
+)
+
+type schemer struct {
+	scheme *runtime.Scheme
+}
+
+func (s *schemer) GetScheme() *runtime.Scheme {
+	return s.scheme
+}
+
+// This test requires that the task target `bundle-crds` has been run
+func Test_AllCRDsReady_NoneAreFiltered(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	testData := testSetup(t)
+
+	// load crds
+	goalCRDs, err := testData.crdManager.LoadOperatorCRDs(testData.crdPath, testData.namespace)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	readyResources := crdmanagement.MakeCRDMap(goalCRDs)
+
+	knownTypes, err := testData.getKnownStorageTypes()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Filter the types to register
+	objs, err := crdmanagement.FilterStorageTypesByReadyCRDs(testData.logger, testData.s.GetScheme(), readyResources, knownTypes)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(objs).To(Equal(knownTypes))
+}
+
+// This test requires that the task target `bundle-crds` has been run
+func Test_FiveCRDsReady_AllOthersAreFiltered(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	testData := testSetup(t)
+
+	// load crds
+	goalCRDs, err := testData.crdManager.LoadOperatorCRDs(testData.crdPath, testData.namespace)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Filter all but the first 5 CRDs
+	filteredGoalCRDs := make([]apiextensions.CustomResourceDefinition, 0, 5)
+	for i, goalCRD := range goalCRDs {
+		if i >= 5 {
+			break
+		}
+		filteredGoalCRDs = append(filteredGoalCRDs, goalCRD)
+	}
+
+	readyResources := crdmanagement.MakeCRDMap(filteredGoalCRDs)
+
+	knownTypes, err := testData.getKnownStorageTypes()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Filter the types to register
+	objs, err := crdmanagement.FilterStorageTypesByReadyCRDs(testData.logger, testData.s.GetScheme(), readyResources, knownTypes)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(objs).To(HaveLen(5))
+}
+
+/*
+ * Helpers
+ */
+
+func NewFakeKubeClient(s *runtime.Scheme) kubeclient.Client {
+	fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+	return kubeclient.NewClient(fakeClient)
+}
+
+type testData struct {
+	cfg        config.Values
+	s          controllers.Schemer
+	kubeClient kubeclient.Client
+	logger     logr.Logger
+	crdManager *crdmanagement.Manager
+	crdPath    string
+	namespace  string
+}
+
+func testSetup(t *testing.T) *testData {
+	asoScheme := api.CreateScheme()
+	s := &schemer{scheme: asoScheme}
+
+	kubeClient := NewFakeKubeClient(asoScheme)
+	logger := testcommon.NewTestLogger(t)
+	cfg := config.Values{}
+
+	crdManager := crdmanagement.NewManager(logger, kubeClient)
+
+	return &testData{
+		cfg:        cfg,
+		s:          s,
+		kubeClient: kubeClient,
+		logger:     logger,
+		crdManager: crdManager,
+		crdPath:    "../../out/crds",
+		namespace:  "azureserviceoperator-system",
+	}
+}
+
+func (t *testData) getKnownStorageTypes() ([]*registration.StorageType, error) {
+	return controllers.GetKnownStorageTypes(
+		t.s,
+		func(ctx context.Context, object genruntime.ARMMetaObject) (arm.Connection, error) {
+			// For the purposes of this test, we're not really going to go to ARM so we can just do nothing here
+			return nil, nil
+		},
+		nil, // Not used for this test
+		t.kubeClient,
+		nil, // Not used for this test
+		generic.Options{})
+}

--- a/v2/internal/crdmanagement/manager.go
+++ b/v2/internal/crdmanagement/manager.go
@@ -321,7 +321,7 @@ func (m *Manager) loadCRDs(path string) ([]apiextensions.CustomResourceDefinitio
 			return nil, errors.Wrapf(err, "failed to unmarshal %s to CRD", filePath)
 		}
 
-		m.logger.V(Verbose).Info("Loaded CRD", "path", filePath, "name", crd.Name)
+		m.logger.V(Verbose).Info("Loaded CRD", "crdPath", filePath, "name", crd.Name)
 		results = append(results, crd)
 	}
 

--- a/v2/internal/crdmanagement/manager_test.go
+++ b/v2/internal/crdmanagement/manager_test.go
@@ -424,13 +424,9 @@ func Test_BundledCRDs_HaveExactlyTwoInstancesOfNamespace(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	path := "../../out/crds"
-	logger := testcommon.NewTestLogger(t)
-	crdManager := crdmanagement.NewManager(logger, nil)
+	testData := testSetup(t)
 
-	defaultNamespace := "azureserviceoperator-system"
-
-	loadedCRDs, err := crdManager.LoadOperatorCRDs(path, defaultNamespace)
+	loadedCRDs, err := testData.crdManager.LoadOperatorCRDs(testData.crdPath, testData.namespace)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(loadedCRDs).ToNot(BeEmpty())
 	// The raw JSON should contain exactly 2 locations where the namespace is referenced. If this changes, we need
@@ -440,7 +436,7 @@ func Test_BundledCRDs_HaveExactlyTwoInstancesOfNamespace(t *testing.T) {
 	bytes, err := json.Marshal(crd)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	count := strings.Count(string(bytes), defaultNamespace)
+	count := strings.Count(string(bytes), testData.namespace)
 	g.Expect(count).To(Equal(2))
 }
 


### PR DESCRIPTION
This happened because in 'none' mode goalCRDs was the set of installed CRDs, but we built an exclusion list from that set and used it to filter the set of known storage types from the scheme. When count(existing) = 5 and count(scheme)=200, the most you can possibly filter from the scheme with an exclusion list is 5 which leaves 195 CRDs being mistakenly installed.

Fixes #4146.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
