### PR TITLE
Don't use globbing for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,11 @@ updates:
   # ASO v2 controller 
   - package-ecosystem: "gomod"
     directories:
-      - "/v2/**/*"
+      # These are not recursive, need to list each directory individually.
+      # We don't use wildcard/globbing because it times out w/ our large repo.
+      - "/v2"
+      - "/v2/cmd/asoctl"
+      - "/v2/tools/generator"
     schedule:
       interval: "weekly"
     rebase-strategy: "disabled"


### PR DESCRIPTION
It seems to cause the job to time out, probably scanning the embedded submodule or all of our generated code directories for more go.mod's. Instead just list the 3 we have explicitly.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
