### PR TITLE
Fix the type of DelegatedManagedIdentityResourceId 

### DIFF
--- a/v2/api/authorization/v1api20200801preview/role_assignment_spec_arm_types_gen.go
+++ b/v2/api/authorization/v1api20200801preview/role_assignment_spec_arm_types_gen.go
@@ -37,9 +37,7 @@ type RoleAssignmentProperties_ARM struct {
 	Condition *string `json:"condition,omitempty"`
 
 	// ConditionVersion: Version of the condition. Currently accepted value is '2.0'
-	ConditionVersion *string `json:"conditionVersion,omitempty"`
-
-	// DelegatedManagedIdentityResourceId: Id of the delegated managed identity resource
+	ConditionVersion                   *string `json:"conditionVersion,omitempty"`
 	DelegatedManagedIdentityResourceId *string `json:"delegatedManagedIdentityResourceId,omitempty"`
 
 	// Description: Description of role assignment

--- a/v2/api/authorization/v1api20200801preview/role_assignment_types_gen.go
+++ b/v2/api/authorization/v1api20200801preview/role_assignment_types_gen.go
@@ -342,8 +342,8 @@ type RoleAssignment_Spec struct {
 	// ConditionVersion: Version of the condition. Currently accepted value is '2.0'
 	ConditionVersion *string `json:"conditionVersion,omitempty"`
 
-	// DelegatedManagedIdentityResourceId: Id of the delegated managed identity resource
-	DelegatedManagedIdentityResourceId *string `json:"delegatedManagedIdentityResourceId,omitempty"`
+	// DelegatedManagedIdentityResourceReference: Id of the delegated managed identity resource
+	DelegatedManagedIdentityResourceReference *genruntime.ResourceReference `armReference:"DelegatedManagedIdentityResourceId" json:"delegatedManagedIdentityResourceReference,omitempty"`
 
 	// Description: Description of role assignment
 	Description *string `json:"description,omitempty"`
@@ -383,7 +383,7 @@ func (assignment *RoleAssignment_Spec) ConvertToARM(resolved genruntime.ConvertT
 	// Set property "Properties":
 	if assignment.Condition != nil ||
 		assignment.ConditionVersion != nil ||
-		assignment.DelegatedManagedIdentityResourceId != nil ||
+		assignment.DelegatedManagedIdentityResourceReference != nil ||
 		assignment.Description != nil ||
 		assignment.PrincipalId != nil ||
 		assignment.PrincipalIdFromConfig != nil ||
@@ -399,8 +399,12 @@ func (assignment *RoleAssignment_Spec) ConvertToARM(resolved genruntime.ConvertT
 		conditionVersion := *assignment.ConditionVersion
 		result.Properties.ConditionVersion = &conditionVersion
 	}
-	if assignment.DelegatedManagedIdentityResourceId != nil {
-		delegatedManagedIdentityResourceId := *assignment.DelegatedManagedIdentityResourceId
+	if assignment.DelegatedManagedIdentityResourceReference != nil {
+		delegatedManagedIdentityResourceIdARMID, err := resolved.ResolvedReferences.Lookup(*assignment.DelegatedManagedIdentityResourceReference)
+		if err != nil {
+			return nil, err
+		}
+		delegatedManagedIdentityResourceId := delegatedManagedIdentityResourceIdARMID
 		result.Properties.DelegatedManagedIdentityResourceId = &delegatedManagedIdentityResourceId
 	}
 	if assignment.Description != nil {
@@ -467,14 +471,7 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property "DelegatedManagedIdentityResourceId":
-	// copying flattened property:
-	if typedInput.Properties != nil {
-		if typedInput.Properties.DelegatedManagedIdentityResourceId != nil {
-			delegatedManagedIdentityResourceId := *typedInput.Properties.DelegatedManagedIdentityResourceId
-			assignment.DelegatedManagedIdentityResourceId = &delegatedManagedIdentityResourceId
-		}
-	}
+	// no assignment for property "DelegatedManagedIdentityResourceReference"
 
 	// Set property "Description":
 	// copying flattened property:
@@ -576,8 +573,13 @@ func (assignment *RoleAssignment_Spec) AssignProperties_From_RoleAssignment_Spec
 	// ConditionVersion
 	assignment.ConditionVersion = genruntime.ClonePointerToString(source.ConditionVersion)
 
-	// DelegatedManagedIdentityResourceId
-	assignment.DelegatedManagedIdentityResourceId = genruntime.ClonePointerToString(source.DelegatedManagedIdentityResourceId)
+	// DelegatedManagedIdentityResourceReference
+	if source.DelegatedManagedIdentityResourceReference != nil {
+		delegatedManagedIdentityResourceReference := source.DelegatedManagedIdentityResourceReference.Copy()
+		assignment.DelegatedManagedIdentityResourceReference = &delegatedManagedIdentityResourceReference
+	} else {
+		assignment.DelegatedManagedIdentityResourceReference = nil
+	}
 
 	// Description
 	assignment.Description = genruntime.ClonePointerToString(source.Description)
@@ -636,8 +638,13 @@ func (assignment *RoleAssignment_Spec) AssignProperties_To_RoleAssignment_Spec(d
 	// ConditionVersion
 	destination.ConditionVersion = genruntime.ClonePointerToString(assignment.ConditionVersion)
 
-	// DelegatedManagedIdentityResourceId
-	destination.DelegatedManagedIdentityResourceId = genruntime.ClonePointerToString(assignment.DelegatedManagedIdentityResourceId)
+	// DelegatedManagedIdentityResourceReference
+	if assignment.DelegatedManagedIdentityResourceReference != nil {
+		delegatedManagedIdentityResourceReference := assignment.DelegatedManagedIdentityResourceReference.Copy()
+		destination.DelegatedManagedIdentityResourceReference = &delegatedManagedIdentityResourceReference
+	} else {
+		destination.DelegatedManagedIdentityResourceReference = nil
+	}
 
 	// Description
 	destination.Description = genruntime.ClonePointerToString(assignment.Description)

--- a/v2/api/authorization/v1api20200801preview/role_assignment_types_gen_test.go
+++ b/v2/api/authorization/v1api20200801preview/role_assignment_types_gen_test.go
@@ -389,7 +389,6 @@ func AddIndependentPropertyGeneratorsForRoleAssignment_Spec(gens map[string]gopt
 	gens["AzureName"] = gen.AlphaString()
 	gens["Condition"] = gen.PtrOf(gen.AlphaString())
 	gens["ConditionVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["DelegatedManagedIdentityResourceId"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["PrincipalId"] = gen.PtrOf(gen.AlphaString())
 	gens["PrincipalType"] = gen.PtrOf(gen.OneConstOf(

--- a/v2/api/authorization/v1api20200801preview/storage/role_assignment_types_gen.go
+++ b/v2/api/authorization/v1api20200801preview/storage/role_assignment_types_gen.go
@@ -240,12 +240,14 @@ type augmentConversionForRoleAssignment interface {
 type RoleAssignment_Spec struct {
 	// AzureName: The name of the resource in Azure. This is often the same as the name of the resource in Kubernetes but it
 	// doesn't have to be.
-	AzureName                          string  `json:"azureName,omitempty"`
-	Condition                          *string `json:"condition,omitempty"`
-	ConditionVersion                   *string `json:"conditionVersion,omitempty"`
-	DelegatedManagedIdentityResourceId *string `json:"delegatedManagedIdentityResourceId,omitempty"`
-	Description                        *string `json:"description,omitempty"`
-	OriginalVersion                    string  `json:"originalVersion,omitempty"`
+	AzureName        string  `json:"azureName,omitempty"`
+	Condition        *string `json:"condition,omitempty"`
+	ConditionVersion *string `json:"conditionVersion,omitempty"`
+
+	// DelegatedManagedIdentityResourceReference: Id of the delegated managed identity resource
+	DelegatedManagedIdentityResourceReference *genruntime.ResourceReference `armReference:"DelegatedManagedIdentityResourceId" json:"delegatedManagedIdentityResourceReference,omitempty"`
+	Description                               *string                       `json:"description,omitempty"`
+	OriginalVersion                           string                        `json:"originalVersion,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Owner: The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also
@@ -326,8 +328,13 @@ func (assignment *RoleAssignment_Spec) AssignProperties_From_RoleAssignment_Spec
 	// ConditionVersion
 	assignment.ConditionVersion = genruntime.ClonePointerToString(source.ConditionVersion)
 
-	// DelegatedManagedIdentityResourceId
-	assignment.DelegatedManagedIdentityResourceId = genruntime.ClonePointerToString(source.DelegatedManagedIdentityResourceId)
+	// DelegatedManagedIdentityResourceReference
+	if source.DelegatedManagedIdentityResourceReference != nil {
+		delegatedManagedIdentityResourceReference := source.DelegatedManagedIdentityResourceReference.Copy()
+		assignment.DelegatedManagedIdentityResourceReference = &delegatedManagedIdentityResourceReference
+	} else {
+		assignment.DelegatedManagedIdentityResourceReference = nil
+	}
 
 	// Description
 	assignment.Description = genruntime.ClonePointerToString(source.Description)
@@ -399,8 +406,13 @@ func (assignment *RoleAssignment_Spec) AssignProperties_To_RoleAssignment_Spec(d
 	// ConditionVersion
 	destination.ConditionVersion = genruntime.ClonePointerToString(assignment.ConditionVersion)
 
-	// DelegatedManagedIdentityResourceId
-	destination.DelegatedManagedIdentityResourceId = genruntime.ClonePointerToString(assignment.DelegatedManagedIdentityResourceId)
+	// DelegatedManagedIdentityResourceReference
+	if assignment.DelegatedManagedIdentityResourceReference != nil {
+		delegatedManagedIdentityResourceReference := assignment.DelegatedManagedIdentityResourceReference.Copy()
+		destination.DelegatedManagedIdentityResourceReference = &delegatedManagedIdentityResourceReference
+	} else {
+		destination.DelegatedManagedIdentityResourceReference = nil
+	}
 
 	// Description
 	destination.Description = genruntime.ClonePointerToString(assignment.Description)

--- a/v2/api/authorization/v1api20200801preview/storage/role_assignment_types_gen_test.go
+++ b/v2/api/authorization/v1api20200801preview/storage/role_assignment_types_gen_test.go
@@ -384,7 +384,6 @@ func AddIndependentPropertyGeneratorsForRoleAssignment_Spec(gens map[string]gopt
 	gens["AzureName"] = gen.AlphaString()
 	gens["Condition"] = gen.PtrOf(gen.AlphaString())
 	gens["ConditionVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["DelegatedManagedIdentityResourceId"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["OriginalVersion"] = gen.AlphaString()
 	gens["PrincipalId"] = gen.PtrOf(gen.AlphaString())

--- a/v2/api/authorization/v1api20200801preview/storage/structure.txt
+++ b/v2/api/authorization/v1api20200801preview/storage/structure.txt
@@ -8,7 +8,7 @@ RoleAssignment: Resource
 │   ├── AzureName: string
 │   ├── Condition: *string
 │   ├── ConditionVersion: *string
-│   ├── DelegatedManagedIdentityResourceId: *string
+│   ├── DelegatedManagedIdentityResourceReference: *genruntime.ResourceReference
 │   ├── Description: *string
 │   ├── OriginalVersion: string
 │   ├── Owner: *genruntime.ArbitraryOwnerReference

--- a/v2/api/authorization/v1api20200801preview/storage/zz_generated.deepcopy.go
+++ b/v2/api/authorization/v1api20200801preview/storage/zz_generated.deepcopy.go
@@ -191,9 +191,9 @@ func (in *RoleAssignment_Spec) DeepCopyInto(out *RoleAssignment_Spec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.DelegatedManagedIdentityResourceId != nil {
-		in, out := &in.DelegatedManagedIdentityResourceId, &out.DelegatedManagedIdentityResourceId
-		*out = new(string)
+	if in.DelegatedManagedIdentityResourceReference != nil {
+		in, out := &in.DelegatedManagedIdentityResourceReference, &out.DelegatedManagedIdentityResourceReference
+		*out = new(genruntime.ResourceReference)
 		**out = **in
 	}
 	if in.Description != nil {

--- a/v2/api/authorization/v1api20200801preview/structure.txt
+++ b/v2/api/authorization/v1api20200801preview/structure.txt
@@ -8,7 +8,7 @@ RoleAssignment: Resource
 │   ├── AzureName: string
 │   ├── Condition: *string
 │   ├── ConditionVersion: *string
-│   ├── DelegatedManagedIdentityResourceId: *string
+│   ├── DelegatedManagedIdentityResourceReference: *genruntime.ResourceReference
 │   ├── Description: *string
 │   ├── Owner: *genruntime.ArbitraryOwnerReference
 │   ├── PrincipalId: *string

--- a/v2/api/authorization/v1api20200801preview/zz_generated.deepcopy.go
+++ b/v2/api/authorization/v1api20200801preview/zz_generated.deepcopy.go
@@ -344,9 +344,9 @@ func (in *RoleAssignment_Spec) DeepCopyInto(out *RoleAssignment_Spec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.DelegatedManagedIdentityResourceId != nil {
-		in, out := &in.DelegatedManagedIdentityResourceId, &out.DelegatedManagedIdentityResourceId
-		*out = new(string)
+	if in.DelegatedManagedIdentityResourceReference != nil {
+		in, out := &in.DelegatedManagedIdentityResourceReference, &out.DelegatedManagedIdentityResourceReference
+		*out = new(genruntime.ResourceReference)
 		**out = **in
 	}
 	if in.Description != nil {

--- a/v2/api/authorization/v1api20220401/role_assignment_spec_arm_types_gen.go
+++ b/v2/api/authorization/v1api20220401/role_assignment_spec_arm_types_gen.go
@@ -37,9 +37,7 @@ type RoleAssignmentProperties_ARM struct {
 	Condition *string `json:"condition,omitempty"`
 
 	// ConditionVersion: Version of the condition. Currently the only accepted value is '2.0'
-	ConditionVersion *string `json:"conditionVersion,omitempty"`
-
-	// DelegatedManagedIdentityResourceId: Id of the delegated managed identity resource
+	ConditionVersion                   *string `json:"conditionVersion,omitempty"`
 	DelegatedManagedIdentityResourceId *string `json:"delegatedManagedIdentityResourceId,omitempty"`
 
 	// Description: Description of role assignment

--- a/v2/api/authorization/v1api20220401/role_assignment_types_gen.go
+++ b/v2/api/authorization/v1api20220401/role_assignment_types_gen.go
@@ -339,8 +339,8 @@ type RoleAssignment_Spec struct {
 	// ConditionVersion: Version of the condition. Currently the only accepted value is '2.0'
 	ConditionVersion *string `json:"conditionVersion,omitempty"`
 
-	// DelegatedManagedIdentityResourceId: Id of the delegated managed identity resource
-	DelegatedManagedIdentityResourceId *string `json:"delegatedManagedIdentityResourceId,omitempty"`
+	// DelegatedManagedIdentityResourceReference: Id of the delegated managed identity resource
+	DelegatedManagedIdentityResourceReference *genruntime.ResourceReference `armReference:"DelegatedManagedIdentityResourceId" json:"delegatedManagedIdentityResourceReference,omitempty"`
 
 	// Description: Description of role assignment
 	Description *string `json:"description,omitempty"`
@@ -380,7 +380,7 @@ func (assignment *RoleAssignment_Spec) ConvertToARM(resolved genruntime.ConvertT
 	// Set property "Properties":
 	if assignment.Condition != nil ||
 		assignment.ConditionVersion != nil ||
-		assignment.DelegatedManagedIdentityResourceId != nil ||
+		assignment.DelegatedManagedIdentityResourceReference != nil ||
 		assignment.Description != nil ||
 		assignment.PrincipalId != nil ||
 		assignment.PrincipalIdFromConfig != nil ||
@@ -396,8 +396,12 @@ func (assignment *RoleAssignment_Spec) ConvertToARM(resolved genruntime.ConvertT
 		conditionVersion := *assignment.ConditionVersion
 		result.Properties.ConditionVersion = &conditionVersion
 	}
-	if assignment.DelegatedManagedIdentityResourceId != nil {
-		delegatedManagedIdentityResourceId := *assignment.DelegatedManagedIdentityResourceId
+	if assignment.DelegatedManagedIdentityResourceReference != nil {
+		delegatedManagedIdentityResourceIdARMID, err := resolved.ResolvedReferences.Lookup(*assignment.DelegatedManagedIdentityResourceReference)
+		if err != nil {
+			return nil, err
+		}
+		delegatedManagedIdentityResourceId := delegatedManagedIdentityResourceIdARMID
 		result.Properties.DelegatedManagedIdentityResourceId = &delegatedManagedIdentityResourceId
 	}
 	if assignment.Description != nil {
@@ -464,14 +468,7 @@ func (assignment *RoleAssignment_Spec) PopulateFromARM(owner genruntime.Arbitrar
 		}
 	}
 
-	// Set property "DelegatedManagedIdentityResourceId":
-	// copying flattened property:
-	if typedInput.Properties != nil {
-		if typedInput.Properties.DelegatedManagedIdentityResourceId != nil {
-			delegatedManagedIdentityResourceId := *typedInput.Properties.DelegatedManagedIdentityResourceId
-			assignment.DelegatedManagedIdentityResourceId = &delegatedManagedIdentityResourceId
-		}
-	}
+	// no assignment for property "DelegatedManagedIdentityResourceReference"
 
 	// Set property "Description":
 	// copying flattened property:
@@ -573,8 +570,13 @@ func (assignment *RoleAssignment_Spec) AssignProperties_From_RoleAssignment_Spec
 	// ConditionVersion
 	assignment.ConditionVersion = genruntime.ClonePointerToString(source.ConditionVersion)
 
-	// DelegatedManagedIdentityResourceId
-	assignment.DelegatedManagedIdentityResourceId = genruntime.ClonePointerToString(source.DelegatedManagedIdentityResourceId)
+	// DelegatedManagedIdentityResourceReference
+	if source.DelegatedManagedIdentityResourceReference != nil {
+		delegatedManagedIdentityResourceReference := source.DelegatedManagedIdentityResourceReference.Copy()
+		assignment.DelegatedManagedIdentityResourceReference = &delegatedManagedIdentityResourceReference
+	} else {
+		assignment.DelegatedManagedIdentityResourceReference = nil
+	}
 
 	// Description
 	assignment.Description = genruntime.ClonePointerToString(source.Description)
@@ -633,8 +635,13 @@ func (assignment *RoleAssignment_Spec) AssignProperties_To_RoleAssignment_Spec(d
 	// ConditionVersion
 	destination.ConditionVersion = genruntime.ClonePointerToString(assignment.ConditionVersion)
 
-	// DelegatedManagedIdentityResourceId
-	destination.DelegatedManagedIdentityResourceId = genruntime.ClonePointerToString(assignment.DelegatedManagedIdentityResourceId)
+	// DelegatedManagedIdentityResourceReference
+	if assignment.DelegatedManagedIdentityResourceReference != nil {
+		delegatedManagedIdentityResourceReference := assignment.DelegatedManagedIdentityResourceReference.Copy()
+		destination.DelegatedManagedIdentityResourceReference = &delegatedManagedIdentityResourceReference
+	} else {
+		destination.DelegatedManagedIdentityResourceReference = nil
+	}
 
 	// Description
 	destination.Description = genruntime.ClonePointerToString(assignment.Description)
@@ -697,8 +704,13 @@ func (assignment *RoleAssignment_Spec) Initialize_From_RoleAssignment_STATUS(sou
 	// ConditionVersion
 	assignment.ConditionVersion = genruntime.ClonePointerToString(source.ConditionVersion)
 
-	// DelegatedManagedIdentityResourceId
-	assignment.DelegatedManagedIdentityResourceId = genruntime.ClonePointerToString(source.DelegatedManagedIdentityResourceId)
+	// DelegatedManagedIdentityResourceReference
+	if source.DelegatedManagedIdentityResourceId != nil {
+		delegatedManagedIdentityResourceReference := genruntime.CreateResourceReferenceFromARMID(*source.DelegatedManagedIdentityResourceId)
+		assignment.DelegatedManagedIdentityResourceReference = &delegatedManagedIdentityResourceReference
+	} else {
+		assignment.DelegatedManagedIdentityResourceReference = nil
+	}
 
 	// Description
 	assignment.Description = genruntime.ClonePointerToString(source.Description)

--- a/v2/api/authorization/v1api20220401/role_assignment_types_gen_test.go
+++ b/v2/api/authorization/v1api20220401/role_assignment_types_gen_test.go
@@ -389,7 +389,6 @@ func AddIndependentPropertyGeneratorsForRoleAssignment_Spec(gens map[string]gopt
 	gens["AzureName"] = gen.AlphaString()
 	gens["Condition"] = gen.PtrOf(gen.AlphaString())
 	gens["ConditionVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["DelegatedManagedIdentityResourceId"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["PrincipalId"] = gen.PtrOf(gen.AlphaString())
 	gens["PrincipalType"] = gen.PtrOf(gen.OneConstOf(

--- a/v2/api/authorization/v1api20220401/storage/role_assignment_types_gen.go
+++ b/v2/api/authorization/v1api20220401/storage/role_assignment_types_gen.go
@@ -147,12 +147,14 @@ const APIVersion_Value = APIVersion("2022-04-01")
 type RoleAssignment_Spec struct {
 	// AzureName: The name of the resource in Azure. This is often the same as the name of the resource in Kubernetes but it
 	// doesn't have to be.
-	AzureName                          string  `json:"azureName,omitempty"`
-	Condition                          *string `json:"condition,omitempty"`
-	ConditionVersion                   *string `json:"conditionVersion,omitempty"`
-	DelegatedManagedIdentityResourceId *string `json:"delegatedManagedIdentityResourceId,omitempty"`
-	Description                        *string `json:"description,omitempty"`
-	OriginalVersion                    string  `json:"originalVersion,omitempty"`
+	AzureName        string  `json:"azureName,omitempty"`
+	Condition        *string `json:"condition,omitempty"`
+	ConditionVersion *string `json:"conditionVersion,omitempty"`
+
+	// DelegatedManagedIdentityResourceReference: Id of the delegated managed identity resource
+	DelegatedManagedIdentityResourceReference *genruntime.ResourceReference `armReference:"DelegatedManagedIdentityResourceId" json:"delegatedManagedIdentityResourceReference,omitempty"`
+	Description                               *string                       `json:"description,omitempty"`
+	OriginalVersion                           string                        `json:"originalVersion,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Owner: The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also

--- a/v2/api/authorization/v1api20220401/storage/role_assignment_types_gen_test.go
+++ b/v2/api/authorization/v1api20220401/storage/role_assignment_types_gen_test.go
@@ -214,7 +214,6 @@ func AddIndependentPropertyGeneratorsForRoleAssignment_Spec(gens map[string]gopt
 	gens["AzureName"] = gen.AlphaString()
 	gens["Condition"] = gen.PtrOf(gen.AlphaString())
 	gens["ConditionVersion"] = gen.PtrOf(gen.AlphaString())
-	gens["DelegatedManagedIdentityResourceId"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["OriginalVersion"] = gen.AlphaString()
 	gens["PrincipalId"] = gen.PtrOf(gen.AlphaString())

--- a/v2/api/authorization/v1api20220401/storage/structure.txt
+++ b/v2/api/authorization/v1api20220401/storage/structure.txt
@@ -8,7 +8,7 @@ RoleAssignment: Resource
 │   ├── AzureName: string
 │   ├── Condition: *string
 │   ├── ConditionVersion: *string
-│   ├── DelegatedManagedIdentityResourceId: *string
+│   ├── DelegatedManagedIdentityResourceReference: *genruntime.ResourceReference
 │   ├── Description: *string
 │   ├── OriginalVersion: string
 │   ├── Owner: *genruntime.ArbitraryOwnerReference

--- a/v2/api/authorization/v1api20220401/storage/zz_generated.deepcopy.go
+++ b/v2/api/authorization/v1api20220401/storage/zz_generated.deepcopy.go
@@ -275,9 +275,9 @@ func (in *RoleAssignment_Spec) DeepCopyInto(out *RoleAssignment_Spec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.DelegatedManagedIdentityResourceId != nil {
-		in, out := &in.DelegatedManagedIdentityResourceId, &out.DelegatedManagedIdentityResourceId
-		*out = new(string)
+	if in.DelegatedManagedIdentityResourceReference != nil {
+		in, out := &in.DelegatedManagedIdentityResourceReference, &out.DelegatedManagedIdentityResourceReference
+		*out = new(genruntime.ResourceReference)
 		**out = **in
 	}
 	if in.Description != nil {

--- a/v2/api/authorization/v1api20220401/structure.txt
+++ b/v2/api/authorization/v1api20220401/structure.txt
@@ -8,7 +8,7 @@ RoleAssignment: Resource
 │   ├── AzureName: string
 │   ├── Condition: *string
 │   ├── ConditionVersion: *string
-│   ├── DelegatedManagedIdentityResourceId: *string
+│   ├── DelegatedManagedIdentityResourceReference: *genruntime.ResourceReference
 │   ├── Description: *string
 │   ├── Owner: *genruntime.ArbitraryOwnerReference
 │   ├── PrincipalId: *string

--- a/v2/api/authorization/v1api20220401/zz_generated.deepcopy.go
+++ b/v2/api/authorization/v1api20220401/zz_generated.deepcopy.go
@@ -484,9 +484,9 @@ func (in *RoleAssignment_Spec) DeepCopyInto(out *RoleAssignment_Spec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.DelegatedManagedIdentityResourceId != nil {
-		in, out := &in.DelegatedManagedIdentityResourceId, &out.DelegatedManagedIdentityResourceId
-		*out = new(string)
+	if in.DelegatedManagedIdentityResourceReference != nil {
+		in, out := &in.DelegatedManagedIdentityResourceReference, &out.DelegatedManagedIdentityResourceReference
+		*out = new(genruntime.ResourceReference)
 		**out = **in
 	}
 	if in.Description != nil {

--- a/v2/azure-arm.yaml
+++ b/v2/azure-arm.yaml
@@ -1122,7 +1122,7 @@ objectModelConfiguration:
         $defaultAzureName: false
       RoleAssignmentProperties:
         DelegatedManagedIdentityResourceId:
-          $armReference: false # Actually, this *IS* a resource id, but we want to avoid breaking changes so we're fibbing here
+          $armReference: true 
         RoleDefinitionId:
           $armReference: true
         PrincipalId:
@@ -1134,7 +1134,7 @@ objectModelConfiguration:
         $defaultAzureName: false
       RoleAssignmentProperties:
         DelegatedManagedIdentityResourceId:
-          $armReference: false # Actually, this *IS* a resource id, but we want to avoid breaking changes so we're fibbing here
+          $armReference: true
         RoleDefinitionId:
           $armReference: true
         PrincipalId:


### PR DESCRIPTION
**What this PR does / why we need it**:

The type of `RoleAssignmentProperties.DelegatedManagedIdentityResourceId` is wrong; this PR fixes it.

Closes #3831

**Special notes for your reviewer**:

This is a breaking change - any existing uses of `RoleAssignment` that use `DelegatedManagedIdentityResourceId` will need to be deleted and recreated. Existing uses of `RoleAssignment` that don't use that property are unaffected. 

The property `DelegatedManagedIdentityResourceId` is fairly esoteric, but we haven't found a way to confirm whether it is used or not.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/CrUbhOzsUrRpXrZGp4/giphy.gif?cid=ecf05e47xta4jmpw6n9apbcvrx5c2tn69mrim4xdxvpj7fm3&ep=v1_gifs_search&rid=giphy.gif&ct=g)
