### PR TITLE
Tidyup ARM type naming

### DIFF
--- a/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
@@ -867,7 +867,7 @@ func (builder *convertToARMBuilder) convertComplexTypeNameProperty(
 	}
 
 	var results []dst.Stmt
-	propertyLocalVarName := params.Locals.CreateLocal(params.NameHint, astmodel.ARMSuffix)
+	propertyLocalVarName := params.Locals.CreateLocal(params.NameHint, "_ARM")
 
 	// Call ToARM on the property
 	results = append(results, callToARMFunction(params.GetSource(), dst.NewIdent(propertyLocalVarName), builder.methodName)...)

--- a/v2/tools/generator/internal/astmodel/identifier_factory.go
+++ b/v2/tools/generator/internal/astmodel/identifier_factory.go
@@ -293,11 +293,9 @@ func createReservedWords() map[string]string {
 
 // createForbiddenReceiverSuffixes creates a case-sensitive list of words we don't want to use as receiver names
 func createForbiddenReceiverSuffixes() set.Set[string] {
-	// If/when Status or Spec are all capitals, ARM isn't separated as a different word
 	status := strings.TrimPrefix(StatusSuffix, "_")
 	spec := strings.TrimPrefix(SpecSuffix, "_")
-	arm := strings.TrimPrefix(ARMSuffix, "_")
-	return set.Make(status, spec, arm, status+arm, spec+arm)
+	return set.Make(status, spec)
 }
 
 func (factory *identifierFactory) CreateGroupName(group string) string {

--- a/v2/tools/generator/internal/astmodel/identifier_factory_test.go
+++ b/v2/tools/generator/internal/astmodel/identifier_factory_test.go
@@ -203,8 +203,6 @@ func Test_CreateReceiver_GivenTypeName_ReturnsExpectedResult(t *testing.T) {
 		// Forbidden receiver suffixes
 		{"Address" + StatusSuffix, "address"},
 		{"Address" + SpecSuffix, "address"},
-		{"Address" + StatusSuffix + ARMSuffix, "address"},
-		{"Address" + SpecSuffix + ARMSuffix, "address"},
 		// Real world examples
 		{"EncryptionSettingsCollection", "collection"},
 		{"RedisLinkedServer", "server"},
@@ -217,7 +215,7 @@ func Test_CreateReceiver_GivenTypeName_ReturnsExpectedResult(t *testing.T) {
 		{"DatabaseAccountsMongodbDatabasesCollections" + SpecSuffix, "collections"},
 		{"DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings" + SpecSuffix, "settings"},
 		// Very short receiver names need more detail
-		{"SignalR" + SpecSuffix + ARMSuffix, "signalR"},
+		{"SignalR" + SpecSuffix, "signalR"},
 		{"PublicIPAddressSku" + StatusSuffix, "addressSku"},
 		{"SBSku" + StatusSuffix, "sbSku"},
 		{"ManagedClusterSKU", "clusterSKU"},

--- a/v2/tools/generator/internal/astmodel/internal_type_name.go
+++ b/v2/tools/generator/internal/astmodel/internal_type_name.go
@@ -186,11 +186,7 @@ func (tn InternalTypeName) IsStatus() bool {
 
 // IsARMType returns true if the TypeName identifies an ARM specific type, false otherwise.
 func (tn InternalTypeName) IsARMType() bool {
-	if IsARMPackageReference(tn.InternalPackageReference()) {
-		return true
-	}
-
-	return strings.HasSuffix(tn.Name(), ARMSuffix)
+	return IsARMPackageReference(tn.InternalPackageReference())
 }
 
 func (tn InternalTypeName) IsEmpty() bool {

--- a/v2/tools/generator/internal/astmodel/type_name.go
+++ b/v2/tools/generator/internal/astmodel/type_name.go
@@ -16,8 +16,6 @@ const (
 	SpecSuffix = "_Spec"
 	// StatusSuffix is the suffix used for all Status types
 	StatusSuffix = "_STATUS"
-	// ARMSuffix is the suffix used for all ARM types
-	ARMSuffix = "_ARM"
 	// ARMPackageName is the name used for ARM subpackages
 	ARMPackageName = "arm"
 )

--- a/v2/tools/generator/internal/astmodel/type_name.go
+++ b/v2/tools/generator/internal/astmodel/type_name.go
@@ -5,8 +5,6 @@
 
 package astmodel
 
-import "github.com/Azure/azure-service-operator/v2/internal/set"
-
 type TypeName interface {
 	Type
 	Name() string
@@ -24,16 +22,8 @@ const (
 	ARMPackageName = "arm"
 )
 
-var armPackageDenyList = set.Make(
-	"kusto")
-
 // CreateARMTypeName creates an ARM object type name
 func CreateARMTypeName(name InternalTypeName) InternalTypeName {
-	pkg := name.InternalPackageReference()
-	if armPackageDenyList.Contains(pkg.Group()) {
-		return MakeInternalTypeName(pkg, name.Name()+ARMSuffix)
-	}
-
 	armPackage := MakeSubPackageReference(ARMPackageName, name.InternalPackageReference())
 	return MakeInternalTypeName(armPackage, name.Name())
 }

--- a/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd.go
+++ b/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd.go
@@ -192,7 +192,6 @@ type nameHint struct {
 var suffixesToFloat = []string{
 	astmodel.SpecSuffix,
 	astmodel.StatusSuffix,
-	astmodel.ARMSuffix,
 }
 
 func newNameHint(name astmodel.TypeName) nameHint {

--- a/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd_test.go
@@ -46,17 +46,10 @@ func Test_NewNameHint(t *testing.T) {
 		},
 		{
 			"Simple TypeName",
-			astmodel.MakeInternalTypeName(test.Pkg2020, "Person"+astmodel.ARMSuffix),
+			astmodel.MakeInternalTypeName(test.Pkg2020, "Person"+astmodel.StatusSuffix),
 			"Person",
-			"ARM",
-			"Person_ARM",
-		},
-		{
-			"Simple TypeName",
-			astmodel.MakeInternalTypeName(test.Pkg2020, "Person"+astmodel.StatusSuffix+astmodel.ARMSuffix),
-			"Person",
-			"STATUS_ARM",
-			"Person_STATUS_ARM",
+			"STATUS",
+			"Person_STATUS",
 		},
 	}
 


### PR DESCRIPTION
## What this PR does

Removes the now unused infrastructure that allowed gradual migration of ARM types to the new subpackage location.

Also removes `ARMSuffix`, tidying up related tests and usage.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcmFtNmhybGZiaXNqenIyMGF5NHpqbWtlbzg3YTlkeXdzdDZpNGFuZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Pja8Ied6v7M7Gq5DeK/giphy.gif)

## Checklist

- [x] this PR contains tests
