### PR TITLE
Allow importing of FrontDoor resources

### DIFF
--- a/v2/cmd/asoctl/pkg/importresources/find_child_resources.go
+++ b/v2/cmd/asoctl/pkg/importresources/find_child_resources.go
@@ -24,7 +24,8 @@ func FindChildResourcesForResourceType(resourceType string) []string {
 		childResourceTypes = createChildResourceTypesMap()
 	})
 
-	s, ok := childResourceTypes[resourceType]
+	rt := strings.ToLower(resourceType)
+	s, ok := childResourceTypes[rt]
 	if !ok {
 		return nil
 	}
@@ -55,6 +56,8 @@ func createChildResourceTypesMap() map[string]set.Set[string] {
 		}
 
 		// If the type name has more than one slash, then it's a subtype, and we want to add it to the map
+		// We use strictly lowercase for the keys, so that future lookups are case-insensitive,
+		// but maintain the letter case for the values
 		t := rsrc.GetType()
 		firstSlash := strings.Index(t, "/")
 		lastSlash := strings.LastIndex(t, "/")
@@ -63,7 +66,7 @@ func createChildResourceTypesMap() map[string]set.Set[string] {
 		}
 
 		// Get the parent type name
-		parentType := t[:lastSlash]
+		parentType := strings.ToLower(t[:lastSlash])
 
 		// Add to the set in the map
 		if s, ok := result[parentType]; ok {

--- a/v2/cmd/asoctl/pkg/importresources/find_child_resources_test.go
+++ b/v2/cmd/asoctl/pkg/importresources/find_child_resources_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package importresources
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	cdn "github.com/Azure/azure-service-operator/v2/api/cdn/v1api20230501"
+	dbforpostgresql "github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20221201"
+)
+
+func Test_FindChildResources_GivenParentResource_ReturnsExpectedChildResources(t *testing.T) {
+	t.Parallel()
+
+	postgreSQLServer := &dbforpostgresql.FlexibleServer{}
+	postgreSQLConfiguration := &dbforpostgresql.FlexibleServersConfiguration{}
+
+	ruleset := &cdn.RuleSet{}
+	rule := &cdn.Rule{}
+
+	cases := map[string]struct {
+		parentResourceType        string
+		expectedChildResourceType string
+	}{
+		"PostgreSQL servers have configurations": {
+			parentResourceType:        postgreSQLServer.GetType(),
+			expectedChildResourceType: postgreSQLConfiguration.GetType(),
+		},
+		"CDN rulesets have rules": {
+			parentResourceType:        ruleset.GetType(),
+			expectedChildResourceType: rule.GetType(),
+		},
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			childResources := FindChildResourcesForResourceType(c.parentResourceType)
+
+			g.Expect(childResources).NotTo(BeEmpty())
+			g.Expect(childResources).To(ContainElement(c.expectedChildResourceType))
+		})
+	}
+}

--- a/v2/cmd/asoctl/pkg/importresources/find_child_resources_test.go
+++ b/v2/cmd/asoctl/pkg/importresources/find_child_resources_test.go
@@ -6,6 +6,7 @@
 package importresources
 
 import (
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -34,6 +35,10 @@ func Test_FindChildResources_GivenParentResource_ReturnsExpectedChildResources(t
 		"CDN rulesets have rules": {
 			parentResourceType:        ruleset.GetType(),
 			expectedChildResourceType: rule.GetType(),
+		},
+		"Can find PostgreSQL configurations when parent is lowercase": {
+			parentResourceType:        strings.ToLower(postgreSQLServer.GetType()),
+			expectedChildResourceType: postgreSQLConfiguration.GetType(),
 		},
 	}
 

--- a/v2/cmd/asoctl/pkg/importresources/find_child_resources_test.go
+++ b/v2/cmd/asoctl/pkg/importresources/find_child_resources_test.go
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package importresources
+package importresources_test
 
 import (
 	"strings"
@@ -13,6 +13,8 @@ import (
 
 	cdn "github.com/Azure/azure-service-operator/v2/api/cdn/v1api20230501"
 	dbforpostgresql "github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1api20221201"
+
+	. "github.com/Azure/azure-service-operator/v2/cmd/asoctl/pkg/importresources"
 )
 
 func Test_FindChildResources_GivenParentResource_ReturnsExpectedChildResources(t *testing.T) {

--- a/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
+++ b/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
@@ -371,7 +371,8 @@ func (*importableARMResource) classifyError(err error) (string, bool) {
 
 		if responseError.StatusCode == http.StatusBadRequest {
 			if strings.Contains(responseError.Error(), "RequestUrlInvalid") ||
-				strings.Contains(responseError.Error(), "ValidationFailed") {
+				strings.Contains(responseError.Error(), "ValidationFailed") ||
+				strings.Contains(responseError.Error(), "NoRegisteredProviderFound") {
 				// We constructed an invalid URL
 				// (Seems that some extension resources aren't permitted on some resource types)
 				// An empty error is special cased as a silent skip, so we don't alarm casual users

--- a/v2/cmd/asoctl/pkg/importresources/importable_arm_resource_test.go
+++ b/v2/cmd/asoctl/pkg/importresources/importable_arm_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
 	. "github.com/onsi/gomega"
 
 	"github.com/Azure/azure-service-operator/v2/api"


### PR DESCRIPTION
**What this PR does / why we need it**:

When scanning for child/extension resources in the `cdn` group, `asoctl` runs into a `NoRegisteredProviderFound` error which is incorrectly treated as a fatal error. 

Changing this to a known case, where we simply skip the check for that particular kind of child resource, results in the import working correctly.

Closes #4260 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/PfHrNe1cSKAjC/giphy.gif?cid=790b761194lnoo8ys75x0wwf6k6kjgwqnnf0hvqsamb6aqaf&ep=v1_gifs_search&rid=giphy.gif&ct=g)
