### PR TITLE
Document origin of key for the Azure Storage Emulator

### DIFF
--- a/pkg/resourcemanager/autorest/authorization_helpers.go
+++ b/pkg/resourcemanager/autorest/authorization_helpers.go
@@ -55,7 +55,13 @@ const HeaderRange = "Range"
 // StorageEmulatorAccountName is the Storage Account Name for the Azure Storage Emulator
 const StorageEmulatorAccountName = "devstoreaccount1"
 
-// StorageEmulatorAccountKey is the Storage Account Key for the Azure Storage Emulator
+// StorageEmulatorAccountKey is the Storage Account Key for the Azure Storage Emulator.
+// 
+// The emulator supports a single fixed account and a well-known authentication key for 
+// Shared Key authentication. This account and key are the only Shared Key credentials 
+// permitted for use with the emulator. 
+//
+// See https://learn.microsoft.com/en-us/azure/storage/common/storage-use-emulator#authorize-with-shared-key-credentials
 const StorageEmulatorAccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
 
 // buildCanonicalizedHeader builds the Canonicalized Header required to sign Storage Requests


### PR DESCRIPTION
## What this PR does / why we need it

The Azure Storage Emulator was used by ASOv1 for testing; it requires a fixed account name and key (as [documented](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-emulator#authorize-with-shared-key-credentials))  for use. 

Adding documentation of this so that any future reviewers are aware that any apparent security breach is not actually the case.
