### PR TITLE
Fix panic in log

### DIFF
--- a/v2/internal/reconcilers/common.go
+++ b/v2/internal/reconcilers/common.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/ownerutil"
 	"github.com/Azure/azure-service-operator/v2/internal/resolver"
 	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
+	"github.com/Azure/azure-service-operator/v2/internal/util/to"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
@@ -47,8 +48,8 @@ func LogObj(log logr.Logger, level int, note string, obj genruntime.MetaObject) 
 			"generation", obj.GetGeneration(),
 			"uid", obj.GetUID(),
 			"ownerReferences", obj.GetOwnerReferences(),
-			"creationTimestamp", obj.GetCreationTimestamp(),
-			"deletionTimestamp", obj.GetDeletionTimestamp(),
+			"creationTimestamp", obj.GetCreationTimestamp().String(),
+			"deletionTimestamp", to.Value(obj.GetDeletionTimestamp()).String(),
 			"finalizers", obj.GetFinalizers(),
 			"annotations", ourAnnotations,
 			// Use fmt here to ensure the output uses the String() method, which log.Info doesn't seem to do by default
@@ -56,7 +57,7 @@ func LogObj(log logr.Logger, level int, note string, obj genruntime.MetaObject) 
 		}
 
 		if armObj, ok := obj.(genruntime.ARMMetaObject); ok {
-			keysAndValues = append(keysAndValues, "owner", armObj.Owner())
+			keysAndValues = append(keysAndValues, "owner", to.Value(armObj.Owner()).String())
 		}
 
 		// Log just what we're interested in. We avoid logging the whole obj


### PR DESCRIPTION
Fixes some pancis I noticed in logs. The panics were captured so no crashes of the operator occurred but it's still not ideal.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
