### PR TITLE
Increase randomness of naming

### DIFF
--- a/v2/internal/testcommon/resource_namer.go
+++ b/v2/internal/testcommon/resource_namer.go
@@ -37,14 +37,8 @@ type ResourceNamer struct {
 }
 
 // WithTestName returns a new ResourceNamer configured based on the provided test name.
-// If the original ResourceNamer was entirely random (mode == ResourceNamerModeRandom),
-// the returned namer is not actually based on the test name and is instead still entirely random
+// The mode of the original resource namer is preserved.
 func (n ResourceNamer) WithTestName(testName string) ResourceNamer {
-	// Short circuit for the case we're supposed to be totally random, as we already are
-	if n.mode == ResourceNamerModeRandom {
-		return n
-	}
-
 	return n.NewResourceNamer(testName)
 }
 


### PR DESCRIPTION
## What this PR does

We use a resource namer that generates a "random" suffix for resources to ensure concurrent tests don't clash during execution.

This namer has two modes - one is predictable (based on the test name) and generates the same results every time, and one is purely random.

We're getting clashes between concurrent tests using _random_ names and we think this is due to a lack of randomness caused by seeding the generator with the current time.

In this PR we switch to _also_ using the test name, increasing the number of bits of entropy.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNTA2d2pwOHZzemhoYXc1bWZlZjB0emF0MDA0bnB3bmtybmNldDZ4ciZlcD12MV9naWZzX3NlYXJjaCZjdD1n/mxXPuScIwPwK2oyD6i/giphy.gif)
