### PR TITLE
Undo force covecov to /mnt

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -110,10 +110,8 @@ jobs:
 
       - name: Run devcontainer image
         id: devcontainer
-        # The -v /mnt/reports/:/workspace/reports/ forces reports to the temp drive. The temp drive is cleaned up between CI runs and is large enough to fit the large coverage.out files.
-        # Note that this is only needed in this CI job because this is the only CI job that produces large output files (code coverage), or does anything with the /reports directory.
         run: |
-          container_id=$(docker create -w /workspace -v $GITHUB_WORKSPACE:/workspace -v /mnt/reports/:/workspace/reports/ -v /var/run/docker.sock:/var/run/docker.sock --network=host devcontainer:latest)
+          container_id=$(docker create -w /workspace -v $GITHUB_WORKSPACE:/workspace -v /var/run/docker.sock:/var/run/docker.sock --network=host devcontainer:latest)
           docker start "$container_id"
           echo "container_id=$container_id" >> $GITHUB_ENV
         if: steps.check-changes.outputs.code-changed == 'true'
@@ -129,7 +127,7 @@ jobs:
           set -e
 
           # generate summary Markdown file for display in Actions
-          cat /mnt/reports/*.md > $GITHUB_STEP_SUMMARY
+          cat reports/*.md > $GITHUB_STEP_SUMMARY
           exit $EXIT_CODE
         if: steps.check-changes.outputs.code-changed == 'true'
 
@@ -138,7 +136,7 @@ jobs:
         uses: actions/upload-artifact@v3.1.2
         with:
           name: test-output
-          path: /mnt/reports/*.json
+          path: reports/*.json
         
       - name: Build docker image & build configuration YAML
         run: |
@@ -168,7 +166,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: /mnt/reports
+          directory: reports
           verbose: true
 
   # TODO: Changing this name requires changing the github API calls in pr-validation-fork.yml
@@ -230,9 +228,8 @@ jobs:
 
       - name: Run devcontainer image
         id: devcontainer
-        # The -v /mnt/reports/:/workspace/reports/ forces reports to the temp drive. The temp drive is cleaned up between CI runs and is large enough to fit the large coverage.out files.
         run: |
-          container_id=$(docker create -w /workspace -v $GITHUB_WORKSPACE:/workspace -v /mnt/reports/:/workspace/reports/ -v /var/run/docker.sock:/var/run/docker.sock --network=host devcontainer:latest)
+          container_id=$(docker create -w /workspace -v $GITHUB_WORKSPACE:/workspace -v /var/run/docker.sock:/var/run/docker.sock --network=host devcontainer:latest)
           docker start "$container_id"
           echo "container_id=$container_id" >> $GITHUB_ENV
         if: steps.check-changes.outputs.code-changed == 'true'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -73,6 +73,11 @@ tasks:
     cmds:
       - task: format-code # Run after the deps to avoid racing with generated file creation
 
+  setup:
+    desc: Perform setup tasks
+    cmds:
+      - "mkdir -p {{.TEST_OUT}}"
+
   ci:
     desc: Run all CI checks.
     cmds:
@@ -145,6 +150,7 @@ tasks:
     desc: Run {{.ASOCTL_APP}} unit tests and output coverage.
     dir: '{{.ASOCTL_ROOT}}'
     deps:
+      - setup
       - controller:generate-crds
     cmds:
       - defer: # want to run even on failure
@@ -221,6 +227,8 @@ tasks:
   generator:unit-tests-cover:
     desc: Run {{.GENERATOR_APP}} unit tests and output coverage.
     dir: '{{.GENERATOR_ROOT}}'
+    deps:
+      - setup
     cmds:
       - defer: # want to run even on failure
           task: produce-markdown-summary
@@ -317,6 +325,7 @@ tasks:
     desc: Run {{.CONTROLLER_APP}} unit tests and output coverage.
     dir: "{{.CONTROLLER_ROOT}}"
     deps:
+    - setup
     - controller:generate-crds
     - controller:bundle-crds # bundle-crds is here because some tests assert on generated CRD shape
     cmds:
@@ -536,7 +545,8 @@ tasks:
   controller:test-integration-envtest-cover:
     desc: Run integration tests with envtest using record/replay and output coverage.
     dir: "{{.CONTROLLER_ROOT}}"
-    deps: 
+    deps:
+      - setup
       - controller:run-kustomize-for-envtest
     cmds:
       - defer: # want to run even on failure

--- a/scripts/v2/linux-docker-use-ssd.sh
+++ b/scripts/v2/linux-docker-use-ssd.sh
@@ -27,7 +27,10 @@ fi
 # Print the current disk usage, useful for diagnosing what's gone wrong if
 # the disk fills up
 df -h
-du -h --threshold=1G --max-depth=5 / 2>&1 | grep -v 'denied' | sort -hr
+
+# Uncomment the below to show more disk stats (including what files are large).
+# Commented out as it can take a long time to run and slows CI down
+# du -h --threshold=1G --max-depth=5 / 2>&1 | grep -v 'denied' | sort -hr
 
 CONTAINERD="false"
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
There was a bug in the GitHub runner infrastructure we use that caused the build to happen on the wrong drive. Now that this bug is fixed we don't need this workaround anymore.

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
