### PR TITLE
Fix ordering bug for OneOf processing

### DIFF
--- a/v2/tools/generator/internal/astmodel/oneof_type.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type.go
@@ -18,7 +18,6 @@ import (
 type OneOfType struct {
 	swaggerName           string        // Name of the OneOf as defined in the Swagger file
 	propertyObjects       []*ObjectType // Object definitions used to specify the properties held by this OneOf. May be empty.
-	options               TypeNameSet   // References to the type names of the options for this OneOf. May be empty.
 	types                 TypeSet       // Set of all possible types
 	discriminatorProperty string        // Identifies the discriminatorProperty property
 	discriminatorValue    string        // Discriminator value used to identify this subtype
@@ -31,7 +30,6 @@ func NewOneOfType(name string, types ...Type) *OneOfType {
 	return &OneOfType{
 		swaggerName: name,
 		types:       MakeTypeSet(types...),
-		options:     NewTypeNameSet(),
 	}
 }
 

--- a/v2/tools/generator/internal/astmodel/type_set.go
+++ b/v2/tools/generator/internal/astmodel/type_set.go
@@ -17,6 +17,7 @@ type ReadonlyTypeSet interface {
 	ForEachError(func(t Type, ix int) error) error
 	Len() int
 	Single() (Type, bool)
+	AsSlice() []Type
 }
 
 var _ ReadonlyTypeSet = TypeSet{}

--- a/v2/tools/generator/internal/codegen/pipeline/assemble_oneof.go
+++ b/v2/tools/generator/internal/codegen/pipeline/assemble_oneof.go
@@ -108,9 +108,12 @@ func (oa *oneOfAssembler) assemble(name astmodel.InternalTypeName) error {
 
 // assemblePair updates a pair of nodes that have a relationship and recursively invokes itself to traverse the entire
 // tree of referenced imports.
-// ancestor is the parent or super-type. It may be a less specialised OneOf, a root OneOf, an Object or an AllOf
+// ancestor is the parent or super-type. It may be a less specialised OneOf, a root OneOf, an Object or an AllOf.
 // descendent is the child or subtype. It will be an intermediate or leaf OneOf.
-func (oa *oneOfAssembler) assemblePair(ancestor astmodel.InternalTypeName, descendant astmodel.InternalTypeName) error {
+func (oa *oneOfAssembler) assemblePair(
+	ancestor astmodel.InternalTypeName,
+	descendant astmodel.InternalTypeName,
+) error {
 	// Remove any direct reference to the parent from the leaf
 	err := oa.removeParentReferenceFromLeaf(ancestor, descendant)
 	if err != nil {

--- a/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
+++ b/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
@@ -8,11 +8,11 @@ package pipeline
 import (
 	"context"
 	"fmt"
-	"golang.org/x/exp/slices"
 	"strings"
 
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )

--- a/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
+++ b/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
@@ -8,6 +8,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"golang.org/x/exp/slices"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -884,35 +885,35 @@ func (synthesizer) handleMapObject(leftMap *astmodel.MapType, rightObj *astmodel
 // makes an ObjectType for an AllOf type
 // We're all about synthesizing a new type, so we resolve TypeNames here
 func (s synthesizer) allOfObject(allOf *astmodel.AllOfType) (astmodel.Type, error) {
-	types := allOf.Types()
-	toMerge := make([]astmodel.Type, types.Len())
-	types.ForEach(func(t astmodel.Type, i int) {
-		toMerge[i] = t
-	})
-
+	toMerge := allOf.Types().AsSlice()
 	return s.allOfSlice(toMerge)
 }
 
 func (s synthesizer) allOfSlice(types []astmodel.Type) (astmodel.Type, error) {
-	toMerge := make([]astmodel.Type, len(types))
-	foundName := false
-	for i, t := range types {
-		// if we find a type name, resolve it to the underlying type
-		if tn, ok := astmodel.AsInternalTypeName(t); ok {
-			if def, ok := s.defs[tn]; ok {
-				toMerge[i] = def.Type()
-				foundName = true
-				continue
+	toMerge := s.simplifyAllOfTypeNames(types)
+
+	// When an ObjectType is merged with a OneOfType, two things happen. The properties on the object type are pushed
+	// down to all the "leaves" of the OneOfType, and the OneOfType is converted to an ObjectType.
+	// If we later try to merge another ObjectType with the OneOf-ObjectType, the properties from the new object end up
+	// merged onto the OneOf-ObjectType itself instead of being pushed down to the leaves.
+	// To avoid this from happening, we need to merge all the ObjectTypes first, before we merge them with the OneOf.
+	// We achieve this by ordering the types so that all ObjectTypes come first.
+	slices.SortFunc(
+		toMerge,
+		func(left astmodel.Type, right astmodel.Type) int {
+			_, leftIsObject := left.(*astmodel.ObjectType)
+			_, rightIsObject := right.(*astmodel.ObjectType)
+
+			if leftIsObject && !rightIsObject {
+				return -1
 			}
-		}
 
-		toMerge[i] = t
-	}
+			if !leftIsObject && rightIsObject {
+				return 1
+			}
 
-	if foundName {
-		// Found a type name, recursive call in case there are more
-		return s.allOfSlice(toMerge)
-	}
+			return 0
+		})
 
 	var result astmodel.Type = astmodel.AnyType
 	for _, t := range toMerge {
@@ -924,6 +925,32 @@ func (s synthesizer) allOfSlice(types []astmodel.Type) (astmodel.Type, error) {
 	}
 
 	return result, nil
+}
+
+// simplifyAllOfTypeNames converts any type names in the allOf slice to their underlying types
+// so that we can merge everything.
+// AllOf types will reference another type to "import" all of its properties.
+// It's possible for a TypeDefinition to be an alias for another, so we recurse to follow any chains.
+func (s synthesizer) simplifyAllOfTypeNames(types []astmodel.Type) []astmodel.Type {
+	foundName := false
+	result := make([]astmodel.Type, len(types))
+	for i, t := range types {
+		if tn, ok := astmodel.AsInternalTypeName(t); ok {
+			if def, ok := s.defs[tn]; ok {
+				result[i] = def.Type()
+				foundName = true
+				continue
+			}
+		}
+
+		result[i] = t
+	}
+
+	if foundName {
+		return s.simplifyAllOfTypeNames(result)
+	}
+
+	return result
 }
 
 func (s synthesizer) handleFlaggedType(left *astmodel.FlaggedType, right astmodel.Type) (astmodel.Type, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects_test.go
@@ -7,14 +7,13 @@ package pipeline
 
 import (
 	"context"
-	"github.com/Azure/azure-service-operator/v2/internal/util/to"
 	"testing"
 
-	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/test"
-
-	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
-
 	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-service-operator/v2/internal/util/to"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/test"
 )
 
 func makeSynth(definitions ...astmodel.TypeDefinition) synthesizer {

--- a/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects_test.go
@@ -7,6 +7,7 @@ package pipeline
 
 import (
 	"context"
+	"github.com/Azure/azure-service-operator/v2/internal/util/to"
 	"testing"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/test"
@@ -712,4 +713,106 @@ func TestConversionOfSequentialOneOf_ReturnsExpectedResults(t *testing.T) {
 	for _, def := range finalState.definitions {
 		test.AssertDefinitionHasExpectedShape(t, def.Name().Name(), def)
 	}
+}
+
+// Checking a scenario discovered while importing the Kusto group.
+// When a resource spec contains an allOf that in turn contains a oneOf, we need all the properties pushed down
+// to the oneof leaves
+func TestConversionOfAllOf_WhenContainingOneOf_ReturnsExpectedResult(t *testing.T) {
+	t.Parallel()
+
+	g := NewGomegaWithT(t)
+
+	idFactory := astmodel.NewIdentifierFactory()
+
+	readwriteDatabase := astmodel.MakeTypeDefinition(
+		astmodel.MakeInternalTypeName(test.Pkg2020, "ReadWriteDatabase"),
+		astmodel.NewObjectType().
+			WithProperties(
+				astmodel.NewPropertyDefinition(
+					"KeyVaultURL",
+					"keyVaultUrl",
+					astmodel.StringType),
+				astmodel.NewPropertyDefinition(
+					"HotCachePeriod",
+					"hotCachePeriod",
+					astmodel.StringType),
+				astmodel.NewPropertyDefinition(
+					"Kind",
+					"kind",
+					astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("ReadWriteDatabase", "ReadWriteDatabase"))),
+				astmodel.NewPropertyDefinition(
+					"Location",
+					"location",
+					astmodel.StringType)),
+	)
+
+	readonlyFollowingDatabase := astmodel.MakeTypeDefinition(
+		astmodel.MakeInternalTypeName(test.Pkg2020, "ReadOnlyFollowingDatabase"),
+		astmodel.NewObjectType().
+			WithProperties(
+				astmodel.NewPropertyDefinition(
+					"DatabaseShareOrigin",
+					"databaseShareOrigin",
+					astmodel.StringType),
+				astmodel.NewPropertyDefinition(
+					"HotCachePeriod",
+					"hotCachePeriod",
+					astmodel.StringType),
+				astmodel.NewPropertyDefinition(
+					"Kind",
+					"kind",
+					astmodel.NewEnumType(astmodel.StringType, astmodel.MakeEnumValue("ReadOnlyFollowingDatabase", "ReadOnlyFollowingDatabase"))),
+				astmodel.NewPropertyDefinition(
+					"Location",
+					"location",
+					astmodel.StringType)),
+	)
+
+	database := astmodel.MakeTypeDefinition(
+		astmodel.MakeInternalTypeName(test.Pkg2020, "Database"),
+		astmodel.NewOneOfType(
+			"database",
+			readwriteDatabase.Name(),
+			readonlyFollowingDatabase.Name()).
+			WithDiscriminatorProperty("Kind"),
+	)
+
+	clusters_database := astmodel.MakeTypeDefinition(
+		astmodel.MakeInternalTypeName(test.Pkg2020, "Clusters_Database"),
+		astmodel.NewResourceType(
+			astmodel.NewAllOfType(
+				database.Name(),
+				astmodel.NewObjectType().
+					WithProperty(
+						astmodel.NewPropertyDefinition(
+							"Name",
+							"name",
+							astmodel.NewValidatedType(
+								astmodel.StringType,
+								astmodel.StringValidations{
+									MaxLength: to.Ptr(int64(96)),
+								}))),
+				astmodel.NewObjectType().
+					WithProperty(
+						astmodel.NewPropertyDefinition(
+							"Name",
+							"name",
+							astmodel.StringType))),
+			astmodel.NewObjectType(),
+		))
+
+	defs := astmodel.MakeTypeDefinitionSetFromDefinitions(
+		readwriteDatabase,
+		readonlyFollowingDatabase,
+		database,
+		clusters_database)
+
+	state := NewState(defs)
+	stage := ConvertAllOfAndOneOfToObjects(idFactory)
+
+	finalState, err := stage.Run(context.TODO(), state)
+	g.Expect(err).To(BeNil())
+
+	test.AssertDefinitionsHaveExpectedShapes(t, "structure.txt", finalState.Definitions())
 }

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestConversionOfAllOf_WhenContainingOneOf_ReturnsExpectedResult/structure.txt.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestConversionOfAllOf_WhenContainingOneOf_ReturnsExpectedResult/structure.txt.golden
@@ -1,0 +1,28 @@
+github.com/Azure/azure-service-operator/testing/person/v20200101
+----------------------------------------------------------------
+Clusters_Database: Resource
+├── Spec: Object (2 properties)
+│   ├── Flag 0: oneof
+│   ├── ReadOnlyFollowing: *ReadOnlyFollowingDatabase
+│   └── ReadWrite: *ReadWriteDatabase
+└── Status: Object (0 properties)
+Database: Object (2 properties)
+├── Flag 0: oneof
+├── ReadOnlyFollowing: *ReadOnlyFollowingDatabase
+└── ReadWrite: *ReadWriteDatabase
+ReadOnlyFollowingDatabase: Object (5 properties)
+├── DatabaseShareOrigin: string
+├── HotCachePeriod: string
+├── Kind: Enum (1 value)
+│   └── ReadOnlyFollowingDatabase
+├── Location: string
+└── Name: Validated<string> (1 rule)
+    └── Rule 0: MaxLength: 96
+ReadWriteDatabase: Object (5 properties)
+├── HotCachePeriod: string
+├── KeyVaultURL: string
+├── Kind: Enum (1 value)
+│   └── ReadWriteDatabase
+├── Location: string
+└── Name: Validated<string> (1 rule)
+    └── Rule 0: MaxLength: 96

--- a/v2/tools/generator/internal/test/asserts.go
+++ b/v2/tools/generator/internal/test/asserts.go
@@ -90,6 +90,20 @@ func AssertDefinitionHasExpectedShape(
 	filename string,
 	def astmodel.TypeDefinition,
 ) {
+	defs := make(astmodel.TypeDefinitionSet)
+	defs.Add(def)
+	AssertDefinitionsHaveExpectedShapes(t, filename, defs)
+}
+
+// AssertDefinitionsHaveExpectedShapes fails the test if the given definition does not have the expected shape.
+// t is the current test.
+// filename is the name of the golden file to write.
+// def is the definition to be asserted.
+func AssertDefinitionsHaveExpectedShapes(
+	t *testing.T,
+	filename string,
+	defs astmodel.TypeDefinitionSet,
+) {
 	t.Helper()
 	g := goldie.New(t)
 
@@ -97,9 +111,6 @@ func AssertDefinitionHasExpectedShape(
 	if err != nil {
 		t.Fatalf("Unable to configure goldie output folder %s", err)
 	}
-
-	defs := make(astmodel.TypeDefinitionSet)
-	defs.Add(def)
 
 	buf := &bytes.Buffer{}
 	report := reporting.NewTypeCatalogReport(defs)


### PR DESCRIPTION
**What this PR does / why we need it**:

Construction of objects representing `OneOf` types has an ordering bug, where it can generate the wrong results if the input types are presented in a different order. This process should give the same results regardless of the order of inputs.

Consider the base case (which works) where we have a OneOf called `Address` we're about to merge common properties from `AddressBase`.

``` mermaid
classDiagram

class AddressBase {
    Location string
}

class Address {
    <<oneOf>>
}

class PostalAddress

class ResidentialAddress 

Address --> PostalAddress : Postal
Address --> ResidentialAddress : Residential
```

The common properties from `AddressBase` are pushed down to the leaves of `Address`, and properties created representing the available cases.

``` mermaid
classDiagram

class Address {
    Residential ResidentialAddress
    Postal PostalAddress
}

class PostalAddress {
    Location string
}

class ResidentialAddress {
    Location string
}

Address *-- PostalAddress
Address *-- ResidentialAddress
```

Things get more complicated when we have to merge multiple objects into the `OneOf`, such as if we want the addresses to be effective for a particular span of time.

``` mermaid
classDiagram

class EffectiveInterval {
    StartDate date
    FinishDate date
}
```

If we merge `AddressBase` and `EffectiveInterval`, then merge the result with `Address` we end up with this correct structure:


``` mermaid
classDiagram

class Address {
    Residential ResidentialAddress
    Postal PostalAddress
}

class PostalAddress {
    Location string
    StartDate date
    FinishDate date
}

class ResidentialAddress {
    Location string
    StartDate date
    FinishDate date
}

Address *-- PostalAddress
Address *-- ResidentialAddress
```

However, if we first merge `AddressBase` and `Address`, by the time we then merge `EffectiveInterval` we're just merging two objects (it's no longer a _OneOf_) so the result is different:

``` mermaid
classDiagram

class Address {
    Residential ResidentialAddress
    Postal PostalAddress
    StartDate date
    FinishDate date
}

class PostalAddress {
    Location string
}

class ResidentialAddress {
    Location string
}

Address *-- PostalAddress
Address *-- ResidentialAddress
```

This PR changes the merge operation so it's no longer sensitive to the order of inputs, by merging all objects up front.

**Special notes for your reviewer**:

There's an independent following problem that emerges after this bug fix; ADR to follow for discussion.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/SM28krqRoam1DyC2be/giphy.gif?cid=790b76118kljnh7ijnxyjev0knxlpm84zt0ky8dirav4s96n&ep=v1_gifs_search&rid=giphy.gif&ct=g)

**If applicable**:
- [x] this PR contains tests
