### PR TITLE
Flatten ARM type references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ hack/tools
 
 # Private powershell scripts
 .ps
+
+# goenv condiguration
+.go-version

--- a/v2/api/apimanagement/v1api20230501preview/backend_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/backend_types_gen.go
@@ -4091,7 +4091,7 @@ func (condition *CircuitBreakerFailureCondition) ConvertToARM(resolved genruntim
 
 	// Set property "ErrorReasons":
 	for _, item := range condition.ErrorReasons {
-		result.ErrorReasons = append(result.ErrorReasons, item)
+		result.ErrorReasons = append(result.ErrorReasons, string(item))
 	}
 
 	// Set property "Interval":
@@ -4137,7 +4137,7 @@ func (condition *CircuitBreakerFailureCondition) PopulateFromARM(owner genruntim
 
 	// Set property "ErrorReasons":
 	for _, item := range typedInput.ErrorReasons {
-		condition.ErrorReasons = append(condition.ErrorReasons, item)
+		condition.ErrorReasons = append(condition.ErrorReasons, CircuitBreakerFailureCondition_ErrorReasons(item))
 	}
 
 	// Set property "Interval":
@@ -4311,7 +4311,7 @@ func (condition *CircuitBreakerFailureCondition_STATUS) PopulateFromARM(owner ge
 
 	// Set property "ErrorReasons":
 	for _, item := range typedInput.ErrorReasons {
-		condition.ErrorReasons = append(condition.ErrorReasons, item)
+		condition.ErrorReasons = append(condition.ErrorReasons, CircuitBreakerFailureCondition_ErrorReasons_STATUS(item))
 	}
 
 	// Set property "Interval":

--- a/v2/api/apimanagement/v1api20230501preview/service_backend_spec_arm_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/service_backend_spec_arm_types_gen.go
@@ -180,7 +180,7 @@ type CircuitBreakerFailureCondition_ARM struct {
 	Count *int `json:"count,omitempty"`
 
 	// ErrorReasons: The error reasons which are considered as failure.
-	ErrorReasons []CircuitBreakerFailureCondition_ErrorReasons `json:"errorReasons,omitempty"`
+	ErrorReasons []string `json:"errorReasons,omitempty"`
 
 	// Interval: The interval during which the failures are counted.
 	Interval *string `json:"interval,omitempty"`

--- a/v2/api/apimanagement/v1api20230501preview/service_backend_spec_arm_types_gen_test.go
+++ b/v2/api/apimanagement/v1api20230501preview/service_backend_spec_arm_types_gen_test.go
@@ -761,9 +761,7 @@ func CircuitBreakerFailureCondition_ARMGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForCircuitBreakerFailureCondition_ARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForCircuitBreakerFailureCondition_ARM(gens map[string]gopter.Gen) {
 	gens["Count"] = gen.PtrOf(gen.Int())
-	gens["ErrorReasons"] = gen.SliceOf(gen.AlphaString().Map(func(it string) CircuitBreakerFailureCondition_ErrorReasons {
-		return CircuitBreakerFailureCondition_ErrorReasons(it)
-	}))
+	gens["ErrorReasons"] = gen.SliceOf(gen.AlphaString())
 	gens["Interval"] = gen.PtrOf(gen.AlphaString())
 	gens["Percentage"] = gen.PtrOf(gen.Int())
 }

--- a/v2/api/apimanagement/v1api20230501preview/service_backend_status_arm_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/service_backend_status_arm_types_gen.go
@@ -170,7 +170,7 @@ type CircuitBreakerFailureCondition_STATUS_ARM struct {
 	Count *int `json:"count,omitempty"`
 
 	// ErrorReasons: The error reasons which are considered as failure.
-	ErrorReasons []CircuitBreakerFailureCondition_ErrorReasons_STATUS `json:"errorReasons,omitempty"`
+	ErrorReasons []string `json:"errorReasons,omitempty"`
 
 	// Interval: The interval during which the failures are counted.
 	Interval *string `json:"interval,omitempty"`

--- a/v2/api/apimanagement/v1api20230501preview/service_backend_status_arm_types_gen_test.go
+++ b/v2/api/apimanagement/v1api20230501preview/service_backend_status_arm_types_gen_test.go
@@ -761,9 +761,7 @@ func CircuitBreakerFailureCondition_STATUS_ARMGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForCircuitBreakerFailureCondition_STATUS_ARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForCircuitBreakerFailureCondition_STATUS_ARM(gens map[string]gopter.Gen) {
 	gens["Count"] = gen.PtrOf(gen.Int())
-	gens["ErrorReasons"] = gen.SliceOf(gen.AlphaString().Map(func(it string) CircuitBreakerFailureCondition_ErrorReasons_STATUS {
-		return CircuitBreakerFailureCondition_ErrorReasons_STATUS(it)
-	}))
+	gens["ErrorReasons"] = gen.SliceOf(gen.AlphaString())
 	gens["Interval"] = gen.PtrOf(gen.AlphaString())
 	gens["Percentage"] = gen.PtrOf(gen.Int())
 }

--- a/v2/api/apimanagement/v1api20230501preview/structure.txt
+++ b/v2/api/apimanagement/v1api20230501preview/structure.txt
@@ -1156,8 +1156,7 @@ Service_Backend_STATUS_ARM: Object (4 properties)
 │   │   └── Rules: Object (3 properties)[]
 │   │       ├── FailureCondition: *Object (5 properties)
 │   │       │   ├── Count: *int
-│   │       │   ├── ErrorReasons: Validated<string> (1 rule)[]
-│   │       │   │   └── Rule 0: MaxLength: 200
+│   │       │   ├── ErrorReasons: string[]
 │   │       │   ├── Interval: *string
 │   │       │   ├── Percentage: *int
 │   │       │   └── StatusCodeRanges: Object (2 properties)[]
@@ -1210,8 +1209,7 @@ Service_Backend_Spec_ARM: Object (2 properties)
     │   └── Rules: Object (3 properties)[]
     │       ├── FailureCondition: *Object (5 properties)
     │       │   ├── Count: *int
-    │       │   ├── ErrorReasons: Validated<string> (1 rule)[]
-    │       │   │   └── Rule 0: MaxLength: 200
+    │       │   ├── ErrorReasons: string[]
     │       │   ├── Interval: *string
     │       │   ├── Percentage: *int
     │       │   └── StatusCodeRanges: Object (2 properties)[]

--- a/v2/api/apimanagement/v1api20230501preview/zz_generated.deepcopy.go
+++ b/v2/api/apimanagement/v1api20230501preview/zz_generated.deepcopy.go
@@ -4229,7 +4229,7 @@ func (in *CircuitBreakerFailureCondition_ARM) DeepCopyInto(out *CircuitBreakerFa
 	}
 	if in.ErrorReasons != nil {
 		in, out := &in.ErrorReasons, &out.ErrorReasons
-		*out = make([]CircuitBreakerFailureCondition_ErrorReasons, len(*in))
+		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
 	if in.Interval != nil {
@@ -4313,7 +4313,7 @@ func (in *CircuitBreakerFailureCondition_STATUS_ARM) DeepCopyInto(out *CircuitBr
 	}
 	if in.ErrorReasons != nil {
 		in, out := &in.ErrorReasons, &out.ErrorReasons
-		*out = make([]CircuitBreakerFailureCondition_ErrorReasons_STATUS, len(*in))
+		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
 	if in.Interval != nil {

--- a/v2/api/containerservice/v1api20210501/managed_cluster_spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20210501/managed_cluster_spec_arm_types_gen.go
@@ -311,8 +311,8 @@ type ManagedClusterAgentPoolProfile_ARM struct {
 	// be within two minor versions of the control plane version. The node pool version cannot be greater than the control
 	// plane version. For more information see [upgrading a node
 	// pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-	OrchestratorVersion *string                 `json:"orchestratorVersion,omitempty"`
-	OsDiskSizeGB        *ContainerServiceOSDisk `json:"osDiskSizeGB,omitempty"`
+	OrchestratorVersion *string `json:"orchestratorVersion,omitempty"`
+	OsDiskSizeGB        *int    `json:"osDiskSizeGB,omitempty"`
 
 	// OsDiskType: The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested
 	// OSDiskSizeGB. Otherwise,  defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral

--- a/v2/api/containerservice/v1api20210501/managed_cluster_spec_arm_types_gen_test.go
+++ b/v2/api/containerservice/v1api20210501/managed_cluster_spec_arm_types_gen_test.go
@@ -646,9 +646,7 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfile_ARM(gens 
 	gens["NodePublicIPPrefixID"] = gen.PtrOf(gen.AlphaString())
 	gens["NodeTaints"] = gen.SliceOf(gen.AlphaString())
 	gens["OrchestratorVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int().Map(func(it int) ContainerServiceOSDisk {
-		return ContainerServiceOSDisk(it)
-	}))
+	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int())
 	gens["OsDiskType"] = gen.PtrOf(gen.OneConstOf(OSDiskType_Ephemeral, OSDiskType_Managed))
 	gens["OsSKU"] = gen.PtrOf(gen.OneConstOf(OSSKU_CBLMariner, OSSKU_Ubuntu))
 	gens["OsType"] = gen.PtrOf(gen.OneConstOf(OSType_Linux, OSType_Windows))

--- a/v2/api/containerservice/v1api20210501/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20210501/managed_cluster_types_gen.go
@@ -4955,7 +4955,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "OsDiskSizeGB":
 	if profile.OsDiskSizeGB != nil {
-		osDiskSizeGB := *profile.OsDiskSizeGB
+		osDiskSizeGB := int(*profile.OsDiskSizeGB)
 		result.OsDiskSizeGB = &osDiskSizeGB
 	}
 
@@ -5196,7 +5196,7 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 
 	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
-		osDiskSizeGB := *typedInput.OsDiskSizeGB
+		osDiskSizeGB := ContainerServiceOSDisk(*typedInput.OsDiskSizeGB)
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 

--- a/v2/api/containerservice/v1api20210501/managed_clusters_agent_pool_spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20210501/managed_clusters_agent_pool_spec_arm_types_gen.go
@@ -99,8 +99,8 @@ type ManagedClusterAgentPoolProfileProperties_ARM struct {
 	// be within two minor versions of the control plane version. The node pool version cannot be greater than the control
 	// plane version. For more information see [upgrading a node
 	// pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-	OrchestratorVersion *string                 `json:"orchestratorVersion,omitempty"`
-	OsDiskSizeGB        *ContainerServiceOSDisk `json:"osDiskSizeGB,omitempty"`
+	OrchestratorVersion *string `json:"orchestratorVersion,omitempty"`
+	OsDiskSizeGB        *int    `json:"osDiskSizeGB,omitempty"`
 
 	// OsDiskType: The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested
 	// OSDiskSizeGB. Otherwise,  defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral

--- a/v2/api/containerservice/v1api20210501/managed_clusters_agent_pool_spec_arm_types_gen_test.go
+++ b/v2/api/containerservice/v1api20210501/managed_clusters_agent_pool_spec_arm_types_gen_test.go
@@ -315,9 +315,7 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfileProperties
 	gens["NodePublicIPPrefixID"] = gen.PtrOf(gen.AlphaString())
 	gens["NodeTaints"] = gen.SliceOf(gen.AlphaString())
 	gens["OrchestratorVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int().Map(func(it int) ContainerServiceOSDisk {
-		return ContainerServiceOSDisk(it)
-	}))
+	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int())
 	gens["OsDiskType"] = gen.PtrOf(gen.OneConstOf(OSDiskType_Ephemeral, OSDiskType_Managed))
 	gens["OsSKU"] = gen.PtrOf(gen.OneConstOf(OSSKU_CBLMariner, OSSKU_Ubuntu))
 	gens["OsType"] = gen.PtrOf(gen.OneConstOf(OSType_Linux, OSType_Windows))

--- a/v2/api/containerservice/v1api20210501/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20210501/managed_clusters_agent_pool_types_gen.go
@@ -607,7 +607,7 @@ func (pool *ManagedClusters_AgentPool_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.OrchestratorVersion = &orchestratorVersion
 	}
 	if pool.OsDiskSizeGB != nil {
-		osDiskSizeGB := *pool.OsDiskSizeGB
+		osDiskSizeGB := int(*pool.OsDiskSizeGB)
 		result.Properties.OsDiskSizeGB = &osDiskSizeGB
 	}
 	if pool.OsDiskType != nil {
@@ -875,7 +875,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
-			osDiskSizeGB := *typedInput.Properties.OsDiskSizeGB
+			osDiskSizeGB := ContainerServiceOSDisk(*typedInput.Properties.OsDiskSizeGB)
 			pool.OsDiskSizeGB = &osDiskSizeGB
 		}
 	}

--- a/v2/api/containerservice/v1api20210501/structure.txt
+++ b/v2/api/containerservice/v1api20210501/structure.txt
@@ -960,9 +960,7 @@ ManagedCluster_Spec_ARM: Object (7 properties)
 │   │   ├── NodePublicIPPrefixID: *string
 │   │   ├── NodeTaints: string[]
 │   │   ├── OrchestratorVersion: *string
-│   │   ├── OsDiskSizeGB: *Validated<int> (2 rules)
-│   │   │   ├── Rule 0: Maximum: 2048
-│   │   │   └── Rule 1: Minimum: 0
+│   │   ├── OsDiskSizeGB: *int
 │   │   ├── OsDiskType: *Enum (2 values)
 │   │   │   ├── "Ephemeral"
 │   │   │   └── "Managed"
@@ -1514,9 +1512,7 @@ ManagedClusters_AgentPool_Spec_ARM: Object (2 properties)
     ├── NodePublicIPPrefixID: *string
     ├── NodeTaints: string[]
     ├── OrchestratorVersion: *string
-    ├── OsDiskSizeGB: *Validated<int> (2 rules)
-    │   ├── Rule 0: Maximum: 2048
-    │   └── Rule 1: Minimum: 0
+    ├── OsDiskSizeGB: *int
     ├── OsDiskType: *Enum (2 values)
     │   ├── "Ephemeral"
     │   └── "Managed"

--- a/v2/api/containerservice/v1api20210501/zz_generated.deepcopy.go
+++ b/v2/api/containerservice/v1api20210501/zz_generated.deepcopy.go
@@ -1919,7 +1919,7 @@ func (in *ManagedClusterAgentPoolProfileProperties_ARM) DeepCopyInto(out *Manage
 	}
 	if in.OsDiskSizeGB != nil {
 		in, out := &in.OsDiskSizeGB, &out.OsDiskSizeGB
-		*out = new(ContainerServiceOSDisk)
+		*out = new(int)
 		**out = **in
 	}
 	if in.OsDiskType != nil {
@@ -2307,7 +2307,7 @@ func (in *ManagedClusterAgentPoolProfile_ARM) DeepCopyInto(out *ManagedClusterAg
 	}
 	if in.OsDiskSizeGB != nil {
 		in, out := &in.OsDiskSizeGB, &out.OsDiskSizeGB
-		*out = new(ContainerServiceOSDisk)
+		*out = new(int)
 		**out = **in
 	}
 	if in.OsDiskType != nil {

--- a/v2/api/containerservice/v1api20230201/managed_cluster_spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20230201/managed_cluster_spec_arm_types_gen.go
@@ -362,8 +362,8 @@ type ManagedClusterAgentPoolProfile_ARM struct {
 	// version must be within two minor versions of the control plane version. The node pool version cannot be greater than the
 	// control plane version. For more information see [upgrading a node
 	// pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-	OrchestratorVersion *string                 `json:"orchestratorVersion,omitempty"`
-	OsDiskSizeGB        *ContainerServiceOSDisk `json:"osDiskSizeGB,omitempty"`
+	OrchestratorVersion *string `json:"orchestratorVersion,omitempty"`
+	OsDiskSizeGB        *int    `json:"osDiskSizeGB,omitempty"`
 
 	// OsDiskType: The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested
 	// OSDiskSizeGB. Otherwise,  defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral

--- a/v2/api/containerservice/v1api20230201/managed_cluster_spec_arm_types_gen_test.go
+++ b/v2/api/containerservice/v1api20230201/managed_cluster_spec_arm_types_gen_test.go
@@ -722,9 +722,7 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfile_ARM(gens 
 	gens["NodePublicIPPrefixID"] = gen.PtrOf(gen.AlphaString())
 	gens["NodeTaints"] = gen.SliceOf(gen.AlphaString())
 	gens["OrchestratorVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int().Map(func(it int) ContainerServiceOSDisk {
-		return ContainerServiceOSDisk(it)
-	}))
+	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int())
 	gens["OsDiskType"] = gen.PtrOf(gen.OneConstOf(OSDiskType_Ephemeral, OSDiskType_Managed))
 	gens["OsSKU"] = gen.PtrOf(gen.OneConstOf(
 		OSSKU_CBLMariner,

--- a/v2/api/containerservice/v1api20230201/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20230201/managed_cluster_types_gen.go
@@ -5981,7 +5981,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "OsDiskSizeGB":
 	if profile.OsDiskSizeGB != nil {
-		osDiskSizeGB := *profile.OsDiskSizeGB
+		osDiskSizeGB := int(*profile.OsDiskSizeGB)
 		result.OsDiskSizeGB = &osDiskSizeGB
 	}
 
@@ -6261,7 +6261,7 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 
 	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
-		osDiskSizeGB := *typedInput.OsDiskSizeGB
+		osDiskSizeGB := ContainerServiceOSDisk(*typedInput.OsDiskSizeGB)
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 

--- a/v2/api/containerservice/v1api20230201/managed_clusters_agent_pool_spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20230201/managed_clusters_agent_pool_spec_arm_types_gen.go
@@ -107,8 +107,8 @@ type ManagedClusterAgentPoolProfileProperties_ARM struct {
 	// version must be within two minor versions of the control plane version. The node pool version cannot be greater than the
 	// control plane version. For more information see [upgrading a node
 	// pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-	OrchestratorVersion *string                 `json:"orchestratorVersion,omitempty"`
-	OsDiskSizeGB        *ContainerServiceOSDisk `json:"osDiskSizeGB,omitempty"`
+	OrchestratorVersion *string `json:"orchestratorVersion,omitempty"`
+	OsDiskSizeGB        *int    `json:"osDiskSizeGB,omitempty"`
 
 	// OsDiskType: The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested
 	// OSDiskSizeGB. Otherwise,  defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral

--- a/v2/api/containerservice/v1api20230201/managed_clusters_agent_pool_spec_arm_types_gen_test.go
+++ b/v2/api/containerservice/v1api20230201/managed_clusters_agent_pool_spec_arm_types_gen_test.go
@@ -376,9 +376,7 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfileProperties
 	gens["NodePublicIPPrefixID"] = gen.PtrOf(gen.AlphaString())
 	gens["NodeTaints"] = gen.SliceOf(gen.AlphaString())
 	gens["OrchestratorVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int().Map(func(it int) ContainerServiceOSDisk {
-		return ContainerServiceOSDisk(it)
-	}))
+	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int())
 	gens["OsDiskType"] = gen.PtrOf(gen.OneConstOf(OSDiskType_Ephemeral, OSDiskType_Managed))
 	gens["OsSKU"] = gen.PtrOf(gen.OneConstOf(
 		OSSKU_CBLMariner,

--- a/v2/api/containerservice/v1api20230201/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20230201/managed_clusters_agent_pool_types_gen.go
@@ -652,7 +652,7 @@ func (pool *ManagedClusters_AgentPool_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.OrchestratorVersion = &orchestratorVersion
 	}
 	if pool.OsDiskSizeGB != nil {
-		osDiskSizeGB := *pool.OsDiskSizeGB
+		osDiskSizeGB := int(*pool.OsDiskSizeGB)
 		result.Properties.OsDiskSizeGB = &osDiskSizeGB
 	}
 	if pool.OsDiskType != nil {
@@ -956,7 +956,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
-			osDiskSizeGB := *typedInput.Properties.OsDiskSizeGB
+			osDiskSizeGB := ContainerServiceOSDisk(*typedInput.Properties.OsDiskSizeGB)
 			pool.OsDiskSizeGB = &osDiskSizeGB
 		}
 	}

--- a/v2/api/containerservice/v1api20230201/structure.txt
+++ b/v2/api/containerservice/v1api20230201/structure.txt
@@ -1250,9 +1250,7 @@ ManagedCluster_Spec_ARM: Object (7 properties)
 │   │   ├── NodePublicIPPrefixID: *string
 │   │   ├── NodeTaints: string[]
 │   │   ├── OrchestratorVersion: *string
-│   │   ├── OsDiskSizeGB: *Validated<int> (2 rules)
-│   │   │   ├── Rule 0: Maximum: 2048
-│   │   │   └── Rule 1: Minimum: 0
+│   │   ├── OsDiskSizeGB: *int
 │   │   ├── OsDiskType: *Enum (2 values)
 │   │   │   ├── "Ephemeral"
 │   │   │   └── "Managed"
@@ -1925,9 +1923,7 @@ ManagedClusters_AgentPool_Spec_ARM: Object (2 properties)
     ├── NodePublicIPPrefixID: *string
     ├── NodeTaints: string[]
     ├── OrchestratorVersion: *string
-    ├── OsDiskSizeGB: *Validated<int> (2 rules)
-    │   ├── Rule 0: Maximum: 2048
-    │   └── Rule 1: Minimum: 0
+    ├── OsDiskSizeGB: *int
     ├── OsDiskType: *Enum (2 values)
     │   ├── "Ephemeral"
     │   └── "Managed"

--- a/v2/api/containerservice/v1api20230201/zz_generated.deepcopy.go
+++ b/v2/api/containerservice/v1api20230201/zz_generated.deepcopy.go
@@ -2314,7 +2314,7 @@ func (in *ManagedClusterAgentPoolProfileProperties_ARM) DeepCopyInto(out *Manage
 	}
 	if in.OsDiskSizeGB != nil {
 		in, out := &in.OsDiskSizeGB, &out.OsDiskSizeGB
-		*out = new(ContainerServiceOSDisk)
+		*out = new(int)
 		**out = **in
 	}
 	if in.OsDiskType != nil {
@@ -2752,7 +2752,7 @@ func (in *ManagedClusterAgentPoolProfile_ARM) DeepCopyInto(out *ManagedClusterAg
 	}
 	if in.OsDiskSizeGB != nil {
 		in, out := &in.OsDiskSizeGB, &out.OsDiskSizeGB
-		*out = new(ContainerServiceOSDisk)
+		*out = new(int)
 		**out = **in
 	}
 	if in.OsDiskType != nil {

--- a/v2/api/containerservice/v1api20230202preview/managed_cluster_spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20230202preview/managed_cluster_spec_arm_types_gen.go
@@ -427,8 +427,8 @@ type ManagedClusterAgentPoolProfile_ARM struct {
 	// must have the same major version as the control plane. The node pool minor version must be within two minor versions of
 	// the control plane version. The node pool version cannot be greater than the control plane version. For more information
 	// see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-	OrchestratorVersion *string                 `json:"orchestratorVersion,omitempty"`
-	OsDiskSizeGB        *ContainerServiceOSDisk `json:"osDiskSizeGB,omitempty"`
+	OrchestratorVersion *string `json:"orchestratorVersion,omitempty"`
+	OsDiskSizeGB        *int    `json:"osDiskSizeGB,omitempty"`
 
 	// OsDiskType: The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested
 	// OSDiskSizeGB. Otherwise,  defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral

--- a/v2/api/containerservice/v1api20230202preview/managed_cluster_spec_arm_types_gen_test.go
+++ b/v2/api/containerservice/v1api20230202preview/managed_cluster_spec_arm_types_gen_test.go
@@ -1236,9 +1236,7 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfile_ARM(gens 
 	gens["NodePublicIPPrefixID"] = gen.PtrOf(gen.AlphaString())
 	gens["NodeTaints"] = gen.SliceOf(gen.AlphaString())
 	gens["OrchestratorVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int().Map(func(it int) ContainerServiceOSDisk {
-		return ContainerServiceOSDisk(it)
-	}))
+	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int())
 	gens["OsDiskType"] = gen.PtrOf(gen.OneConstOf(OSDiskType_Ephemeral, OSDiskType_Managed))
 	gens["OsSKU"] = gen.PtrOf(gen.OneConstOf(
 		OSSKU_CBLMariner,

--- a/v2/api/containerservice/v1api20230202preview/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20230202preview/managed_cluster_types_gen.go
@@ -7291,7 +7291,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "OsDiskSizeGB":
 	if profile.OsDiskSizeGB != nil {
-		osDiskSizeGB := *profile.OsDiskSizeGB
+		osDiskSizeGB := int(*profile.OsDiskSizeGB)
 		result.OsDiskSizeGB = &osDiskSizeGB
 	}
 
@@ -7610,7 +7610,7 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 
 	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
-		osDiskSizeGB := *typedInput.OsDiskSizeGB
+		osDiskSizeGB := ContainerServiceOSDisk(*typedInput.OsDiskSizeGB)
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 

--- a/v2/api/containerservice/v1api20230202preview/managed_clusters_agent_pool_spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20230202preview/managed_clusters_agent_pool_spec_arm_types_gen.go
@@ -122,8 +122,8 @@ type ManagedClusterAgentPoolProfileProperties_ARM struct {
 	// must have the same major version as the control plane. The node pool minor version must be within two minor versions of
 	// the control plane version. The node pool version cannot be greater than the control plane version. For more information
 	// see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-	OrchestratorVersion *string                 `json:"orchestratorVersion,omitempty"`
-	OsDiskSizeGB        *ContainerServiceOSDisk `json:"osDiskSizeGB,omitempty"`
+	OrchestratorVersion *string `json:"orchestratorVersion,omitempty"`
+	OsDiskSizeGB        *int    `json:"osDiskSizeGB,omitempty"`
 
 	// OsDiskType: The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested
 	// OSDiskSizeGB. Otherwise,  defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral

--- a/v2/api/containerservice/v1api20230202preview/managed_clusters_agent_pool_spec_arm_types_gen_test.go
+++ b/v2/api/containerservice/v1api20230202preview/managed_clusters_agent_pool_spec_arm_types_gen_test.go
@@ -517,9 +517,7 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfileProperties
 	gens["NodePublicIPPrefixID"] = gen.PtrOf(gen.AlphaString())
 	gens["NodeTaints"] = gen.SliceOf(gen.AlphaString())
 	gens["OrchestratorVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int().Map(func(it int) ContainerServiceOSDisk {
-		return ContainerServiceOSDisk(it)
-	}))
+	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int())
 	gens["OsDiskType"] = gen.PtrOf(gen.OneConstOf(OSDiskType_Ephemeral, OSDiskType_Managed))
 	gens["OsSKU"] = gen.PtrOf(gen.OneConstOf(
 		OSSKU_CBLMariner,

--- a/v2/api/containerservice/v1api20230202preview/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20230202preview/managed_clusters_agent_pool_types_gen.go
@@ -696,7 +696,7 @@ func (pool *ManagedClusters_AgentPool_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.OrchestratorVersion = &orchestratorVersion
 	}
 	if pool.OsDiskSizeGB != nil {
-		osDiskSizeGB := *pool.OsDiskSizeGB
+		osDiskSizeGB := int(*pool.OsDiskSizeGB)
 		result.Properties.OsDiskSizeGB = &osDiskSizeGB
 	}
 	if pool.OsDiskType != nil {
@@ -1049,7 +1049,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
-			osDiskSizeGB := *typedInput.Properties.OsDiskSizeGB
+			osDiskSizeGB := ContainerServiceOSDisk(*typedInput.Properties.OsDiskSizeGB)
 			pool.OsDiskSizeGB = &osDiskSizeGB
 		}
 	}

--- a/v2/api/containerservice/v1api20230202preview/structure.txt
+++ b/v2/api/containerservice/v1api20230202preview/structure.txt
@@ -1549,9 +1549,7 @@ ManagedCluster_Spec_ARM: Object (7 properties)
 │   │   ├── NodePublicIPPrefixID: *string
 │   │   ├── NodeTaints: string[]
 │   │   ├── OrchestratorVersion: *string
-│   │   ├── OsDiskSizeGB: *Validated<int> (2 rules)
-│   │   │   ├── Rule 0: Maximum: 2048
-│   │   │   └── Rule 1: Minimum: 0
+│   │   ├── OsDiskSizeGB: *int
 │   │   ├── OsDiskType: *Enum (2 values)
 │   │   │   ├── "Ephemeral"
 │   │   │   └── "Managed"
@@ -2373,9 +2371,7 @@ ManagedClusters_AgentPool_Spec_ARM: Object (2 properties)
     ├── NodePublicIPPrefixID: *string
     ├── NodeTaints: string[]
     ├── OrchestratorVersion: *string
-    ├── OsDiskSizeGB: *Validated<int> (2 rules)
-    │   ├── Rule 0: Maximum: 2048
-    │   └── Rule 1: Minimum: 0
+    ├── OsDiskSizeGB: *int
     ├── OsDiskType: *Enum (2 values)
     │   ├── "Ephemeral"
     │   └── "Managed"

--- a/v2/api/containerservice/v1api20230202preview/zz_generated.deepcopy.go
+++ b/v2/api/containerservice/v1api20230202preview/zz_generated.deepcopy.go
@@ -3473,7 +3473,7 @@ func (in *ManagedClusterAgentPoolProfileProperties_ARM) DeepCopyInto(out *Manage
 	}
 	if in.OsDiskSizeGB != nil {
 		in, out := &in.OsDiskSizeGB, &out.OsDiskSizeGB
-		*out = new(ContainerServiceOSDisk)
+		*out = new(int)
 		**out = **in
 	}
 	if in.OsDiskType != nil {
@@ -3961,7 +3961,7 @@ func (in *ManagedClusterAgentPoolProfile_ARM) DeepCopyInto(out *ManagedClusterAg
 	}
 	if in.OsDiskSizeGB != nil {
 		in, out := &in.OsDiskSizeGB, &out.OsDiskSizeGB
-		*out = new(ContainerServiceOSDisk)
+		*out = new(int)
 		**out = **in
 	}
 	if in.OsDiskType != nil {

--- a/v2/api/containerservice/v1api20231001/managed_cluster_spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20231001/managed_cluster_spec_arm_types_gen.go
@@ -394,8 +394,8 @@ type ManagedClusterAgentPoolProfile_ARM struct {
 	// version must be within two minor versions of the control plane version. The node pool version cannot be greater than the
 	// control plane version. For more information see [upgrading a node
 	// pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-	OrchestratorVersion *string                 `json:"orchestratorVersion,omitempty"`
-	OsDiskSizeGB        *ContainerServiceOSDisk `json:"osDiskSizeGB,omitempty"`
+	OrchestratorVersion *string `json:"orchestratorVersion,omitempty"`
+	OsDiskSizeGB        *int    `json:"osDiskSizeGB,omitempty"`
 
 	// OsDiskType: The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested
 	// OSDiskSizeGB. Otherwise,  defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral

--- a/v2/api/containerservice/v1api20231001/managed_cluster_spec_arm_types_gen_test.go
+++ b/v2/api/containerservice/v1api20231001/managed_cluster_spec_arm_types_gen_test.go
@@ -1237,9 +1237,7 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfile_ARM(gens 
 	gens["NodePublicIPPrefixID"] = gen.PtrOf(gen.AlphaString())
 	gens["NodeTaints"] = gen.SliceOf(gen.AlphaString())
 	gens["OrchestratorVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int().Map(func(it int) ContainerServiceOSDisk {
-		return ContainerServiceOSDisk(it)
-	}))
+	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int())
 	gens["OsDiskType"] = gen.PtrOf(gen.OneConstOf(OSDiskType_Ephemeral, OSDiskType_Managed))
 	gens["OsSKU"] = gen.PtrOf(gen.OneConstOf(
 		OSSKU_AzureLinux,

--- a/v2/api/containerservice/v1api20231001/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20231001/managed_cluster_types_gen.go
@@ -7059,7 +7059,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "OsDiskSizeGB":
 	if profile.OsDiskSizeGB != nil {
-		osDiskSizeGB := *profile.OsDiskSizeGB
+		osDiskSizeGB := int(*profile.OsDiskSizeGB)
 		result.OsDiskSizeGB = &osDiskSizeGB
 	}
 
@@ -7352,7 +7352,7 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 
 	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
-		osDiskSizeGB := *typedInput.OsDiskSizeGB
+		osDiskSizeGB := ContainerServiceOSDisk(*typedInput.OsDiskSizeGB)
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 

--- a/v2/api/containerservice/v1api20231001/managed_clusters_agent_pool_spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20231001/managed_clusters_agent_pool_spec_arm_types_gen.go
@@ -111,8 +111,8 @@ type ManagedClusterAgentPoolProfileProperties_ARM struct {
 	// version must be within two minor versions of the control plane version. The node pool version cannot be greater than the
 	// control plane version. For more information see [upgrading a node
 	// pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-	OrchestratorVersion *string                 `json:"orchestratorVersion,omitempty"`
-	OsDiskSizeGB        *ContainerServiceOSDisk `json:"osDiskSizeGB,omitempty"`
+	OrchestratorVersion *string `json:"orchestratorVersion,omitempty"`
+	OsDiskSizeGB        *int    `json:"osDiskSizeGB,omitempty"`
 
 	// OsDiskType: The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested
 	// OSDiskSizeGB. Otherwise,  defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral

--- a/v2/api/containerservice/v1api20231001/managed_clusters_agent_pool_spec_arm_types_gen_test.go
+++ b/v2/api/containerservice/v1api20231001/managed_clusters_agent_pool_spec_arm_types_gen_test.go
@@ -515,9 +515,7 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfileProperties
 	gens["NodePublicIPPrefixID"] = gen.PtrOf(gen.AlphaString())
 	gens["NodeTaints"] = gen.SliceOf(gen.AlphaString())
 	gens["OrchestratorVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int().Map(func(it int) ContainerServiceOSDisk {
-		return ContainerServiceOSDisk(it)
-	}))
+	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int())
 	gens["OsDiskType"] = gen.PtrOf(gen.OneConstOf(OSDiskType_Ephemeral, OSDiskType_Managed))
 	gens["OsSKU"] = gen.PtrOf(gen.OneConstOf(
 		OSSKU_AzureLinux,

--- a/v2/api/containerservice/v1api20231001/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20231001/managed_clusters_agent_pool_types_gen.go
@@ -676,7 +676,7 @@ func (pool *ManagedClusters_AgentPool_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.OrchestratorVersion = &orchestratorVersion
 	}
 	if pool.OsDiskSizeGB != nil {
-		osDiskSizeGB := *pool.OsDiskSizeGB
+		osDiskSizeGB := int(*pool.OsDiskSizeGB)
 		result.Properties.OsDiskSizeGB = &osDiskSizeGB
 	}
 	if pool.OsDiskType != nil {
@@ -996,7 +996,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
-			osDiskSizeGB := *typedInput.Properties.OsDiskSizeGB
+			osDiskSizeGB := ContainerServiceOSDisk(*typedInput.Properties.OsDiskSizeGB)
 			pool.OsDiskSizeGB = &osDiskSizeGB
 		}
 	}

--- a/v2/api/containerservice/v1api20231001/structure.txt
+++ b/v2/api/containerservice/v1api20231001/structure.txt
@@ -1453,9 +1453,7 @@ ManagedCluster_Spec_ARM: Object (7 properties)
 │   │   ├── NodePublicIPPrefixID: *string
 │   │   ├── NodeTaints: string[]
 │   │   ├── OrchestratorVersion: *string
-│   │   ├── OsDiskSizeGB: *Validated<int> (2 rules)
-│   │   │   ├── Rule 0: Maximum: 2048
-│   │   │   └── Rule 1: Minimum: 0
+│   │   ├── OsDiskSizeGB: *int
 │   │   ├── OsDiskType: *Enum (2 values)
 │   │   │   ├── "Ephemeral"
 │   │   │   └── "Managed"
@@ -2237,9 +2235,7 @@ ManagedClusters_AgentPool_Spec_ARM: Object (2 properties)
     ├── NodePublicIPPrefixID: *string
     ├── NodeTaints: string[]
     ├── OrchestratorVersion: *string
-    ├── OsDiskSizeGB: *Validated<int> (2 rules)
-    │   ├── Rule 0: Maximum: 2048
-    │   └── Rule 1: Minimum: 0
+    ├── OsDiskSizeGB: *int
     ├── OsDiskType: *Enum (2 values)
     │   ├── "Ephemeral"
     │   └── "Managed"

--- a/v2/api/containerservice/v1api20231001/zz_generated.deepcopy.go
+++ b/v2/api/containerservice/v1api20231001/zz_generated.deepcopy.go
@@ -3474,7 +3474,7 @@ func (in *ManagedClusterAgentPoolProfileProperties_ARM) DeepCopyInto(out *Manage
 	}
 	if in.OsDiskSizeGB != nil {
 		in, out := &in.OsDiskSizeGB, &out.OsDiskSizeGB
-		*out = new(ContainerServiceOSDisk)
+		*out = new(int)
 		**out = **in
 	}
 	if in.OsDiskType != nil {
@@ -3932,7 +3932,7 @@ func (in *ManagedClusterAgentPoolProfile_ARM) DeepCopyInto(out *ManagedClusterAg
 	}
 	if in.OsDiskSizeGB != nil {
 		in, out := &in.OsDiskSizeGB, &out.OsDiskSizeGB
-		*out = new(ContainerServiceOSDisk)
+		*out = new(int)
 		**out = **in
 	}
 	if in.OsDiskType != nil {

--- a/v2/api/containerservice/v1api20231102preview/managed_cluster_spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20231102preview/managed_cluster_spec_arm_types_gen.go
@@ -454,8 +454,8 @@ type ManagedClusterAgentPoolProfile_ARM struct {
 	// must have the same major version as the control plane. The node pool minor version must be within two minor versions of
 	// the control plane version. The node pool version cannot be greater than the control plane version. For more information
 	// see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-	OrchestratorVersion *string                 `json:"orchestratorVersion,omitempty"`
-	OsDiskSizeGB        *ContainerServiceOSDisk `json:"osDiskSizeGB,omitempty"`
+	OrchestratorVersion *string `json:"orchestratorVersion,omitempty"`
+	OsDiskSizeGB        *int    `json:"osDiskSizeGB,omitempty"`
 
 	// OsDiskType: The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested
 	// OSDiskSizeGB. Otherwise,  defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral

--- a/v2/api/containerservice/v1api20231102preview/managed_cluster_spec_arm_types_gen_test.go
+++ b/v2/api/containerservice/v1api20231102preview/managed_cluster_spec_arm_types_gen_test.go
@@ -1509,9 +1509,7 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfile_ARM(gens 
 	gens["NodePublicIPPrefixID"] = gen.PtrOf(gen.AlphaString())
 	gens["NodeTaints"] = gen.SliceOf(gen.AlphaString())
 	gens["OrchestratorVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int().Map(func(it int) ContainerServiceOSDisk {
-		return ContainerServiceOSDisk(it)
-	}))
+	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int())
 	gens["OsDiskType"] = gen.PtrOf(gen.OneConstOf(OSDiskType_Ephemeral, OSDiskType_Managed))
 	gens["OsSKU"] = gen.PtrOf(gen.OneConstOf(
 		OSSKU_AzureLinux,

--- a/v2/api/containerservice/v1api20231102preview/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20231102preview/managed_cluster_types_gen.go
@@ -7513,7 +7513,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "OsDiskSizeGB":
 	if profile.OsDiskSizeGB != nil {
-		osDiskSizeGB := *profile.OsDiskSizeGB
+		osDiskSizeGB := int(*profile.OsDiskSizeGB)
 		result.OsDiskSizeGB = &osDiskSizeGB
 	}
 
@@ -7884,7 +7884,7 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 
 	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
-		osDiskSizeGB := *typedInput.OsDiskSizeGB
+		osDiskSizeGB := ContainerServiceOSDisk(*typedInput.OsDiskSizeGB)
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 

--- a/v2/api/containerservice/v1api20231102preview/managed_clusters_agent_pool_spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20231102preview/managed_clusters_agent_pool_spec_arm_types_gen.go
@@ -133,8 +133,8 @@ type ManagedClusterAgentPoolProfileProperties_ARM struct {
 	// must have the same major version as the control plane. The node pool minor version must be within two minor versions of
 	// the control plane version. The node pool version cannot be greater than the control plane version. For more information
 	// see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-	OrchestratorVersion *string                 `json:"orchestratorVersion,omitempty"`
-	OsDiskSizeGB        *ContainerServiceOSDisk `json:"osDiskSizeGB,omitempty"`
+	OrchestratorVersion *string `json:"orchestratorVersion,omitempty"`
+	OsDiskSizeGB        *int    `json:"osDiskSizeGB,omitempty"`
 
 	// OsDiskType: The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested
 	// OSDiskSizeGB. Otherwise,  defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral

--- a/v2/api/containerservice/v1api20231102preview/managed_clusters_agent_pool_spec_arm_types_gen_test.go
+++ b/v2/api/containerservice/v1api20231102preview/managed_clusters_agent_pool_spec_arm_types_gen_test.go
@@ -705,9 +705,7 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfileProperties
 	gens["NodePublicIPPrefixID"] = gen.PtrOf(gen.AlphaString())
 	gens["NodeTaints"] = gen.SliceOf(gen.AlphaString())
 	gens["OrchestratorVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int().Map(func(it int) ContainerServiceOSDisk {
-		return ContainerServiceOSDisk(it)
-	}))
+	gens["OsDiskSizeGB"] = gen.PtrOf(gen.Int())
 	gens["OsDiskType"] = gen.PtrOf(gen.OneConstOf(OSDiskType_Ephemeral, OSDiskType_Managed))
 	gens["OsSKU"] = gen.PtrOf(gen.OneConstOf(
 		OSSKU_AzureLinux,

--- a/v2/api/containerservice/v1api20231102preview/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20231102preview/managed_clusters_agent_pool_types_gen.go
@@ -748,7 +748,7 @@ func (pool *ManagedClusters_AgentPool_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.OrchestratorVersion = &orchestratorVersion
 	}
 	if pool.OsDiskSizeGB != nil {
-		osDiskSizeGB := *pool.OsDiskSizeGB
+		osDiskSizeGB := int(*pool.OsDiskSizeGB)
 		result.Properties.OsDiskSizeGB = &osDiskSizeGB
 	}
 	if pool.OsDiskType != nil {
@@ -1153,7 +1153,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
-			osDiskSizeGB := *typedInput.Properties.OsDiskSizeGB
+			osDiskSizeGB := ContainerServiceOSDisk(*typedInput.Properties.OsDiskSizeGB)
 			pool.OsDiskSizeGB = &osDiskSizeGB
 		}
 	}

--- a/v2/api/containerservice/v1api20231102preview/structure.txt
+++ b/v2/api/containerservice/v1api20231102preview/structure.txt
@@ -1765,9 +1765,7 @@ ManagedCluster_Spec_ARM: Object (7 properties)
 │   │   ├── NodePublicIPPrefixID: *string
 │   │   ├── NodeTaints: string[]
 │   │   ├── OrchestratorVersion: *string
-│   │   ├── OsDiskSizeGB: *Validated<int> (2 rules)
-│   │   │   ├── Rule 0: Maximum: 2048
-│   │   │   └── Rule 1: Minimum: 0
+│   │   ├── OsDiskSizeGB: *int
 │   │   ├── OsDiskType: *Enum (2 values)
 │   │   │   ├── "Ephemeral"
 │   │   │   └── "Managed"
@@ -2735,9 +2733,7 @@ ManagedClusters_AgentPool_Spec_ARM: Object (2 properties)
     ├── NodePublicIPPrefixID: *string
     ├── NodeTaints: string[]
     ├── OrchestratorVersion: *string
-    ├── OsDiskSizeGB: *Validated<int> (2 rules)
-    │   ├── Rule 0: Maximum: 2048
-    │   └── Rule 1: Minimum: 0
+    ├── OsDiskSizeGB: *int
     ├── OsDiskType: *Enum (2 values)
     │   ├── "Ephemeral"
     │   └── "Managed"

--- a/v2/api/containerservice/v1api20231102preview/zz_generated.deepcopy.go
+++ b/v2/api/containerservice/v1api20231102preview/zz_generated.deepcopy.go
@@ -4346,7 +4346,7 @@ func (in *ManagedClusterAgentPoolProfileProperties_ARM) DeepCopyInto(out *Manage
 	}
 	if in.OsDiskSizeGB != nil {
 		in, out := &in.OsDiskSizeGB, &out.OsDiskSizeGB
-		*out = new(ContainerServiceOSDisk)
+		*out = new(int)
 		**out = **in
 	}
 	if in.OsDiskType != nil {
@@ -4898,7 +4898,7 @@ func (in *ManagedClusterAgentPoolProfile_ARM) DeepCopyInto(out *ManagedClusterAg
 	}
 	if in.OsDiskSizeGB != nil {
 		in, out := &in.OsDiskSizeGB, &out.OsDiskSizeGB
-		*out = new(ContainerServiceOSDisk)
+		*out = new(int)
 		**out = **in
 	}
 	if in.OsDiskType != nil {

--- a/v2/api/containerservice/v1api20240402preview/managed_cluster_spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20240402preview/managed_cluster_spec_arm_types_gen.go
@@ -472,8 +472,8 @@ type ManagedClusterAgentPoolProfile_ARM struct {
 	// must have the same major version as the control plane. The node pool minor version must be within two minor versions of
 	// the control plane version. The node pool version cannot be greater than the control plane version. For more information
 	// see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-	OrchestratorVersion *string                 `json:"orchestratorVersion,omitempty"`
-	OsDiskSizeGB        *ContainerServiceOSDisk `json:"osDiskSizeGB,omitempty"`
+	OrchestratorVersion *string `json:"orchestratorVersion,omitempty"`
+	OsDiskSizeGB        *int    `json:"osDiskSizeGB,omitempty"`
 
 	// OsDiskType: The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested
 	// OSDiskSizeGB. Otherwise,  defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral

--- a/v2/api/containerservice/v1api20240402preview/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20240402preview/managed_cluster_types_gen.go
@@ -7823,7 +7823,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 
 	// Set property "OsDiskSizeGB":
 	if profile.OsDiskSizeGB != nil {
-		osDiskSizeGB := *profile.OsDiskSizeGB
+		osDiskSizeGB := int(*profile.OsDiskSizeGB)
 		result.OsDiskSizeGB = &osDiskSizeGB
 	}
 
@@ -8211,7 +8211,7 @@ func (profile *ManagedClusterAgentPoolProfile) PopulateFromARM(owner genruntime.
 
 	// Set property "OsDiskSizeGB":
 	if typedInput.OsDiskSizeGB != nil {
-		osDiskSizeGB := *typedInput.OsDiskSizeGB
+		osDiskSizeGB := ContainerServiceOSDisk(*typedInput.OsDiskSizeGB)
 		profile.OsDiskSizeGB = &osDiskSizeGB
 	}
 

--- a/v2/api/containerservice/v1api20240402preview/managed_clusters_agent_pool_spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1api20240402preview/managed_clusters_agent_pool_spec_arm_types_gen.go
@@ -137,8 +137,8 @@ type ManagedClusterAgentPoolProfileProperties_ARM struct {
 	// must have the same major version as the control plane. The node pool minor version must be within two minor versions of
 	// the control plane version. The node pool version cannot be greater than the control plane version. For more information
 	// see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-	OrchestratorVersion *string                 `json:"orchestratorVersion,omitempty"`
-	OsDiskSizeGB        *ContainerServiceOSDisk `json:"osDiskSizeGB,omitempty"`
+	OrchestratorVersion *string `json:"orchestratorVersion,omitempty"`
+	OsDiskSizeGB        *int    `json:"osDiskSizeGB,omitempty"`
 
 	// OsDiskType: The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested
 	// OSDiskSizeGB. Otherwise,  defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral

--- a/v2/api/containerservice/v1api20240402preview/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20240402preview/managed_clusters_agent_pool_types_gen.go
@@ -766,7 +766,7 @@ func (pool *ManagedClusters_AgentPool_Spec) ConvertToARM(resolved genruntime.Con
 		result.Properties.OrchestratorVersion = &orchestratorVersion
 	}
 	if pool.OsDiskSizeGB != nil {
-		osDiskSizeGB := *pool.OsDiskSizeGB
+		osDiskSizeGB := int(*pool.OsDiskSizeGB)
 		result.Properties.OsDiskSizeGB = &osDiskSizeGB
 	}
 	if pool.OsDiskType != nil {
@@ -1189,7 +1189,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 	// copying flattened property:
 	if typedInput.Properties != nil {
 		if typedInput.Properties.OsDiskSizeGB != nil {
-			osDiskSizeGB := *typedInput.Properties.OsDiskSizeGB
+			osDiskSizeGB := ContainerServiceOSDisk(*typedInput.Properties.OsDiskSizeGB)
 			pool.OsDiskSizeGB = &osDiskSizeGB
 		}
 	}

--- a/v2/api/containerservice/v1api20240402preview/structure.txt
+++ b/v2/api/containerservice/v1api20240402preview/structure.txt
@@ -1875,9 +1875,7 @@ ManagedCluster_Spec_ARM: Object (8 properties)
 │   │   ├── NodePublicIPPrefixID: *string
 │   │   ├── NodeTaints: string[]
 │   │   ├── OrchestratorVersion: *string
-│   │   ├── OsDiskSizeGB: *Validated<int> (2 rules)
-│   │   │   ├── Rule 0: Maximum: 2048
-│   │   │   └── Rule 1: Minimum: 0
+│   │   ├── OsDiskSizeGB: *int
 │   │   ├── OsDiskType: *Enum (2 values)
 │   │   │   ├── "Ephemeral"
 │   │   │   └── "Managed"
@@ -2919,9 +2917,7 @@ ManagedClusters_AgentPool_Spec_ARM: Object (2 properties)
     ├── NodePublicIPPrefixID: *string
     ├── NodeTaints: string[]
     ├── OrchestratorVersion: *string
-    ├── OsDiskSizeGB: *Validated<int> (2 rules)
-    │   ├── Rule 0: Maximum: 2048
-    │   └── Rule 1: Minimum: 0
+    ├── OsDiskSizeGB: *int
     ├── OsDiskType: *Enum (2 values)
     │   ├── "Ephemeral"
     │   └── "Managed"

--- a/v2/api/containerservice/v1api20240402preview/zz_generated.deepcopy.go
+++ b/v2/api/containerservice/v1api20240402preview/zz_generated.deepcopy.go
@@ -4753,7 +4753,7 @@ func (in *ManagedClusterAgentPoolProfileProperties_ARM) DeepCopyInto(out *Manage
 	}
 	if in.OsDiskSizeGB != nil {
 		in, out := &in.OsDiskSizeGB, &out.OsDiskSizeGB
-		*out = new(ContainerServiceOSDisk)
+		*out = new(int)
 		**out = **in
 	}
 	if in.OsDiskType != nil {
@@ -5330,7 +5330,7 @@ func (in *ManagedClusterAgentPoolProfile_ARM) DeepCopyInto(out *ManagedClusterAg
 	}
 	if in.OsDiskSizeGB != nil {
 		in, out := &in.OsDiskSizeGB, &out.OsDiskSizeGB
-		*out = new(ContainerServiceOSDisk)
+		*out = new(int)
 		**out = **in
 	}
 	if in.OsDiskType != nil {

--- a/v2/tools/generator/internal/astmodel/conversion_function_builder.go
+++ b/v2/tools/generator/internal/astmodel/conversion_function_builder.go
@@ -157,6 +157,7 @@ func NewConversionFunctionBuilder(
 			IdentityAssignPrimitiveType,
 			AssignToOptional,
 			AssignFromOptional,
+			AssignToAliasOfPrimitive,
 			IdentityDeepCopyJSON,
 			IdentityAssignTypeName,
 		},
@@ -679,6 +680,57 @@ func AssignFromOptional(
 		astbuilder.IfNotNil(
 			params.GetSource(),
 			result...)), nil
+}
+
+// AssignToAliasOfPrimitive assigns a primitive value to an alias of that same type.
+// This function generates code that looks like this:
+//
+// <destination> <assignmentHandler> <destinationType>(<source>)
+func AssignToAliasOfPrimitive(
+	builder *ConversionFunctionBuilder,
+	params ConversionParameters,
+) ([]dst.Stmt, error) {
+	// Source must be a primitive type
+	srcPrim, ok := params.SourceType.(*PrimitiveType)
+	if !ok {
+		return nil, nil
+	}
+
+	// Destination must be an internal type name
+	dstName, ok := params.DestinationType.(InternalTypeName)
+	if !ok {
+		return nil, nil
+	}
+
+	// ... who's definition we know ...
+	dstDef, err := builder.CodeGenerationContext.GetDefinition(dstName)
+	if err != nil {
+		return nil, nil
+	}
+
+	// ... and it's not optional (hedging against oddities) ...
+	if _, ok := AsOptionalType(dstDef.Type()); ok {
+		return nil, nil
+	}
+
+	// ... and it is a primitive type ...
+	dstPrim, ok := AsPrimitiveType(dstDef.Type())
+	if !ok {
+		return nil, nil
+	}
+
+	// ... and is an alias of the source type ...
+	if !TypeEquals(srcPrim, dstPrim) {
+		return nil, nil
+	}
+
+	return astbuilder.Statements(
+			params.AssignmentHandlerOrDefault()(
+				params.GetDestination(),
+				astbuilder.CallFunc(
+					dstName.Name(),
+					params.GetSource()))),
+		nil
 }
 
 // IdentityAssignValidatedTypeDestination generates an assignment to the underlying validated type Element

--- a/v2/tools/generator/internal/astmodel/conversion_function_builder.go
+++ b/v2/tools/generator/internal/astmodel/conversion_function_builder.go
@@ -706,17 +706,19 @@ func AssignToAliasOfPrimitive(
 	// ... who's definition we know ...
 	dstDef, err := builder.CodeGenerationContext.GetDefinition(dstName)
 	if err != nil {
+		//nolint:nilerr // err is not nil, we defer to a different conversion
 		return nil, nil
 	}
 
 	// ... and it's not optional (hedging against oddities) ...
-	if _, ok := AsOptionalType(dstDef.Type()); ok {
+	if _, ok = AsOptionalType(dstDef.Type()); ok {
 		return nil, nil
 	}
 
 	// ... and it is a primitive type ...
 	dstPrim, ok := AsPrimitiveType(dstDef.Type())
 	if !ok {
+		//nolint:nilerr // err is not nil, we defer to a different conversion
 		return nil, nil
 	}
 
@@ -751,11 +753,12 @@ func AssignFromAliasOfPrimitive(
 	// ... who's definition we know ...
 	srcDef, err := builder.CodeGenerationContext.GetDefinition(srcName)
 	if err != nil {
+		//nolint:nilerr // err is not nil, we defer to a different conversion
 		return nil, nil
 	}
 
 	// ... and it's not optional (hedging against oddities) ...
-	if _, ok := AsOptionalType(srcDef.Type()); ok {
+	if _, ok = AsOptionalType(srcDef.Type()); ok {
 		return nil, nil
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
@@ -95,6 +95,7 @@ func newARMTypeCreator(
 
 	result.visitor = astmodel.TypeVisitorBuilder[any]{
 		VisitInternalTypeName: result.visitARMTypeName,
+		VisitValidatedType:    result.visitARMValidatedType,
 	}.Build()
 
 	return result
@@ -532,6 +533,14 @@ func (c *armTypeCreator) visitARMTypeName(
 	}
 
 	return astmodel.CreateARMTypeName(def.Name()), nil
+}
+
+func (c *armTypeCreator) visitARMValidatedType(
+	this *astmodel.TypeVisitor[any],
+	it *astmodel.ValidatedType,
+	ctx any,
+) (astmodel.Type, error) {
+	return this.Visit(it.ElementType(), ctx)
 }
 
 func (c *armTypeCreator) createSpecConversionContext(name astmodel.InternalTypeName) *armPropertyTypeConversionContext {

--- a/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
@@ -532,6 +532,16 @@ func (c *armTypeCreator) visitARMTypeName(
 		return updatedType, nil
 	}
 
+	// If the name is an alias for a map type, we reuse that alias (for now)
+	if _, ok := astmodel.AsMapType(def.Type()); ok {
+		return it, nil
+	}
+
+	// Ditto if the name is an alias for an array type
+	if _, ok := astmodel.AsArrayType(def.Type()); ok {
+		return it, nil
+	}
+
 	// We may or may not need to use an updated type name (i.e. if it's an aliased primitive type we can
 	// just keep using that alias)
 	updatedType, err := this.Visit(def.Type(), ctx)

--- a/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
@@ -524,7 +524,8 @@ func (c *armTypeCreator) visitARMTypeName(
 	// If the name is an alias for a primitive type, we look through it to the underlying type
 	if _, ok := astmodel.AsPrimitiveType(def.Type()); ok {
 		// We use the visitor to simplify the type
-		updatedType, err := this.Visit(def.Type(), ctx)
+		var updatedType astmodel.Type
+		updatedType, err = this.Visit(def.Type(), ctx)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to look through definition %s", def.Name())
 		}

--- a/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
@@ -521,7 +521,9 @@ func (c *armTypeCreator) visitARMTypeName(
 		return astmodel.CreateARMTypeName(def.Name()), nil
 	}
 
-	// If the name is an alias for a primitive type, we look through it to the underlying type
+	// If the name is an alias for a primitive type, we look through it to the underlying type,
+	// allowing us define the property using the primitive type directly
+	// and avoiding any potential circular dependencies
 	if _, ok := astmodel.AsPrimitiveType(def.Type()); ok {
 		// We use the visitor to simplify the type
 		var updatedType astmodel.Type
@@ -534,11 +536,13 @@ func (c *armTypeCreator) visitARMTypeName(
 	}
 
 	// If the name is an alias for a map type, we reuse that alias (for now)
+	// A future PR will change things to use the underlying type directly
 	if _, ok := astmodel.AsMapType(def.Type()); ok {
 		return it, nil
 	}
 
 	// Ditto if the name is an alias for an array type
+	// A future PR will change things to use the underlying type directly
 	if _, ok := astmodel.AsArrayType(def.Type()); ok {
 		return it, nil
 	}

--- a/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
@@ -521,6 +521,17 @@ func (c *armTypeCreator) visitARMTypeName(
 		return astmodel.CreateARMTypeName(def.Name()), nil
 	}
 
+	// If the name is an alias for a primitive type, we look through it to the underlying type
+	if _, ok := astmodel.AsPrimitiveType(def.Type()); ok {
+		// We use the visitor to simplify the type
+		updatedType, err := this.Visit(def.Type(), ctx)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to look through definition %s", def.Name())
+		}
+
+		return updatedType, nil
+	}
+
 	// We may or may not need to use an updated type name (i.e. if it's an aliased primitive type we can
 	// just keep using that alias)
 	updatedType, err := this.Visit(def.Type(), ctx)


### PR DESCRIPTION
**What this PR does / why we need it**:

In preparation for moving the ARM types into subpackages, we need to eliminate reuse of CRD types by the ARM types (if we don't, we'll get circular reference errors and things won't work). 

This PR takes the first step, replacing use of simple primitive type aliases with the underlying types.

**Special notes for your reviewer**:

Currently only handling single values, will have a followup PR to handle collections.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/rWbbNv8E0JBq8/giphy.gif?cid=790b76119spoaoshipfmaqz6txmab276g1dzbofm6ztl48gy&ep=v1_gifs_search&rid=giphy.gif&ct=g)

