### PR TITLE
Skip checking for inherited roleassignment if owner is unavailable

### DIFF
--- a/v2/api/authorization/customizations/role_assignment_extensions.go
+++ b/v2/api/authorization/customizations/role_assignment_extensions.go
@@ -34,7 +34,7 @@ func (extension *RoleAssignmentExtension) Import(
 	if assignment, ok := rsrc.(*api.RoleAssignment); ok {
 		// Check to see whether this role assignment is inherited or not
 		// (we can tell by looking at the scope of the assignment)
-		if assignment.Status.Scope != nil {
+		if assignment.Status.Scope != nil && owner != nil {
 			if !strings.EqualFold(owner.ARMID, *assignment.Status.Scope) {
 				// Scope isn't our owner, so it's inherited from further up and should not be imported
 				return extensions.ImportSkipped("role assignment is inherited"), nil


### PR DESCRIPTION
## What this PR does

When importing a `RoleAssignment` we have a check to detect whether it has been inherited from a wider scope. This check is currently triggering a **panic** if we try to directly import a role assignment without an owner.

Closes #4444

## How does this PR make you feel?

![gif](https://media.giphy.com/media/XVmiO0JhJpRgA/giphy.gif?cid=790b7611rn9cj7a8wp41sz94ie84x2tk7kfgtqruppo7dv9f&ep=v1_gifs_search&rid=giphy.gif&ct=g)
