### PR TITLE
Add configuration to allow resolving name collisions when loading resources

### DIFF
--- a/hack/crossplane/apis/sql/v1api20201101preview/servers_database_types_gen.go
+++ b/hack/crossplane/apis/sql/v1api20201101preview/servers_database_types_gen.go
@@ -15,7 +15,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // Generator information:
-// - Generated from: /sql/resource-manager/Microsoft.Sql/preview/2020-11-01-preview/Databases_legacy.json
+// - Generated from: /sql/resource-manager/Microsoft.Sql/preview/2020-11-01-preview/Databases.json
 // - ARM URI: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}
 type Servers_Database struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -26,7 +26,7 @@ type Servers_Database struct {
 
 // +kubebuilder:object:root=true
 // Generator information:
-// - Generated from: /sql/resource-manager/Microsoft.Sql/preview/2020-11-01-preview/Databases_legacy.json
+// - Generated from: /sql/resource-manager/Microsoft.Sql/preview/2020-11-01-preview/Databases.json
 // - ARM URI: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}
 type Servers_DatabaseList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/v2/azure-arm.yaml
+++ b/v2/azure-arm.yaml
@@ -129,6 +129,22 @@ typeFilters:
     group: costmanagement
     because: QueryFilter is a self-referential, infinitely recursive type. We can't easily unroll it and controller-gen doesn't support recursive types
 
+#
+# When loading resources, it's possible for us to end up with a name collision if two resources 
+# specify similar URLs (we derive the names from the structure of the ARM URL specified for the 
+# resource). This is an extremely rare event.
+# Because this happens so early in the operation of our pipeline, our existing mechanisms for 
+# disambiguation and renaming can't be applied, so we special case them here.
+#
+# This is configuration of last resort; in most cases, you should use the objectModelConfiguration
+# to rename things as it is much more flexible.
+#
+typeLoaderRenames:
+  - group: insights
+    name: DiagnosticSetting
+    scope: Location
+    renameTo: SubscriptionDiagnosticSetting
+
 # Exclusions for packages that currently produce types including AnyType.
 # TODO: get rid of these, either by chasing the teams generating
 # weird json or by handling them differently in the generator.

--- a/v2/tools/generator/internal/codegen/pipeline/load_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/load_types.go
@@ -406,17 +406,14 @@ type typesFromFile struct {
 	filePath string
 }
 
-type typesFromFilesSorter struct{ x []typesFromFile }
-
-var _ sort.Interface = typesFromFilesSorter{}
-
-func (s typesFromFilesSorter) Len() int           { return len(s.x) }
-func (s typesFromFilesSorter) Swap(i, j int)      { s.x[i], s.x[j] = s.x[j], s.x[i] }
-func (s typesFromFilesSorter) Less(i, j int) bool { return s.x[i].filePath < s.x[j].filePath }
-
 // mergeTypesForPackage merges the types for a single package from multiple files
 func mergeTypesForPackage(idFactory astmodel.IdentifierFactory, typesFromFiles []typesFromFile) jsonast.SwaggerTypes {
-	sort.Sort(typesFromFilesSorter{typesFromFiles})
+	// Sort into order by filePath so we're deterministic
+	slices.SortFunc(
+		typesFromFiles,
+		func(left typesFromFile, right typesFromFile) int {
+			return strings.Compare(left.filePath, right.filePath)
+		})
 
 	typeNameCounts := make(map[astmodel.InternalTypeName]int)
 	for _, typesFromFile := range typesFromFiles {

--- a/v2/tools/generator/internal/codegen/pipeline/load_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/load_types.go
@@ -450,6 +450,7 @@ func mergeTypesForPackage(
 			// but they might be structurally equal
 		}
 
+		defs := mergedResult.OtherDefinitions
 		for rn, rt := range typesFromFile.ResourceDefinitions {
 			if foundRT, ok := mergedResult.ResourceDefinitions[rn]; ok {
 				// We have two resources with the same name, if they have exact same structure, they're the same

--- a/v2/tools/generator/internal/codegen/pipeline/load_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/load_types.go
@@ -91,8 +91,7 @@ func LoadTypes(
 
 				// add on ARM Type, URI, and supported operations
 				resourceType = resourceType.WithARMType(resourceInfo.ARMType).WithARMURI(resourceInfo.ARMURI)
-				scope := categorizeResourceScope(resourceInfo.ARMURI)
-				resourceType = resourceType.WithScope(scope)
+				resourceType = resourceType.WithScope(resourceInfo.Scope)
 				resourceType = resourceType.WithSupportedOperations(resourceInfo.SupportedOperations)
 
 				resourceDefinition := astmodel.MakeTypeDefinition(resourceName, resourceType)
@@ -123,31 +122,6 @@ func LoadTypes(
 
 			return defs, nil
 		})
-}
-
-var (
-	resourceGroupScopeRegex = regexp.MustCompile(`(?i)^/subscriptions/[^/]+/resourcegroups/[^/]+/.*`)
-	locationScopeRegex      = regexp.MustCompile(`(?i)^/subscriptions/[^/]+/.*`)
-)
-
-func categorizeResourceScope(armURI string) astmodel.ResourceScope {
-	// this is a bit of a hack, eventually we should have better scope support.
-	// at the moment we assume that a resource is an extension if it can be applied to
-	// any scope or if armURI contains more than 1 provider:
-	if strings.HasPrefix(armURI, "/{scope}/") || strings.Count(armURI, "providers") > 1 {
-		return astmodel.ResourceScopeExtension
-	}
-
-	if resourceGroupScopeRegex.MatchString(armURI) {
-		return astmodel.ResourceScopeResourceGroup
-	}
-
-	if locationScopeRegex.MatchString(armURI) {
-		return astmodel.ResourceScopeLocation
-	}
-
-	// TODO: Not currently possible to generate a resource with scope Location, we should fix that
-	return astmodel.ResourceScopeTenant
 }
 
 var requiredSpecFields = astmodel.NewObjectType().WithProperties(
@@ -593,6 +567,7 @@ func applyRenames(
 			ARMURI:              rt.ARMURI,
 			ARMType:             rt.ARMType,
 			SupportedOperations: rt.SupportedOperations,
+			Scope:               rt.Scope,
 		}
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/load_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/load_types.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"

--- a/v2/tools/generator/internal/config/configuration.go
+++ b/v2/tools/generator/internal/config/configuration.go
@@ -47,6 +47,8 @@ type Configuration struct {
 	AnyTypePackages []string `yaml:"anyTypePackages"`
 	// Filters used to control which types are created from the JSON schema
 	TypeFilters []*TypeFilter `yaml:"typeFilters"`
+	// Renamers used to resolve naming collisions during loading
+	TypeLoaderRenames []*TypeLoaderRename `yaml:"typeLoaderRenames"`
 	// Transformers used to remap types
 	Transformers []*TypeTransformer `yaml:"typeTransformers"`
 	// RootURL is the root URL for ASOv2 repo, paths are appended to this to generate resource links.

--- a/v2/tools/generator/internal/config/type_loader_rename.go
+++ b/v2/tools/generator/internal/config/type_loader_rename.go
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package config
+
+// A TypeLoaderRename is used to resolve a naming conflict that happens during loading of types
+// right at the start of the code generator.
+type TypeLoaderRename struct {
+	TypeMatcher `yaml:",inline"`
+	Scope       *string `yaml:"scope,omitempty"`
+	RenameTo    *string `yaml:"renameTo,omitempty"`
+}

--- a/v2/tools/generator/internal/jsonast/swagger_type_extractor.go
+++ b/v2/tools/generator/internal/jsonast/swagger_type_extractor.go
@@ -70,6 +70,7 @@ type ResourceDefinition struct {
 	ARMType             string // e.g. Microsoft.XYZ/resourceThings
 	ARMURI              string
 	SupportedOperations set.Set[astmodel.ResourceOperation]
+	Scope               astmodel.ResourceScope
 	// TODO: use ARMURI for generating Resource URIs (only used for documentation & ownership at the moment)
 }
 
@@ -278,6 +279,7 @@ func (extractor *SwaggerTypeExtractor) extractOneResourceType(
 			ARMType:             armType,
 			ARMURI:              operationPath,
 			SupportedOperations: supportedOperations,
+			Scope:               categorizeResourceScope(operationPath),
 		}
 	}
 
@@ -952,4 +954,40 @@ func makeSchemaFromSimpleSchemaParam(param schemaAndValidations) *spec.Schema {
 	schema = schema.WithValidations(param.Validations())
 
 	return schema
+}
+
+var (
+	resourceGroupScopeRegex = regexp.MustCompile(`(?i)^/subscriptions/[^/]+/resourcegroups/[^/]+/.*`)
+	locationScopeRegex      = regexp.MustCompile(`(?i)^/subscriptions/[^/]+/.*`)
+	resourceScopePrefixes   = []string{
+		"/{scope}/",
+		"/{resourceUri}/",
+	}
+)
+
+func categorizeResourceScope(armURI string) astmodel.ResourceScope {
+	// this is a bit of a hack, eventually we should have better scope support.
+	// at the moment we assume that a resource is an extension if it has a specific prefix
+	for _, prefix := range resourceScopePrefixes {
+		// Case-insensitive prefix check, as befits a heuristic
+		if strings.EqualFold(prefix, armURI[:len(prefix)]) {
+			return astmodel.ResourceScopeExtension
+		}
+	}
+
+	// Assume that a resource is an extension if armURI contains more than 1 provider:
+	if strings.Count(armURI, "providers") > 1 {
+		return astmodel.ResourceScopeExtension
+	}
+
+	if resourceGroupScopeRegex.MatchString(armURI) {
+		return astmodel.ResourceScopeResourceGroup
+	}
+
+	if locationScopeRegex.MatchString(armURI) {
+		return astmodel.ResourceScopeLocation
+	}
+
+	// TODO: Not currently possible to generate a resource with scope Location, we should fix that
+	return astmodel.ResourceScopeTenant
 }

--- a/v2/tools/generator/internal/jsonast/swagger_type_extractor.go
+++ b/v2/tools/generator/internal/jsonast/swagger_type_extractor.go
@@ -959,7 +959,7 @@ func makeSchemaFromSimpleSchemaParam(param schemaAndValidations) *spec.Schema {
 var (
 	resourceGroupScopeRegex = regexp.MustCompile(`(?i)^/subscriptions/[^/]+/resourcegroups/[^/]+/.*`)
 	locationScopeRegex      = regexp.MustCompile(`(?i)^/subscriptions/[^/]+/.*`)
-	resourceScopePrefixes   = []string{
+	extensionScopePrefixes  = []string{
 		"/{scope}/",
 		"/{resourceUri}/",
 	}
@@ -968,7 +968,7 @@ var (
 func categorizeResourceScope(armURI string) astmodel.ResourceScope {
 	// this is a bit of a hack, eventually we should have better scope support.
 	// at the moment we assume that a resource is an extension if it has a specific prefix
-	for _, prefix := range resourceScopePrefixes {
+	for _, prefix := range extensionScopePrefixes {
 		// Case-insensitive prefix check, as befits a heuristic
 		if strings.EqualFold(prefix, armURI[:len(prefix)]) {
 			return astmodel.ResourceScopeExtension


### PR DESCRIPTION
## What this PR does / why we need it

When loading resources from `Microsoft.Insights` we are encountering a panic caused by a naming collision between two near identical resources, `DiagnosticsSettings`. 

To resolve this, we need to target specific renaming to the two types so they end up with different names. Our existing configuration doesn't operate this early in the pipeline, so we need to special case things.

Closes #4337 

## Special notes for your reviewer

I've left the configuration required for `insights` in our configuration file so things are ready to go for our contributer.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/wEgs1cd7vDTt6/giphy.gif?cid=790b7611fz05k6wahum6gcqy0ibfr188b88gru61cxywrlgr&ep=v1_gifs_search&rid=giphy.gif&ct=g)
