### PR TITLE
Include flags in the type catalog report

### DIFF
--- a/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
+++ b/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
@@ -15,8 +15,6 @@ import (
 	"sync"
 	"unicode"
 
-	"github.com/Azure/azure-service-operator/v2/cmd/asoctl/pkg/importreporter"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/go-logr/logr"

--- a/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
+++ b/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 	"unicode"
 
+	"github.com/Azure/azure-service-operator/v2/cmd/asoctl/pkg/importreporter"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/go-logr/logr"

--- a/v2/tools/generator/internal/astmodel/flagged_type.go
+++ b/v2/tools/generator/internal/astmodel/flagged_type.go
@@ -55,6 +55,11 @@ func (ft *FlaggedType) HasFlag(flag TypeFlag) bool {
 	return ft.flags.Contains(flag)
 }
 
+// Flags returns all the flags present on this type
+func (ft *FlaggedType) Flags() []TypeFlag {
+	return set.AsSortedSlice(ft.flags)
+}
+
 // WithFlag returns a new FlaggedType with the specified flag added
 func (ft *FlaggedType) WithFlag(flag TypeFlag) *FlaggedType {
 	return NewFlaggedType(ft, flag)

--- a/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
+++ b/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
@@ -25,8 +25,14 @@ type OneOfJSONMarshalFunction struct {
 }
 
 // NewOneOfJSONMarshalFunction creates a new OneOfJSONMarshalFunction struct
-func NewOneOfJSONMarshalFunction(oneOfObject *astmodel.ObjectType, idFactory astmodel.IdentifierFactory) *OneOfJSONMarshalFunction {
-	return &OneOfJSONMarshalFunction{oneOfObject, idFactory}
+func NewOneOfJSONMarshalFunction(
+	oneOfObject *astmodel.ObjectType,
+	idFactory astmodel.IdentifierFactory,
+) *OneOfJSONMarshalFunction {
+	return &OneOfJSONMarshalFunction{
+		oneOfObject,
+		idFactory,
+	}
 }
 
 // Ensure OneOfJSONMarshalFunction implements Function interface correctly

--- a/v2/tools/generator/internal/reporting/type_catalog_report.go
+++ b/v2/tools/generator/internal/reporting/type_catalog_report.go
@@ -208,6 +208,8 @@ func (tcr *TypeCatalogReport) writeType(
 		tcr.writeErroredType(rpt, t, currentPackage, parentTypes)
 	case *astmodel.ValidatedType:
 		tcr.writeValidatedType(rpt, t, currentPackage, parentTypes)
+	case *astmodel.FlaggedType:
+		tcr.writeFlaggedType(rpt, t, currentPackage, parentTypes)
 	case astmodel.MetaType:
 		tcr.writeType(rpt, t.Unwrap(), currentPackage, parentTypes)
 	default:
@@ -350,12 +352,27 @@ func (tcr *TypeCatalogReport) writeErroredType(
 func (tcr *TypeCatalogReport) writeValidatedType(
 	rpt *StructureReport,
 	vt *astmodel.ValidatedType,
-	_ astmodel.InternalPackageReference,
-	_ astmodel.TypeNameSet,
+	currentPackage astmodel.InternalPackageReference,
+	types astmodel.TypeNameSet,
 ) {
 	for index, rule := range vt.Validations().ToKubeBuilderValidations() {
 		rpt.Addf("Rule %d: %s", index, rule)
 	}
+
+	tcr.writeType(rpt, vt.ElementType(), currentPackage, types)
+}
+
+func (tcr *TypeCatalogReport) writeFlaggedType(
+	rpt *StructureReport,
+	ft *astmodel.FlaggedType,
+	currentPackage astmodel.InternalPackageReference,
+	types astmodel.TypeNameSet,
+) {
+	for index, flag := range ft.Flags() {
+		rpt.Addf("Flag %d: %s", index, flag)
+	}
+
+	tcr.writeType(rpt, ft.Element(), currentPackage, types)
 }
 
 // asDefinitionToInline returns the definition to inline, if any.


### PR DESCRIPTION
# What this PR does 

Our type catalog report was omitting flags, which caused problems solving a problem with OneOf types recently. 

This PR adds flags into the report for visibility.

## Special notes for your reviewer

Includes a few minor pieces of code gardening.

## How does this PR make you feel
![gif](https://media.giphy.com/media/tXEXqNME36QO2fWOnd/giphy.gif?cid=790b7611nolhydps3bw9wcos9vhlrqsfcj5whio6tm9txtrx&ep=v1_gifs_search&rid=giphy.gif&ct=g)
