### PR TITLE
Update action versions and fix broken workflows

### DIFF
--- a/.github/workflows/api-docs-repo.yaml
+++ b/.github/workflows/api-docs-repo.yaml
@@ -98,10 +98,21 @@ jobs:
       - name: Take Ownership
         run: sudo chown -R $USER:$USER .
 
+
+      # Generating docs can take so long that the original token expires, so we create a new one
+      # and use that to create the PR
+      - name: Create token for PR
+        uses: actions/create-github-app-token@v1
+        id: pr-token
+        with:
+          # required
+          app-id: ${{ secrets.AUTOMATION_ID }}
+          private-key: ${{ secrets.AUTOMATION_KEY }}
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # pinned to v7.0.5
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.pr-token.outputs.token }}
           commit-message: Update API Docs
           branch: ${{ format('bot/update-api-docs-{0}', github.run_number) }}
           base: main

--- a/.github/workflows/api-docs-repo.yaml
+++ b/.github/workflows/api-docs-repo.yaml
@@ -99,7 +99,7 @@ jobs:
         run: sudo chown -R $USER:$USER .
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5.0.0
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # pinned to v7.0.5
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: Update API Docs

--- a/.github/workflows/build-devcontainer-image.yml
+++ b/.github/workflows/build-devcontainer-image.yml
@@ -36,7 +36,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push Devcontainer image 
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .devcontainer
           push: true

--- a/.github/workflows/create-release-experimental.yml
+++ b/.github/workflows/create-release-experimental.yml
@@ -65,7 +65,7 @@ jobs:
         run: sleep 60s
 
       - name: Upload release assets
-        uses: svenstaro/upload-release-action@1beeb572c19a9242f4361f4cee78f8e0d9aec5df # this is v2.7.0, but pinned
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # this is v2.9.0, but pinned
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: refs/tags/${{ env.ARTIFACT_VERSION }}

--- a/.github/workflows/create-release-official.yml
+++ b/.github/workflows/create-release-official.yml
@@ -42,7 +42,7 @@ jobs:
           docker exec "$container_id" task make-release-artifacts
 
       - name: Upload release assets
-        uses: svenstaro/upload-release-action@1beeb572c19a9242f4361f4cee78f8e0d9aec5df # this is v2.7.0, but pinned
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # this is v2.9.0, but pinned
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}

--- a/.github/workflows/helm-chart-repo.yaml
+++ b/.github/workflows/helm-chart-repo.yaml
@@ -105,7 +105,7 @@ jobs:
         run: sudo chown -R $USER:$USER .
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5.0.0
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # pinned to v7.0.5
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: Add Helm Chart

--- a/.github/workflows/live-validation.yml
+++ b/.github/workflows/live-validation.yml
@@ -10,8 +10,13 @@ jobs:
   test-generator:
     concurrency: live-resources # only permit one run at a time
     runs-on: [self-hosted, 1ES.Pool=aso-1es-pool]
+
     permissions:
       contents: read
+
+    # Only run this scheduled job on the main repo, it can't work elsewhere
+    if: ${{ github.repository == 'Azure/azure-service-operator' }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Save JSON logs on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: test-output
           path: reports/*.json
@@ -146,7 +146,7 @@ jobs:
         if: steps.check-changes.outputs.code-changed == 'true'
 
       - name: Archive outputs
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: output
           path: v2/bin/*

--- a/.github/workflows/pre-release-tests.yaml
+++ b/.github/workflows/pre-release-tests.yaml
@@ -14,6 +14,9 @@ jobs:
     permissions:
       contents: read
 
+    # Only run this scheduled job on the main repo, it can't work elsewhere
+    if: ${{ github.repository == 'Azure/azure-service-operator' }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7

--- a/.github/workflows/visualize-repo.yml
+++ b/.github/workflows/visualize-repo.yml
@@ -81,7 +81,7 @@ jobs:
           should_push: false
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5.0.0
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # pinned to v7.0.5
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: Update Code Structure Diagrams


### PR DESCRIPTION
## What this PR does

Earlier versions of the `actions/upload-artifacts` action are being deprecated shortly and will stop working, so they need to be updated.

We also have a few versions triggering warnings because they target old versions of Node.js:

```
The following actions use a deprecated Node.js version and will be forced to run on node20:
```

Plus, our CRD documentation workflow has been failing for a while, so that needs a fix.
