### PR TITLE
Move validator helpers to genruntime/secrets or genruntime/configmaps

### DIFF
--- a/v2/api/apimanagement/v1api20220801/authorization_providers_authorizations_access_policy_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/authorization_providers_authorizations_access_policy_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -240,7 +241,7 @@ func (policy *AuthorizationProvidersAuthorizationsAccessPolicy) validateOptional
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/apimanagement/v1api20220801/named_value_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/named_value_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -239,7 +240,7 @@ func (value *NamedValue) validateOptionalConfigMapReferences() (admission.Warnin
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/apimanagement/v1api20220801/service_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/service_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -238,7 +239,7 @@ func (service *Service) validateOptionalConfigMapReferences() (admission.Warning
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/apimanagement/v1api20220801/subscription_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/subscription_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -259,7 +260,7 @@ func (subscription *Subscription) validateSecretDestinations() (admission.Warnin
 		subscription.Spec.OperatorSpec.Secrets.PrimaryKey,
 		subscription.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/apimanagement/v1api20230501preview/authorization_providers_authorizations_access_policy_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/authorization_providers_authorizations_access_policy_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -243,7 +244,7 @@ func (policy *AuthorizationProvidersAuthorizationsAccessPolicy) validateOptional
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/apimanagement/v1api20230501preview/named_value_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/named_value_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -242,7 +243,7 @@ func (value *NamedValue) validateOptionalConfigMapReferences() (admission.Warnin
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/apimanagement/v1api20230501preview/service_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/service_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -241,7 +242,7 @@ func (service *Service) validateOptionalConfigMapReferences() (admission.Warning
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/apimanagement/v1api20230501preview/subscription_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/subscription_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -262,7 +263,7 @@ func (subscription *Subscription) validateSecretDestinations() (admission.Warnin
 		subscription.Spec.OperatorSpec.Secrets.PrimaryKey,
 		subscription.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/appconfiguration/v1api20220501/configuration_store_types_gen.go
+++ b/v2/api/appconfiguration/v1api20220501/configuration_store_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -268,7 +269,7 @@ func (store *ConfigurationStore) validateSecretDestinations() (admission.Warning
 		store.Spec.OperatorSpec.Secrets.SecondaryReadOnlyKey,
 		store.Spec.OperatorSpec.Secrets.SecondaryReadOnlyKeyID,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/authorization/v1api20200801preview/role_assignment_types_gen.go
+++ b/v2/api/authorization/v1api20200801preview/role_assignment_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -230,7 +231,7 @@ func (assignment *RoleAssignment) validateOptionalConfigMapReferences() (admissi
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateResourceReferences validates all resource references

--- a/v2/api/authorization/v1api20220401/role_assignment_types_gen.go
+++ b/v2/api/authorization/v1api20220401/role_assignment_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -227,7 +228,7 @@ func (assignment *RoleAssignment) validateOptionalConfigMapReferences() (admissi
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateResourceReferences validates all resource references

--- a/v2/api/cache/v1api20201201/redis_types_gen.go
+++ b/v2/api/cache/v1api20201201/redis_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -264,7 +265,7 @@ func (redis *Redis) validateSecretDestinations() (admission.Warnings, error) {
 		redis.Spec.OperatorSpec.Secrets.SSLPort,
 		redis.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/cache/v1api20230401/redis_types_gen.go
+++ b/v2/api/cache/v1api20230401/redis_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -261,7 +262,7 @@ func (redis *Redis) validateSecretDestinations() (admission.Warnings, error) {
 		redis.Spec.OperatorSpec.Secrets.SSLPort,
 		redis.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/compute/v1api20220702/disk_encryption_set_types_gen.go
+++ b/v2/api/compute/v1api20220702/disk_encryption_set_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -241,7 +242,7 @@ func (encryptionSet *DiskEncryptionSet) validateOptionalConfigMapReferences() (a
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/compute/v1api20240302/disk_encryption_set_types_gen.go
+++ b/v2/api/compute/v1api20240302/disk_encryption_set_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -238,7 +239,7 @@ func (encryptionSet *DiskEncryptionSet) validateOptionalConfigMapReferences() (a
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/containerservice/v1api20210501/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20210501/managed_cluster_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -261,7 +262,7 @@ func (cluster *ManagedCluster) validateSecretDestinations() (admission.Warnings,
 		cluster.Spec.OperatorSpec.Secrets.AdminCredentials,
 		cluster.Spec.OperatorSpec.Secrets.UserCredentials,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/containerservice/v1api20230201/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20230201/managed_cluster_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -281,7 +282,7 @@ func (cluster *ManagedCluster) validateConfigMapDestinations() (admission.Warnin
 		cluster.Spec.OperatorSpec.ConfigMaps.OIDCIssuerProfile,
 		cluster.Spec.OperatorSpec.ConfigMaps.PrincipalId,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -310,7 +311,7 @@ func (cluster *ManagedCluster) validateSecretDestinations() (admission.Warnings,
 		cluster.Spec.OperatorSpec.Secrets.AdminCredentials,
 		cluster.Spec.OperatorSpec.Secrets.UserCredentials,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/containerservice/v1api20230315preview/fleet_types_gen.go
+++ b/v2/api/containerservice/v1api20230315preview/fleet_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -257,7 +258,7 @@ func (fleet *Fleet) validateSecretDestinations() (admission.Warnings, error) {
 	toValidate := []*genruntime.SecretDestination{
 		fleet.Spec.OperatorSpec.Secrets.UserCredentials,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/containerservice/v1api20231001/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20231001/managed_cluster_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -278,7 +279,7 @@ func (cluster *ManagedCluster) validateConfigMapDestinations() (admission.Warnin
 		cluster.Spec.OperatorSpec.ConfigMaps.OIDCIssuerProfile,
 		cluster.Spec.OperatorSpec.ConfigMaps.PrincipalId,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -307,7 +308,7 @@ func (cluster *ManagedCluster) validateSecretDestinations() (admission.Warnings,
 		cluster.Spec.OperatorSpec.Secrets.AdminCredentials,
 		cluster.Spec.OperatorSpec.Secrets.UserCredentials,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/containerservice/v1api20231102preview/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20231102preview/managed_cluster_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -273,7 +274,7 @@ func (cluster *ManagedCluster) validateConfigMapDestinations() (admission.Warnin
 	toValidate := []*genruntime.ConfigMapDestination{
 		cluster.Spec.OperatorSpec.ConfigMaps.OIDCIssuerProfile,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -302,7 +303,7 @@ func (cluster *ManagedCluster) validateSecretDestinations() (admission.Warnings,
 		cluster.Spec.OperatorSpec.Secrets.AdminCredentials,
 		cluster.Spec.OperatorSpec.Secrets.UserCredentials,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/containerservice/v1api20240402preview/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20240402preview/managed_cluster_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -273,7 +274,7 @@ func (cluster *ManagedCluster) validateConfigMapDestinations() (admission.Warnin
 	toValidate := []*genruntime.ConfigMapDestination{
 		cluster.Spec.OperatorSpec.ConfigMaps.OIDCIssuerProfile,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -302,7 +303,7 @@ func (cluster *ManagedCluster) validateSecretDestinations() (admission.Warnings,
 		cluster.Spec.OperatorSpec.Secrets.AdminCredentials,
 		cluster.Spec.OperatorSpec.Secrets.UserCredentials,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/dataprotection/v1api20230101/backup_vault_types_gen.go
+++ b/v2/api/dataprotection/v1api20230101/backup_vault_types_gen.go
@@ -270,7 +270,7 @@ func (vault *BackupVault) validateConfigMapDestinations() (admission.Warnings, e
 	toValidate := []*genruntime.ConfigMapDestination{
 		vault.Spec.OperatorSpec.ConfigMaps.PrincipalId,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/dataprotection/v1api20231101/backup_vault_types_gen.go
+++ b/v2/api/dataprotection/v1api20231101/backup_vault_types_gen.go
@@ -267,7 +267,7 @@ func (vault *BackupVault) validateConfigMapDestinations() (admission.Warnings, e
 	toValidate := []*genruntime.ConfigMapDestination{
 		vault.Spec.OperatorSpec.ConfigMaps.PrincipalId,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/dbformariadb/v1api20180601/server_types_gen.go
+++ b/v2/api/dbformariadb/v1api20180601/server_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -257,7 +258,7 @@ func (server *Server) validateSecretDestinations() (admission.Warnings, error) {
 	toValidate := []*genruntime.SecretDestination{
 		server.Spec.OperatorSpec.Secrets.FullyQualifiedDomainName,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/dbformysql/v1api20210501/flexible_server_types_gen.go
+++ b/v2/api/dbformysql/v1api20210501/flexible_server_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -278,7 +279,7 @@ func (server *FlexibleServer) validateConfigMapDestinations() (admission.Warning
 		server.Spec.OperatorSpec.ConfigMaps.AdministratorLogin,
 		server.Spec.OperatorSpec.ConfigMaps.FullyQualifiedDomainName,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -306,7 +307,7 @@ func (server *FlexibleServer) validateSecretDestinations() (admission.Warnings, 
 	toValidate := []*genruntime.SecretDestination{
 		server.Spec.OperatorSpec.Secrets.FullyQualifiedDomainName,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/dbformysql/v1api20220101/flexible_servers_administrator_types_gen.go
+++ b/v2/api/dbformysql/v1api20220101/flexible_servers_administrator_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -234,7 +235,7 @@ func (administrator *FlexibleServersAdministrator) validateOptionalConfigMapRefe
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/dbformysql/v1api20230630/flexible_server_types_gen.go
+++ b/v2/api/dbformysql/v1api20230630/flexible_server_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -275,7 +276,7 @@ func (server *FlexibleServer) validateConfigMapDestinations() (admission.Warning
 		server.Spec.OperatorSpec.ConfigMaps.AdministratorLogin,
 		server.Spec.OperatorSpec.ConfigMaps.FullyQualifiedDomainName,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -303,7 +304,7 @@ func (server *FlexibleServer) validateSecretDestinations() (admission.Warnings, 
 	toValidate := []*genruntime.SecretDestination{
 		server.Spec.OperatorSpec.Secrets.FullyQualifiedDomainName,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/dbformysql/v1api20230630/flexible_servers_administrator_types_gen.go
+++ b/v2/api/dbformysql/v1api20230630/flexible_servers_administrator_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -231,7 +232,7 @@ func (administrator *FlexibleServersAdministrator) validateOptionalConfigMapRefe
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/dbforpostgresql/v1api20210601/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20210601/flexible_server_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -260,7 +261,7 @@ func (server *FlexibleServer) validateSecretDestinations() (admission.Warnings, 
 	toValidate := []*genruntime.SecretDestination{
 		server.Spec.OperatorSpec.Secrets.FullyQualifiedDomainName,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/dbforpostgresql/v1api20220120preview/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20220120preview/flexible_server_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -271,7 +272,7 @@ func (server *FlexibleServer) validateConfigMapDestinations() (admission.Warning
 	toValidate := []*genruntime.ConfigMapDestination{
 		server.Spec.OperatorSpec.ConfigMaps.FullyQualifiedDomainName,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -299,7 +300,7 @@ func (server *FlexibleServer) validateSecretDestinations() (admission.Warnings, 
 	toValidate := []*genruntime.SecretDestination{
 		server.Spec.OperatorSpec.Secrets.FullyQualifiedDomainName,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/dbforpostgresql/v1api20221201/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20221201/flexible_server_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -268,7 +269,7 @@ func (server *FlexibleServer) validateConfigMapDestinations() (admission.Warning
 	toValidate := []*genruntime.ConfigMapDestination{
 		server.Spec.OperatorSpec.ConfigMaps.FullyQualifiedDomainName,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -296,7 +297,7 @@ func (server *FlexibleServer) validateSecretDestinations() (admission.Warnings, 
 	toValidate := []*genruntime.SecretDestination{
 		server.Spec.OperatorSpec.Secrets.FullyQualifiedDomainName,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/dbforpostgresql/v1api20230601preview/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20230601preview/flexible_server_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -271,7 +272,7 @@ func (server *FlexibleServer) validateConfigMapDestinations() (admission.Warning
 	toValidate := []*genruntime.ConfigMapDestination{
 		server.Spec.OperatorSpec.ConfigMaps.FullyQualifiedDomainName,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -299,7 +300,7 @@ func (server *FlexibleServer) validateSecretDestinations() (admission.Warnings, 
 	toValidate := []*genruntime.SecretDestination{
 		server.Spec.OperatorSpec.Secrets.FullyQualifiedDomainName,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/devices/v1api20210702/iot_hub_types_gen.go
+++ b/v2/api/devices/v1api20210702/iot_hub_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -266,7 +267,7 @@ func (iotHub *IotHub) validateSecretDestinations() (admission.Warnings, error) {
 		iotHub.Spec.OperatorSpec.Secrets.ServicePrimaryKey,
 		iotHub.Spec.OperatorSpec.Secrets.ServiceSecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/documentdb/v1api20210515/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/database_account_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -264,7 +265,7 @@ func (account *DatabaseAccount) validateSecretDestinations() (admission.Warnings
 		account.Spec.OperatorSpec.Secrets.SecondaryMasterKey,
 		account.Spec.OperatorSpec.Secrets.SecondaryReadonlyMasterKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/documentdb/v1api20210515/sql_role_assignment_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_role_assignment_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -234,7 +235,7 @@ func (assignment *SqlRoleAssignment) validateOptionalConfigMapReferences() (admi
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/documentdb/v1api20231115/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/database_account_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -261,7 +262,7 @@ func (account *DatabaseAccount) validateSecretDestinations() (admission.Warnings
 		account.Spec.OperatorSpec.Secrets.SecondaryMasterKey,
 		account.Spec.OperatorSpec.Secrets.SecondaryReadonlyMasterKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/documentdb/v1api20231115/sql_role_assignment_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/sql_role_assignment_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -231,7 +232,7 @@ func (assignment *SqlRoleAssignment) validateOptionalConfigMapReferences() (admi
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/eventgrid/v1api20200601/topic_types_gen.go
+++ b/v2/api/eventgrid/v1api20200601/topic_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -268,7 +269,7 @@ func (topic *Topic) validateConfigMapDestinations() (admission.Warnings, error) 
 	toValidate := []*genruntime.ConfigMapDestination{
 		topic.Spec.OperatorSpec.ConfigMaps.Endpoint,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -297,7 +298,7 @@ func (topic *Topic) validateSecretDestinations() (admission.Warnings, error) {
 		topic.Spec.OperatorSpec.Secrets.Key1,
 		topic.Spec.OperatorSpec.Secrets.Key2,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/eventhub/v1api20211101/namespace_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/namespace_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -260,7 +261,7 @@ func (namespace *Namespace) validateSecretDestinations() (admission.Warnings, er
 		namespace.Spec.OperatorSpec.Secrets.SecondaryConnectionString,
 		namespace.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/eventhub/v1api20211101/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/namespaces_authorization_rule_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -260,7 +261,7 @@ func (rule *NamespacesAuthorizationRule) validateSecretDestinations() (admission
 		rule.Spec.OperatorSpec.Secrets.SecondaryConnectionString,
 		rule.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/eventhub/v1api20211101/namespaces_eventhubs_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/namespaces_eventhubs_authorization_rule_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -260,7 +261,7 @@ func (rule *NamespacesEventhubsAuthorizationRule) validateSecretDestinations() (
 		rule.Spec.OperatorSpec.Secrets.SecondaryConnectionString,
 		rule.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/insights/v1api20200202/component_types_gen.go
+++ b/v2/api/insights/v1api20200202/component_types_gen.go
@@ -271,7 +271,7 @@ func (component *Component) validateConfigMapDestinations() (admission.Warnings,
 		component.Spec.OperatorSpec.ConfigMaps.ConnectionString,
 		component.Spec.OperatorSpec.ConfigMaps.InstrumentationKey,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/keyvault/v1api20210401preview/vault_types_gen.go
+++ b/v2/api/keyvault/v1api20210401preview/vault_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -241,7 +242,7 @@ func (vault *Vault) validateOptionalConfigMapReferences() (admission.Warnings, e
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/keyvault/v1api20230701/vault_types_gen.go
+++ b/v2/api/keyvault/v1api20230701/vault_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -238,7 +239,7 @@ func (vault *Vault) validateOptionalConfigMapReferences() (admission.Warnings, e
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/kubernetesconfiguration/v1api20230501/extension_types_gen.go
+++ b/v2/api/kubernetesconfiguration/v1api20230501/extension_types_gen.go
@@ -264,7 +264,7 @@ func (extension *Extension) validateConfigMapDestinations() (admission.Warnings,
 	toValidate := []*genruntime.ConfigMapDestination{
 		extension.Spec.OperatorSpec.ConfigMaps.PrincipalId,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateResourceReferences validates all resource references

--- a/v2/api/machinelearningservices/v1api20210701/workspace_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20210701/workspace_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -263,7 +264,7 @@ func (workspace *Workspace) validateSecretDestinations() (admission.Warnings, er
 		workspace.Spec.OperatorSpec.Secrets.SecondaryNotebookAccessKey,
 		workspace.Spec.OperatorSpec.Secrets.UserStorageKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/managedidentity/v1api20181130/user_assigned_identity_types_gen.go
+++ b/v2/api/managedidentity/v1api20181130/user_assigned_identity_types_gen.go
@@ -280,7 +280,7 @@ func (identity *UserAssignedIdentity) validateConfigMapDestinations() (admission
 		identity.Spec.OperatorSpec.ConfigMaps.PrincipalId,
 		identity.Spec.OperatorSpec.ConfigMaps.TenantId,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/managedidentity/v1api20220131preview/federated_identity_credential_types_gen.go
+++ b/v2/api/managedidentity/v1api20220131preview/federated_identity_credential_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -241,7 +242,7 @@ func (credential *FederatedIdentityCredential) validateOptionalConfigMapReferenc
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/managedidentity/v1api20230131/federated_identity_credential_types_gen.go
+++ b/v2/api/managedidentity/v1api20230131/federated_identity_credential_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -238,7 +239,7 @@ func (credential *FederatedIdentityCredential) validateOptionalConfigMapReferenc
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/managedidentity/v1api20230131/user_assigned_identity_types_gen.go
+++ b/v2/api/managedidentity/v1api20230131/user_assigned_identity_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -280,7 +281,7 @@ func (identity *UserAssignedIdentity) validateConfigMapDestinations() (admission
 		identity.Spec.OperatorSpec.ConfigMaps.PrincipalId,
 		identity.Spec.OperatorSpec.ConfigMaps.TenantId,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -310,7 +311,7 @@ func (identity *UserAssignedIdentity) validateSecretDestinations() (admission.Wa
 		identity.Spec.OperatorSpec.Secrets.PrincipalId,
 		identity.Spec.OperatorSpec.Secrets.TenantId,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/network/v1api20220401/traffic_manager_profile_types_gen.go
+++ b/v2/api/network/v1api20220401/traffic_manager_profile_types_gen.go
@@ -267,7 +267,7 @@ func (profile *TrafficManagerProfile) validateConfigMapDestinations() (admission
 	toValidate := []*genruntime.ConfigMapDestination{
 		profile.Spec.OperatorSpec.ConfigMaps.DnsConfigFqdn,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/network/v1api20220701/dns_forwarding_rule_sets_forwarding_rule_types_gen.go
+++ b/v2/api/network/v1api20220701/dns_forwarding_rule_sets_forwarding_rule_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -238,7 +239,7 @@ func (rule *DnsForwardingRuleSetsForwardingRule) validateOptionalConfigMapRefere
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/network/v1api20220701/private_endpoint_types_gen.go
+++ b/v2/api/network/v1api20220701/private_endpoint_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -243,7 +244,7 @@ func (endpoint *PrivateEndpoint) validateConfigMapDestinations() (admission.Warn
 	toValidate := []*genruntime.ConfigMapDestination{
 		endpoint.Spec.OperatorSpec.ConfigMaps.PrimaryNicPrivateIpAddress,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/network/v1api20220701/private_link_service_types_gen.go
+++ b/v2/api/network/v1api20220701/private_link_service_types_gen.go
@@ -265,7 +265,7 @@ func (service *PrivateLinkService) validateConfigMapDestinations() (admission.Wa
 	toValidate := []*genruntime.ConfigMapDestination{
 		service.Spec.OperatorSpec.ConfigMaps.Alias,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/search/v1api20220901/search_service_types_gen.go
+++ b/v2/api/search/v1api20220901/search_service_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -260,7 +261,7 @@ func (service *SearchService) validateSecretDestinations() (admission.Warnings, 
 		service.Spec.OperatorSpec.Secrets.AdminSecondaryKey,
 		service.Spec.OperatorSpec.Secrets.QueryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/servicebus/v1api20210101preview/namespace_types_gen.go
+++ b/v2/api/servicebus/v1api20210101preview/namespace_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -264,7 +265,7 @@ func (namespace *Namespace) validateSecretDestinations() (admission.Warnings, er
 		namespace.Spec.OperatorSpec.Secrets.SecondaryConnectionString,
 		namespace.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/servicebus/v1api20210101preview/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/servicebus/v1api20210101preview/namespaces_authorization_rule_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -263,7 +264,7 @@ func (rule *NamespacesAuthorizationRule) validateSecretDestinations() (admission
 		rule.Spec.OperatorSpec.Secrets.SecondaryConnectionString,
 		rule.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/servicebus/v1api20211101/namespace_types_gen.go
+++ b/v2/api/servicebus/v1api20211101/namespace_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -261,7 +262,7 @@ func (namespace *Namespace) validateSecretDestinations() (admission.Warnings, er
 		namespace.Spec.OperatorSpec.Secrets.SecondaryConnectionString,
 		namespace.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/servicebus/v1api20211101/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/servicebus/v1api20211101/namespaces_authorization_rule_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -260,7 +261,7 @@ func (rule *NamespacesAuthorizationRule) validateSecretDestinations() (admission
 		rule.Spec.OperatorSpec.Secrets.SecondaryConnectionString,
 		rule.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/servicebus/v1api20221001preview/namespace_types_gen.go
+++ b/v2/api/servicebus/v1api20221001preview/namespace_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -264,7 +265,7 @@ func (namespace *Namespace) validateSecretDestinations() (admission.Warnings, er
 		namespace.Spec.OperatorSpec.Secrets.SecondaryConnectionString,
 		namespace.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/servicebus/v1api20221001preview/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/servicebus/v1api20221001preview/namespaces_authorization_rule_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -263,7 +264,7 @@ func (rule *NamespacesAuthorizationRule) validateSecretDestinations() (admission
 		rule.Spec.OperatorSpec.Secrets.SecondaryConnectionString,
 		rule.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/signalrservice/v1api20211001/signal_r_types_gen.go
+++ b/v2/api/signalrservice/v1api20211001/signal_r_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -260,7 +261,7 @@ func (signalR *SignalR) validateSecretDestinations() (admission.Warnings, error)
 		signalR.Spec.OperatorSpec.Secrets.SecondaryConnectionString,
 		signalR.Spec.OperatorSpec.Secrets.SecondaryKey,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/sql/v1api20211101/server_types_gen.go
+++ b/v2/api/sql/v1api20211101/server_types_gen.go
@@ -265,7 +265,7 @@ func (server *Server) validateConfigMapDestinations() (admission.Warnings, error
 	toValidate := []*genruntime.ConfigMapDestination{
 		server.Spec.OperatorSpec.ConfigMaps.FullyQualifiedDomainName,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/sql/v1api20211101/servers_administrator_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_administrator_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -231,7 +232,7 @@ func (administrator *ServersAdministrator) validateOptionalConfigMapReferences()
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/sql/v1api20211101/servers_databases_vulnerability_assessment_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_databases_vulnerability_assessment_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -231,7 +232,7 @@ func (assessment *ServersDatabasesVulnerabilityAssessment) validateOptionalConfi
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/sql/v1api20211101/servers_vulnerability_assessment_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_vulnerability_assessment_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -231,7 +232,7 @@ func (assessment *ServersVulnerabilityAssessment) validateOptionalConfigMapRefer
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/api/storage/v1api20210401/storage_account_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_account_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -313,7 +314,7 @@ func (account *StorageAccount) validateConfigMapDestinations() (admission.Warnin
 		account.Spec.OperatorSpec.ConfigMaps.TableEndpoint,
 		account.Spec.OperatorSpec.ConfigMaps.WebEndpoint,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -348,7 +349,7 @@ func (account *StorageAccount) validateSecretDestinations() (admission.Warnings,
 		account.Spec.OperatorSpec.Secrets.TableEndpoint,
 		account.Spec.OperatorSpec.Secrets.WebEndpoint,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/storage/v1api20220901/storage_account_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_account_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -313,7 +314,7 @@ func (account *StorageAccount) validateConfigMapDestinations() (admission.Warnin
 		account.Spec.OperatorSpec.ConfigMaps.TableEndpoint,
 		account.Spec.OperatorSpec.ConfigMaps.WebEndpoint,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -348,7 +349,7 @@ func (account *StorageAccount) validateSecretDestinations() (admission.Warnings,
 		account.Spec.OperatorSpec.Secrets.TableEndpoint,
 		account.Spec.OperatorSpec.Secrets.WebEndpoint,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/storage/v1api20230101/storage_account_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_account_types_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -310,7 +311,7 @@ func (account *StorageAccount) validateConfigMapDestinations() (admission.Warnin
 		account.Spec.OperatorSpec.ConfigMaps.TableEndpoint,
 		account.Spec.OperatorSpec.ConfigMaps.WebEndpoint,
 	}
-	return genruntime.ValidateConfigMapDestinations(toValidate)
+	return configmaps.ValidateDestinations(toValidate)
 }
 
 // validateOwnerReference validates the owner field
@@ -345,7 +346,7 @@ func (account *StorageAccount) validateSecretDestinations() (admission.Warnings,
 		account.Spec.OperatorSpec.Secrets.TableEndpoint,
 		account.Spec.OperatorSpec.Secrets.WebEndpoint,
 	}
-	return genruntime.ValidateSecretDestinations(toValidate)
+	return secrets.ValidateDestinations(toValidate)
 }
 
 // validateWriteOnceProperties validates all WriteOnce properties

--- a/v2/api/synapse/v1api20210601/workspace_types_gen.go
+++ b/v2/api/synapse/v1api20210601/workspace_types_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 	"github.com/pkg/errors"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -239,7 +240,7 @@ func (workspace *Workspace) validateOptionalConfigMapReferences() (admission.War
 	if err != nil {
 		return nil, err
 	}
-	return genruntime.ValidateOptionalConfigMapReferences(refs)
+	return configmaps.ValidateOptionalReferences(refs)
 }
 
 // validateOwnerReference validates the owner field

--- a/v2/internal/reflecthelpers/reflect_helpers.go
+++ b/v2/internal/reflecthelpers/reflect_helpers.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/configmaps"
 )
 
 // ValueOfPtr dereferences a pointer and returns the value the pointer points to.
@@ -147,13 +148,13 @@ func Find[T comparable](obj interface{}) (set.Set[T], error) {
 }
 
 // FindOptionalConfigMapReferences finds all the genruntime.ConfigMapReference's on the provided object
-func FindOptionalConfigMapReferences(obj interface{}) ([]*genruntime.OptionalConfigMapReferencePair, error) {
+func FindOptionalConfigMapReferences(obj interface{}) ([]*configmaps.OptionalReferencePair, error) {
 	untypedResult, err := FindPropertiesWithTag(obj, "optionalConfigMapPair") // TODO: This is astmodel.OptionalConfigMapPairTag
 	if err != nil {
 		return nil, err
 	}
 
-	collector := make(map[string][]*genruntime.OptionalConfigMapReferencePair)
+	collector := make(map[string][]*configmaps.OptionalReferencePair)
 	suffix := "FromConfig" // TODO This is astmodel.OptionalConfigMapReferenceSuffix
 
 	// This could probably be more efficient, but this avoids code duplication, and we're not dealing
@@ -163,13 +164,13 @@ func FindOptionalConfigMapReferences(obj interface{}) ([]*genruntime.OptionalCon
 			continue
 		}
 
-		collector[key] = make([]*genruntime.OptionalConfigMapReferencePair, 0, len(values))
+		collector[key] = make([]*configmaps.OptionalReferencePair, 0, len(values))
 		for _, val := range values {
 			typedValue, ok := val.(*string)
 			if !ok {
 				return nil, errors.Errorf("value of property %s was not a *string like expected", key)
 			}
-			collector[key] = append(collector[key], &genruntime.OptionalConfigMapReferencePair{
+			collector[key] = append(collector[key], &configmaps.OptionalReferencePair{
 				Name:  key,
 				Value: typedValue,
 			})
@@ -196,7 +197,7 @@ func FindOptionalConfigMapReferences(obj interface{}) ([]*genruntime.OptionalCon
 	}
 
 	// Translate our collector into a simple list
-	var result []*genruntime.OptionalConfigMapReferencePair
+	var result []*configmaps.OptionalReferencePair
 	for _, values := range collector {
 		for _, val := range values {
 			result = append(result, val)

--- a/v2/internal/testcommon/vcr/redact.go
+++ b/v2/internal/testcommon/vcr/redact.go
@@ -117,7 +117,6 @@ func (r *Redactor) RedactResponseHeaders(headers http.Header) {
 }
 
 func (r *Redactor) HideRecordingData(s string) string {
-
 	// Hide custom redactions
 	s = r.hideRecordingDataWithCustomRedaction(s)
 
@@ -195,7 +194,6 @@ func hideCustomKeys(s string) string {
 }
 
 func (r *Redactor) HideURLData(s string) string {
-
 	s = r.hideRecordingDataWithCustomRedaction(s)
 	s = hideBaseRequestURL(s)
 

--- a/v2/pkg/genruntime/configmaps/validation.go
+++ b/v2/pkg/genruntime/configmaps/validation.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package configmaps
+
+import (
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/Azure/azure-service-operator/v2/internal/set"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+)
+
+type keyPair struct {
+	name string
+	key  string
+}
+
+// ValidateDestinations checks that no two destinations are writing to the same configmap/key, as that could cause
+// those values to overwrite one another.
+func ValidateDestinations(destinations []*genruntime.ConfigMapDestination) (admission.Warnings, error) {
+	locations := set.Make[keyPair]()
+
+	for _, dest := range destinations {
+		if dest == nil {
+			continue
+		}
+
+		pair := keyPair{
+			name: dest.Name,
+			key:  dest.Key,
+		}
+		if locations.Contains(pair) {
+			return nil, errors.Errorf("cannot write more than one configmap value to destination %s", dest.String())
+		}
+
+		locations.Add(pair)
+	}
+
+	return nil, nil
+}
+
+// OptionalReferencePair represents an optional configmap pair. Each pair has two optional fields, a
+// string and a ConfigMapReference.
+// This type is used purely for validation. The actual user supplied types are inline on the objects themselves as
+// two properties: Foo and FooFromConfig
+type OptionalReferencePair struct {
+	Value   *string
+	Ref     *genruntime.ConfigMapReference
+	Name    string
+	RefName string
+}
+
+// ValidateOptionalReferences checks that only one of Foo and FooFromConfig are set
+func ValidateOptionalReferences(pairs []*OptionalReferencePair) (admission.Warnings, error) {
+	for _, pair := range pairs {
+		if pair.Value != nil && pair.Ref != nil {
+			return nil, errors.Errorf("cannot specify both %s and %s", pair.Name, pair.RefName)
+		}
+	}
+
+	return nil, nil
+}

--- a/v2/pkg/genruntime/secrets/validation.go
+++ b/v2/pkg/genruntime/secrets/validation.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package secrets
+
+import (
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/Azure/azure-service-operator/v2/internal/set"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+)
+
+type keyPair struct {
+	name string
+	key  string
+}
+
+// ValidateDestinations checks that no two destinations are writing to the same secret/key, as that could cause
+// those secrets to overwrite one another.
+func ValidateDestinations(destinations []*genruntime.SecretDestination) (admission.Warnings, error) {
+	// Map of secret -> keys
+	locations := set.Make[keyPair]()
+
+	for _, dest := range destinations {
+		if dest == nil {
+			continue
+		}
+
+		pair := keyPair{
+			name: dest.Name,
+			key:  dest.Key,
+		}
+		if locations.Contains(pair) {
+			return nil, errors.Errorf("cannot write more than one secret to destination %s", dest.String())
+		}
+
+		locations.Add(pair)
+	}
+
+	return nil, nil
+}

--- a/v2/pkg/genruntime/secrets/validation_test.go
+++ b/v2/pkg/genruntime/secrets/validation_test.go
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
 
-package genruntime_test
+package secrets_test
 
 import (
 	"testing"
@@ -11,13 +11,14 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 )
 
 func Test_ValidateSecretDestination_EmptyListValidates(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	warnings, err := genruntime.ValidateSecretDestinations(nil)
+	warnings, err := secrets.ValidateDestinations(nil)
 	g.Expect(warnings).To(BeNil())
 	g.Expect(err).To(BeNil())
 }
@@ -31,7 +32,7 @@ func Test_ValidateSecretDestination_ListWithNilElementsValidates(t *testing.T) {
 		nil,
 	}
 
-	warnings, err := genruntime.ValidateSecretDestinations(destinations)
+	warnings, err := secrets.ValidateDestinations(destinations)
 	g.Expect(warnings).To(BeNil())
 	g.Expect(err).To(BeNil())
 }
@@ -44,7 +45,7 @@ func Test_ValidateSecretDestination_LengthOneListValidates(t *testing.T) {
 		{Name: "n1", Key: "key1"},
 	}
 
-	warnings, err := genruntime.ValidateSecretDestinations(destinations)
+	warnings, err := secrets.ValidateDestinations(destinations)
 	g.Expect(warnings).To(BeNil())
 	g.Expect(err).To(BeNil())
 }
@@ -60,7 +61,7 @@ func Test_ValidateSecretDestination_ListWithoutCollisionsValidates(t *testing.T)
 		{Name: "n1", Key: "key4"},
 	}
 
-	warnings, err := genruntime.ValidateSecretDestinations(destinations)
+	warnings, err := secrets.ValidateDestinations(destinations)
 	g.Expect(warnings).To(BeNil())
 	g.Expect(err).To(BeNil())
 }
@@ -76,7 +77,7 @@ func Test_ValidateSecretDestination_ListWithDifferentCasesValidates(t *testing.T
 		{Name: "n1", Key: "key4"},
 	}
 
-	warnings, err := genruntime.ValidateSecretDestinations(destinations)
+	warnings, err := secrets.ValidateDestinations(destinations)
 	g.Expect(warnings).To(BeNil())
 	g.Expect(err).To(BeNil())
 }
@@ -91,7 +92,7 @@ func Test_ValidateSecretDestination_ListWithCollisionsFailsValidation(t *testing
 		{Name: "n3", Key: "key1"},
 		{Name: "n1", Key: "key1"},
 	}
-	_, err := genruntime.ValidateSecretDestinations(destinations)
+	_, err := secrets.ValidateDestinations(destinations)
 	g.Expect(err).ToNot(BeNil())
 	g.Expect(err.Error()).To(Equal("cannot write more than one secret to destination Name: \"n1\", Key: \"key1\""))
 }

--- a/v2/tools/generator/internal/astmodel/std_references.go
+++ b/v2/tools/generator/internal/astmodel/std_references.go
@@ -27,6 +27,7 @@ var (
 	GenRuntimeRegistrationReference = MakeExternalPackageReference(genRuntimePathPrefix + "/registration")
 	ReflectHelpersReference         = MakeExternalPackageReference(reflectHelpersPath)
 	GenRuntimeConfigMapsReference   = MakeExternalPackageReference(genRuntimePathPrefix + "/configmaps")
+	GenRuntimeSecretsReference      = MakeExternalPackageReference(genRuntimePathPrefix + "/secrets")
 	GenericARMClientReference       = MakeExternalPackageReference(genericARMClientPath)
 
 	// References to other libraries

--- a/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
@@ -124,7 +124,6 @@ func getValidations(
 	if err != nil {
 		return nil, err
 	}
-
 	if secrets != nil {
 		validations[functions.ValidationKindCreate] = append(
 			validations[functions.ValidationKindCreate],
@@ -173,7 +172,7 @@ func NewValidateSecretDestinationsFunction(resource *astmodel.ResourceType, idFa
 		resource,
 		idFactory,
 		validateSecretDestinations,
-		astmodel.NewPackageReferenceSet(astmodel.GenRuntimeReference))
+		astmodel.NewPackageReferenceSet(astmodel.GenRuntimeSecretsReference))
 }
 
 func validateSecretDestinations(
@@ -194,7 +193,8 @@ func validateSecretDestinations(
 		receiverIdent,
 		astmodel.OperatorSpecSecretsProperty,
 		astmodel.NewOptionalType(astmodel.SecretDestinationType),
-		"ValidateSecretDestinations")
+		astmodel.GenRuntimeSecretsReference,
+		"ValidateDestinations")
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating body of method %s", methodName)
 	}
@@ -219,7 +219,7 @@ func NewValidateConfigMapDestinationsFunction(resource *astmodel.ResourceType, i
 		resource,
 		idFactory,
 		validateConfigMapDestinations,
-		astmodel.NewPackageReferenceSet(astmodel.GenRuntimeReference))
+		astmodel.NewPackageReferenceSet(astmodel.GenRuntimeConfigMapsReference))
 }
 
 func validateConfigMapDestinations(
@@ -240,7 +240,8 @@ func validateConfigMapDestinations(
 		receiverIdent,
 		astmodel.OperatorSpecConfigMapsProperty,
 		astmodel.NewOptionalType(astmodel.ConfigMapDestinationType),
-		"ValidateConfigMapDestinations")
+		astmodel.GenRuntimeConfigMapsReference,
+		"ValidateDestinations")
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating body of method %s", methodName)
 	}
@@ -282,9 +283,10 @@ func validateOperatorSpecSliceBody(
 	receiverIdent string,
 	operatorSpecProperty string,
 	validateType astmodel.Type,
+	validatePackage astmodel.ExternalPackageReference,
 	validateFunctionName string,
 ) ([]dst.Stmt, error) {
-	genRuntime := codeGenerationContext.MustGetImportedPackageName(astmodel.GenRuntimeReference)
+	pkg := codeGenerationContext.MustGetImportedPackageName(validatePackage)
 
 	operatorSpecPropertyObj, err := getOperatorSpecSubType(codeGenerationContext, resource, operatorSpecProperty)
 	if err != nil {
@@ -329,7 +331,7 @@ func validateOperatorSpecSliceBody(
 		body,
 		astbuilder.Returns(
 			astbuilder.CallQualifiedFunc(
-				genRuntime,
+				pkg,
 				validateFunctionName,
 				dst.NewIdent(toValidateVar))))
 

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
@@ -48,7 +48,7 @@ func NewValidateOptionalConfigMapReferenceFunction(resource *astmodel.ResourceTy
 		resource,
 		idFactory,
 		validateOptionalConfigMapReferences,
-		astmodel.NewPackageReferenceSet(astmodel.GenRuntimeReference, astmodel.ReflectHelpersReference))
+		astmodel.NewPackageReferenceSet(astmodel.GenRuntimeConfigMapsReference, astmodel.ReflectHelpersReference))
 }
 
 func validateResourceReferences(
@@ -263,7 +263,7 @@ func validateOptionalConfigMapReferences(
 //	return genruntime.ValidateOptionalConfigMapReferences(refs)
 func validateOptionalConfigMapReferencesBody(codeGenerationContext *astmodel.CodeGenerationContext, receiverIdent string) []dst.Stmt {
 	reflectHelpers := codeGenerationContext.MustGetImportedPackageName(astmodel.ReflectHelpersReference)
-	genRuntime := codeGenerationContext.MustGetImportedPackageName(astmodel.GenRuntimeReference)
+	genRuntimeConfigMaps := codeGenerationContext.MustGetImportedPackageName(astmodel.GenRuntimeConfigMapsReference)
 
 	var body []dst.Stmt
 
@@ -281,8 +281,8 @@ func validateOptionalConfigMapReferencesBody(codeGenerationContext *astmodel.Cod
 		body,
 		astbuilder.Returns(
 			astbuilder.CallQualifiedFunc(
-				genRuntime,
-				"ValidateOptionalConfigMapReferences",
+				genRuntimeConfigMaps,
+				"ValidateOptionalReferences",
 				dst.NewIdent("refs"))))
 
 	return body


### PR DESCRIPTION
This cleans up the genruntime package slightly and sets the stage for additional validation helpers for configmaps or secrets.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
