### PR TITLE
Built-in role definitions should be skiped by asoctl

### DIFF
--- a/v2/api/authorization/customizations/role_assignment_extensions.go
+++ b/v2/api/authorization/customizations/role_assignment_extensions.go
@@ -28,6 +28,9 @@ func (extension *RoleAssignmentExtension) Import(
 		return extensions.ImportResult{}, err
 	}
 
+	// If this cast doesn't compile, update the `api` import to reference the now latest
+	// stable version of the authorization group (this will happen when we import a new
+	// API version in the generator.)
 	if assignment, ok := rsrc.(*api.RoleAssignment); ok {
 		// Check to see whether this role assignment is inherited or not
 		// (we can tell by looking at the scope of the assignment)

--- a/v2/api/authorization/customizations/role_definition_extensions.go
+++ b/v2/api/authorization/customizations/role_definition_extensions.go
@@ -28,6 +28,9 @@ func (extension *RoleDefinitionExtension) Import(
 		return extensions.ImportResult{}, err
 	}
 
+	// If this cast doesn't compile, update the `api` import to reference the now latest
+	// stable version of the authorization group (this will happen when we import a new
+	// API version in the generator.)
 	if definition, ok := rsrc.(*api.RoleDefinition); ok {
 		// If this role definition is built in, we don't need to export it
 		if definition.Spec.Type != nil {

--- a/v2/api/authorization/customizations/role_definition_extensions.go
+++ b/v2/api/authorization/customizations/role_definition_extensions.go
@@ -1,0 +1,41 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package customizations
+
+import (
+	"context"
+	"strings"
+
+	api "github.com/Azure/azure-service-operator/v2/api/authorization/v1api20220401"
+
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
+)
+
+var _ extensions.Importer = &RoleDefinitionExtension{}
+
+func (extension *RoleDefinitionExtension) Import(
+	ctx context.Context,
+	rsrc genruntime.ImportableResource,
+	owner *genruntime.ResourceReference,
+	next extensions.ImporterFunc,
+) (extensions.ImportResult, error) {
+	result, err := next(ctx, rsrc, owner)
+	if err != nil {
+		return extensions.ImportResult{}, err
+	}
+
+	if definition, ok := rsrc.(*api.RoleDefinition); ok {
+		// If this role definition is built in, we don't need to export it
+		if definition.Spec.Type != nil {
+			if strings.EqualFold(*definition.Spec.Type, "BuiltInRole") {
+				return extensions.ImportSkipped("role definition is built-in"), nil
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/v2/api/dbforpostgresql/customizations/flexible_servers_configuration_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_servers_configuration_extensions.go
@@ -27,6 +27,9 @@ func (extension *FlexibleServersConfigurationExtension) Import(
 		return extensions.ImportResult{}, err
 	}
 
+	// If this cast doesn't compile, update the `api` import to reference the now latest
+	// stable version of the authorization group (this will happen when we import a new
+	// API version in the generator.)
 	if config, ok := rsrc.(*api.FlexibleServersConfiguration); ok {
 		// Skip system defaults
 		if config.Spec.Source != nil && *config.Spec.Source == "system-default" {

--- a/v2/api/dbforpostgresql/customizations/flexible_servers_database_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_servers_database_extensions.go
@@ -58,6 +58,9 @@ func (extension *FlexibleServersDatabaseExtension) Import(
 	owner *genruntime.ResourceReference,
 	next extensions.ImporterFunc,
 ) (extensions.ImportResult, error) {
+	// If this cast doesn't compile, update the `api` import to reference the now latest
+	// stable version of the authorization group (this will happen when we import a new
+	// API version in the generator.)
 	if server, ok := rsrc.(*api.FlexibleServersDatabase); ok {
 		if server.Spec.AzureName == "azure_maintenance" {
 			return extensions.ImportSkipped("azure_maintenance database is not accessible by users"), nil


### PR DESCRIPTION
**What this PR does / why we need it**:

They can't be created by ASO because they'd conflict - they're built in, so already present.

`asoctl` shouldn't include built in role definitions in the output.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/1wPlBSdWGZS409uWtE/giphy.gif?cid=790b7611dyhwiy6est6rit0izbr3ozkvbpmb85t9avq5serz&ep=v1_gifs_search&rid=giphy.gif&ct=g)
