### PR TITLE
Allow the data encryption keys for PostgreSQL Flexible server to be configured

### DIFF
--- a/v2/api/dbforpostgresql/v1api20221201/flexible_server_spec_arm_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20221201/flexible_server_spec_arm_types_gen.go
@@ -129,7 +129,7 @@ type Backup_ARM struct {
 // Data encryption properties of a server
 type DataEncryption_ARM struct {
 	// PrimaryKeyURI: URI for the key for data encryption for primary server.
-	PrimaryKeyURI                 *string `json:"primaryKeyURI,omitempty"`
+	PrimaryKeyURI                 *string `json:"primaryKeyURI,omitempty" optionalConfigMapPair:"PrimaryKeyURI"`
 	PrimaryUserAssignedIdentityId *string `json:"primaryUserAssignedIdentityId,omitempty"`
 
 	// Type: Data encryption type to depict if it is System Managed vs Azure Key vault.

--- a/v2/api/dbforpostgresql/v1api20221201/storage/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20221201/storage/flexible_server_types_gen.go
@@ -315,7 +315,8 @@ type Backup_STATUS struct {
 // Storage version of v1api20221201.DataEncryption
 // Data encryption properties of a server
 type DataEncryption struct {
-	PrimaryKeyURI *string `json:"primaryKeyURI,omitempty"`
+	PrimaryKeyURI           *string                        `json:"primaryKeyURI,omitempty" optionalConfigMapPair:"PrimaryKeyURI"`
+	PrimaryKeyURIFromConfig *genruntime.ConfigMapReference `json:"primaryKeyURIFromConfig,omitempty" optionalConfigMapPair:"PrimaryKeyURI"`
 
 	// PrimaryUserAssignedIdentityReference: Resource Id for the User assigned identity to be used for data encryption for
 	// primary server.

--- a/v2/api/dbforpostgresql/v1api20221201/storage/structure.txt
+++ b/v2/api/dbforpostgresql/v1api20221201/storage/structure.txt
@@ -20,8 +20,9 @@ FlexibleServer: Resource
 │   │   ├── GeoRedundantBackup: *string
 │   │   └── PropertyBag: genruntime.PropertyBag
 │   ├── CreateMode: *string
-│   ├── DataEncryption: *Object (4 properties)
+│   ├── DataEncryption: *Object (5 properties)
 │   │   ├── PrimaryKeyURI: *string
+│   │   ├── PrimaryKeyURIFromConfig: *genruntime.ConfigMapReference
 │   │   ├── PrimaryUserAssignedIdentityReference: *genruntime.ResourceReference
 │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   └── Type: *string

--- a/v2/api/dbforpostgresql/v1api20221201/storage/zz_generated.deepcopy.go
+++ b/v2/api/dbforpostgresql/v1api20221201/storage/zz_generated.deepcopy.go
@@ -166,6 +166,11 @@ func (in *DataEncryption) DeepCopyInto(out *DataEncryption) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.PrimaryKeyURIFromConfig != nil {
+		in, out := &in.PrimaryKeyURIFromConfig, &out.PrimaryKeyURIFromConfig
+		*out = new(genruntime.ConfigMapReference)
+		**out = **in
+	}
 	if in.PrimaryUserAssignedIdentityReference != nil {
 		in, out := &in.PrimaryUserAssignedIdentityReference, &out.PrimaryUserAssignedIdentityReference
 		*out = new(genruntime.ResourceReference)

--- a/v2/api/dbforpostgresql/v1api20221201/structure.txt
+++ b/v2/api/dbforpostgresql/v1api20221201/structure.txt
@@ -33,8 +33,9 @@ FlexibleServer: Resource
 │   │   ├── "PointInTimeRestore"
 │   │   ├── "Replica"
 │   │   └── "Update"
-│   ├── DataEncryption: *Object (3 properties)
+│   ├── DataEncryption: *Object (4 properties)
 │   │   ├── PrimaryKeyURI: *string
+│   │   ├── PrimaryKeyURIFromConfig: *genruntime.ConfigMapReference
 │   │   ├── PrimaryUserAssignedIdentityReference: *genruntime.ResourceReference
 │   │   └── Type: *Enum (2 values)
 │   │       ├── "AzureKeyVault"

--- a/v2/api/dbforpostgresql/v1api20221201/zz_generated.deepcopy.go
+++ b/v2/api/dbforpostgresql/v1api20221201/zz_generated.deepcopy.go
@@ -348,6 +348,11 @@ func (in *DataEncryption) DeepCopyInto(out *DataEncryption) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.PrimaryKeyURIFromConfig != nil {
+		in, out := &in.PrimaryKeyURIFromConfig, &out.PrimaryKeyURIFromConfig
+		*out = new(genruntime.ConfigMapReference)
+		**out = **in
+	}
 	if in.PrimaryUserAssignedIdentityReference != nil {
 		in, out := &in.PrimaryUserAssignedIdentityReference, &out.PrimaryUserAssignedIdentityReference
 		*out = new(genruntime.ResourceReference)

--- a/v2/api/dbforpostgresql/v1api20230601preview/flexible_server_spec_arm_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20230601preview/flexible_server_spec_arm_types_gen.go
@@ -136,14 +136,14 @@ type DataEncryption_ARM struct {
 	GeoBackupEncryptionKeyStatus *DataEncryption_GeoBackupEncryptionKeyStatus_ARM `json:"geoBackupEncryptionKeyStatus,omitempty"`
 
 	// GeoBackupKeyURI: URI for the key in keyvault for data encryption for geo-backup of server.
-	GeoBackupKeyURI                 *string `json:"geoBackupKeyURI,omitempty"`
+	GeoBackupKeyURI                 *string `json:"geoBackupKeyURI,omitempty" optionalConfigMapPair:"GeoBackupKeyURI"`
 	GeoBackupUserAssignedIdentityId *string `json:"geoBackupUserAssignedIdentityId,omitempty"`
 
 	// PrimaryEncryptionKeyStatus: Primary encryption key status for Data encryption enabled server.
 	PrimaryEncryptionKeyStatus *DataEncryption_PrimaryEncryptionKeyStatus_ARM `json:"primaryEncryptionKeyStatus,omitempty"`
 
 	// PrimaryKeyURI: URI for the key in keyvault for data encryption of the primary server.
-	PrimaryKeyURI                 *string `json:"primaryKeyURI,omitempty"`
+	PrimaryKeyURI                 *string `json:"primaryKeyURI,omitempty" optionalConfigMapPair:"PrimaryKeyURI"`
 	PrimaryUserAssignedIdentityId *string `json:"primaryUserAssignedIdentityId,omitempty"`
 
 	// Type: Data encryption type to depict if it is System Managed vs Azure Key vault.

--- a/v2/api/dbforpostgresql/v1api20230601preview/storage/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20230601preview/storage/flexible_server_types_gen.go
@@ -1597,14 +1597,16 @@ func (backup *Backup_STATUS) AssignProperties_To_Backup_STATUS(destination *stor
 // Storage version of v1api20230601preview.DataEncryption
 // Data encryption properties of a server
 type DataEncryption struct {
-	GeoBackupEncryptionKeyStatus *string `json:"geoBackupEncryptionKeyStatus,omitempty"`
-	GeoBackupKeyURI              *string `json:"geoBackupKeyURI,omitempty"`
+	GeoBackupEncryptionKeyStatus *string                        `json:"geoBackupEncryptionKeyStatus,omitempty"`
+	GeoBackupKeyURI              *string                        `json:"geoBackupKeyURI,omitempty" optionalConfigMapPair:"GeoBackupKeyURI"`
+	GeoBackupKeyURIFromConfig    *genruntime.ConfigMapReference `json:"geoBackupKeyURIFromConfig,omitempty" optionalConfigMapPair:"GeoBackupKeyURI"`
 
 	// GeoBackupUserAssignedIdentityReference: Resource Id for the User assigned identity to be used for data encryption for
 	// geo-backup of server.
-	GeoBackupUserAssignedIdentityReference *genruntime.ResourceReference `armReference:"GeoBackupUserAssignedIdentityId" json:"geoBackupUserAssignedIdentityReference,omitempty"`
-	PrimaryEncryptionKeyStatus             *string                       `json:"primaryEncryptionKeyStatus,omitempty"`
-	PrimaryKeyURI                          *string                       `json:"primaryKeyURI,omitempty"`
+	GeoBackupUserAssignedIdentityReference *genruntime.ResourceReference  `armReference:"GeoBackupUserAssignedIdentityId" json:"geoBackupUserAssignedIdentityReference,omitempty"`
+	PrimaryEncryptionKeyStatus             *string                        `json:"primaryEncryptionKeyStatus,omitempty"`
+	PrimaryKeyURI                          *string                        `json:"primaryKeyURI,omitempty" optionalConfigMapPair:"PrimaryKeyURI"`
+	PrimaryKeyURIFromConfig                *genruntime.ConfigMapReference `json:"primaryKeyURIFromConfig,omitempty" optionalConfigMapPair:"PrimaryKeyURI"`
 
 	// PrimaryUserAssignedIdentityReference: Resource Id for the User assigned identity to be used for data encryption of the
 	// primary server.
@@ -1644,6 +1646,19 @@ func (encryption *DataEncryption) AssignProperties_From_DataEncryption(source *s
 		encryption.GeoBackupKeyURI = nil
 	}
 
+	// GeoBackupKeyURIFromConfig
+	if propertyBag.Contains("GeoBackupKeyURIFromConfig") {
+		var geoBackupKeyURIFromConfig genruntime.ConfigMapReference
+		err := propertyBag.Pull("GeoBackupKeyURIFromConfig", &geoBackupKeyURIFromConfig)
+		if err != nil {
+			return errors.Wrap(err, "pulling 'GeoBackupKeyURIFromConfig' from propertyBag")
+		}
+
+		encryption.GeoBackupKeyURIFromConfig = &geoBackupKeyURIFromConfig
+	} else {
+		encryption.GeoBackupKeyURIFromConfig = nil
+	}
+
 	// GeoBackupUserAssignedIdentityReference
 	if propertyBag.Contains("GeoBackupUserAssignedIdentityReference") {
 		var geoBackupUserAssignedIdentityReference genruntime.ResourceReference
@@ -1672,6 +1687,14 @@ func (encryption *DataEncryption) AssignProperties_From_DataEncryption(source *s
 
 	// PrimaryKeyURI
 	encryption.PrimaryKeyURI = genruntime.ClonePointerToString(source.PrimaryKeyURI)
+
+	// PrimaryKeyURIFromConfig
+	if source.PrimaryKeyURIFromConfig != nil {
+		primaryKeyURIFromConfig := source.PrimaryKeyURIFromConfig.Copy()
+		encryption.PrimaryKeyURIFromConfig = &primaryKeyURIFromConfig
+	} else {
+		encryption.PrimaryKeyURIFromConfig = nil
+	}
 
 	// PrimaryUserAssignedIdentityReference
 	if source.PrimaryUserAssignedIdentityReference != nil {
@@ -1723,6 +1746,13 @@ func (encryption *DataEncryption) AssignProperties_To_DataEncryption(destination
 		propertyBag.Remove("GeoBackupKeyURI")
 	}
 
+	// GeoBackupKeyURIFromConfig
+	if encryption.GeoBackupKeyURIFromConfig != nil {
+		propertyBag.Add("GeoBackupKeyURIFromConfig", *encryption.GeoBackupKeyURIFromConfig)
+	} else {
+		propertyBag.Remove("GeoBackupKeyURIFromConfig")
+	}
+
 	// GeoBackupUserAssignedIdentityReference
 	if encryption.GeoBackupUserAssignedIdentityReference != nil {
 		propertyBag.Add("GeoBackupUserAssignedIdentityReference", *encryption.GeoBackupUserAssignedIdentityReference)
@@ -1739,6 +1769,14 @@ func (encryption *DataEncryption) AssignProperties_To_DataEncryption(destination
 
 	// PrimaryKeyURI
 	destination.PrimaryKeyURI = genruntime.ClonePointerToString(encryption.PrimaryKeyURI)
+
+	// PrimaryKeyURIFromConfig
+	if encryption.PrimaryKeyURIFromConfig != nil {
+		primaryKeyURIFromConfig := encryption.PrimaryKeyURIFromConfig.Copy()
+		destination.PrimaryKeyURIFromConfig = &primaryKeyURIFromConfig
+	} else {
+		destination.PrimaryKeyURIFromConfig = nil
+	}
 
 	// PrimaryUserAssignedIdentityReference
 	if encryption.PrimaryUserAssignedIdentityReference != nil {

--- a/v2/api/dbforpostgresql/v1api20230601preview/storage/structure.txt
+++ b/v2/api/dbforpostgresql/v1api20230601preview/storage/structure.txt
@@ -20,12 +20,14 @@ FlexibleServer: Resource
 │   │   ├── GeoRedundantBackup: *string
 │   │   └── PropertyBag: genruntime.PropertyBag
 │   ├── CreateMode: *string
-│   ├── DataEncryption: *Object (8 properties)
+│   ├── DataEncryption: *Object (10 properties)
 │   │   ├── GeoBackupEncryptionKeyStatus: *string
 │   │   ├── GeoBackupKeyURI: *string
+│   │   ├── GeoBackupKeyURIFromConfig: *genruntime.ConfigMapReference
 │   │   ├── GeoBackupUserAssignedIdentityReference: *genruntime.ResourceReference
 │   │   ├── PrimaryEncryptionKeyStatus: *string
 │   │   ├── PrimaryKeyURI: *string
+│   │   ├── PrimaryKeyURIFromConfig: *genruntime.ConfigMapReference
 │   │   ├── PrimaryUserAssignedIdentityReference: *genruntime.ResourceReference
 │   │   ├── PropertyBag: genruntime.PropertyBag
 │   │   └── Type: *string

--- a/v2/api/dbforpostgresql/v1api20230601preview/storage/zz_generated.deepcopy.go
+++ b/v2/api/dbforpostgresql/v1api20230601preview/storage/zz_generated.deepcopy.go
@@ -171,6 +171,11 @@ func (in *DataEncryption) DeepCopyInto(out *DataEncryption) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.GeoBackupKeyURIFromConfig != nil {
+		in, out := &in.GeoBackupKeyURIFromConfig, &out.GeoBackupKeyURIFromConfig
+		*out = new(genruntime.ConfigMapReference)
+		**out = **in
+	}
 	if in.GeoBackupUserAssignedIdentityReference != nil {
 		in, out := &in.GeoBackupUserAssignedIdentityReference, &out.GeoBackupUserAssignedIdentityReference
 		*out = new(genruntime.ResourceReference)
@@ -184,6 +189,11 @@ func (in *DataEncryption) DeepCopyInto(out *DataEncryption) {
 	if in.PrimaryKeyURI != nil {
 		in, out := &in.PrimaryKeyURI, &out.PrimaryKeyURI
 		*out = new(string)
+		**out = **in
+	}
+	if in.PrimaryKeyURIFromConfig != nil {
+		in, out := &in.PrimaryKeyURIFromConfig, &out.PrimaryKeyURIFromConfig
+		*out = new(genruntime.ConfigMapReference)
 		**out = **in
 	}
 	if in.PrimaryUserAssignedIdentityReference != nil {

--- a/v2/api/dbforpostgresql/v1api20230601preview/structure.txt
+++ b/v2/api/dbforpostgresql/v1api20230601preview/structure.txt
@@ -34,16 +34,18 @@ FlexibleServer: Resource
 │   │   ├── "Replica"
 │   │   ├── "ReviveDropped"
 │   │   └── "Update"
-│   ├── DataEncryption: *Object (7 properties)
+│   ├── DataEncryption: *Object (9 properties)
 │   │   ├── GeoBackupEncryptionKeyStatus: *Enum (2 values)
 │   │   │   ├── "Invalid"
 │   │   │   └── "Valid"
 │   │   ├── GeoBackupKeyURI: *string
+│   │   ├── GeoBackupKeyURIFromConfig: *genruntime.ConfigMapReference
 │   │   ├── GeoBackupUserAssignedIdentityReference: *genruntime.ResourceReference
 │   │   ├── PrimaryEncryptionKeyStatus: *Enum (2 values)
 │   │   │   ├── "Invalid"
 │   │   │   └── "Valid"
 │   │   ├── PrimaryKeyURI: *string
+│   │   ├── PrimaryKeyURIFromConfig: *genruntime.ConfigMapReference
 │   │   ├── PrimaryUserAssignedIdentityReference: *genruntime.ResourceReference
 │   │   └── Type: *Enum (2 values)
 │   │       ├── "AzureKeyVault"

--- a/v2/api/dbforpostgresql/v1api20230601preview/zz_generated.deepcopy.go
+++ b/v2/api/dbforpostgresql/v1api20230601preview/zz_generated.deepcopy.go
@@ -353,6 +353,11 @@ func (in *DataEncryption) DeepCopyInto(out *DataEncryption) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.GeoBackupKeyURIFromConfig != nil {
+		in, out := &in.GeoBackupKeyURIFromConfig, &out.GeoBackupKeyURIFromConfig
+		*out = new(genruntime.ConfigMapReference)
+		**out = **in
+	}
 	if in.GeoBackupUserAssignedIdentityReference != nil {
 		in, out := &in.GeoBackupUserAssignedIdentityReference, &out.GeoBackupUserAssignedIdentityReference
 		*out = new(genruntime.ResourceReference)
@@ -366,6 +371,11 @@ func (in *DataEncryption) DeepCopyInto(out *DataEncryption) {
 	if in.PrimaryKeyURI != nil {
 		in, out := &in.PrimaryKeyURI, &out.PrimaryKeyURI
 		*out = new(string)
+		**out = **in
+	}
+	if in.PrimaryKeyURIFromConfig != nil {
+		in, out := &in.PrimaryKeyURIFromConfig, &out.PrimaryKeyURIFromConfig
+		*out = new(genruntime.ConfigMapReference)
 		**out = **in
 	}
 	if in.PrimaryUserAssignedIdentityReference != nil {

--- a/v2/azure-arm.yaml
+++ b/v2/azure-arm.yaml
@@ -1974,6 +1974,8 @@ objectModelConfiguration:
           $armReference: true
     2022-12-01:
       DataEncryption:
+        PrimaryKeyURI:
+          $importConfigMapMode: optional
         PrimaryUserAssignedIdentityId:
           $armReference: true
       FlexibleServer:
@@ -2002,9 +2004,13 @@ objectModelConfiguration:
           $armReference: true
     2023-06-01-preview:
       DataEncryption:
-        PrimaryUserAssignedIdentityId:
-          $armReference: true
+        GeoBackupKeyURI:
+          $importConfigMapMode: optional
         GeoBackupUserAssignedIdentityId:
+          $armReference: true
+        PrimaryKeyURI:
+          $importConfigMapMode: optional
+        PrimaryUserAssignedIdentityId:
           $armReference: true
       FlexibleServer:
         $azureGeneratedSecrets:

--- a/v2/internal/controllers/controller_resources_gen.go
+++ b/v2/internal/controllers/controller_resources_gen.go
@@ -618,11 +618,19 @@ func getKnownStorageTypes() []*registration.StorageType {
 				Key:  ".spec.administratorLoginPassword",
 				Func: indexDbforpostgresqlFlexibleServerAdministratorLoginPassword,
 			},
+			{
+				Key:  ".spec.dataEncryption.primaryKeyURIFromConfig",
+				Func: indexDbforpostgresqlFlexibleServerPrimaryKeyURIFromConfig,
+			},
 		},
 		Watches: []registration.Watch{
 			{
 				Type:             &v1.Secret{},
 				MakeEventHandler: watchSecretsFactory([]string{".spec.administratorLoginPassword"}, &dbforpostgresql_v20221201s.FlexibleServerList{}),
+			},
+			{
+				Type:             &v1.ConfigMap{},
+				MakeEventHandler: watchConfigMapsFactory([]string{".spec.dataEncryption.primaryKeyURIFromConfig"}, &dbforpostgresql_v20221201s.FlexibleServerList{}),
 			},
 		},
 	})
@@ -2941,6 +2949,21 @@ func indexDbforpostgresqlFlexibleServerAdministratorLoginPassword(rawObj client.
 		return nil
 	}
 	return obj.Spec.AdministratorLoginPassword.Index()
+}
+
+// indexDbforpostgresqlFlexibleServerPrimaryKeyURIFromConfig an index function for dbforpostgresql_v20221201s.FlexibleServer .spec.dataEncryption.primaryKeyURIFromConfig
+func indexDbforpostgresqlFlexibleServerPrimaryKeyURIFromConfig(rawObj client.Object) []string {
+	obj, ok := rawObj.(*dbforpostgresql_v20221201s.FlexibleServer)
+	if !ok {
+		return nil
+	}
+	if obj.Spec.DataEncryption == nil {
+		return nil
+	}
+	if obj.Spec.DataEncryption.PrimaryKeyURIFromConfig == nil {
+		return nil
+	}
+	return obj.Spec.DataEncryption.PrimaryKeyURIFromConfig.Index()
 }
 
 // indexDevicesIotHubEventHubsConnectionString an index function for devices_v20210702s.IotHub .spec.properties.routing.endpoints.eventHubs.connectionString


### PR DESCRIPTION
## What this PR does

Allows the values for `geoBackupKeyURI` and `primaryKeyURI` to be pulled from a configmap instead of requiring them to be hard coded in the resource.

Partially addresses #4298 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/D2hncA3u88gmeCFeoh/giphy.gif?cid=790b7611vvg815msf8zhu62q3vuadns8lx2nu2aetjf0kvcc&ep=v1_gifs_search&rid=giphy.gif&ct=g)
