### PR TITLE
Update ASO's NetworkPolicy to allow egress to SqlServer's default port

### DIFF
--- a/v2/charts/azure-service-operator/templates/networkpolicies.yaml
+++ b/v2/charts/azure-service-operator/templates/networkpolicies.yaml
@@ -53,6 +53,13 @@ spec:
     to:
     - ipBlock:
         cidr: {{ .Values.networkPolicies.postgresqlCIDR }}
+    # Required for communication with SQL servers when using SQL user object
+  - ports:
+      - port: 1433
+        protocol: TCP
+    to:
+      - ipBlock:
+          cidr: {{ .Values.networkPolicies.sqlCIDR }}
   podSelector:
     matchLabels:
       control-plane: controller-manager

--- a/v2/charts/azure-service-operator/values.yaml
+++ b/v2/charts/azure-service-operator/values.yaml
@@ -154,6 +154,9 @@ networkPolicies:
   mysqlCIDR: 0.0.0.0/0
   # Destination CIDR for talking to PostgreSQL servers
   postgresqlCIDR: 0.0.0.0/0
+  # Destination CIDR for talking to Sql servers
+  sqlCIDR: 0.0.0.0/0
+
 
 # Node labels for pod assignment
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/


### PR DESCRIPTION


Closes #4225 

**What this PR does / why we need it**:

Expose port `1433` in ASO's Network policies for SQL server user creation. 