### PR TITLE
Update Action step versions

### DIFF
--- a/.github/workflows/add-needs-triage-label.yml
+++ b/.github/workflows/add-needs-triage-label.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pinned to v7.0.1
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/api-docs-repo.yaml
+++ b/.github/workflows/api-docs-repo.yaml
@@ -24,7 +24,7 @@ jobs:
           private-key: ${{ secrets.AUTOMATION_KEY }}
           
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           ref: main
 
@@ -36,7 +36,7 @@ jobs:
           branch: ${{ format('bot/update-api-docs-{0}', github.run_number) }}
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           ref: ${{ format('bot/update-api-docs-{0}', github.run_number) }}
           fetch-depth: 0 # required to access tags

--- a/.github/workflows/api-docs-repo.yaml
+++ b/.github/workflows/api-docs-repo.yaml
@@ -43,7 +43,7 @@ jobs:
           submodules: "true"
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned to v3.3.0
         with:
           registry: docker.pkg.github.com # ghcr.io not yet enabled for Azure org
           username: ${{ github.actor }}

--- a/.github/workflows/api-docs-repo.yaml
+++ b/.github/workflows/api-docs-repo.yaml
@@ -29,7 +29,7 @@ jobs:
           ref: main
 
       - name: Create Branch
-        uses: peterjgrainger/action-create-branch@v2.4.0 # Pinned to v2.4.0
+        uses: peterjgrainger/action-create-branch@10c7d268152480ae859347db45dc69086cef1d9c # pinned to v3.0.0
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:

--- a/.github/workflows/build-devcontainer-image.yml
+++ b/.github/workflows/build-devcontainer-image.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
 
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v2

--- a/.github/workflows/build-devcontainer-image.yml
+++ b/.github/workflows/build-devcontainer-image.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned to v3.3.0
         with:
           registry: docker.pkg.github.com # ghcr.io not yet enabled for Azure org
           username: ${{ github.actor }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
 
       # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/create-release-experimental.yml
+++ b/.github/workflows/create-release-experimental.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           fetch-depth: 0 # required to access tags
           submodules: "true"

--- a/.github/workflows/create-release-official.yml
+++ b/.github/workflows/create-release-official.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           fetch-depth: 0 # required to access tags
           submodules: "true"

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -22,7 +22,7 @@ jobs:
           private-key: ${{ secrets.AUTOMATION_KEY }}
           
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           fetch-depth: 0 # required to access tags
           submodules: "true"

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -28,7 +28,7 @@ jobs:
           submodules: "true"
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v2.1.0 # pinned version
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned to v3.3.0
         with:
           registry: docker.pkg.github.com # ghcr.io not yet enabled for Azure org
           username: ${{ github.actor }}

--- a/.github/workflows/helm-chart-repo.yaml
+++ b/.github/workflows/helm-chart-repo.yaml
@@ -33,7 +33,7 @@ jobs:
           private-key: ${{ secrets.AUTOMATION_KEY }}
           
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           ref: ${{ env.ref }}
           fetch-depth: 0 # required to access tags
@@ -52,7 +52,7 @@ jobs:
           sha: ${{ env.sha }}
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           ref: ${{ format('bot/update-helm-chart-{0}', env.ref) }}
           fetch-depth: 0 # required to access tags

--- a/.github/workflows/helm-chart-repo.yaml
+++ b/.github/workflows/helm-chart-repo.yaml
@@ -44,7 +44,7 @@ jobs:
           echo "sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Create Branch
-        uses: peterjgrainger/action-create-branch@v2.4.0 # Pinned to v2.4.0
+        uses: peterjgrainger/action-create-branch@10c7d268152480ae859347db45dc69086cef1d9c # pinned to v3.0.0
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:

--- a/.github/workflows/helm-chart-repo.yaml
+++ b/.github/workflows/helm-chart-repo.yaml
@@ -59,7 +59,7 @@ jobs:
           submodules: 'true'
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned to v3.3.0
         with:
           registry: docker.pkg.github.com # ghcr.io not yet enabled for Azure org
           username: ${{ github.actor }}

--- a/.github/workflows/live-validation.yml
+++ b/.github/workflows/live-validation.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           fetch-depth: 0 # required to access tags
           submodules: "true"

--- a/.github/workflows/pr-validation-docs.yml
+++ b/.github/workflows/pr-validation-docs.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           fetch-depth: 0 # required to access tags
           submodules: "true"

--- a/.github/workflows/pr-validation-docs.yml
+++ b/.github/workflows/pr-validation-docs.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: "true"
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned to v3.3.0
         with:
           registry: docker.pkg.github.com # ghcr.io not yet enabled for Azure org
           username: ${{ github.actor }}

--- a/.github/workflows/pr-validation-fork.yml
+++ b/.github/workflows/pr-validation-fork.yml
@@ -53,7 +53,7 @@ jobs:
             return result;
 
       - name: Fork based /ok-to-test checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           fetch-depth: 0 # required to access tags
           submodules: 'true'

--- a/.github/workflows/pr-validation-fork.yml
+++ b/.github/workflows/pr-validation-fork.yml
@@ -26,7 +26,7 @@ jobs:
       # of this job we update the "integration-tests" check to be passing as well (so this single job really
       # ends up writing the status 2 checks, 1 is "integration-tests" and one is "integration-tests-fork").
       - name: set-check-run-in-progress
-        uses: actions/github-script@v6
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pinned to v7.0.1
         id: set-check-run-in-progress
         env:
           number: ${{ github.event.client_payload.pull_request.number }}
@@ -115,7 +115,7 @@ jobs:
 
       # Update check run called "integration-fork"
       - name: update-integration-tests-result
-        uses: actions/github-script@v6
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pinned to v7.0.1
         id: update-check-run
         if: ${{ always() }}
         env:

--- a/.github/workflows/pr-validation-fork.yml
+++ b/.github/workflows/pr-validation-fork.yml
@@ -67,7 +67,7 @@ jobs:
         run: scripts/v2/check-changes.sh
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned to v3.3.0
         with:
           registry: docker.pkg.github.com # ghcr.io not yet enabled for Azure org
           username: ${{ github.actor }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           fetch-depth: 0 # required to access tags
           submodules: 'true'
@@ -183,7 +183,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           fetch-depth: 0 # required to access tags
           submodules: 'true'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -255,7 +255,7 @@ jobs:
     
       # Update check run called "integration-tests-fork"
       - name: update-integration-tests-result
-        uses: actions/github-script@v6
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pinned to v7.0.1
         id: update-check-run
         if: ${{ always() }}
         env:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -79,7 +79,7 @@ jobs:
         run: scripts/v2/check-changes.sh
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned to v3.3.0
         with:
           registry: docker.pkg.github.com # ghcr.io not yet enabled for Azure org
           username: ${{ github.actor }}
@@ -196,7 +196,7 @@ jobs:
         run: scripts/v2/check-changes.sh
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned to v3.3.0
         with:
           registry: docker.pkg.github.com # ghcr.io not yet enabled for Azure org
           username: ${{ github.actor }}

--- a/.github/workflows/pre-release-tests.yaml
+++ b/.github/workflows/pre-release-tests.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           fetch-depth: 0 # required to access tags
           submodules: 'true'

--- a/.github/workflows/scan-controller-image.yaml
+++ b/.github/workflows/scan-controller-image.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           fetch-depth: 0 # required to access tags
           submodules: 'true'

--- a/.github/workflows/scan-controller-image.yaml
+++ b/.github/workflows/scan-controller-image.yaml
@@ -29,7 +29,7 @@ jobs:
           submodules: 'true'
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pinned to v3.3.0
         with:
           registry: docker.pkg.github.com # ghcr.io not yet enabled for Azure org
           username: ${{ github.actor }}

--- a/.github/workflows/visualize-repo.yml
+++ b/.github/workflows/visualize-repo.yml
@@ -22,7 +22,7 @@ jobs:
           private-key: ${{ secrets.AUTOMATION_KEY }}
           
       - name: Checkout code
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           ref: main
 
@@ -34,7 +34,7 @@ jobs:
           branch: "bot/update-diagrams"
 
       - name: Checkout code
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           ref: bot/update-diagrams
 

--- a/.github/workflows/visualize-repo.yml
+++ b/.github/workflows/visualize-repo.yml
@@ -27,7 +27,7 @@ jobs:
           ref: main
 
       - name: Create Branch
-        uses: peterjgrainger/action-create-branch@v2.4.0 # Pinned to v2.4.0
+        uses: peterjgrainger/action-create-branch@10c7d268152480ae859347db45dc69086cef1d9c # pinned to v3.0.0
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:


### PR DESCRIPTION
## What this PR does / why we need it

GitHub has deprecated use of Node 16 and has started [forcing actions to run on Node 20](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) instead.

Warnings are generated for workflows using old versions of actions:

```
The following actions use a deprecated Node.js version and will be forced to run on node20: 
actions/checkout@v3, docker/login-action@v2, actions/github-script@v6. 
For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

This PR updates versions of actions to the latest versions, pinned via commit-id as recommended.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/3o6wrnnFtAdQAv939u/giphy.gif?cid=790b7611o57s88gyhhkut6ywm6gxq1wn6benddf3r1y3xnqu&ep=v1_gifs_search&rid=giphy.gif&ct=g)
