### PR TITLE
Add some validation of crd-pattern to asoctl export template

### DIFF
--- a/docs/hugo/content/tools/asoctl.md
+++ b/docs/hugo/content/tools/asoctl.md
@@ -142,6 +142,12 @@ Global Flags:
       --verbose   Enable verbose logging
 ```
 
+### --crd-pattern
+
+From v2.10, `asoctl` does proactive checking of the `--crd-pattern` parameter to see how many CRDs are selected.
+
+A warning is displayed if a pattern does not match any CRDs. This is nonfatal - the export of the template will proceed - as it's possible the pattern will match a CRD included in a newer version of ASO.
+
 ## Clean CRDs
 
 This command can be used to prepare ASOv2 `v1alpha1api`(deprecated in v2.0.0) CustomResources and CustomResourceDefinitions for ASO `v2.0.0` release. 

--- a/v2/cmd/asoctl/cmd/export_template.go
+++ b/v2/cmd/asoctl/cmd/export_template.go
@@ -31,7 +31,7 @@ func newTemplateCommand() *cobra.Command {
 	var options templateOptions
 
 	cmd := &cobra.Command{
-		Use:   "template [--source <string> |--version <string>] [--crd-pattern <string>|--raw]",
+		Use:   "template [--source <string> | --version <string>] [--crd-pattern <string> | --raw]",
 		Short: "Template creates a YAML file from the specified ASO yaml template",
 		Example: `asoctl export template --version v2.6.0 --crd-pattern "resources.azure.com/*" --crd-pattern "containerservice.azure.com/*"
 

--- a/v2/cmd/asoctl/cmd/export_template.go
+++ b/v2/cmd/asoctl/cmd/export_template.go
@@ -32,7 +32,7 @@ type templateOptions struct {
 	crdPattern []string
 }
 
-var expectedVersionRegex = regexp.MustCompile(`^v\d\.\d?\d\.\d$`)
+var expectedVersionRegex = regexp.MustCompile(`^v\d\.\d+\.\d+$`)
 
 // newTemplateCommand creates a new cobra Command when invoked from the command line
 func newTemplateCommand() *cobra.Command {

--- a/v2/cmd/asoctl/cmd/export_template.go
+++ b/v2/cmd/asoctl/cmd/export_template.go
@@ -24,7 +24,7 @@ type templateOptions struct {
 	crdPattern []string
 }
 
-var expectedVersionRegex = regexp.MustCompile(`^v\d\.\d\.\d$`)
+var expectedVersionRegex = regexp.MustCompile(`^v\d\.\d?\d\.\d$`)
 
 // newTemplateCommand creates a new cobra Command when invoked from the command line
 func newTemplateCommand() *cobra.Command {

--- a/v2/cmd/asoctl/cmd/export_template.go
+++ b/v2/cmd/asoctl/cmd/export_template.go
@@ -6,8 +6,11 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"os"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -16,7 +19,9 @@ import (
 
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 
+	"github.com/Azure/azure-service-operator/v2/api"
 	"github.com/Azure/azure-service-operator/v2/cmd/asoctl/internal/template"
+	"github.com/Azure/azure-service-operator/v2/internal/util/match"
 )
 
 type templateOptions struct {
@@ -77,7 +82,10 @@ asoctl export template --version v2.6.0 --crd-pattern "resources.azure.com/*;con
 			}
 
 			if !options.raw {
-				// Render the CRDPattern w/ `;` separating them
+				// Check to see if the CRD patterns are valid
+				validateCRDPatternsForTemplate(options.crdPattern, log)
+
+				// Render the CRDPattern w/ `;` separating them and inject into the template
 				crdPattern := strings.Join(options.crdPattern, ";")
 				result, err = template.Apply(result, crdPattern)
 				if err != nil {
@@ -128,4 +136,46 @@ asoctl export template --version v2.6.0 --crd-pattern "resources.azure.com/*;con
 	cmd.MarkFlagsMutuallyExclusive("crd-pattern", "raw")
 
 	return cmd
+}
+
+func validateCRDPatternsForTemplate(
+	crdPatterns []string,
+	log logr.Logger,
+) {
+	scheme := api.CreateScheme()
+	knownCRDs := scheme.AllKnownTypes()
+	warnings := 0
+	for _, p := range crdPatterns {
+		// We split patterns by `;` so we can check them individually and provide more fine-grained feedback
+		for _, pattern := range strings.Split(p, ";") {
+			count := countCRDsMatchingPattern(knownCRDs, pattern)
+			if count == 0 {
+				log.V(Status).Info("No CRDs matched pattern", "pattern", pattern)
+				warnings++
+			} else {
+				log.V(Info).Info("Pattern matched CRDs", "pattern", pattern, "count", count)
+			}
+		}
+	}
+
+	if warnings > 0 {
+		log.V(Status).Info("Possibly ineffective CRD patterns detected")
+		log.V(Status).Info("Please check the CRDs supported by the installed version of ASO")
+	}
+}
+
+func countCRDsMatchingPattern(
+	knownCRDs map[schema.GroupVersionKind]reflect.Type,
+	pattern string,
+) int {
+	result := 0
+	matcher := match.NewStringMatcher(pattern)
+	for gvk := range knownCRDs {
+		key := fmt.Sprintf("%s/%s", gvk.Group, gvk.Kind)
+		if matcher.Matches(key).Matched {
+			result++
+		}
+	}
+
+	return result
 }

--- a/v2/cmd/asoctl/cmd/export_template.go
+++ b/v2/cmd/asoctl/cmd/export_template.go
@@ -6,12 +6,15 @@
 package cmd
 
 import (
+	"github.com/go-logr/logr"
 	"os"
 	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 
 	"github.com/Azure/azure-service-operator/v2/cmd/asoctl/internal/template"
 )
@@ -63,6 +66,10 @@ asoctl export template --version v2.6.0 --crd-pattern "resources.azure.com/*;con
 
 				uri = template.URIFromVersion(options.version)
 			}
+
+			log := CreateLogger()
+			log.V(Status).Info("Export ASO Template", "version", options.version)
+			log.V(Status).Info("Downloading template", "uri", uri)
 
 			result, err := template.Get(ctx, uri)
 			if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it

When using `asoctl export template` the values passed for `--crd-pattern` aren't currently checked at all, so they might not do what the user wants.

Closes #3969 

## Special notes for your reviewer

Validation is done against the CRDs known to that version of `asoctl`, which might be different to the `--version` specified on the command-line. Not sure how to handle this - we should discuss.

## How does this PR make you feel

![gif](https://media.giphy.com/media/ZwrL2hpF5E9QagNa1P/giphy.gif?cid=790b7611y082pq8t3aeljy1rgp0xw6sok0kwshddgynm72tq&ep=v1_gifs_search&rid=giphy.gif&ct=g)

- [x] this PR contains documentation
