### PR TITLE
Update redis migration docs with correct redis key

### DIFF
--- a/docs/hugo/content/guide/asov1-asov2-migration/redis.md
+++ b/docs/hugo/content/guide/asov1-asov2-migration/redis.md
@@ -25,8 +25,8 @@ spec:
     secrets:
       primaryKey:
         name: rediscache-rediscache-sample-1-asov2
-        key: primarykey
-      key1:
+        key: primaryKey
+      secondaryKey:
         name: rediscache-rediscache-sample-1-asov2
         key: secondaryKey
 ```


### PR DESCRIPTION
https://azure.github.io/azure-service-operator/reference/cache/v1api20230401/#cache.azure.com/v1api20230401.Redis It should definitely be 'secondaryKey' not key1

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Closes #[issue number]

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://giphy.com/)

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
