### PR TITLE
Read aso-controller-settings ConfigMap via volume rather than env variables

### DIFF
--- a/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
+++ b/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
@@ -67,111 +67,6 @@ spec:
         - --webhook-cert-dir={{ .Values.webhook.certDir }}
         {{- end }}
         env:
-        - name: AZURE_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              key: AZURE_CLIENT_ID
-              name: aso-controller-settings
-        - name: AZURE_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: AZURE_CLIENT_SECRET
-              name: aso-controller-settings
-              optional: true
-        - name: AZURE_TENANT_ID
-          valueFrom:
-            secretKeyRef:
-              key: AZURE_TENANT_ID
-              name: aso-controller-settings
-        - name: AZURE_SUBSCRIPTION_ID
-          valueFrom:
-            secretKeyRef:
-              key: AZURE_SUBSCRIPTION_ID
-              name: aso-controller-settings
-        - name: AZURE_CLIENT_CERTIFICATE
-          valueFrom:
-            secretKeyRef:
-              key: AZURE_CLIENT_CERTIFICATE
-              name: aso-controller-settings
-              optional: true
-        - name: AZURE_CLIENT_CERTIFICATE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: AZURE_CLIENT_CERTIFICATE_PASSWORD
-              name: aso-controller-settings
-              optional: true
-        - name: AZURE_AUTHORITY_HOST
-          valueFrom:
-            secretKeyRef:
-              key: AZURE_AUTHORITY_HOST
-              name: aso-controller-settings
-              optional: true
-        - name: AZURE_RESOURCE_MANAGER_ENDPOINT
-          valueFrom:
-            secretKeyRef:
-              key: AZURE_RESOURCE_MANAGER_ENDPOINT
-              name: aso-controller-settings
-              optional: true
-        - name: AZURE_RESOURCE_MANAGER_AUDIENCE
-          valueFrom:
-            secretKeyRef:
-              key: AZURE_RESOURCE_MANAGER_AUDIENCE
-              name: aso-controller-settings
-              optional: true
-        - name: AZURE_TARGET_NAMESPACES
-          valueFrom:
-            secretKeyRef:
-              key: AZURE_TARGET_NAMESPACES
-              name: aso-controller-settings
-              optional: true
-        - name: AZURE_OPERATOR_MODE
-          valueFrom:
-            secretKeyRef:
-              key: AZURE_OPERATOR_MODE
-              name: aso-controller-settings
-              optional: true
-        - name: AZURE_SYNC_PERIOD
-          valueFrom:
-            secretKeyRef:
-              key: AZURE_SYNC_PERIOD
-              name: aso-controller-settings
-              optional: true
-        - name: USE_WORKLOAD_IDENTITY_AUTH
-          valueFrom:
-            secretKeyRef:
-              key: USE_WORKLOAD_IDENTITY_AUTH
-              name: aso-controller-settings
-              optional: true
-        - name: AZURE_USER_AGENT_SUFFIX
-          valueFrom:
-            secretKeyRef:
-              key: AZURE_USER_AGENT_SUFFIX
-              name: aso-controller-settings
-              optional: true
-        - name: MAX_CONCURRENT_RECONCILES
-          valueFrom:
-            secretKeyRef:
-              key: MAX_CONCURRENT_RECONCILES
-              name: aso-controller-settings
-              optional: true
-        - name: RATE_LIMIT_MODE
-          valueFrom:
-            secretKeyRef:
-              key: RATE_LIMIT_MODE
-              name: aso-controller-settings
-              optional: true
-        - name: RATE_LIMIT_QPS
-          valueFrom:
-            secretKeyRef:
-              key: RATE_LIMIT_QPS
-              name: aso-controller-settings
-              optional: true
-        - name: RATE_LIMIT_BUCKET_SIZE
-          valueFrom:
-            secretKeyRef:
-              key: RATE_LIMIT_BUCKET_SIZE
-              name: aso-controller-settings
-              optional: true
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -216,6 +111,9 @@ spec:
           name: cert
           readOnly: true
         {{- end }}
+        - name: settings-volume
+          readOnly: true
+          mountPath: "/etc/aso-controller-settings"
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}
@@ -244,3 +142,6 @@ spec:
               audience: api://AzureADTokenExchange
               expirationSeconds: 3600
               path: azure-identity
+      - name: settings-volume
+        secret:
+          secretName: aso-controller-settings

--- a/v2/charts/azure-service-operator/templates/secret.yaml
+++ b/v2/charts/azure-service-operator/templates/secret.yaml
@@ -6,9 +6,15 @@ metadata:
   namespace: {{.Release.Namespace}}
 type: Opaque
 data:
+  {{- if .Values.azureSubscriptionID }}
   AZURE_SUBSCRIPTION_ID: {{ .Values.azureSubscriptionID | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.azureTenantID }}
   AZURE_TENANT_ID: {{ .Values.azureTenantID | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.azureClientID }}
   AZURE_CLIENT_ID: {{ .Values.azureClientID | b64enc | quote }}
+  {{- end }}
   {{- if .Values.azureClientSecret }}
   AZURE_CLIENT_SECRET: {{ .Values.azureClientSecret | b64enc | quote }}
   {{- end }}

--- a/v2/config/manager/manager_image_patch.yaml
+++ b/v2/config/manager/manager_image_patch.yaml
@@ -8,119 +8,22 @@ spec:
     spec:
       nodeSelector:
         "kubernetes.io/os": linux
+      volumes:
+        - name: settings-volume
+          secret:
+            secretName: aso-controller-settings
       containers:
         # Change the value of image field below to your controller image URL
         - image: localhost:5000/azureserviceoperator:latest
           name: manager
           env:
-            - name: AZURE_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: aso-controller-settings
-                  key: AZURE_CLIENT_ID
-            - name: AZURE_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: aso-controller-settings
-                  key: AZURE_CLIENT_SECRET
-                  optional: true
-            - name: AZURE_TENANT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: aso-controller-settings
-                  key: AZURE_TENANT_ID
-            - name: AZURE_SUBSCRIPTION_ID
-              valueFrom:
-                secretKeyRef:
-                  name: aso-controller-settings
-                  key: AZURE_SUBSCRIPTION_ID
-            - name: AZURE_CLIENT_CERTIFICATE
-              valueFrom:
-                secretKeyRef:
-                  name: aso-controller-settings
-                  key: AZURE_CLIENT_CERTIFICATE
-                  optional: true
-            - name: AZURE_CLIENT_CERTIFICATE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aso-controller-settings
-                  key: AZURE_CLIENT_CERTIFICATE_PASSWORD
-                  optional: true
-            - name: AZURE_AUTHORITY_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: aso-controller-settings
-                  key: AZURE_AUTHORITY_HOST
-                  optional: true
-            - name: AZURE_RESOURCE_MANAGER_ENDPOINT
-              valueFrom:
-                secretKeyRef:
-                  name: aso-controller-settings
-                  key: AZURE_RESOURCE_MANAGER_ENDPOINT
-                  optional: true
-            - name: AZURE_RESOURCE_MANAGER_AUDIENCE
-              valueFrom:
-                secretKeyRef:
-                  name: aso-controller-settings
-                  key: AZURE_RESOURCE_MANAGER_AUDIENCE
-                  optional: true
-            - name: AZURE_TARGET_NAMESPACES
-              valueFrom:
-                secretKeyRef:
-                  name: aso-controller-settings
-                  key: AZURE_TARGET_NAMESPACES
-                  optional: true
-            - name: AZURE_OPERATOR_MODE
-              valueFrom:
-                secretKeyRef:
-                  name: aso-controller-settings
-                  key: AZURE_OPERATOR_MODE
-                  optional: true
-            - name: AZURE_SYNC_PERIOD
-              valueFrom:
-                secretKeyRef:
-                  name: aso-controller-settings
-                  key: AZURE_SYNC_PERIOD
-                  optional: true
-            - name: USE_WORKLOAD_IDENTITY_AUTH
-              valueFrom:
-                secretKeyRef:
-                  key: USE_WORKLOAD_IDENTITY_AUTH
-                  name: aso-controller-settings
-                  optional: true
-            - name: AZURE_USER_AGENT_SUFFIX
-              valueFrom:
-                secretKeyRef:
-                  key: AZURE_USER_AGENT_SUFFIX
-                  name: aso-controller-settings
-                  optional: true
-            - name: MAX_CONCURRENT_RECONCILES
-              valueFrom:
-                secretKeyRef:
-                  key: MAX_CONCURRENT_RECONCILES
-                  name: aso-controller-settings
-                  optional: true
-            - name: RATE_LIMIT_MODE
-              valueFrom:
-                secretKeyRef:
-                  key: RATE_LIMIT_MODE
-                  name: aso-controller-settings
-                  optional: true
-            - name: RATE_LIMIT_QPS
-              valueFrom:
-                secretKeyRef:
-                  key: RATE_LIMIT_QPS
-                  name: aso-controller-settings
-                  optional: true
-            - name: RATE_LIMIT_BUCKET_SIZE
-              valueFrom:
-                secretKeyRef:
-                  key: RATE_LIMIT_BUCKET_SIZE
-                  name: aso-controller-settings
-                  optional: true
             # Used for setting the operator-namespace annotation (and
             # for aad-pod-identity once we support it).
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          volumeMounts:
+            - name: settings-volume
+              readOnly: true
+              mountPath: "/etc/aso-controller-settings"

--- a/v2/internal/config/vars_internal_test.go
+++ b/v2/internal/config/vars_internal_test.go
@@ -17,7 +17,7 @@ func Test_ParseSyncPeriod_ReturnsNever(t *testing.T) {
 	g := NewGomegaWithT(t)
 	t.Setenv(config.SyncPeriod, "never") // Can't run in parallel
 
-	dur, err := parseSyncPeriod()
+	dur, err := parseSyncPeriod(newEnvReader())
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(dur).To(BeNil()) // Nil means no sync
@@ -28,7 +28,7 @@ func Test_ParseSyncPeriod_ReturnsDefaultWhenEmpty(t *testing.T) {
 	g := NewGomegaWithT(t)
 	t.Setenv(config.SyncPeriod, "") // Can't run in parallel
 
-	dur, err := parseSyncPeriod()
+	dur, err := parseSyncPeriod(newEnvReader())
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(dur).ToNot(BeNil())
@@ -40,7 +40,7 @@ func Test_ParseSyncPeriod_ReturnsValue(t *testing.T) {
 	g := NewGomegaWithT(t)
 	t.Setenv(config.SyncPeriod, "21m") // Can't run in parallel
 
-	dur, err := parseSyncPeriod()
+	dur, err := parseSyncPeriod(newEnvReader())
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(dur).ToNot(BeNil())

--- a/v2/internal/config/watcher.go
+++ b/v2/internal/config/watcher.go
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package config
+
+import (
+	"context"
+	"os"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/go-logr/logr"
+
+	. "github.com/Azure/azure-service-operator/v2/internal/logging"
+)
+
+type Watcher struct {
+	path string
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	logger logr.Logger
+}
+
+func NewWatcher(logger logr.Logger) *Watcher {
+	logger = logger.WithName("configwatcher")
+
+	return &Watcher{
+		path:   MountPath,
+		logger: logger,
+	}
+}
+
+func (w *Watcher) Start(ctx context.Context) error {
+	w.ctx, w.cancel = context.WithCancel(ctx)
+	w.logger.V(Info).Info("starting watcher", "path", w.path)
+	go w.runImpl()
+
+	return nil
+}
+
+func (w *Watcher) Stop() {
+	w.logger.V(Info).Info("stopping watcher", "path", w.path)
+	w.cancel()
+}
+
+func (w *Watcher) runImpl() {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		w.logger.Error(err, "failed to create fsnotify watcher")
+		return
+	}
+	defer watcher.Close()
+
+	err = watcher.Add(w.path)
+
+	for {
+		var ok bool
+		var event fsnotify.Event
+
+		select {
+		case <-w.ctx.Done():
+			w.logger.Error(err, "Aborting watcher")
+			return
+		case event, ok = <-watcher.Events:
+			if !ok {
+				w.logger.Error(err, "Watcher events channel closed")
+				return
+			}
+			if event.Has(fsnotify.Write | fsnotify.Create | fsnotify.Remove | fsnotify.Rename) {
+				w.logger.V(Info).Info("Secret updated, exiting...")
+				// TODO: Ideally we would give up the lease here too
+				os.Exit(0)
+			}
+		case err, ok = <-watcher.Errors:
+			if !ok {
+				w.logger.Error(err, "Watcher error channel closed")
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
Moving from a model where we have to explicitly set each secret in the pod env to a model where we just mount the whole secret into the pod. This has the added benefit of allowing us to autodetect secret changes and restart the pod AND means that users can totally omit the secret now as opposed to having to create the secret with empty values.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
