### PR TITLE
Upgrade version of docsy and address broken links

### DIFF
--- a/docs/hugo/.htmltest.yml
+++ b/docs/hugo/.htmltest.yml
@@ -17,5 +17,6 @@ IgnoreURLs:
   - "https://armwiki.azurewebsites.net/api_contracts/guidelines/templatedeployment.html" # Returns 404 even though valid
   - "https://marketplace.visualstudio.com/items" # Marketplace links return 401 even if valid
   - "https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/async-api-reference.md" # Manually checked, not a 404
+  - "https://code.visualstudio.com/docs/devcontainers/containers" # Returns 403 even though valid
   - "azure-workload-identity" # TODO: Work out why this fails
 LogLevel: 3

--- a/docs/hugo/content/contributing/developer-setup.md
+++ b/docs/hugo/content/contributing/developer-setup.md
@@ -22,9 +22,9 @@ Each of these is described in a different section below. See also the [troublesh
 
 Use these steps if you've checked out the ASO code into a Linux environment (_including_ WSL 2 on Windows). We've found this to be the best performing option.
 
-The ASO repository contains a [devcontainer](https://code.visualstudio.com/docs/remote/containers) configuration that can be used in conjunction with VS Code to set up an environment with all the required tools preinstalled.
+The ASO repository contains a [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) configuration that can be used in conjunction with VS Code to set up an environment with all the required tools preinstalled.
 
-0. Make sure you have installed [the prerequisites to use Docker](https://code.visualstudio.com/docs/remote/containers#_system-requirements), including [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) if on Windows. 
+0. Make sure you have installed [the prerequisites to use Docker](https://code.visualstudio.com/docs/devcontainers/containers#_system-requirements), including [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) if on Windows. 
 1. Install VS Code and the [Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension (check installation instructions there).
 2. Ensure you have ASO checked out, and that your [repo is healthy](#troubleshooting-repo-health).
 3. Open VS Code by running `code .` from the root folder of the ASO repo.
@@ -37,9 +37,9 @@ The ASO repository contains a [devcontainer](https://code.visualstudio.com/docs/
 
 If you're working on Windows and _**not**_ using WSL 2, this is the recommended setup.
 
-The ASO repository contains a [devcontainer](https://code.visualstudio.com/docs/remote/containers) configuration that can be used in conjunction with VS Code to set up an environment with all the required tools preinstalled.
+The ASO repository contains a [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) configuration that can be used in conjunction with VS Code to set up an environment with all the required tools preinstalled.
 
-0. Make sure you have installed [the prerequisites to use Docker](https://code.visualstudio.com/docs/remote/containers#_system-requirements), including [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) if on Windows. 
+0. Make sure you have installed [the prerequisites to use Docker](https://code.visualstudio.com/docs/devcontainers/containers#_system-requirements), including [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) if on Windows. 
 1. Install VS Code and the [Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension (check installation instructions there).
 2. Open VS Code
 3. Run the VS Code command (with `Ctrl-Shift-P`): `Dev Containers: Clone Repository in Container Volume...`

--- a/docs/hugo/go.mod
+++ b/docs/hugo/go.mod
@@ -2,4 +2,7 @@ module github.com/azure/azure-service-operator/docs/hugo
 
 go 1.20
 
-require github.com/google/docsy v0.6.0 // indirect
+require (
+	github.com/google/docsy v0.10.0 // indirect
+	github.com/google/docsy/dependencies v0.7.2 // indirect
+)

--- a/docs/hugo/go.sum
+++ b/docs/hugo/go.sum
@@ -1,5 +1,13 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
 github.com/google/docsy v0.6.0/go.mod h1:VKKLqD8PQ7AglJc98yBorATfW7GrNVsn0kGXVYF6G+M=
+github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
+github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
 github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
+github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
+github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
 github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
## What this PR does / why we need it

Upgrading `hugo` seems to have broken our docs site; upgrading to a matching version of `docsy` appears to fix it.

Also adds a suppression for links that can't be verified by `htmltest`.

## How does this PR make you feel

![gif](https://media.giphy.com/media/YolMjnQDeDvnsZd3uB/giphy.gif?cid=790b7611d0jclyq0f6h6sk76bthl9vidoy79l4zsycchnmz3&ep=v1_gifs_search&rid=giphy.gif&ct=g)
