### PR TITLE
Update version of Go

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/devcontainers/images/blob/main/src/go/.devcontainer/Dockerfile
 
 # This is pinned to a particular version of go:
-FROM mcr.microsoft.com/devcontainers/go:1.22
+FROM mcr.microsoft.com/devcontainers/go:1.23
 
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 ARG TARGETARCH

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -104,7 +104,7 @@ GOVER=$(go version)
 write-info "Go version: ${GOVER[*]}"
 
 GOVERREGEX=".*go1.([0-9]+).([0-9]+).*"
-GOVERREQUIRED="go1.22.*"
+GOVERREQUIRED="go1.23.*"
 GOVERACTUAL=$(go version | { read _ _ ver _; echo "$ver"; })
 
 if ! [[ $GOVERACTUAL =~ $GOVERREGEX ]]; then


### PR DESCRIPTION
## What this PR does / why we need it

Updates version of Go to 1.23 to avoid this error:

```
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@latest: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20241014151821-aa78068bdf55 requires go >= 1.23.0 (running go 1.22.7; GOTOOLCHAIN=local)
```

Tested by rebuilding the container and running `task ci` locally.

## How does this PR make you feel
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2t1aW8wMXowa3VsZXR0cTRpdjg3NGo1Y2RudG02Y2pzc3V3bjc4MCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3oxHQrAmG6bd6RRh4s/giphy.gif)

