### PR TITLE
Reduce noise when importing PostgreSQL Flexible Server Configurations

### DIFF
--- a/v2/api/dbforpostgresql/customizations/flexible_servers_configuration_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_servers_configuration_extensions.go
@@ -42,6 +42,13 @@ func (extension *FlexibleServersConfigurationExtension) Import(
 			*config.Status.IsReadOnly {
 			return extensions.ImportSkipped("readonly configuration can't be set"), nil
 		}
+
+		// Skip default values
+		if config.Status.DefaultValue != nil &&
+			config.Status.Value != nil &&
+			*config.Status.DefaultValue == *config.Status.Value {
+			return extensions.ImportSkipped("default value is the same as the current value"), nil
+		}
 	}
 
 	return result, nil

--- a/v2/api/dbforpostgresql/customizations/flexible_servers_configuration_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_servers_configuration_extensions.go
@@ -32,7 +32,8 @@ func (extension *FlexibleServersConfigurationExtension) Import(
 	// API version in the generator.)
 	if config, ok := rsrc.(*api.FlexibleServersConfiguration); ok {
 		// Skip system defaults
-		if config.Spec.Source != nil && *config.Spec.Source == "system-default" {
+		if config.Spec.Source != nil &&
+			*config.Spec.Source == "system-default" {
 			return extensions.ImportSkipped("system-defaults don't need to be imported"), nil
 		}
 	}

--- a/v2/api/dbforpostgresql/customizations/flexible_servers_configuration_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_servers_configuration_extensions.go
@@ -36,6 +36,12 @@ func (extension *FlexibleServersConfigurationExtension) Import(
 			*config.Spec.Source == "system-default" {
 			return extensions.ImportSkipped("system-defaults don't need to be imported"), nil
 		}
+
+		// Skip readonly configuration
+		if config.Status.IsReadOnly != nil &&
+			*config.Status.IsReadOnly {
+			return extensions.ImportSkipped("readonly configuration can't be set"), nil
+		}
 	}
 
 	return result, nil


### PR DESCRIPTION
## What this PR does

When importing a PostgreSQL Flexible Server, `asoctl` was including more than 400 configuration options, many of which couldn't be changed by the user.

With this PR, we now
* Skip configurations that haven't been changed from their default
* Skip configurations marked readonly that the user cannot modify

Closes #4278 

### How does this PR make you feel

![gif](https://media.giphy.com/media/f9RGSf5eLZ8TpSCgJP/giphy.gif?cid=790b7611x7bxdn72j51r0m7xi0iv787pusfl7x0n72o36go6&ep=v1_gifs_search&rid=giphy.gif&ct=g)

