### PR TITLE
Relax enum restrictions on Storage bypass parameter

### DIFF
--- a/v2/api/storage/v1api20210401/storage_account_spec_arm_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_account_spec_arm_types_gen.go
@@ -237,7 +237,7 @@ type KeyPolicy_ARM struct {
 type NetworkRuleSet_ARM struct {
 	// Bypass: Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Possible values are any combination of
 	// Logging|Metrics|AzureServices (For example, "Logging, Metrics"), or None to bypass none of those traffics.
-	Bypass *NetworkRuleSet_Bypass_ARM `json:"bypass,omitempty"`
+	Bypass *string `json:"bypass,omitempty"`
 
 	// DefaultAction: Specifies the default action of allow or deny when no other rules match.
 	DefaultAction *NetworkRuleSet_DefaultAction_ARM `json:"defaultAction,omitempty"`
@@ -475,24 +475,6 @@ type KeyVaultProperties_ARM struct {
 
 	// Keyversion: The version of KeyVault key.
 	Keyversion *string `json:"keyversion,omitempty"`
-}
-
-// +kubebuilder:validation:Enum={"AzureServices","Logging","Metrics","None"}
-type NetworkRuleSet_Bypass_ARM string
-
-const (
-	NetworkRuleSet_Bypass_ARM_AzureServices = NetworkRuleSet_Bypass_ARM("AzureServices")
-	NetworkRuleSet_Bypass_ARM_Logging       = NetworkRuleSet_Bypass_ARM("Logging")
-	NetworkRuleSet_Bypass_ARM_Metrics       = NetworkRuleSet_Bypass_ARM("Metrics")
-	NetworkRuleSet_Bypass_ARM_None          = NetworkRuleSet_Bypass_ARM("None")
-)
-
-// Mapping from string to NetworkRuleSet_Bypass_ARM
-var networkRuleSet_Bypass_ARM_Values = map[string]NetworkRuleSet_Bypass_ARM{
-	"azureservices": NetworkRuleSet_Bypass_ARM_AzureServices,
-	"logging":       NetworkRuleSet_Bypass_ARM_Logging,
-	"metrics":       NetworkRuleSet_Bypass_ARM_Metrics,
-	"none":          NetworkRuleSet_Bypass_ARM_None,
 }
 
 // +kubebuilder:validation:Enum={"Allow","Deny"}

--- a/v2/api/storage/v1api20210401/storage_account_spec_arm_types_gen_test.go
+++ b/v2/api/storage/v1api20210401/storage_account_spec_arm_types_gen_test.go
@@ -881,11 +881,7 @@ func NetworkRuleSet_ARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForNetworkRuleSet_ARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNetworkRuleSet_ARM(gens map[string]gopter.Gen) {
-	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(
-		NetworkRuleSet_Bypass_ARM_AzureServices,
-		NetworkRuleSet_Bypass_ARM_Logging,
-		NetworkRuleSet_Bypass_ARM_Metrics,
-		NetworkRuleSet_Bypass_ARM_None))
+	gens["Bypass"] = gen.PtrOf(gen.AlphaString())
 	gens["DefaultAction"] = gen.PtrOf(gen.OneConstOf(NetworkRuleSet_DefaultAction_ARM_Allow, NetworkRuleSet_DefaultAction_ARM_Deny))
 }
 

--- a/v2/api/storage/v1api20210401/storage_account_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_account_types_gen.go
@@ -5029,7 +5029,7 @@ func (policy *KeyPolicy_STATUS) AssignProperties_To_KeyPolicy_STATUS(destination
 type NetworkRuleSet struct {
 	// Bypass: Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Possible values are any combination of
 	// Logging|Metrics|AzureServices (For example, "Logging, Metrics"), or None to bypass none of those traffics.
-	Bypass *NetworkRuleSet_Bypass `json:"bypass,omitempty"`
+	Bypass *string `json:"bypass,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// DefaultAction: Specifies the default action of allow or deny when no other rules match.
@@ -5056,9 +5056,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Bypass":
 	if ruleSet.Bypass != nil {
-		var temp string
-		temp = string(*ruleSet.Bypass)
-		bypass := NetworkRuleSet_Bypass_ARM(temp)
+		bypass := *ruleSet.Bypass
 		result.Bypass = &bypass
 	}
 
@@ -5113,9 +5111,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 
 	// Set property "Bypass":
 	if typedInput.Bypass != nil {
-		var temp string
-		temp = string(*typedInput.Bypass)
-		bypass := NetworkRuleSet_Bypass(temp)
+		bypass := *typedInput.Bypass
 		ruleSet.Bypass = &bypass
 	}
 
@@ -5165,13 +5161,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 func (ruleSet *NetworkRuleSet) AssignProperties_From_NetworkRuleSet(source *storage.NetworkRuleSet) error {
 
 	// Bypass
-	if source.Bypass != nil {
-		bypass := *source.Bypass
-		bypassTemp := genruntime.ToEnum(bypass, networkRuleSet_Bypass_Values)
-		ruleSet.Bypass = &bypassTemp
-	} else {
-		ruleSet.Bypass = nil
-	}
+	ruleSet.Bypass = genruntime.ClonePointerToString(source.Bypass)
 
 	// DefaultAction
 	if source.DefaultAction != nil {
@@ -5246,12 +5236,7 @@ func (ruleSet *NetworkRuleSet) AssignProperties_To_NetworkRuleSet(destination *s
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Bypass
-	if ruleSet.Bypass != nil {
-		bypass := string(*ruleSet.Bypass)
-		destination.Bypass = &bypass
-	} else {
-		destination.Bypass = nil
-	}
+	destination.Bypass = genruntime.ClonePointerToString(ruleSet.Bypass)
 
 	// DefaultAction
 	if ruleSet.DefaultAction != nil {
@@ -8208,24 +8193,6 @@ func (properties *KeyVaultProperties_STATUS) AssignProperties_To_KeyVaultPropert
 
 	// No error
 	return nil
-}
-
-// +kubebuilder:validation:Enum={"AzureServices","Logging","Metrics","None"}
-type NetworkRuleSet_Bypass string
-
-const (
-	NetworkRuleSet_Bypass_AzureServices = NetworkRuleSet_Bypass("AzureServices")
-	NetworkRuleSet_Bypass_Logging       = NetworkRuleSet_Bypass("Logging")
-	NetworkRuleSet_Bypass_Metrics       = NetworkRuleSet_Bypass("Metrics")
-	NetworkRuleSet_Bypass_None          = NetworkRuleSet_Bypass("None")
-)
-
-// Mapping from string to NetworkRuleSet_Bypass
-var networkRuleSet_Bypass_Values = map[string]NetworkRuleSet_Bypass{
-	"azureservices": NetworkRuleSet_Bypass_AzureServices,
-	"logging":       NetworkRuleSet_Bypass_Logging,
-	"metrics":       NetworkRuleSet_Bypass_Metrics,
-	"none":          NetworkRuleSet_Bypass_None,
 }
 
 type NetworkRuleSet_Bypass_STATUS string

--- a/v2/api/storage/v1api20210401/storage_account_types_gen_test.go
+++ b/v2/api/storage/v1api20210401/storage_account_types_gen_test.go
@@ -3395,11 +3395,7 @@ func NetworkRuleSetGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForNetworkRuleSet is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNetworkRuleSet(gens map[string]gopter.Gen) {
-	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(
-		NetworkRuleSet_Bypass_AzureServices,
-		NetworkRuleSet_Bypass_Logging,
-		NetworkRuleSet_Bypass_Metrics,
-		NetworkRuleSet_Bypass_None))
+	gens["Bypass"] = gen.PtrOf(gen.AlphaString())
 	gens["DefaultAction"] = gen.PtrOf(gen.OneConstOf(NetworkRuleSet_DefaultAction_Allow, NetworkRuleSet_DefaultAction_Deny))
 }
 

--- a/v2/api/storage/v1api20210401/structure.txt
+++ b/v2/api/storage/v1api20210401/structure.txt
@@ -99,11 +99,7 @@ StorageAccount: Resource
 │   │   ├── "TLS1_1"
 │   │   └── "TLS1_2"
 │   ├── NetworkAcls: *Object (5 properties)
-│   │   ├── Bypass: *Enum (4 values)
-│   │   │   ├── "AzureServices"
-│   │   │   ├── "Logging"
-│   │   │   ├── "Metrics"
-│   │   │   └── "None"
+│   │   ├── Bypass: *string
 │   │   ├── DefaultAction: *Enum (2 values)
 │   │   │   ├── "Allow"
 │   │   │   └── "Deny"
@@ -721,11 +717,7 @@ StorageAccount_Spec_ARM: Object (8 properties)
 │   │   ├── "TLS1_1"
 │   │   └── "TLS1_2"
 │   ├── NetworkAcls: *Object (5 properties)
-│   │   ├── Bypass: *Enum (4 values)
-│   │   │   ├── "AzureServices"
-│   │   │   ├── "Logging"
-│   │   │   ├── "Metrics"
-│   │   │   └── "None"
+│   │   ├── Bypass: *string
 │   │   ├── DefaultAction: *Enum (2 values)
 │   │   │   ├── "Allow"
 │   │   │   └── "Deny"

--- a/v2/api/storage/v1api20210401/zz_generated.deepcopy.go
+++ b/v2/api/storage/v1api20210401/zz_generated.deepcopy.go
@@ -4021,7 +4021,7 @@ func (in *NetworkRuleSet) DeepCopyInto(out *NetworkRuleSet) {
 	*out = *in
 	if in.Bypass != nil {
 		in, out := &in.Bypass, &out.Bypass
-		*out = new(NetworkRuleSet_Bypass)
+		*out = new(string)
 		**out = **in
 	}
 	if in.DefaultAction != nil {
@@ -4067,7 +4067,7 @@ func (in *NetworkRuleSet_ARM) DeepCopyInto(out *NetworkRuleSet_ARM) {
 	*out = *in
 	if in.Bypass != nil {
 		in, out := &in.Bypass, &out.Bypass
-		*out = new(NetworkRuleSet_Bypass_ARM)
+		*out = new(string)
 		**out = **in
 	}
 	if in.DefaultAction != nil {

--- a/v2/api/storage/v1api20220901/storage_account_spec_arm_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_account_spec_arm_types_gen.go
@@ -278,7 +278,7 @@ type KeyPolicy_ARM struct {
 type NetworkRuleSet_ARM struct {
 	// Bypass: Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Possible values are any combination of
 	// Logging|Metrics|AzureServices (For example, "Logging, Metrics"), or None to bypass none of those traffics.
-	Bypass *NetworkRuleSet_Bypass_ARM `json:"bypass,omitempty"`
+	Bypass *string `json:"bypass,omitempty"`
 
 	// DefaultAction: Specifies the default action of allow or deny when no other rules match.
 	DefaultAction *NetworkRuleSet_DefaultAction_ARM `json:"defaultAction,omitempty"`
@@ -588,24 +588,6 @@ type KeyVaultProperties_ARM struct {
 
 	// Keyversion: The version of KeyVault key.
 	Keyversion *string `json:"keyversion,omitempty"`
-}
-
-// +kubebuilder:validation:Enum={"AzureServices","Logging","Metrics","None"}
-type NetworkRuleSet_Bypass_ARM string
-
-const (
-	NetworkRuleSet_Bypass_ARM_AzureServices = NetworkRuleSet_Bypass_ARM("AzureServices")
-	NetworkRuleSet_Bypass_ARM_Logging       = NetworkRuleSet_Bypass_ARM("Logging")
-	NetworkRuleSet_Bypass_ARM_Metrics       = NetworkRuleSet_Bypass_ARM("Metrics")
-	NetworkRuleSet_Bypass_ARM_None          = NetworkRuleSet_Bypass_ARM("None")
-)
-
-// Mapping from string to NetworkRuleSet_Bypass_ARM
-var networkRuleSet_Bypass_ARM_Values = map[string]NetworkRuleSet_Bypass_ARM{
-	"azureservices": NetworkRuleSet_Bypass_ARM_AzureServices,
-	"logging":       NetworkRuleSet_Bypass_ARM_Logging,
-	"metrics":       NetworkRuleSet_Bypass_ARM_Metrics,
-	"none":          NetworkRuleSet_Bypass_ARM_None,
 }
 
 // +kubebuilder:validation:Enum={"Allow","Deny"}

--- a/v2/api/storage/v1api20220901/storage_account_spec_arm_types_gen_test.go
+++ b/v2/api/storage/v1api20220901/storage_account_spec_arm_types_gen_test.go
@@ -1025,11 +1025,7 @@ func NetworkRuleSet_ARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForNetworkRuleSet_ARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNetworkRuleSet_ARM(gens map[string]gopter.Gen) {
-	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(
-		NetworkRuleSet_Bypass_ARM_AzureServices,
-		NetworkRuleSet_Bypass_ARM_Logging,
-		NetworkRuleSet_Bypass_ARM_Metrics,
-		NetworkRuleSet_Bypass_ARM_None))
+	gens["Bypass"] = gen.PtrOf(gen.AlphaString())
 	gens["DefaultAction"] = gen.PtrOf(gen.OneConstOf(NetworkRuleSet_DefaultAction_ARM_Allow, NetworkRuleSet_DefaultAction_ARM_Deny))
 }
 

--- a/v2/api/storage/v1api20220901/storage_account_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_account_types_gen.go
@@ -5812,7 +5812,7 @@ func (policy *KeyPolicy_STATUS) AssignProperties_To_KeyPolicy_STATUS(destination
 type NetworkRuleSet struct {
 	// Bypass: Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Possible values are any combination of
 	// Logging|Metrics|AzureServices (For example, "Logging, Metrics"), or None to bypass none of those traffics.
-	Bypass *NetworkRuleSet_Bypass `json:"bypass,omitempty"`
+	Bypass *string `json:"bypass,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// DefaultAction: Specifies the default action of allow or deny when no other rules match.
@@ -5839,9 +5839,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Bypass":
 	if ruleSet.Bypass != nil {
-		var temp string
-		temp = string(*ruleSet.Bypass)
-		bypass := NetworkRuleSet_Bypass_ARM(temp)
+		bypass := *ruleSet.Bypass
 		result.Bypass = &bypass
 	}
 
@@ -5896,9 +5894,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 
 	// Set property "Bypass":
 	if typedInput.Bypass != nil {
-		var temp string
-		temp = string(*typedInput.Bypass)
-		bypass := NetworkRuleSet_Bypass(temp)
+		bypass := *typedInput.Bypass
 		ruleSet.Bypass = &bypass
 	}
 
@@ -5948,13 +5944,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 func (ruleSet *NetworkRuleSet) AssignProperties_From_NetworkRuleSet(source *storage.NetworkRuleSet) error {
 
 	// Bypass
-	if source.Bypass != nil {
-		bypass := *source.Bypass
-		bypassTemp := genruntime.ToEnum(bypass, networkRuleSet_Bypass_Values)
-		ruleSet.Bypass = &bypassTemp
-	} else {
-		ruleSet.Bypass = nil
-	}
+	ruleSet.Bypass = genruntime.ClonePointerToString(source.Bypass)
 
 	// DefaultAction
 	if source.DefaultAction != nil {
@@ -6029,12 +6019,7 @@ func (ruleSet *NetworkRuleSet) AssignProperties_To_NetworkRuleSet(destination *s
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Bypass
-	if ruleSet.Bypass != nil {
-		bypass := string(*ruleSet.Bypass)
-		destination.Bypass = &bypass
-	} else {
-		destination.Bypass = nil
-	}
+	destination.Bypass = genruntime.ClonePointerToString(ruleSet.Bypass)
 
 	// DefaultAction
 	if ruleSet.DefaultAction != nil {
@@ -9635,24 +9620,6 @@ func (properties *KeyVaultProperties_STATUS) AssignProperties_To_KeyVaultPropert
 
 	// No error
 	return nil
-}
-
-// +kubebuilder:validation:Enum={"AzureServices","Logging","Metrics","None"}
-type NetworkRuleSet_Bypass string
-
-const (
-	NetworkRuleSet_Bypass_AzureServices = NetworkRuleSet_Bypass("AzureServices")
-	NetworkRuleSet_Bypass_Logging       = NetworkRuleSet_Bypass("Logging")
-	NetworkRuleSet_Bypass_Metrics       = NetworkRuleSet_Bypass("Metrics")
-	NetworkRuleSet_Bypass_None          = NetworkRuleSet_Bypass("None")
-)
-
-// Mapping from string to NetworkRuleSet_Bypass
-var networkRuleSet_Bypass_Values = map[string]NetworkRuleSet_Bypass{
-	"azureservices": NetworkRuleSet_Bypass_AzureServices,
-	"logging":       NetworkRuleSet_Bypass_Logging,
-	"metrics":       NetworkRuleSet_Bypass_Metrics,
-	"none":          NetworkRuleSet_Bypass_None,
 }
 
 type NetworkRuleSet_Bypass_STATUS string

--- a/v2/api/storage/v1api20220901/storage_account_types_gen_test.go
+++ b/v2/api/storage/v1api20220901/storage_account_types_gen_test.go
@@ -3857,11 +3857,7 @@ func NetworkRuleSetGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForNetworkRuleSet is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNetworkRuleSet(gens map[string]gopter.Gen) {
-	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(
-		NetworkRuleSet_Bypass_AzureServices,
-		NetworkRuleSet_Bypass_Logging,
-		NetworkRuleSet_Bypass_Metrics,
-		NetworkRuleSet_Bypass_None))
+	gens["Bypass"] = gen.PtrOf(gen.AlphaString())
 	gens["DefaultAction"] = gen.PtrOf(gen.OneConstOf(NetworkRuleSet_DefaultAction_Allow, NetworkRuleSet_DefaultAction_Deny))
 }
 

--- a/v2/api/storage/v1api20220901/structure.txt
+++ b/v2/api/storage/v1api20220901/structure.txt
@@ -125,11 +125,7 @@ StorageAccount: Resource
 │   │   ├── "TLS1_1"
 │   │   └── "TLS1_2"
 │   ├── NetworkAcls: *Object (5 properties)
-│   │   ├── Bypass: *Enum (4 values)
-│   │   │   ├── "AzureServices"
-│   │   │   ├── "Logging"
-│   │   │   ├── "Metrics"
-│   │   │   └── "None"
+│   │   ├── Bypass: *string
 │   │   ├── DefaultAction: *Enum (2 values)
 │   │   │   ├── "Allow"
 │   │   │   └── "Deny"
@@ -862,11 +858,7 @@ StorageAccount_Spec_ARM: Object (8 properties)
 │   │   ├── "TLS1_1"
 │   │   └── "TLS1_2"
 │   ├── NetworkAcls: *Object (5 properties)
-│   │   ├── Bypass: *Enum (4 values)
-│   │   │   ├── "AzureServices"
-│   │   │   ├── "Logging"
-│   │   │   ├── "Metrics"
-│   │   │   └── "None"
+│   │   ├── Bypass: *string
 │   │   ├── DefaultAction: *Enum (2 values)
 │   │   │   ├── "Allow"
 │   │   │   └── "Deny"

--- a/v2/api/storage/v1api20220901/zz_generated.deepcopy.go
+++ b/v2/api/storage/v1api20220901/zz_generated.deepcopy.go
@@ -4909,7 +4909,7 @@ func (in *NetworkRuleSet) DeepCopyInto(out *NetworkRuleSet) {
 	*out = *in
 	if in.Bypass != nil {
 		in, out := &in.Bypass, &out.Bypass
-		*out = new(NetworkRuleSet_Bypass)
+		*out = new(string)
 		**out = **in
 	}
 	if in.DefaultAction != nil {
@@ -4955,7 +4955,7 @@ func (in *NetworkRuleSet_ARM) DeepCopyInto(out *NetworkRuleSet_ARM) {
 	*out = *in
 	if in.Bypass != nil {
 		in, out := &in.Bypass, &out.Bypass
-		*out = new(NetworkRuleSet_Bypass_ARM)
+		*out = new(string)
 		**out = **in
 	}
 	if in.DefaultAction != nil {

--- a/v2/api/storage/v1api20230101/storage_account_spec_arm_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_account_spec_arm_types_gen.go
@@ -279,7 +279,7 @@ type KeyPolicy_ARM struct {
 type NetworkRuleSet_ARM struct {
 	// Bypass: Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Possible values are any combination of
 	// Logging|Metrics|AzureServices (For example, "Logging, Metrics"), or None to bypass none of those traffics.
-	Bypass *NetworkRuleSet_Bypass_ARM `json:"bypass,omitempty"`
+	Bypass *string `json:"bypass,omitempty"`
 
 	// DefaultAction: Specifies the default action of allow or deny when no other rules match.
 	DefaultAction *NetworkRuleSet_DefaultAction_ARM `json:"defaultAction,omitempty"`
@@ -589,24 +589,6 @@ type KeyVaultProperties_ARM struct {
 
 	// Keyversion: The version of KeyVault key.
 	Keyversion *string `json:"keyversion,omitempty"`
-}
-
-// +kubebuilder:validation:Enum={"AzureServices","Logging","Metrics","None"}
-type NetworkRuleSet_Bypass_ARM string
-
-const (
-	NetworkRuleSet_Bypass_ARM_AzureServices = NetworkRuleSet_Bypass_ARM("AzureServices")
-	NetworkRuleSet_Bypass_ARM_Logging       = NetworkRuleSet_Bypass_ARM("Logging")
-	NetworkRuleSet_Bypass_ARM_Metrics       = NetworkRuleSet_Bypass_ARM("Metrics")
-	NetworkRuleSet_Bypass_ARM_None          = NetworkRuleSet_Bypass_ARM("None")
-)
-
-// Mapping from string to NetworkRuleSet_Bypass_ARM
-var networkRuleSet_Bypass_ARM_Values = map[string]NetworkRuleSet_Bypass_ARM{
-	"azureservices": NetworkRuleSet_Bypass_ARM_AzureServices,
-	"logging":       NetworkRuleSet_Bypass_ARM_Logging,
-	"metrics":       NetworkRuleSet_Bypass_ARM_Metrics,
-	"none":          NetworkRuleSet_Bypass_ARM_None,
 }
 
 // +kubebuilder:validation:Enum={"Allow","Deny"}

--- a/v2/api/storage/v1api20230101/storage_account_spec_arm_types_gen_test.go
+++ b/v2/api/storage/v1api20230101/storage_account_spec_arm_types_gen_test.go
@@ -1025,11 +1025,7 @@ func NetworkRuleSet_ARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForNetworkRuleSet_ARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNetworkRuleSet_ARM(gens map[string]gopter.Gen) {
-	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(
-		NetworkRuleSet_Bypass_ARM_AzureServices,
-		NetworkRuleSet_Bypass_ARM_Logging,
-		NetworkRuleSet_Bypass_ARM_Metrics,
-		NetworkRuleSet_Bypass_ARM_None))
+	gens["Bypass"] = gen.PtrOf(gen.AlphaString())
 	gens["DefaultAction"] = gen.PtrOf(gen.OneConstOf(NetworkRuleSet_DefaultAction_ARM_Allow, NetworkRuleSet_DefaultAction_ARM_Deny))
 }
 

--- a/v2/api/storage/v1api20230101/storage_account_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_account_types_gen.go
@@ -6418,7 +6418,7 @@ func (policy *KeyPolicy_STATUS) AssignProperties_To_KeyPolicy_STATUS(destination
 type NetworkRuleSet struct {
 	// Bypass: Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Possible values are any combination of
 	// Logging|Metrics|AzureServices (For example, "Logging, Metrics"), or None to bypass none of those traffics.
-	Bypass *NetworkRuleSet_Bypass `json:"bypass,omitempty"`
+	Bypass *string `json:"bypass,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// DefaultAction: Specifies the default action of allow or deny when no other rules match.
@@ -6445,9 +6445,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 
 	// Set property "Bypass":
 	if ruleSet.Bypass != nil {
-		var temp string
-		temp = string(*ruleSet.Bypass)
-		bypass := NetworkRuleSet_Bypass_ARM(temp)
+		bypass := *ruleSet.Bypass
 		result.Bypass = &bypass
 	}
 
@@ -6502,9 +6500,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 
 	// Set property "Bypass":
 	if typedInput.Bypass != nil {
-		var temp string
-		temp = string(*typedInput.Bypass)
-		bypass := NetworkRuleSet_Bypass(temp)
+		bypass := *typedInput.Bypass
 		ruleSet.Bypass = &bypass
 	}
 
@@ -6554,13 +6550,7 @@ func (ruleSet *NetworkRuleSet) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 func (ruleSet *NetworkRuleSet) AssignProperties_From_NetworkRuleSet(source *storage.NetworkRuleSet) error {
 
 	// Bypass
-	if source.Bypass != nil {
-		bypass := *source.Bypass
-		bypassTemp := genruntime.ToEnum(bypass, networkRuleSet_Bypass_Values)
-		ruleSet.Bypass = &bypassTemp
-	} else {
-		ruleSet.Bypass = nil
-	}
+	ruleSet.Bypass = genruntime.ClonePointerToString(source.Bypass)
 
 	// DefaultAction
 	if source.DefaultAction != nil {
@@ -6635,12 +6625,7 @@ func (ruleSet *NetworkRuleSet) AssignProperties_To_NetworkRuleSet(destination *s
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Bypass
-	if ruleSet.Bypass != nil {
-		bypass := string(*ruleSet.Bypass)
-		destination.Bypass = &bypass
-	} else {
-		destination.Bypass = nil
-	}
+	destination.Bypass = genruntime.ClonePointerToString(ruleSet.Bypass)
 
 	// DefaultAction
 	if ruleSet.DefaultAction != nil {
@@ -6720,7 +6705,7 @@ func (ruleSet *NetworkRuleSet) Initialize_From_NetworkRuleSet_STATUS(source *Net
 
 	// Bypass
 	if source.Bypass != nil {
-		bypass := genruntime.ToEnum(string(*source.Bypass), networkRuleSet_Bypass_Values)
+		bypass := string(*source.Bypass)
 		ruleSet.Bypass = &bypass
 	} else {
 		ruleSet.Bypass = nil
@@ -10586,24 +10571,6 @@ func (properties *KeyVaultProperties_STATUS) AssignProperties_To_KeyVaultPropert
 
 	// No error
 	return nil
-}
-
-// +kubebuilder:validation:Enum={"AzureServices","Logging","Metrics","None"}
-type NetworkRuleSet_Bypass string
-
-const (
-	NetworkRuleSet_Bypass_AzureServices = NetworkRuleSet_Bypass("AzureServices")
-	NetworkRuleSet_Bypass_Logging       = NetworkRuleSet_Bypass("Logging")
-	NetworkRuleSet_Bypass_Metrics       = NetworkRuleSet_Bypass("Metrics")
-	NetworkRuleSet_Bypass_None          = NetworkRuleSet_Bypass("None")
-)
-
-// Mapping from string to NetworkRuleSet_Bypass
-var networkRuleSet_Bypass_Values = map[string]NetworkRuleSet_Bypass{
-	"azureservices": NetworkRuleSet_Bypass_AzureServices,
-	"logging":       NetworkRuleSet_Bypass_Logging,
-	"metrics":       NetworkRuleSet_Bypass_Metrics,
-	"none":          NetworkRuleSet_Bypass_None,
 }
 
 type NetworkRuleSet_Bypass_STATUS string

--- a/v2/api/storage/v1api20230101/storage_account_types_gen_test.go
+++ b/v2/api/storage/v1api20230101/storage_account_types_gen_test.go
@@ -3863,11 +3863,7 @@ func NetworkRuleSetGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForNetworkRuleSet is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNetworkRuleSet(gens map[string]gopter.Gen) {
-	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(
-		NetworkRuleSet_Bypass_AzureServices,
-		NetworkRuleSet_Bypass_Logging,
-		NetworkRuleSet_Bypass_Metrics,
-		NetworkRuleSet_Bypass_None))
+	gens["Bypass"] = gen.PtrOf(gen.AlphaString())
 	gens["DefaultAction"] = gen.PtrOf(gen.OneConstOf(NetworkRuleSet_DefaultAction_Allow, NetworkRuleSet_DefaultAction_Deny))
 }
 

--- a/v2/api/storage/v1api20230101/structure.txt
+++ b/v2/api/storage/v1api20230101/structure.txt
@@ -126,11 +126,7 @@ StorageAccount: Resource
 │   │   ├── "TLS1_1"
 │   │   └── "TLS1_2"
 │   ├── NetworkAcls: *Object (5 properties)
-│   │   ├── Bypass: *Enum (4 values)
-│   │   │   ├── "AzureServices"
-│   │   │   ├── "Logging"
-│   │   │   ├── "Metrics"
-│   │   │   └── "None"
+│   │   ├── Bypass: *string
 │   │   ├── DefaultAction: *Enum (2 values)
 │   │   │   ├── "Allow"
 │   │   │   └── "Deny"
@@ -885,11 +881,7 @@ StorageAccount_Spec_ARM: Object (8 properties)
 │   │   ├── "TLS1_1"
 │   │   └── "TLS1_2"
 │   ├── NetworkAcls: *Object (5 properties)
-│   │   ├── Bypass: *Enum (4 values)
-│   │   │   ├── "AzureServices"
-│   │   │   ├── "Logging"
-│   │   │   ├── "Metrics"
-│   │   │   └── "None"
+│   │   ├── Bypass: *string
 │   │   ├── DefaultAction: *Enum (2 values)
 │   │   │   ├── "Allow"
 │   │   │   └── "Deny"

--- a/v2/api/storage/v1api20230101/zz_generated.deepcopy.go
+++ b/v2/api/storage/v1api20230101/zz_generated.deepcopy.go
@@ -4939,7 +4939,7 @@ func (in *NetworkRuleSet) DeepCopyInto(out *NetworkRuleSet) {
 	*out = *in
 	if in.Bypass != nil {
 		in, out := &in.Bypass, &out.Bypass
-		*out = new(NetworkRuleSet_Bypass)
+		*out = new(string)
 		**out = **in
 	}
 	if in.DefaultAction != nil {
@@ -4985,7 +4985,7 @@ func (in *NetworkRuleSet_ARM) DeepCopyInto(out *NetworkRuleSet_ARM) {
 	*out = *in
 	if in.Bypass != nil {
 		in, out := &in.Bypass, &out.Bypass
-		*out = new(NetworkRuleSet_Bypass_ARM)
+		*out = new(string)
 		**out = **in
 	}
 	if in.DefaultAction != nil {

--- a/v2/api/storage/versions_matrix.md
+++ b/v2/api/storage/versions_matrix.md
@@ -125,7 +125,6 @@
 | Multichannel                                                         |               | v1api20220901 | v1api20230101 |
 | Multichannel_STATUS                                                  |               | v1api20220901 | v1api20230101 |
 | NetworkRuleSet                                                       | v1api20210401 | v1api20220901 | v1api20230101 |
-| NetworkRuleSet_Bypass                                                | v1api20210401 | v1api20220901 | v1api20230101 |
 | NetworkRuleSet_Bypass_STATUS                                         | v1api20210401 | v1api20220901 | v1api20230101 |
 | NetworkRuleSet_DefaultAction                                         | v1api20210401 | v1api20220901 | v1api20230101 |
 | NetworkRuleSet_DefaultAction_STATUS                                  | v1api20210401 | v1api20220901 | v1api20230101 |

--- a/v2/azure-arm.yaml
+++ b/v2/azure-arm.yaml
@@ -487,6 +487,14 @@ typeTransformers:
     remove: true
     because: This property should have been marked readonly but wasn't.
 
+  - group: storage
+    name: NetworkRuleSet  # This type is subsequently flattened into NamespacesTopics_Spec
+    property: Bypass
+    target:
+      name: string
+      optional: true
+    because: The enum restrictions on this type are incomplete. Storage allows a,b,c but doesn't document that in the enum.
+
   - group: servicebus
     name: SBSubscriptionProperties  # This type is subsequently flattened into Namespaces_Topics_Subscription_Spec
     property: Status


### PR DESCRIPTION
Fixes #4247.

Storage supports passing multiple values to the Bypass parameter separated by a comma, but that's not how Swagger enums work so the fact they've specified this field as an enum is technically incorrect. We just treat it as a string to allow the user to pass multiple values

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
