### PR TITLE
feat(helm): allow to use existing service account

### DIFF
--- a/v2/charts/azure-service-operator/templates/_helpers.tpl
+++ b/v2/charts/azure-service-operator/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "azure-service-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default "azureserviceoperator-default" .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
+++ b/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
@@ -212,7 +212,7 @@ spec:
         {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
-      serviceAccountName: azureserviceoperator-default
+      serviceAccountName: {{ include "azure-service-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
       volumes:
       {{- if or (eq .Values.multitenant.enable false) (eq .Values.azureOperatorMode "webhooks") }}

--- a/v2/charts/azure-service-operator/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_azureserviceoperator-crd-manager-rolebinding.yaml
+++ b/v2/charts/azure-service-operator/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_azureserviceoperator-crd-manager-rolebinding.yaml
@@ -10,7 +10,7 @@ roleRef:
   name: azureserviceoperator-crd-manager-role
 subjects:
 - kind: ServiceAccount
-  name: azureserviceoperator-default
+  name: {{ include "azure-service-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/v2/charts/azure-service-operator/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_azureserviceoperator-crd-reader-rolebinding.yaml
+++ b/v2/charts/azure-service-operator/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_azureserviceoperator-crd-reader-rolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
   name: azureserviceoperator-crd-reader-role
 subjects:
 - kind: ServiceAccount
-  name: azureserviceoperator-default
+  name: {{ include "azure-service-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/v2/charts/azure-service-operator/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_azureserviceoperator-manager-rolebinding.yaml
+++ b/v2/charts/azure-service-operator/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_azureserviceoperator-manager-rolebinding.yaml
@@ -13,6 +13,6 @@ roleRef:
   name: azureserviceoperator-manager-role
 subjects:
 - kind: ServiceAccount
-  name: azureserviceoperator-default
+  name: {{ include "azure-service-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/v2/charts/azure-service-operator/templates/rbac.authorization.k8s.io_v1_rolebinding_azureserviceoperator-leader-election-rolebinding.yaml
+++ b/v2/charts/azure-service-operator/templates/rbac.authorization.k8s.io_v1_rolebinding_azureserviceoperator-leader-election-rolebinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: azureserviceoperator-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: azureserviceoperator-default
+  name: {{ include "azure-service-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/v2/charts/azure-service-operator/templates/v1_serviceaccount_azureserviceoperator-default.yaml
+++ b/v2/charts/azure-service-operator/templates/v1_serviceaccount_azureserviceoperator-default.yaml
@@ -1,7 +1,13 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: azure-service-operator
-  name: azureserviceoperator-default
+  name: {{ include "azure-service-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/v2/charts/azure-service-operator/values.yaml
+++ b/v2/charts/azure-service-operator/values.yaml
@@ -200,3 +200,11 @@ rateLimit:
   qps: 5
   # The size of the bucket. This value only has an effect if mode is 'bucket'.
   bucketSize: 100
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, `azureserviceoperator-default` would be used as a name
+  name: ""
+  annotations: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Allows to use existing service account and/or control the name of the created service account so that prerequisites (like federated identity setup) could be successfully passed during deployment without hardcoding service account name used in the chart.

**How does this PR make you feel**:
![gif](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3U0NnprNWFmNjNjbmZqZXVwZXozdnVtbmpvZmc4dDRlZ216aHdueSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/TuZ8v66TzGeYJW23as/giphy.gif)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
