### PR TITLE
Update secret generation rune values

### DIFF
--- a/v2/internal/controllers/crd_redhatopenshift_openshiftcluster_20230401_test.go
+++ b/v2/internal/controllers/crd_redhatopenshift_openshiftcluster_20230401_test.go
@@ -33,10 +33,6 @@ type servicePrincipalDetails struct {
 func Test_RedHatOpenShift_OpenShiftCluster_CRUD(t *testing.T) {
 	t.Parallel()
 
-	if *isLive {
-		t.Skip("ARO cluster test requires ServicePrincipal creation and referenced in the cluster object.")
-	}
-
 	tc := globalTestContext.ForTest(t)
 	rg := tc.CreateTestResourceGroupAndWait()
 

--- a/v2/internal/testcommon/resource_namer.go
+++ b/v2/internal/testcommon/resource_namer.go
@@ -145,7 +145,7 @@ func (n ResourceNamer) GeneratePassword() string {
 	return n.GeneratePasswordOfLength(n.randomChars)
 }
 
-var runes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789~!@#$%^&*()")
+var runes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789~!@#$%^*()._-")
 
 // GeneratePasswordOfLength generates and returns a non-deterministic password.
 // This method does not use any seed value, so the returned password is never stable.


### PR DESCRIPTION

**What this PR does / why we need it**:

Updating rune values for secret generation to remove `&` as it gets recorded in the response body as unicode `\u0026` which results in mis match while redacting the secrets. 

This was found in CI run [here](https://github.com/Azure/azure-service-operator/actions/runs/10480765442/job/29028989632?pr=4203)
![image](https://github.com/user-attachments/assets/f5fb88a9-6c2d-4537-8fd9-713334187834)

**Special notes for your reviewer**:
Added a few more rune values `-`, `_` and `.` which are allowed in passwords/secrets. 

