### PR TITLE
Improve Type manipulation

### DIFF
--- a/v2/tools/generator/internal/astmodel/object_type_test.go
+++ b/v2/tools/generator/internal/astmodel/object_type_test.go
@@ -19,6 +19,7 @@ var (
 	fullName             = NewPropertyDefinition("FullName", "full-name", StringType)
 	familyName           = NewPropertyDefinition("FamilyName", "family-name", StringType)
 	knownAs              = NewPropertyDefinition("KnownAs", "known-as", StringType)
+	legalName            = NewPropertyDefinition("LegalName", "legalName", StringType)
 	gender               = NewPropertyDefinition("Gender", "gender", StringType)
 	embeddedProp         = NewPropertyDefinition("", "-", MakeExternalTypeName(GenRuntimeReference, "DummyType"))
 	optionalEmbeddedProp = NewPropertyDefinition("", "-", MakeExternalTypeName(GenRuntimeReference, "DummyType")).MakeTypeOptional()

--- a/v2/tools/generator/internal/astmodel/property_remover.go
+++ b/v2/tools/generator/internal/astmodel/property_remover.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import "github.com/pkg/errors"
+
+// PropertyRemover is a utility for removing property definitions from objects
+type PropertyRemover struct {
+	// visitor is used to do the actual injection
+	visitor TypeVisitor[PropertyName]
+}
+
+// NewPropertyRemover creates a new property remover for modifying objects
+func NewPropertyRemover() *PropertyRemover {
+	result := &PropertyRemover{}
+
+	result.visitor = TypeVisitorBuilder[PropertyName]{
+		VisitObjectType: result.removePropertyFromObject,
+	}.Build()
+
+	return result
+}
+
+// Remove modifies the passed type definition by removing the passed property
+func (pi *PropertyRemover) Remove(def TypeDefinition, name PropertyName) (TypeDefinition, error) {
+	result, err := pi.visitor.VisitDefinition(def, name)
+	if err != nil {
+		return TypeDefinition{}, errors.Wrapf(err, "failed to remove property %q from %q", name, def.Name())
+	}
+
+	return result, nil
+}
+
+// injectPropertyIntoObject takes the property provided as a context and includes it on the provided object type
+func (pi *PropertyRemover) removePropertyFromObject(
+	_ *TypeVisitor[PropertyName], ot *ObjectType, name PropertyName,
+) (Type, error) {
+	return ot.WithoutProperty(name), nil
+}

--- a/v2/tools/generator/internal/astmodel/property_remover_test.go
+++ b/v2/tools/generator/internal/astmodel/property_remover_test.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_PropertyRemover_GivenDefinition_RemovesExpectedProperty(t *testing.T) {
+	t.Parallel()
+
+	simpleObject := NewObjectType().WithProperties(fullName, familyName, legalName, knownAs)
+	validatedObject := NewValidatedType(simpleObject, StringValidations{})
+	optionalObject := NewOptionalType(validatedObject)
+
+	cases := map[string]struct {
+		theType               Type
+		propName              PropertyName
+		expectedPropertyCount int
+	}{
+		"Remove existing property from object": {
+			theType:               simpleObject,
+			propName:              legalName.propertyName,
+			expectedPropertyCount: 3,
+		},
+		"Remove existing property from validated object": {
+			theType:               validatedObject,
+			propName:              legalName.propertyName,
+			expectedPropertyCount: 3,
+		},
+		"Remove existing property from optional object": {
+			theType:               optionalObject,
+			propName:              legalName.propertyName,
+			expectedPropertyCount: 3,
+		},
+		"Remove non-existent property from object": {
+			theType:               simpleObject,
+			propName:              "DoesNotExist",
+			expectedPropertyCount: 4,
+		},
+	}
+
+	ref := makeTestLocalPackageReference("group", "2024-09-01")
+
+	remover := NewPropertyRemover()
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			// Arrange
+			def := MakeTypeDefinition(
+				MakeInternalTypeName(ref, "TestDef"),
+				c.theType)
+
+			// Act
+			newDef, err := remover.Remove(def, c.propName)
+			g.Expect(err).To(Succeed())
+
+			// Assert
+			obj, ok := AsObjectType(newDef.Type())
+			g.Expect(ok).To(BeTrue())
+			g.Expect(obj.properties.Len()).To(Equal(c.expectedPropertyCount))
+		})
+	}
+}

--- a/v2/tools/generator/internal/astmodel/readonly_object_type.go
+++ b/v2/tools/generator/internal/astmodel/readonly_object_type.go
@@ -1,0 +1,25 @@
+package astmodel
+
+type ReadonlyObjectType interface {
+	// Properties returns all the property definitions
+	Properties() ReadOnlyPropertySet
+
+	// Property returns the details of a specific property based on its unique case-sensitive name
+	Property(name PropertyName) (*PropertyDefinition, bool)
+
+	// EmbeddedProperties returns all the embedded properties
+	// A sorted slice is returned to preserve immutability and provide determinism
+	EmbeddedProperties() []*PropertyDefinition
+
+	IsResource() bool
+	Resources() TypeNameSet
+
+	// Functions returns all the function implementations
+	// A sorted slice is returned to preserve immutability and provide determinism
+	Functions() []Function
+
+	// HasFunctionWithName determines if this object has a function with the given name
+	HasFunctionWithName(name string) bool
+
+	TestCases() []TestCase
+}

--- a/v2/tools/generator/internal/astmodel/readonly_object_type.go
+++ b/v2/tools/generator/internal/astmodel/readonly_object_type.go
@@ -1,5 +1,13 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
 package astmodel
 
+// ReadonlyObjectType allows exposing an ObjectType for querying while prohibiting any modification.
+// This is useful as a convenience to consumers for working with ObjectTypes, while ensuring they
+// make any modifications using a TypeVisitor (or one of the Injectors based on TypeVisitor).
 type ReadonlyObjectType interface {
 	// Properties returns all the property definitions
 	Properties() ReadOnlyPropertySet

--- a/v2/tools/generator/internal/astmodel/type_definition_set.go
+++ b/v2/tools/generator/internal/astmodel/type_definition_set.go
@@ -373,7 +373,7 @@ func (set TypeDefinitionSet) AsSlice() []TypeDefinition {
 	return result
 }
 
-type ResolvedResourceDefinition struct {
+type ResourceSpecAndStatusResult struct {
 	ResourceDef  TypeDefinition
 	ResourceType *ResourceType
 
@@ -385,8 +385,8 @@ type ResolvedResourceDefinition struct {
 }
 
 // ResolveResourceSpecAndStatus takes a TypeDefinition that is a ResourceType and looks up its Spec and Status (as well as
-// the TypeDefinition's corresponding to them) and returns a ResolvedResourceDefinition
-func (set TypeDefinitionSet) ResolveResourceSpecAndStatus(resourceDef TypeDefinition) (*ResolvedResourceDefinition, error) {
+// the TypeDefinition's corresponding to them) and returns a ResourceSpecAndStatusResult
+func (set TypeDefinitionSet) ResolveResourceSpecAndStatus(resourceDef TypeDefinition) (*ResourceSpecAndStatusResult, error) {
 	return ResolveResourceSpecAndStatus(set, resourceDef)
 }
 
@@ -442,8 +442,8 @@ func ResolveResourceStatusDefinition(defs ReadonlyTypeDefinitions, resourceType 
 }
 
 // ResolveResourceSpecAndStatus takes a TypeDefinition that is a ResourceType and looks up its Spec and Status (as well as
-// the TypeDefinition's corresponding to them) and returns a ResolvedResourceDefinition
-func ResolveResourceSpecAndStatus(defs ReadonlyTypeDefinitions, resourceDef TypeDefinition) (*ResolvedResourceDefinition, error) {
+// the TypeDefinition's corresponding to them) and returns a ResourceSpecAndStatusResult
+func ResolveResourceSpecAndStatus(defs ReadonlyTypeDefinitions, resourceDef TypeDefinition) (*ResourceSpecAndStatusResult, error) {
 	resource, ok := AsResourceType(resourceDef.Type())
 	if !ok {
 		return nil, errors.Errorf("expected %q to be a Resource but instead it was a %T", resourceDef.Name(), resourceDef.Type())
@@ -474,7 +474,7 @@ func ResolveResourceSpecAndStatus(defs ReadonlyTypeDefinitions, resourceDef Type
 		}
 	}
 
-	return &ResolvedResourceDefinition{
+	return &ResourceSpecAndStatusResult{
 		ResourceDef:  resourceDef,
 		ResourceType: resource,
 		SpecDef:      specDef,

--- a/v2/tools/generator/internal/astmodel/type_definition_set.go
+++ b/v2/tools/generator/internal/astmodel/type_definition_set.go
@@ -378,10 +378,10 @@ type ResourceSpecAndStatusResult struct {
 	ResourceType *ResourceType
 
 	SpecDef  TypeDefinition
-	SpecType *ObjectType
+	SpecType ReadonlyObjectType
 
 	StatusDef  TypeDefinition
-	StatusType *ObjectType
+	StatusType ReadonlyObjectType
 }
 
 // ResolveResourceSpecAndStatus takes a TypeDefinition that is a ResourceType and looks up its Spec and Status (as well as

--- a/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
@@ -159,7 +159,7 @@ func (c *armTypeCreator) createARMResourceSpecDefinition(
 	if !ok {
 		return astmodel.TypeDefinition{},
 			errors.Errorf(
-				"expected resource %n to be a resource type, but got %s",
+				"expected resource %s to be a resource type, but got %s",
 				rsrcDef.Name(),
 				astmodel.DebugDescription(rsrcDef.Type(), rsrcDef.Name().InternalPackageReference()))
 	}

--- a/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
@@ -114,7 +114,7 @@ func (c *armTypeCreator) createARMTypes() (astmodel.TypeDefinitionSet, error) {
 
 		resourceSpecDefs.Add(resolved.SpecDef)
 
-		armSpecDef, err := c.createARMResourceSpecDefinition(resolved.ResourceType, resolved.SpecDef)
+		armSpecDef, err := c.createARMResourceSpecDefinition(resolved.ResourceDef, resolved.SpecDef)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to create arm resource spec definition for resource %s", def.Name())
 		}
@@ -152,14 +152,23 @@ func (c *armTypeCreator) createARMTypes() (astmodel.TypeDefinitionSet, error) {
 }
 
 func (c *armTypeCreator) createARMResourceSpecDefinition(
-	resource *astmodel.ResourceType,
-	resourceSpecDef astmodel.TypeDefinition,
+	rsrcDef astmodel.TypeDefinition,
+	specDef astmodel.TypeDefinition,
 ) (astmodel.TypeDefinition, error) {
+	resource, ok := astmodel.AsResourceType(rsrcDef.Type())
+	if !ok {
+		return astmodel.TypeDefinition{},
+			errors.Errorf(
+				"expected resource %n to be a resource type, but got %s",
+				rsrcDef.Name(),
+				astmodel.DebugDescription(rsrcDef.Type(), rsrcDef.Name().InternalPackageReference()))
+	}
+
 	emptyDef := astmodel.TypeDefinition{}
 
-	convContext := c.createSpecConversionContext(resourceSpecDef.Name())
+	convContext := c.createSpecConversionContext(specDef.Name())
 
-	armTypeDef, err := c.createARMTypeDefinition(resourceSpecDef, convContext)
+	armTypeDef, err := c.createARMTypeDefinition(specDef, convContext)
 	if err != nil {
 		return emptyDef, err
 	}

--- a/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
@@ -157,8 +157,6 @@ func AddKubernetesResourceInterfaceImpls(
 	return result, nil
 }
 
-// note that this can, as a side effect, update the resource type
-// it is a bit ugly!
 func createAzureNameFunctionHandlersForType(
 	t astmodel.Type,
 	definitions astmodel.TypeDefinitionSet,

--- a/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
@@ -59,7 +59,8 @@ func AddKubernetesResourceInterfaceImpls(
 	if nameFns.removeAzureNameProperty {
 		// remove the AzureName property from the spec of the resource
 		remover := astmodel.NewPropertyRemover()
-		updated, err := remover.Remove(resolved.SpecDef, astmodel.AzureNameProperty)
+		var updated astmodel.TypeDefinition
+		updated, err = remover.Remove(resolved.SpecDef, astmodel.AzureNameProperty)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to remove AzureName property from resource %s", resourceDef.Name())
 		}

--- a/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
@@ -20,46 +20,54 @@ import (
 )
 
 // AddKubernetesResourceInterfaceImpls adds the required interfaces for
-// the resource to be a Kubernetes resource
+// the resource to be a Kubernetes resource.
+// Returns a set of modified definitions.
 func AddKubernetesResourceInterfaceImpls(
 	resourceDef astmodel.TypeDefinition,
 	idFactory astmodel.IdentifierFactory,
 	definitions astmodel.TypeDefinitionSet,
 	log logr.Logger,
-) (*astmodel.ResourceType, error) {
+) (astmodel.TypeDefinitionSet, error) {
 	resolved, err := definitions.ResolveResourceSpecAndStatus(resourceDef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to resolve resource %s", resourceDef.Name())
 	}
 
-	spec := resolved.SpecType
+	specDef := resolved.SpecDef
 	r := resolved.ResourceType
 
 	// Check the spec first to ensure it looks how we expect
 	if r.Scope() == astmodel.ResourceScopeResourceGroup || r.Scope() == astmodel.ResourceScopeExtension {
 		ownerProperty := idFactory.CreatePropertyName(astmodel.OwnerProperty, astmodel.Exported)
-		_, ok := spec.Property(ownerProperty)
+		_, ok := resolved.SpecType.Property(ownerProperty)
 		if !ok {
 			return nil, errors.Errorf("resource spec doesn't have %q property", ownerProperty)
 		}
 	}
 
-	azureNameProp, ok := spec.Property(astmodel.AzureNameProperty)
+	azureNameProp, ok := resolved.SpecType.Property(astmodel.AzureNameProperty)
 	if !ok {
 		return nil, errors.Errorf("resource spec doesn't have %q property", astmodel.AzureNameProperty)
 	}
 
-	getNameFunction, setNameFunction, err := getAzureNameFunctionsForType(
-		&r,
-		spec,
-		azureNameProp.PropertyType(),
-		definitions,
-		log)
+	nameFns, err := createAzureNameFunctionHandlersForType(azureNameProp.PropertyType(), definitions, log)
 	if err != nil {
 		return nil, err
 	}
 
-	getAzureNameProperty := functions.NewObjectFunction(astmodel.AzureNameProperty, idFactory, getNameFunction)
+	// Sometimes we need to remove the AzureName property from our Spec because the name is forced
+	if nameFns.removeAzureNameProperty {
+		// remove the AzureName property from the spec of the resource
+		remover := astmodel.NewPropertyRemover()
+		updated, err := remover.Remove(resolved.SpecDef, astmodel.AzureNameProperty)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to remove AzureName property from resource %s", resourceDef.Name())
+		}
+
+		specDef = updated
+	}
+
+	getAzureNameProperty := functions.NewObjectFunction(astmodel.AzureNameProperty, idFactory, nameFns.getNameFunction)
 	getAzureNameProperty.AddPackageReference(astmodel.GenRuntimeReference)
 
 	getOwnerProperty := functions.NewResourceFunction(
@@ -119,38 +127,42 @@ func AddKubernetesResourceInterfaceImpls(
 
 	kubernetesResourceImplementation := astmodel.NewInterfaceImplementation(astmodel.KubernetesResourceType, fns...)
 
-	r = r.WithInterface(kubernetesResourceImplementation)
-
-	if setNameFunction != nil {
-		// this function applies to Spec not the resource
-		// re-fetch the spec ObjectType since the getAzureNameFunctionsForType
-		// could have updated it
-		spec := r.SpecType()
-		spec, err = definitions.FullyResolve(spec)
-		if err != nil {
-			return nil, err
-		}
-
-		specObj := spec.(*astmodel.ObjectType)
-
-		setFn := functions.NewObjectFunction(astmodel.SetAzureNameFunc, idFactory, setNameFunction)
-		setFn.AddPackageReference(astmodel.GenRuntimeReference)
-
-		r = r.WithSpec(specObj.WithFunction(setFn))
+	interfaceInjector := astmodel.NewInterfaceInjector()
+	updatedResource, err := interfaceInjector.Inject(resolved.ResourceDef, kubernetesResourceImplementation)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to inject KubernetesResource interface into resource %s", resourceDef.Name())
 	}
 
-	return r, nil
+	if nameFns.setNameFunction != nil {
+		// this function applies to Spec not the resource
+		functionInjector := astmodel.NewFunctionInjector()
+
+		setFn := functions.NewObjectFunction(astmodel.SetAzureNameFunc, idFactory, nameFns.setNameFunction)
+		setFn.AddPackageReference(astmodel.GenRuntimeReference)
+
+		updated, err := functionInjector.Inject(specDef, setFn)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to inject SetAzureName function into resource %s", resourceDef.Name())
+		}
+
+		specDef = updated
+	}
+
+	result := astmodel.MakeTypeDefinitionSetFromDefinitions(
+		updatedResource,
+		specDef,
+	)
+
+	return result, nil
 }
 
 // note that this can, as a side effect, update the resource type
 // it is a bit ugly!
-func getAzureNameFunctionsForType(
-	r **astmodel.ResourceType,
-	spec *astmodel.ObjectType,
+func createAzureNameFunctionHandlersForType(
 	t astmodel.Type,
 	definitions astmodel.TypeDefinitionSet,
 	log logr.Logger,
-) (functions.ObjectFunctionHandler, functions.ObjectFunctionHandler, error) {
+) (createAzureNameFunctionsForTypeResult, error) {
 	if opt, ok := astmodel.AsOptionalType(t); ok {
 		t = opt.BaseType()
 	}
@@ -159,36 +171,48 @@ func getAzureNameFunctionsForType(
 	switch azureNamePropType := t.(type) {
 	case *astmodel.ValidatedType:
 		if !astmodel.TypeEquals(azureNamePropType.ElementType(), astmodel.StringType) {
-			return nil, nil, errors.Errorf("unable to handle non-string validated definitions in AzureName property")
+			return createAzureNameFunctionsForTypeResult{},
+				errors.Errorf("unable to handle non-string validated definitions in AzureName property")
 		}
 
 		validations := azureNamePropType.Validations().(astmodel.StringValidations)
 		if len(validations.Patterns) != 0 {
 			if len(validations.Patterns) == 1 &&
 				validations.Patterns[0].String() == "^.*/default$" {
-				*r = (*r).WithSpec(spec.WithoutProperty(astmodel.AzureNameProperty))
-				return fixedValueGetAzureNameFunction("default"), nil, nil // no SetAzureName for this case
-			} else {
-				// ignoring for now:
-				log.V(1).Info("ignoring pattern validation on Name property", "pattern", validations.Patterns[0].String())
-				return getStringAzureNameFunction, setStringAzureNameFunction, nil
+				// Validation requires the resource be named exactly "default"
+				return createAzureNameFunctionsForTypeResult{
+					getNameFunction:         fixedValueGetAzureNameFunction("default"),
+					removeAzureNameProperty: true,
+				}, nil
 			}
-		} else {
-			// ignoring length validations for now
-			// return nil, errors.Errorf("unable to handle validations on Name property …TODO")
-			return getStringAzureNameFunction, setStringAzureNameFunction, nil
+
+			// ignoring for now:
+			log.V(1).Info("ignoring pattern validation on Name property", "pattern", validations.Patterns[0].String())
+			return createAzureNameFunctionsForTypeResult{
+				getNameFunction: getStringAzureNameFunction,
+				setNameFunction: setStringAzureNameFunction,
+			}, nil
 		}
+
+		// ignoring length validations for now
+		// return nil, errors.Errorf("unable to handle validations on Name property …TODO")
+		return createAzureNameFunctionsForTypeResult{
+			getNameFunction: getStringAzureNameFunction,
+			setNameFunction: setStringAzureNameFunction,
+		}, nil
 
 	case astmodel.TypeName:
 		// resolve property type if it is a typename
 		resolvedPropType, err := definitions.FullyResolve(azureNamePropType)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "unable to resolve type of resource Name property: %s", azureNamePropType.String())
+			return createAzureNameFunctionsForTypeResult{},
+				errors.Wrapf(err, "unable to resolve type of resource Name property: %s", azureNamePropType.String())
 		}
 
 		if t, ok := resolvedPropType.(*astmodel.EnumType); ok {
 			if !astmodel.TypeEquals(t.BaseType(), astmodel.StringType) {
-				return nil, nil, errors.Errorf("unable to handle non-string enum base type in Name property")
+				return createAzureNameFunctionsForTypeResult{},
+					errors.Errorf("unable to handle non-string enum base type in Name property")
 			}
 
 			options := t.Options()
@@ -196,27 +220,44 @@ func getAzureNameFunctionsForType(
 				// if there is only one possible value,
 				// we make an AzureName function that returns it, and do not
 				// provide an AzureName property on the spec
-				*r = (*r).WithSpec(spec.WithoutProperty(astmodel.AzureNameProperty))
-				return fixedValueGetAzureNameFunction(options[0].Value), nil, nil // no SetAzureName for this case
-			} else {
-				// with multiple values, provide an AzureName function that casts from the
-				// enum-valued AzureName property:
-				return getEnumAzureNameFunction(azureNamePropType), setEnumAzureNameFunction(azureNamePropType), nil
+				return createAzureNameFunctionsForTypeResult{
+					getNameFunction:         fixedValueGetAzureNameFunction(options[0].Value),
+					removeAzureNameProperty: true,
+				}, nil
 			}
-		} else {
-			return nil, nil, errors.Errorf("unable to produce AzureName()/SetAzureName() for Name property with type %s", resolvedPropType.String())
+
+			// with multiple values, provide an AzureName function that casts from the
+			// enum-valued AzureName property:
+			return createAzureNameFunctionsForTypeResult{
+				getNameFunction: getEnumAzureNameFunction(azureNamePropType),
+				setNameFunction: setEnumAzureNameFunction(azureNamePropType),
+			}, nil
 		}
+
+		return createAzureNameFunctionsForTypeResult{},
+			errors.Errorf("unable to produce AzureName()/SetAzureName() for Name property with type %s", resolvedPropType.String())
 
 	case *astmodel.PrimitiveType:
 		if !astmodel.TypeEquals(azureNamePropType, astmodel.StringType) {
-			return nil, nil, errors.Errorf("cannot use type %s as type of AzureName property", azureNamePropType.String())
+			return createAzureNameFunctionsForTypeResult{},
+				errors.Errorf("cannot use type %s as type of AzureName property", azureNamePropType.String())
 		}
 
-		return getStringAzureNameFunction, setStringAzureNameFunction, nil
+		return createAzureNameFunctionsForTypeResult{
+			getNameFunction: getStringAzureNameFunction,
+			setNameFunction: setStringAzureNameFunction,
+		}, nil
 
 	default:
-		return nil, nil, errors.Errorf("unsupported type for AzureName property: %s", azureNamePropType.String())
+		return createAzureNameFunctionsForTypeResult{},
+			errors.Errorf("unsupported type for AzureName property: %s", azureNamePropType.String())
 	}
+}
+
+type createAzureNameFunctionsForTypeResult struct {
+	getNameFunction         functions.ObjectFunctionHandler
+	setNameFunction         functions.ObjectFunctionHandler
+	removeAzureNameProperty bool
 }
 
 // getEnumAzureNameFunction adds an AzureName() function that casts the AzureName property


### PR DESCRIPTION
**What this PR does / why we need it**:

While convenience functions like `AsObjectType()` and `AsResourceType()` are, well, convenient, they can cause issues if the results are then used to create new types - because they will strip out and discard type structure information that should be retained.

While troubleshooting issues related to import of the `kusto` group of resources, we discovered a couple places where this was happening, resulting in issues. This PR addresses those issues.

**Special notes for your reviewer**:

Once merged, @super-harsh should be able to merge the changes into their working branch.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/l4q8hciiYNT5RGi4w/giphy.gif?cid=790b7611hr4xqximt4glpzgbdy1nw49nkbhs72lfa055st1w&ep=v1_gifs_search&rid=giphy.gif&ct=g)
