### PR TITLE
Force coverage files to /mnt (tempdir) during CI

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -110,8 +110,10 @@ jobs:
 
       - name: Run devcontainer image
         id: devcontainer
+        # The -v /mnt/reports/:/workspace/reports/ forces reports to the temp drive. The temp drive is cleaned up between CI runs and is large enough to fit the large coverage.out files.
+        # Note that this is only needed in this CI job because this is the only CI job that produces large output files (code coverage), or does anything with the /reports directory.
         run: |
-          container_id=$(docker create -w /workspace -v $GITHUB_WORKSPACE:/workspace -v /var/run/docker.sock:/var/run/docker.sock --network=host devcontainer:latest)
+          container_id=$(docker create -w /workspace -v $GITHUB_WORKSPACE:/workspace -v /mnt/reports/:/workspace/reports/ -v /var/run/docker.sock:/var/run/docker.sock --network=host devcontainer:latest)
           docker start "$container_id"
           echo "container_id=$container_id" >> $GITHUB_ENV
         if: steps.check-changes.outputs.code-changed == 'true'
@@ -127,7 +129,7 @@ jobs:
           set -e
 
           # generate summary Markdown file for display in Actions
-          cat reports/*.md > $GITHUB_STEP_SUMMARY
+          cat /mnt/reports/*.md > $GITHUB_STEP_SUMMARY
           exit $EXIT_CODE
         if: steps.check-changes.outputs.code-changed == 'true'
 
@@ -136,7 +138,7 @@ jobs:
         uses: actions/upload-artifact@v3.1.2
         with:
           name: test-output
-          path: reports/*.json
+          path: /mnt/reports/*.json
         
       - name: Build docker image & build configuration YAML
         run: |
@@ -166,6 +168,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          directory: /mnt/reports
           verbose: true
 
   # TODO: Changing this name requires changing the github API calls in pr-validation-fork.yml
@@ -227,8 +230,9 @@ jobs:
 
       - name: Run devcontainer image
         id: devcontainer
+        # The -v /mnt/reports/:/workspace/reports/ forces reports to the temp drive. The temp drive is cleaned up between CI runs and is large enough to fit the large coverage.out files.
         run: |
-          container_id=$(docker create -w /workspace -v $GITHUB_WORKSPACE:/workspace -v /var/run/docker.sock:/var/run/docker.sock --network=host devcontainer:latest)
+          container_id=$(docker create -w /workspace -v $GITHUB_WORKSPACE:/workspace -v /mnt/reports/:/workspace/reports/ -v /var/run/docker.sock:/var/run/docker.sock --network=host devcontainer:latest)
           docker start "$container_id"
           echo "container_id=$container_id" >> $GITHUB_ENV
         if: steps.check-changes.outputs.code-changed == 'true'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -152,7 +152,7 @@ tasks:
           vars:
             INPUT_FILE: '{{.TEST_OUT}}/asoctl-unit-tests.json'
             OUTPUT_FILE: '{{.TEST_OUT}}/asoctl-unit-tests.md'
-      - go test ./... -tags=noexit -race -covermode atomic -coverprofile=asoctl-coverage.out -json -coverpkg=./... -run '{{default ".*" .TEST_FILTER}}' > '{{.TEST_OUT}}/asoctl-unit-tests.json'
+      - go test ./... -tags=noexit -race -covermode atomic -coverprofile='{{.TEST_OUT}}/asoctl-coverage.out' -json -coverpkg=./... -run '{{default ".*" .TEST_FILTER}}' > '{{.TEST_OUT}}/asoctl-unit-tests.json'
 
   asoctl:lint:
     desc: Run {{.ASOCTL_APP}} fast lint checks.
@@ -227,7 +227,7 @@ tasks:
           vars:
             INPUT_FILE: '{{.TEST_OUT}}/generator-unit-tests.json'
             OUTPUT_FILE: '{{.TEST_OUT}}/generator-unit-tests.md'
-      - go test ./... -tags=noexit -race -covermode atomic -coverprofile=generator-coverage.out -json -coverpkg=./... -run '{{default ".*" .TEST_FILTER}}' > '{{.TEST_OUT}}/generator-unit-tests.json'
+      - go test ./... -tags=noexit -race -covermode atomic -coverprofile='{{.TEST_OUT}}/generator-coverage.out' -json -coverpkg=./... -run '{{default ".*" .TEST_FILTER}}' > '{{.TEST_OUT}}/generator-unit-tests.json'
 
   generator:update-golden-tests:
     desc: Update {{.GENERATOR_APP}} golden test outputs.
@@ -326,7 +326,7 @@ tasks:
             INPUT_FILE: '{{.TEST_OUT}}/controller-unit-tests.json'
             OUTPUT_FILE: '{{.TEST_OUT}}/controller-unit-tests.md'
       # -race fails at the moment in gopter - possibly due to our shared generator variable?
-      - go test -short -tags=noexit -timeout 10m -covermode atomic -coverprofile=controller-coverage.out -json -coverpkg="./..." -run '{{default ".*" .TEST_FILTER}}' ./... > '{{.TEST_OUT}}/controller-unit-tests.json'
+      - go test -short -tags=noexit -timeout 10m -covermode atomic -coverprofile='{{.TEST_OUT}}/controller-coverage.out' -json -coverpkg="./..." -run '{{default ".*" .TEST_FILTER}}' ./... > '{{.TEST_OUT}}/controller-unit-tests.json'
 
   controller:test-upgrade-setup:
     desc: Setup for upgrade test
@@ -555,9 +555,9 @@ tasks:
             INPUT_FILE: '{{.TEST_OUT}}/controller-integration-genericarmclient-tests.json'
             OUTPUT_FILE: '{{.TEST_OUT}}/controller-integration-genericarmclient-tests.md'
       # -race fails at the moment in controller-runtime
-      - go test -covermode atomic -coverprofile=coverage-integration-envtest.out -coverpkg="./..." -json -timeout 15m -run '{{default ".*" .TEST_FILTER}}' ./internal/controllers > '{{.TEST_OUT}}/controller-integration-tests.json'
-      - go test -covermode atomic -coverprofile=coverage-integration-genruntime-envtest.out -coverpkg="./..." -json -timeout 15m -run '{{default ".*" .TEST_FILTER}}' ./pkg/genruntime/test > '{{.TEST_OUT}}/controller-integration-genruntime-tests.json'
-      - go test -covermode atomic -coverprofile=coverage-integration-genericarmclient-envtest.out -coverpkg="./..." -json -timeout 15m -run '{{default ".*" .TEST_FILTER}}' ./internal/genericarmclient > '{{.TEST_OUT}}/controller-integration-genericarmclient-tests.json'
+      - go test -covermode atomic -coverprofile='{{.TEST_OUT}}/coverage-integration-envtest.out' -coverpkg="./..." -json -timeout 15m -run '{{default ".*" .TEST_FILTER}}' ./internal/controllers > '{{.TEST_OUT}}/controller-integration-tests.json'
+      - go test -covermode atomic -coverprofile='{{.TEST_OUT}}/coverage-integration-genruntime-envtest.out' -coverpkg="./..." -json -timeout 15m -run '{{default ".*" .TEST_FILTER}}' ./pkg/genruntime/test > '{{.TEST_OUT}}/controller-integration-genruntime-tests.json'
+      - go test -covermode atomic -coverprofile='{{.TEST_OUT}}/coverage-integration-genericarmclient-envtest.out' -coverpkg="./..." -json -timeout 15m -run '{{default ".*" .TEST_FILTER}}' ./internal/genericarmclient > '{{.TEST_OUT}}/controller-integration-genericarmclient-tests.json'
 
   controller:test-integration-envtest-live:
     desc: Run integration tests with envtest against live data and output coverage.
@@ -567,7 +567,7 @@ tasks:
       - cleanup-azure-resources
     cmds:
       # -race fails at the moment in controller-runtime
-      - go test -timeout {{.LIVE_TEST_TIMEOUT}} -covermode atomic -coverprofile=coverage-integration-envtest-live.out -coverpkg="./..." -run '{{default ".*" .TEST_FILTER}}' ./internal/controllers -args -live
+      - go test -timeout {{.LIVE_TEST_TIMEOUT}} -covermode atomic -coverprofile='{{.TEST_OUT}}/coverage-integration-envtest-live.out' -coverpkg="./..." -run '{{default ".*" .TEST_FILTER}}' ./internal/controllers -args -live
     env:
       RECORD_REPLAY: 0
 

--- a/reports/README
+++ b/reports/README
@@ -1,3 +1,0 @@
-# Reports
-
-The makefile testing targets in this project will save their report outputs to this directory when run.

--- a/scripts/v2/linux-docker-use-ssd.sh
+++ b/scripts/v2/linux-docker-use-ssd.sh
@@ -24,6 +24,11 @@ if ! command -v jq &> /dev/null; then
     exit 1
 fi
 
+# Print the current disk usage, useful for diagnosing what's gone wrong if
+# the disk fills up
+df -h
+du -h --threshold=1G --max-depth=5 / 2>&1 | grep -v 'denied' | sort -hr
+
 CONTAINERD="false"
 while [[ $# -gt 0 ]]; do
     case $1 in


### PR DESCRIPTION
Force coverage files to /mnt (tempdir) during CI

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
