### PR TITLE
Fix deadlock and ux bugs in asoctl

### DIFF
--- a/v2/cmd/asoctl/cmd/import_azure_resource.go
+++ b/v2/cmd/asoctl/cmd/import_azure_resource.go
@@ -7,12 +7,15 @@ package cmd
 
 import (
 	"context"
+	"github.com/go-logr/logr"
+	"io"
+	"os"
+	"sync"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"os"
-	"sync"
 
 	internalconfig "github.com/Azure/azure-service-operator/v2/internal/config"
 
@@ -107,25 +110,22 @@ func importAzureResource(
 	armIDs []string,
 	options *importAzureResourceOptions,
 ) error {
-	creds, err := azidentity.NewDefaultAzureCredential(nil)
-	if err != nil {
-		return errors.Wrap(err, "unable to get default Azure credential")
+	// Check we're being asked to do something ... anything ...
+	if len(armIDs) == 0 {
+		return errors.New("no ARM IDs provided")
 	}
 
-	clientOptions := &genericarmclient.GenericClientOptions{
-		UserAgent: "asoctl/" + version.BuildVersion,
-	}
-
-	activeCloud := options.cloud()
-	client, err := genericarmclient.NewGenericClient(activeCloud, creds, clientOptions)
+	// Create an ARM client for requesting resources
+	client, err := createARMClient(options)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create ARM client")
 	}
 
-	//
+	// Caution: the progress bar can deadlock if no bar is ever created, so make sure the gap between
+	// this and the call to importer.Import() is as small as possible.
 	log, progressBar := CreateLoggerAndProgressBar()
 
-	done := make(chan struct{}) // signal that we're done
+	done := make(chan struct{}) // signal for when we're done
 	pb := importreporter.NewBar("Import Azure Resources", progressBar, done)
 
 	importer := importresources.New(api.CreateScheme(), client, log, pb)
@@ -136,7 +136,9 @@ func importAzureResource(
 		}
 	}
 
-	// Make sure all output is written when we're done
+	// Make sure all output is written when we're done.
+	// This defer has to be immediately before the call the importer.Import();
+	// if you move it earler, any `return err` between there and here will cause a deadlock.
 	defer progressBar.Wait()
 
 	result, err := importer.Import(ctx, done)
@@ -159,11 +161,45 @@ func importAzureResource(
 		return nil
 	}
 
-	// Apply additional configuration to imported resources.
+	err = configureImportedResources(options, result)
+	if err != nil {
+		return errors.Wrap(err, "failed to apply options to imported resources")
+	}
+
+	err = writeResources(result, options, log, progressBar)
+	if err != nil {
+		return errors.Wrap(err, "failed to write resources")
+	}
+
+	return nil
+}
+
+// createARMClient creates our client for talking to ARM
+func createARMClient(options *importAzureResourceOptions) (*genericarmclient.GenericClient, error) {
+	creds, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get default Azure credential")
+	}
+
+	clientOptions := &genericarmclient.GenericClientOptions{
+		UserAgent: "asoctl/" + version.BuildVersion,
+	}
+
+	activeCloud := options.cloud()
+	return genericarmclient.NewGenericClient(activeCloud, creds, clientOptions)
+}
+
+// configureImportedResources applies additional configuration to imported resources
+func configureImportedResources(
+	options *importAzureResourceOptions,
+	result *importresources.Result,
+) error {
+	// Set the namespace on all resources
 	if options.namespace != "" {
 		result.SetNamespace(options.namespace)
 	}
 
+	// Apply labels
 	if len(options.labels) > 0 {
 		err = result.AddLabels(options.labels)
 		if err != nil {
@@ -171,6 +207,7 @@ func importAzureResource(
 		}
 	}
 
+	// Apply annotations
 	if len(options.annotations) > 0 {
 		err = result.AddAnnotations(options.annotations)
 		if err != nil {
@@ -178,6 +215,16 @@ func importAzureResource(
 		}
 	}
 
+	return nil
+}
+
+func writeResources(
+	result *importresources.Result,
+	options *importAzureResourceOptions,
+	log logr.Logger,
+	out io.Writer,
+) error {
+	// Write all the resources to a single file
 	if file, ok := options.writeToFile(); ok {
 		log.Info(
 			"Writing to a single file",
@@ -186,7 +233,12 @@ func importAzureResource(
 		if err != nil {
 			return errors.Wrapf(err, "failed to write to file %s", file)
 		}
-	} else if folder, ok := options.writeToFolder(); ok {
+
+		return nil
+	}
+
+	// Write each resource to an individual file in a folder
+	if folder, ok := options.writeToFolder(); ok {
 		log.Info(
 			"Writing to individual files in folder",
 			"folder", folder)
@@ -194,11 +246,14 @@ func importAzureResource(
 		if err != nil {
 			return errors.Wrapf(err, "failed to write into folder %s", folder)
 		}
-	} else {
-		err := result.SaveToWriter(progressBar)
-		if err != nil {
-			return errors.Wrapf(err, "failed to write to stdout")
-		}
+
+		return nil
+	}
+
+	// Write all the resources to stdout
+	err := result.SaveToWriter(out)
+	if err != nil {
+		return errors.Wrapf(err, "failed to write to stdout")
 	}
 
 	return nil

--- a/v2/cmd/asoctl/cmd/import_azure_resource.go
+++ b/v2/cmd/asoctl/cmd/import_azure_resource.go
@@ -138,7 +138,7 @@ func importAzureResource(
 
 	// Make sure all output is written when we're done.
 	// This defer has to be immediately before the call the importer.Import();
-	// if you move it earler, any `return err` between there and here will cause a deadlock.
+	// if you move it earlier, any `return err` between there and here will cause a deadlock.
 	defer progressBar.Wait()
 
 	result, err := importer.Import(ctx, done)
@@ -201,7 +201,7 @@ func configureImportedResources(
 
 	// Apply labels
 	if len(options.labels) > 0 {
-		err = result.AddLabels(options.labels)
+		err := result.AddLabels(options.labels)
 		if err != nil {
 			return errors.Wrap(err, "failed to add labels")
 		}
@@ -209,7 +209,7 @@ func configureImportedResources(
 
 	// Apply annotations
 	if len(options.annotations) > 0 {
-		err = result.AddAnnotations(options.annotations)
+		err := result.AddAnnotations(options.annotations)
 		if err != nil {
 			return errors.Wrap(err, "failed to add annotations")
 		}

--- a/v2/cmd/asoctl/cmd/import_azure_resource.go
+++ b/v2/cmd/asoctl/cmd/import_azure_resource.go
@@ -7,13 +7,12 @@ package cmd
 
 import (
 	"context"
-	"os"
-	"sync"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"os"
+	"sync"
 
 	internalconfig "github.com/Azure/azure-service-operator/v2/internal/config"
 
@@ -108,11 +107,6 @@ func importAzureResource(
 	armIDs []string,
 	options *importAzureResourceOptions,
 ) error {
-	log, progressBar := CreateLoggerAndProgressBar()
-
-	// Make sure all output is written when we're done
-	defer progressBar.Wait()
-
 	creds, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return errors.Wrap(err, "unable to get default Azure credential")
@@ -128,6 +122,9 @@ func importAzureResource(
 		return errors.Wrapf(err, "failed to create ARM client")
 	}
 
+	//
+	log, progressBar := CreateLoggerAndProgressBar()
+
 	done := make(chan struct{}) // signal that we're done
 	pb := importreporter.NewBar("Import Azure Resources", progressBar, done)
 
@@ -138,6 +135,9 @@ func importAzureResource(
 			return errors.Wrapf(err, "failed to add %q to import list", armID)
 		}
 	}
+
+	// Make sure all output is written when we're done
+	defer progressBar.Wait()
 
 	result, err := importer.Import(ctx, done)
 

--- a/v2/cmd/asoctl/cmd/log.go
+++ b/v2/cmd/asoctl/cmd/log.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 
 	"github.com/go-logr/logr"
@@ -22,9 +23,25 @@ var (
 // CreateLogger creates a logger  for console output.
 // Use this when your command wants to show only log messages
 func CreateLogger() logr.Logger {
+	return createLoggerCore(os.Stderr)
+}
+
+// CreateLoggerAndProgressBar creates a logger and progress bar for console output.
+// Use this when your command wants to show progress to the user.
+func CreateLoggerAndProgressBar() (logr.Logger, *mpb.Progress) {
+	// Create Progressbar for console output
+	progress := mpb.New(
+		mpb.WithOutput(os.Stderr), // Write to StdErr
+	)
+
+	log := createLoggerCore(progress)
+	return log, progress
+}
+
+func createLoggerCore(writer io.Writer) logr.Logger {
 	// Configure console writer for ZeroLog
 	output := zerolog.ConsoleWriter{
-		Out:        os.Stderr,      // Write to StdErr
+		Out:        writer,
 		TimeFormat: "15:04:05.999", // Display time to the millisecond
 	}
 
@@ -38,30 +55,4 @@ func CreateLogger() logr.Logger {
 	log := zerologr.New(&zl)
 
 	return log
-}
-
-// CreateLoggerAndProgressBar creates a logger and progress bar for console output.
-// Use this when your command wants to show progress to the user.
-func CreateLoggerAndProgressBar() (logr.Logger, *mpb.Progress) {
-	// Create Progressbar for console output
-	progress := mpb.New(
-		mpb.WithOutput(os.Stderr), // Write to StdErr
-	)
-
-	// Configure console writer for ZeroLog
-	output := zerolog.ConsoleWriter{
-		Out:        progress,       // Write via the progressbar
-		TimeFormat: "15:04:05.999", // Display time to the millisecond
-	}
-
-	// Create zerolog logger
-	zl := zerolog.New(output).
-		With().Timestamp().
-		Logger()
-
-	// Use standard interface for logging
-	zerologr.VerbosityFieldName = "" // Don't include verbosity in output
-
-	log := zerologr.New(&zl)
-	return log, progress
 }

--- a/v2/cmd/asoctl/pkg/importreporter/bar.go
+++ b/v2/cmd/asoctl/pkg/importreporter/bar.go
@@ -38,7 +38,8 @@ func newBarProgress(
 		mpb.PrependDecorators(
 			decor.Name(name, decor.WCSyncSpaceR)),
 		mpb.AppendDecorators(
-			decor.CountersNoUnit("%d/%d", decor.WCSyncSpaceR)))
+			decor.CountersNoUnit("%d/%d", decor.WCSyncSpaceR)),
+		mpb.BarRemoveOnComplete())
 
 	result := &barReporter{
 		updates:  make(chan progressDelta),


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a deadlock bug that occurs if an error is returned before the first progressbar is created.

Fixes a UX bug where completed progress bars are left on screen as debris.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOWo0ZDd2aHk5eHQxamo3czZua2sybzJ1NDFpbDhyMzd4enU1Z3NnZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/gUqFOTDagWIBG/giphy.gif)
