### PR TITLE
Add envtest panic handler

### DIFF
--- a/v2/cmd/controller/app/setup.go
+++ b/v2/cmd/controller/app/setup.go
@@ -405,6 +405,7 @@ func makeControllerOptions(log logr.Logger, cfg config.Values) generic.Options {
 			// These rate limits are used for happy-path backoffs (for example polling async operation IDs for PUT/DELETE)
 			RateLimiter: generic.NewRateLimiter(1*time.Second, 1*time.Minute, additionalRateLimiters...),
 		},
+		PanicHandler: func() {},
 		RequeueIntervalCalculator: interval.NewCalculator(
 			// These rate limits are primarily for ReadyConditionImpactingError's
 			interval.CalculatorParameters{

--- a/v2/internal/reconcilers/generic/generic_reconciler.go
+++ b/v2/internal/reconcilers/generic/generic_reconciler.go
@@ -51,6 +51,8 @@ type GenericReconciler struct {
 	GVK                       schema.GroupVersionKind
 	PositiveConditions        *conditions.PositiveConditionBuilder
 	RequeueIntervalCalculator interval.Calculator
+
+	PanicHandler func()
 }
 
 var _ reconcile.Reconciler = &GenericReconciler{} // GenericReconciler is a reconcile.Reconciler
@@ -72,6 +74,8 @@ func (gr *GenericReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	metaObj = metaObj.DeepCopyObject().(genruntime.MetaObject)
 
 	log := gr.LoggerFactory(metaObj).WithValues("name", req.Name, "namespace", req.Namespace)
+
+	defer gr.PanicHandler()
 	reconcilers.LogObj(log, Verbose, "Reconcile invoked", metaObj)
 
 	// Ensure the resource is tagged with the operator's namespace.

--- a/v2/internal/reconcilers/generic/register.go
+++ b/v2/internal/reconcilers/generic/register.go
@@ -36,6 +36,8 @@ type Options struct {
 	RequeueIntervalCalculator interval.Calculator
 	Config                    config.Values
 	LoggerFactory             func(obj metav1.Object) logr.Logger
+
+	PanicHandler func()
 }
 
 func RegisterWebhooks(mgr ctrl.Manager, objs []client.Object) error {
@@ -126,6 +128,7 @@ func register(
 		GVK:                       gvk,
 		PositiveConditions:        positiveConditions,
 		RequeueIntervalCalculator: options.RequeueIntervalCalculator,
+		PanicHandler:              options.PanicHandler,
 	}
 
 	builder := ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
We disable controller-runtime logging for our envtest instances because we create multiple of them and it can be a lot of extra logs we don't need, but we rely on controller-runtime logs for panic-detection.

We want panic logging with controller-runtime logging disabled for envtest, but we don't want duplicate panic logs in production, so we introduce a PanicHandler that is set only in envtest contexts.

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
