### PR TITLE
Ensure resource names are always K8s compliant

### DIFF
--- a/v2/cmd/asoctl/internal/importing/importable_arm_resource.go
+++ b/v2/cmd/asoctl/internal/importing/importable_arm_resource.go
@@ -574,27 +574,32 @@ func safeResourceName(name string) string {
 	buffer := make([]rune, 0, len(name))
 
 	for _, r := range name {
-		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+
+		mapped, isMapped := safeResourceNameMappings[r]
+
+		switch {
+		case unicode.IsLetter(r):
+			// Transform letters to lowercase
 			buffer = append(buffer, unicode.ToLower(r))
-			continue
-		}
 
-		// Discard leading special characters so that the result always starts with a letter or number
-		if len(buffer) == 0 {
-			continue
-		}
+		case unicode.IsNumber(r):
+			// Keep numbers as they are
+			buffer = append(buffer, r)
 
-		if c, ok := safeResourceNameMappings[r]; ok {
-			buffer = append(buffer, c)
-			continue
-		}
+		case len(buffer) == 0:
+			// Discard leading special characters so that the result always starts with a letter or number
 
-		if unicode.IsSpace(r) {
+		case isMapped:
+			// Convert special characters
+			buffer = append(buffer, mapped)
+
+		case unicode.IsSpace(r):
+			// Convert all kinds of spaces to hyphens
 			buffer = append(buffer, '-')
-			continue
-		}
 
-		// Otherwise skip
+		default:
+			// Skip other characters
+		}
 	}
 
 	result := string(buffer)

--- a/v2/cmd/asoctl/internal/importing/importable_arm_resource_test.go
+++ b/v2/cmd/asoctl/internal/importing/importable_arm_resource_test.go
@@ -168,3 +168,51 @@ func Test_ARMResourceImporter_GroupVersionKindFromARMID(t *testing.T) {
 		})
 	}
 }
+
+func Test_safeResourceName_GivenName_ReturnsExpectedResult(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		name     string
+		expected string
+	}{
+		"simple": {
+			name:     "simple",
+			expected: "simple",
+		},
+		"with spaces": {
+			name:     "with spaces",
+			expected: "with-spaces",
+		},
+		"with special characters": {
+			name:     "with!@#$%^&*()_+special characters",
+			expected: "with-special-characters",
+		},
+		"with underscores": {
+			name:     "with_underscores",
+			expected: "with-underscores",
+		},
+		"with multiple spaces": {
+			name:     "with    multiple    spaces",
+			expected: "with-multiple-spaces",
+		},
+		"with linux style paths": {
+			name:     "/path/to/resource",
+			expected: "path-to-resource",
+		},
+		"with windows style paths": {
+			name:     "\\path\\to\\resource",
+			expected: "path-to-resource",
+		},
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			g := NewGomegaWithT(t)
+			g.Expect(safeResourceName(c.name)).To(Equal(c.expected))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Modifies resources names pulled from Azure to make them valid names for Kubernetes Resources.

Closes #4156 

Closes #4153 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/GRPy8MKag9U1U88hzY/giphy.gif?cid=790b7611hpa33cabryu8vg0w7yk6857x01fat8ja7vzrx5ta&ep=v1_gifs_search&rid=giphy.gif&ct=g)

**If applicable**:
- [x] this PR contains tests
