### PR TITLE
Create app-token and use instead of GH_PAT

### DIFF
--- a/.github/workflows/api-docs-repo.yaml
+++ b/.github/workflows/api-docs-repo.yaml
@@ -15,6 +15,14 @@ jobs:
       contents: read
       packages: read
     steps:
+      - name: Create token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          # required
+          app-id: ${{ secrets.AUTOMATION_ID }}
+          private-key: ${{ secrets.AUTOMATION_KEY }}
+          
       - name: Checkout code
         uses: actions/checkout@v3
         with:
@@ -23,7 +31,7 @@ jobs:
       - name: Create Branch
         uses: peterjgrainger/action-create-branch@v2.4.0 # Pinned to v2.4.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           branch: ${{ format('bot/update-api-docs-{0}', github.run_number) }}
 
@@ -87,7 +95,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5.0.0
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: Update API Docs
           branch: ${{ format('bot/update-api-docs-{0}', github.run_number) }}
           base: main

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -13,6 +13,14 @@ jobs:
       packages: read
 
     steps:
+      - name: Create token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          # required
+          app-id: ${{ secrets.AUTOMATION_ID }}
+          private-key: ${{ secrets.AUTOMATION_KEY }}
+          
       - name: Checkout code
         uses: actions/checkout@v3
         with:
@@ -62,5 +70,5 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.4.1 # pinned version
         with:
           branch: gh-pages
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           folder: docs/hugo/public

--- a/.github/workflows/helm-chart-repo.yaml
+++ b/.github/workflows/helm-chart-repo.yaml
@@ -24,6 +24,14 @@ jobs:
       packages: read
 
     steps:
+      - name: Create token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          # required
+          app-id: ${{ secrets.AUTOMATION_ID }}
+          private-key: ${{ secrets.AUTOMATION_KEY }}
+          
       - name: Checkout code
         uses: actions/checkout@v3
         with:
@@ -38,7 +46,7 @@ jobs:
       - name: Create Branch
         uses: peterjgrainger/action-create-branch@v2.4.0 # Pinned to v2.4.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           branch: ${{ format('bot/update-helm-chart-{0}', env.ref) }}
           sha: ${{ env.sha }}
@@ -96,7 +104,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5.0.0
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: Add Helm Chart
           branch: ${{ format('bot/update-helm-chart-{0}', env.ref) }}
           base: main

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -14,10 +14,18 @@ jobs:
     # Only run for PRs, not issue comments
     if: ${{ github.event.issue.pull_request }}
     steps:
+      - name: Create token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          # required
+          app-id: ${{ secrets.AUTOMATION_ID }}
+          private-key: ${{ secrets.AUTOMATION_KEY }}
+          
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v4
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           issue-type: pull-request
           commands: ok-to-test

--- a/.github/workflows/visualize-repo.yml
+++ b/.github/workflows/visualize-repo.yml
@@ -13,6 +13,14 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Create token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          # required
+          app-id: ${{ secrets.AUTOMATION_ID }}
+          private-key: ${{ secrets.AUTOMATION_KEY }}
+          
       - name: Checkout code
         uses: actions/checkout@v3.3.0
         with:
@@ -21,7 +29,7 @@ jobs:
       - name: Create Branch
         uses: peterjgrainger/action-create-branch@v2.4.0 # Pinned to v2.4.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           branch: "bot/update-diagrams"
 
@@ -69,7 +77,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5.0.0
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: Update Code Structure Diagrams
           branch: bot/update-diagrams
           base: main

--- a/docs/hugo/content/contributing/testing.md
+++ b/docs/hugo/content/contributing/testing.md
@@ -13,33 +13,31 @@ Basic use: run `task controller:test-integration-envtest`.
 | AZURE_SUBSCRIPTION_ID | The Azure Subscription ID                                                                               | Yes                            | Yes (when recording)                         |
 | AZURE_TENANT_ID       | The Azure Tenant ID                                                                                     | Yes                            | Yes (when recording)                         |
 | TEST_BILLING_ID       | The Azure billing ID                                                                                    | No                             | Yes (when recording SubscriptionAlias tests) |
-| CODECOV_TOKEN         | The token to https://app.codecov.io/gh/Azure/azure-service-operator                                     | Yes                            | No                                           |
-| GH_PAT                | GitHub PAT, used for PR automation                                                                      | Yes                            | No                                           |
+| CODECOV_TOKEN         | The token to <https://app.codecov.io/gh/Azure/azure-service-operator>                                     | Yes                            | No                                           |
 | REGISTRY_LOGIN        | The Azure Container Registry to log in to (for az acr login --name {name})                              | Yes                            | No                                           |
 | REGISTRY_PRERELEASE   | The path to the container prerelease registry (right now this isn't used)                               | No                             | No                                           |
 | REGISTRY_PUBLIC       | The path to the container release registry, used in --tag "{REGISTRY_PUBLIC}/{CONTROLLER_DOCKER_IMAGE}" | No                             | No                                           |
 
-
 ### Record/replay
 
-The task `controller:test-integration-envtest` runs the tests in a record/replay mode by default, so that it does not 
-touch any live Azure resources. (This uses the [go-vcr](https://github.com/dnaeon/go-vcr) library.) If you change the controller or other code in 
+The task `controller:test-integration-envtest` runs the tests in a record/replay mode by default, so that it does not
+touch any live Azure resources. (This uses the [go-vcr](https://github.com/dnaeon/go-vcr) library.) If you change the controller or other code in
 such a way that the required requests/responses from ARM change, you will need to update the recordings.
 
-To do this, delete the recordings for the failing tests (under `{test-dir}/recordings/{test-name}.yaml`), and re-run 
-`controller:test-integration-envtest`. If the test passes, a new recording will be saved, which you can commit to 
+To do this, delete the recordings for the failing tests (under `{test-dir}/recordings/{test-name}.yaml`), and re-run
+`controller:test-integration-envtest`. If the test passes, a new recording will be saved, which you can commit to
 include with your change. All authentication and subscription information is removed from the recording.
 
-To run the test and produce a new recording you will need to have set the required authentication environment variables 
-`AZURE_SUBSCRIPTION_ID` and `AZURE_TENANT_ID`, _and_ logged in via `az login` (or you just use the `task` commands 
-mentioned below and it will prompt you to `az login` if needed for that specific command). 
+To run the test and produce a new recording you will need to have set the required authentication environment variables
+`AZURE_SUBSCRIPTION_ID` and `AZURE_TENANT_ID`, _and_ logged in via `az login` (or you just use the `task` commands
+mentioned below and it will prompt you to `az login` if needed for that specific command).
 Note that you must be `Owner` on the subscription to execute some tests in record mode.
 
-A few tests also need the `TEST_BILLING_ID` environment variable set to a valid Azure Billing ID when running in record mode. 
-In replay mode this variable is never required. Note that the billing ID is redacted from all recording files so that 
+A few tests also need the `TEST_BILLING_ID` environment variable set to a valid Azure Billing ID when running in record mode.
+In replay mode this variable is never required. Note that the billing ID is redacted from all recording files so that
 the resulting file can be replayed by anybody, even somebody who does not know the Billing ID the test was recorded with.
 
-Some Azure resources take longer to provision or delete than the default test timeout of 15m. To change the timeout, 
+Some Azure resources take longer to provision or delete than the default test timeout of 15m. To change the timeout,
 set `TIMEOUT` to a suitable value when running task. For example, to give your test a 60m timeout, use:
 
 ``` bash
@@ -48,12 +46,13 @@ TIMEOUT=60m task controller:test-integration-envtest
 
 ### Running live tests
 
-If you want to skip all recordings and run all tests directly against live Azure resources, you can use the 
-`controller:test-integration-envtest-live` task. This will also require you to set the authentication environment 
+If you want to skip all recordings and run all tests directly against live Azure resources, you can use the
+`controller:test-integration-envtest-live` task. This will also require you to set the authentication environment
 variables and `az login`, as detailed above.
 
 ### Running a single test
-By default `task controller:test-integration-envtest` and its variants run all tests. This is often undesirable 
+
+By default `task controller:test-integration-envtest` and its variants run all tests. This is often undesirable
 as you may just be working on a single feature or test. In order to run a subset of tests, use the `TEST_FILTER`:
 
 ```bash

--- a/docs/hugo/content/contributing/testing.md
+++ b/docs/hugo/content/contributing/testing.md
@@ -13,7 +13,7 @@ Basic use: run `task controller:test-integration-envtest`.
 | AZURE_SUBSCRIPTION_ID | The Azure Subscription ID                                                                               | Yes                            | Yes (when recording)                         |
 | AZURE_TENANT_ID       | The Azure Tenant ID                                                                                     | Yes                            | Yes (when recording)                         |
 | TEST_BILLING_ID       | The Azure billing ID                                                                                    | No                             | Yes (when recording SubscriptionAlias tests) |
-| CODECOV_TOKEN         | The token to <https://app.codecov.io/gh/Azure/azure-service-operator>                                     | Yes                            | No                                           |
+| CODECOV_TOKEN         | The token to <https://app.codecov.io/gh/Azure/azure-service-operator>                                   | Yes                            | No                                           |
 | REGISTRY_LOGIN        | The Azure Container Registry to log in to (for az acr login --name {name})                              | Yes                            | No                                           |
 | REGISTRY_PRERELEASE   | The path to the container prerelease registry (right now this isn't used)                               | No                             | No                                           |
 | REGISTRY_PUBLIC       | The path to the container release registry, used in --tag "{REGISTRY_PUBLIC}/{CONTROLLER_DOCKER_IMAGE}" | No                             | No                                           |


### PR DESCRIPTION
**What this PR does / why we need it**:

Switches from use of GH_PAT for authentication in our workflows to use of our new GitHub App, `azure-service-operator-automation`.

Workflows tested manually: 
* Generate CRD docs ✅ [Passed](https://github.com/Azure/azure-service-operator/actions/runs/10569804539/job/29283244390)
* Render Source Visualizations ✅ [Passed](https://github.com/Azure/azure-service-operator/actions/runs/10478268721)

Other workflows will need to be checked post merge.

Closes #3907 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/DlGaTfcMeDmz6/giphy.gif?cid=790b7611r6b0v7hv534ribtdl0zwhzazc9gkrxchv8gqvbda&ep=v1_gifs_search&rid=giphy.gif&ct=g)
