### PR TITLE
Reduce noise when importing MySQL Flexible Server Configurations

### DIFF
--- a/v2/api/dbformysql/customizations/flexible_servers_configuration_extensions.go
+++ b/v2/api/dbformysql/customizations/flexible_servers_configuration_extensions.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package customizations
+
+import (
+	"context"
+
+	api "github.com/Azure/azure-service-operator/v2/api/dbformysql/v1api20230630"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
+)
+
+var _ extensions.Importer = &FlexibleServersConfigurationExtension{}
+
+// Import skips databases that can't be managed by ARM
+func (extension *FlexibleServersConfigurationExtension) Import(
+	ctx context.Context,
+	rsrc genruntime.ImportableResource,
+	owner *genruntime.ResourceReference,
+	next extensions.ImporterFunc,
+) (extensions.ImportResult, error) {
+	result, err := next(ctx, rsrc, owner)
+	if err != nil {
+		return extensions.ImportResult{}, err
+	}
+
+	// If this cast doesn't compile, update the `api` import to reference the now latest
+	// stable version of the dbformysql group (this will happen when we import a new
+	// API version in the generator.)
+	if config, ok := rsrc.(*api.FlexibleServersConfiguration); ok {
+		// Skip system defaults
+		if config.Spec.Source != nil &&
+			*config.Spec.Source == "system-default" {
+			return extensions.ImportSkipped("system-defaults don't need to be imported"), nil
+		}
+	}
+
+	return result, nil
+}

--- a/v2/api/dbformysql/customizations/flexible_servers_configuration_extensions.go
+++ b/v2/api/dbformysql/customizations/flexible_servers_configuration_extensions.go
@@ -42,6 +42,13 @@ func (extension *FlexibleServersConfigurationExtension) Import(
 			*config.Status.IsReadOnly == api.ConfigurationProperties_IsReadOnly_STATUS_True {
 			return extensions.ImportSkipped("readonly configuration can't be set"), nil
 		}
+
+		// Skip default values
+		if config.Status.DefaultValue != nil &&
+			config.Status.Value != nil &&
+			*config.Status.DefaultValue == *config.Status.Value {
+			return extensions.ImportSkipped("default value is the same as the current value"), nil
+		}
 	}
 
 	return result, nil

--- a/v2/api/dbformysql/customizations/flexible_servers_configuration_extensions.go
+++ b/v2/api/dbformysql/customizations/flexible_servers_configuration_extensions.go
@@ -36,6 +36,12 @@ func (extension *FlexibleServersConfigurationExtension) Import(
 			*config.Spec.Source == "system-default" {
 			return extensions.ImportSkipped("system-defaults don't need to be imported"), nil
 		}
+
+		// Skip readonly configuration
+		if config.Status.IsReadOnly != nil &&
+			*config.Status.IsReadOnly == api.ConfigurationProperties_IsReadOnly_STATUS_True {
+			return extensions.ImportSkipped("readonly configuration can't be set"), nil
+		}
 	}
 
 	return result, nil

--- a/v2/api/dbforpostgresql/customizations/flexible_servers_configuration_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_servers_configuration_extensions.go
@@ -28,7 +28,7 @@ func (extension *FlexibleServersConfigurationExtension) Import(
 	}
 
 	// If this cast doesn't compile, update the `api` import to reference the now latest
-	// stable version of the authorization group (this will happen when we import a new
+	// stable version of the dbforpostgresql group (this will happen when we import a new
 	// API version in the generator.)
 	if config, ok := rsrc.(*api.FlexibleServersConfiguration); ok {
 		// Skip system defaults

--- a/v2/api/dbforpostgresql/customizations/flexible_servers_database_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_servers_database_extensions.go
@@ -59,7 +59,7 @@ func (extension *FlexibleServersDatabaseExtension) Import(
 	next extensions.ImporterFunc,
 ) (extensions.ImportResult, error) {
 	// If this cast doesn't compile, update the `api` import to reference the now latest
-	// stable version of the authorization group (this will happen when we import a new
+	// stable version of the dbforpostgresql group (this will happen when we import a new
 	// API version in the generator.)
 	if server, ok := rsrc.(*api.FlexibleServersDatabase); ok {
 		if server.Spec.AzureName == "azure_maintenance" {


### PR DESCRIPTION
## What this PR does 

When importing a MySQL Flexible Server, `asoctl` was including 450 configuration options, including both default values that hadn't been changed by the user, and readonly values that cannot be changed by the user.

### Special notes for your reviewer

Similar to #4279 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/Y2yDVpzv9kpVxAmF9B/giphy.gif?cid=790b76111modh9sncpqb16ix8ae0y773774831wtyfug3rs1&ep=v1_gifs_search&rid=giphy.gif&ct=g)
