### PR TITLE
Migrate code generator to `eris`

### DIFF
--- a/v2/tools/generator/gen_kustomize.go
+++ b/v2/tools/generator/gen_kustomize.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"github.com/spf13/cobra"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -99,7 +99,7 @@ func NewGenKustomizeCommand() (*cobra.Command, error) {
 			}
 
 			if len(result.Resources) == 0 {
-				err = errors.Errorf("no files found in %q", basesPath)
+				err = eris.Errorf("no files found in %q", basesPath)
 				log.Error(
 					err,
 					"No CRD files found")

--- a/v2/tools/generator/gen_types.go
+++ b/v2/tools/generator/gen_types.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"github.com/spf13/cobra"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen"
@@ -61,7 +61,7 @@ func NewGenTypesCommand() (*cobra.Command, error) {
 
 			err = cg.Generate(ctx, log)
 			if err != nil {
-				err = errors.Wrap(err, "error generating code")
+				err = eris.Wrap(err, "error generating code")
 				return err
 			}
 

--- a/v2/tools/generator/go.mod
+++ b/v2/tools/generator/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
+	github.com/rotisserie/eris v0.5.4 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/v2/tools/generator/go.sum
+++ b/v2/tools/generator/go.sum
@@ -266,6 +266,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/rotisserie/eris v0.5.4 h1:Il6IvLdAapsMhvuOahHWiBnl1G++Q0/L5UIkI5mARSk=
+github.com/rotisserie/eris v0.5.4/go.mod h1:Z/kgYTJiJtocxCbFfvRmO+QejApzG6zpyky9G1A4g9s=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=

--- a/v2/tools/generator/internal/armconversion/arm_conversion_function.go
+++ b/v2/tools/generator/internal/armconversion/arm_conversion_function.go
@@ -7,7 +7,7 @@ package armconversion
 
 import (
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -80,7 +80,7 @@ func (c *ConvertToARMFunction) AsFunc(
 		receiver,
 		c.Name())
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"error creating ConvertToARM function for %s",
 			receiver.Name())
@@ -88,7 +88,7 @@ func (c *ConvertToARMFunction) AsFunc(
 
 	decl, err := builder.functionDeclaration()
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"error generating ConvertToARM function for %s",
 			c.Name())
@@ -107,7 +107,7 @@ func (c *PopulateFromARMFunction) AsFunc(
 		receiver,
 		c.Name())
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"error creating ConvertFromARM function for %s",
 			receiver.Name())
@@ -115,7 +115,7 @@ func (c *PopulateFromARMFunction) AsFunc(
 
 	decl, err := builder.functionDeclaration()
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"error generating ConvertFromARM function for %s",
 			c.Name())

--- a/v2/tools/generator/internal/armconversion/arm_spec_interface.go
+++ b/v2/tools/generator/internal/armconversion/arm_spec_interface.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -19,7 +19,7 @@ import (
 func checkPropertyPresence(o *astmodel.ObjectType, name astmodel.PropertyName) error {
 	_, ok := o.Property(name)
 	if !ok {
-		return errors.Errorf("resource spec doesn't have %q property", name)
+		return eris.Errorf("resource spec doesn't have %q property", name)
 	}
 
 	return nil
@@ -83,7 +83,7 @@ func armSpecInterfaceSimpleGetFunction(
 	receiverIdent := fn.IdFactory().CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", receiver.Name())
+		return nil, eris.Wrapf(err, "creating type expression for %s", receiver.Name())
 	}
 
 	var result dst.Expr = astbuilder.Selector(dst.NewIdent(receiverIdent), propertyName)

--- a/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
+++ b/v2/tools/generator/internal/armconversion/convert_to_arm_function_builder.go
@@ -10,7 +10,7 @@ import (
 	"go/token"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -35,7 +35,7 @@ func newConvertToARMFunctionBuilder(
 ) (*convertToARMBuilder, error) {
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+		return nil, eris.Wrapf(err, "creating type expression for %s", receiver)
 	}
 
 	result := &convertToARMBuilder{
@@ -90,7 +90,7 @@ func newConvertToARMFunctionBuilder(
 func (builder *convertToARMBuilder) functionDeclaration() (*dst.FuncDecl, error) {
 	body, err := builder.functionBodyStatements()
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to generate body for %s", builder.methodName)
+		return nil, eris.Wrapf(err, "unable to generate body for %s", builder.methodName)
 	}
 
 	fn := &astbuilder.FuncDetails{
@@ -102,7 +102,7 @@ func (builder *convertToARMBuilder) functionDeclaration() (*dst.FuncDecl, error)
 
 	convertToARMResolvedDetailsExpr, err := astmodel.ConvertToARMResolvedDetailsType.AsTypeExpr(builder.codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", astmodel.ConvertToARMResolvedDetailsType)
+		return nil, eris.Wrapf(err, "creating type expression for %s", astmodel.ConvertToARMResolvedDetailsType)
 	}
 
 	fn.AddParameter(resolvedParameterString, convertToARMResolvedDetailsExpr)
@@ -127,7 +127,7 @@ func (builder *convertToARMBuilder) functionBodyStatements() ([]dst.Stmt, error)
 		builder.destinationType,
 		builder.propertyConversionHandler)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to generate property conversions for %s", builder.methodName)
+		return nil, eris.Wrapf(err, "unable to generate property conversions for %s", builder.methodName)
 	}
 
 	returnStatement := &dst.ReturnStmt{
@@ -247,7 +247,7 @@ func (builder *convertToARMBuilder) configMapReferencePropertyHandler(
 	)
 	if err != nil {
 		return notHandled,
-			errors.Wrapf(err,
+			eris.Wrapf(err,
 				"unable to build conversion for property %s",
 				strProp.PropertyName())
 	}
@@ -267,7 +267,7 @@ func (builder *convertToARMBuilder) configMapReferencePropertyHandler(
 	)
 	if err != nil {
 		return notHandled,
-			errors.Wrapf(err,
+			eris.Wrapf(err,
 				"unable to build conversion for property %s",
 				refProp.PropertyName())
 	}
@@ -324,7 +324,7 @@ func (builder *convertToARMBuilder) referencePropertyHandler(
 	)
 	if err != nil {
 		return notHandled,
-			errors.Wrapf(err,
+			eris.Wrapf(err,
 				"unable to build conversion for property %s",
 				fromProp.PropertyName())
 	}
@@ -374,7 +374,7 @@ func (builder *convertToARMBuilder) flattenedPropertyHandler(
 	toPropType, err := allDefs.FullyResolve(toProp.PropertyType())
 	if err != nil {
 		return notHandled,
-			errors.Wrapf(err,
+			eris.Wrapf(err,
 				"unable to resolve type %s",
 				toProp.PropertyType().String())
 	}
@@ -389,7 +389,7 @@ func (builder *convertToARMBuilder) flattenedPropertyHandler(
 		toPropType, err = allDefs.FullyResolve(optType.Element())
 		if err != nil {
 			return notHandled,
-				errors.Wrapf(err,
+				eris.Wrapf(err,
 					"unable to resolve type %s",
 					optType.Element().String())
 		}
@@ -406,7 +406,7 @@ func (builder *convertToARMBuilder) flattenedPropertyHandler(
 		initializer, err := builder.buildToPropInitializer(fromProps, toPropTypeName, toPropName)
 		if err != nil {
 			return notHandled,
-				errors.Wrapf(err,
+				eris.Wrapf(err,
 					"unable to build initializer for property %s",
 					toPropName)
 		}
@@ -427,7 +427,7 @@ func (builder *convertToARMBuilder) flattenedPropertyHandler(
 		toSubProp, ok := toPropObjType.Property(toSubPropName)
 		if !ok {
 			return notHandled,
-				errors.Errorf(
+				eris.Errorf(
 					"unable to find expected property %s inside property %s",
 					fromProp.PropertyName(),
 					toPropName)
@@ -449,7 +449,7 @@ func (builder *convertToARMBuilder) flattenedPropertyHandler(
 			})
 		if err != nil {
 			return notHandled,
-				errors.Wrapf(err,
+				eris.Wrapf(err,
 					"unable to build conversion for property %s",
 					fromProp.PropertyName())
 		}
@@ -490,7 +490,7 @@ func (builder *convertToARMBuilder) buildToPropInitializer(
 
 	toPropTypeExpr, err := toPropTypeName.AsTypeExpr(builder.codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", toPropTypeName)
+		return nil, eris.Wrapf(err, "creating type expression for %s", toPropTypeName)
 	}
 
 	literal := astbuilder.NewCompositeLiteralBuilder(toPropTypeExpr)
@@ -545,7 +545,7 @@ func (builder *convertToARMBuilder) propertiesByNameHandler(
 	)
 	if err != nil {
 		return notHandled,
-			errors.Wrapf(err,
+			eris.Wrapf(err,
 				"unable to build conversion for property %s",
 				fromProp.PropertyName())
 	}
@@ -600,7 +600,7 @@ func (builder *convertToARMBuilder) convertUserAssignedIdentitiesCollection(
 	refProperty, ok := uaiType.Property("Reference")
 	if !ok {
 		return nil,
-			errors.New("found UserAssignedIdentity type without Reference property")
+			eris.New("found UserAssignedIdentity type without Reference property")
 	}
 
 	locals := params.Locals.Clone()
@@ -609,7 +609,7 @@ func (builder *convertToARMBuilder) convertUserAssignedIdentitiesCollection(
 	keyTypeExpr, err := destinationType.KeyType().AsTypeExpr(conversionBuilder.CodeGenerationContext)
 	if err != nil {
 		return nil,
-			errors.Wrapf(err,
+			eris.Wrapf(err,
 				"creating type expression for key type %s",
 				destinationType.KeyType())
 	}
@@ -617,7 +617,7 @@ func (builder *convertToARMBuilder) convertUserAssignedIdentitiesCollection(
 	valueTypeExpr, err := destinationType.ValueType().AsTypeExpr(conversionBuilder.CodeGenerationContext)
 	if err != nil {
 		return nil,
-			errors.Wrapf(err,
+			eris.Wrapf(err,
 				"creating type expression for value type %s",
 				destinationType.ValueType())
 	}
@@ -648,7 +648,7 @@ func (builder *convertToARMBuilder) convertUserAssignedIdentitiesCollection(
 		})
 	if err != nil {
 		return nil,
-			errors.Wrapf(err,
+			eris.Wrapf(err,
 				"unable to build conversion for property %s",
 				refProperty.PropertyName())
 	}

--- a/v2/tools/generator/internal/armconversion/shared.go
+++ b/v2/tools/generator/internal/armconversion/shared.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
@@ -122,10 +122,10 @@ func (builder conversionBuilder) propertyConversionHandler(
 		armDescription.String())
 
 	if err != nil {
-		return nil, errors.Wrap(err, message)
+		return nil, eris.Wrap(err, message)
 	}
 
-	return nil, errors.New(message)
+	return nil, eris.New(message)
 }
 
 type propertyConversionHandler = func(

--- a/v2/tools/generator/internal/astmodel/allof_type.go
+++ b/v2/tools/generator/internal/astmodel/allof_type.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 )
 
 // AllOfType represents something that is the union
@@ -82,7 +82,7 @@ func BuildAllOfType(types ...Type) Type {
 		return onlyOneOf.WithTypes(ts)
 	} else if len(oneOfs) > 1 {
 		// panic if this ever comes up (it doesn't at the moment)
-		panic(errors.New("More than one oneOf inside allOf"))
+		panic(eris.New("More than one oneOf inside allOf"))
 	}
 
 	// 0 oneOf (nothing to do) or >1 oneOf (too hard)
@@ -110,7 +110,7 @@ var allOfFailureMsg = "AllOfType should have been replaced by generation time by
 // AsType always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
 func (allOf *AllOfType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
-	panic(errors.New(allOfFailureMsg))
+	panic(eris.New(allOfFailureMsg))
 }
 
 // AsDeclarations always panics; AllOf cannot be represented by the Go AST and must be
@@ -119,19 +119,19 @@ func (allOf *AllOfType) AsDeclarations(
 	codeGenerationContext *CodeGenerationContext,
 	declContext DeclarationContext,
 ) ([]dst.Decl, error) {
-	panic(errors.New(allOfFailureMsg))
+	panic(eris.New(allOfFailureMsg))
 }
 
 // AsZero always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
 func (allOf *AllOfType) AsZero(_ TypeDefinitionSet, _ *CodeGenerationContext) dst.Expr {
-	panic(errors.New(allOfFailureMsg))
+	panic(eris.New(allOfFailureMsg))
 }
 
 // RequiredPackageReferences always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
 func (allOf *AllOfType) RequiredPackageReferences() *PackageReferenceSet {
-	panic(errors.New(allOfFailureMsg))
+	panic(eris.New(allOfFailureMsg))
 }
 
 // Equals returns true if the other Type is a AllOf that contains

--- a/v2/tools/generator/internal/astmodel/array_type.go
+++ b/v2/tools/generator/internal/astmodel/array_type.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 )
@@ -54,7 +54,7 @@ func (array *ArrayType) AsDeclarations(codeGenerationContext *CodeGenerationCont
 func (array *ArrayType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	elementExpr, err := array.element.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating array element type")
+		return nil, eris.Wrap(err, "creating array element type")
 	}
 
 	return &dst.ArrayType{

--- a/v2/tools/generator/internal/astmodel/code_generation_context.go
+++ b/v2/tools/generator/internal/astmodel/code_generation_context.go
@@ -8,7 +8,7 @@ package astmodel
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 )
 
 // CodeGenerationContext stores context about the location code-generation is occurring.
@@ -67,7 +67,7 @@ func (ctx *CodeGenerationContext) UsedPackageImports() *PackageImportSet {
 func (ctx *CodeGenerationContext) GetImportedPackageName(reference PackageReference) (string, error) {
 	packageImport, ok := ctx.packageImports.ImportFor(reference)
 	if !ok {
-		return "", errors.Errorf("package %s not imported", reference)
+		return "", eris.Errorf("package %s not imported", reference)
 	}
 
 	ctx.usedImports.AddImport(packageImport)
@@ -95,7 +95,7 @@ func (ctx *CodeGenerationContext) GetGeneratedPackage(reference InternalPackageR
 
 	packageDef, ok := ctx.generatedPackages[reference]
 	if !ok {
-		return nil, errors.Errorf("%s not imported", reference)
+		return nil, eris.Errorf("%s not imported", reference)
 	}
 	return packageDef, nil
 }

--- a/v2/tools/generator/internal/astmodel/conversion_function_builder.go
+++ b/v2/tools/generator/internal/astmodel/conversion_function_builder.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 )
@@ -246,7 +246,7 @@ func IdentityConvertComplexOptionalProperty(
 			DestinationProperty: params.DestinationProperty,
 		})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to build conversion for optional element")
+		return nil, eris.Wrap(err, "unable to build conversion for optional element")
 	}
 
 	// Tack on the final assignment
@@ -300,7 +300,7 @@ func IdentityConvertComplexArrayProperty(
 		destination = dst.NewIdent(innerDestinationIdent)
 		destinationTypeExpr, err := destinationType.AsTypeExpr(builder.CodeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating destination type expression")
+			return nil, eris.Wrap(err, "creating destination type expression")
 		}
 
 		results = append(
@@ -325,7 +325,7 @@ func IdentityConvertComplexArrayProperty(
 			DestinationProperty: params.DestinationProperty,
 		})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to build conversion for array element")
+		return nil, eris.Wrap(err, "unable to build conversion for array element")
 	}
 
 	result := &dst.RangeStmt{
@@ -349,7 +349,7 @@ func IdentityConvertComplexArrayProperty(
 	if depth == 0 && builder.ShouldInitializeCollectionToEmpty(params.SourceProperty) {
 		destinationTypeExpr, err := destinationType.Element().AsTypeExpr(builder.CodeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating destination type expression")
+			return nil, eris.Wrap(err, "creating destination type expression")
 		}
 
 		emptySlice := astbuilder.SliceLiteral(destinationTypeExpr)
@@ -425,12 +425,12 @@ func IdentityConvertComplexMapProperty(
 
 	keyTypeExpr, err := destinationType.KeyType().AsTypeExpr(builder.CodeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating key type expression")
+		return nil, eris.Wrap(err, "creating key type expression")
 	}
 
 	valueTypeExpr, err := destinationType.ValueType().AsTypeExpr(builder.CodeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating value type expression")
+		return nil, eris.Wrap(err, "creating value type expression")
 	}
 
 	makeMapStatement := astbuilder.AssignmentStatement(
@@ -453,7 +453,7 @@ func IdentityConvertComplexMapProperty(
 			DestinationProperty: params.DestinationProperty,
 		})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to build conversion for map value")
+		return nil, eris.Wrap(err, "unable to build conversion for map value")
 	}
 
 	rangeStatement := &dst.RangeStmt{
@@ -596,7 +596,7 @@ func AssignToOptional(
 			DestinationProperty: params.DestinationProperty,
 		})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to build inner conversion to optional")
+		return nil, eris.Wrap(err, "unable to build inner conversion to optional")
 	}
 
 	if len(conversion) == 0 {
@@ -605,7 +605,7 @@ func AssignToOptional(
 
 	destinationTypeExpr, err := dstType.AsTypeExpr(builder.CodeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating destination type expression")
+		return nil, eris.Wrap(err, "creating destination type expression")
 	}
 
 	return astbuilder.Statements(
@@ -664,7 +664,7 @@ func AssignFromOptional(
 			DestinationProperty: params.DestinationProperty,
 		})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to build inner conversion from optional")
+		return nil, eris.Wrap(err, "unable to build inner conversion from optional")
 	}
 
 	if len(conversion) == 0 {
@@ -674,7 +674,7 @@ func AssignFromOptional(
 	var result []dst.Stmt
 	destinationTypeExpr, err := params.DestinationType.AsTypeExpr(builder.CodeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating destination type expression")
+		return nil, eris.Wrap(err, "creating destination type expression")
 	}
 
 	result = append(result, astbuilder.LocalVariableDeclaration(tmpLocal, destinationTypeExpr, ""))
@@ -861,7 +861,7 @@ func AssignToAliasOfCollection(
 			DestinationProperty: params.DestinationProperty,
 		})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to build conversion for array element")
+		return nil, eris.Wrap(err, "unable to build conversion for array element")
 	}
 
 	return astbuilder.Statements(
@@ -930,7 +930,7 @@ func AssignFromAliasOfCollection(
 			DestinationProperty: params.DestinationProperty,
 		})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to build conversion for array element")
+		return nil, eris.Wrap(err, "unable to build conversion for array element")
 	}
 
 	return astbuilder.Statements(
@@ -1000,7 +1000,7 @@ func AssignToEnum(
 			DestinationProperty: params.DestinationProperty,
 		})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to build inner conversion to enum %s", itn.name)
+		return nil, eris.Wrapf(err, "unable to build inner conversion to enum %s", itn.name)
 	}
 
 	if len(conversion) == 0 {
@@ -1010,7 +1010,7 @@ func AssignToEnum(
 
 	destinationTypeExpr, err := dstType.AsTypeExpr(builder.CodeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating destination type expression")
+		return nil, eris.Wrap(err, "creating destination type expression")
 	}
 
 	var cast dst.Expr
@@ -1071,7 +1071,7 @@ func AssignFromEnum(
 			DestinationProperty: params.DestinationProperty,
 		})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to build inner conversion to enum %s", itn.name)
+		return nil, eris.Wrapf(err, "unable to build inner conversion to enum %s", itn.name)
 	}
 
 	if len(conversion) == 0 {

--- a/v2/tools/generator/internal/astmodel/enum_type.go
+++ b/v2/tools/generator/internal/astmodel/enum_type.go
@@ -13,7 +13,7 @@ import (
 	"unicode"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
@@ -99,7 +99,7 @@ func (enum *EnumType) AsDeclarations(
 	valuesDeclaration := enum.createValuesDeclaration(declContext)
 	mapperDeclaration, err := enum.createMappingDeclaration(declContext.Name, codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating mapping declaration")
+		return nil, eris.Wrap(err, "creating mapping declaration")
 	}
 
 	return astbuilder.Declarations(
@@ -174,12 +174,12 @@ func (enum *EnumType) createMappingDeclaration(
 
 	baseTypeExpr, err := enum.baseType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating base type expression")
+		return nil, eris.Wrap(err, "creating base type expression")
 	}
 
 	nameExpr, err := name.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating name expression")
+		return nil, eris.Wrap(err, "creating name expression")
 	}
 
 	literal := astbuilder.NewMapLiteral(
@@ -219,7 +219,7 @@ func (enum *EnumType) createValueDeclaration(name TypeName, value EnumValue) dst
 // AsType implements Type for EnumType
 func (enum *EnumType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	// this should "never" happen as we name all enums; panic if it does
-	panic(errors.New("Emitting unnamed enum, something’s awry"))
+	panic(eris.New("Emitting unnamed enum, something’s awry"))
 }
 
 // AsZero renders an expression for the "zero" value of the type,

--- a/v2/tools/generator/internal/astmodel/errored_type.go
+++ b/v2/tools/generator/internal/astmodel/errored_type.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
@@ -133,14 +133,14 @@ func (e *ErroredType) checkForWarningsAndErrors() error {
 
 	if len(e.errors) > 0 {
 		for _, err := range e.errors {
-			errs = append(errs, errors.New(err))
+			errs = append(errs, eris.New(err))
 		}
 	}
 
 	// Treating warnings as errors isn't quite right, but good enough for now
 	if len(e.warnings) > 0 {
 		for _, wrn := range e.warnings {
-			errs = append(errs, errors.New(wrn))
+			errs = append(errs, eris.New(wrn))
 		}
 	}
 
@@ -173,7 +173,7 @@ func (e *ErroredType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (
 
 	result, err := e.inner.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating inner type expression for errored type")
+		return nil, eris.Wrap(err, "creating inner type expression for errored type")
 	}
 
 	return result, nil

--- a/v2/tools/generator/internal/astmodel/file_definition.go
+++ b/v2/tools/generator/internal/astmodel/file_definition.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
@@ -213,7 +213,7 @@ func (file *FileDefinition) AsAst() (result *dst.File, err error) {
 			for _, t := range resource.SchemeTypes(defn.Name()) {
 				tExpr, err := t.AsTypeExpr(codeGenContext)
 				if err != nil {
-					return nil, errors.Wrapf(err, "creating type expression for %s", t.Name())
+					return nil, eris.Wrapf(err, "creating type expression for %s", t.Name())
 				}
 
 				literal := astbuilder.NewCompositeLiteralBuilder(tExpr)

--- a/v2/tools/generator/internal/astmodel/flagged_type.go
+++ b/v2/tools/generator/internal/astmodel/flagged_type.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
 )
@@ -111,7 +111,7 @@ func (ft *FlaggedType) References() TypeNameSet {
 func (ft *FlaggedType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	result, err := ft.element.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating inner expression for flagged type")
+		return nil, eris.Wrapf(err, "creating inner expression for flagged type")
 	}
 
 	return result, nil

--- a/v2/tools/generator/internal/astmodel/interface_implementer.go
+++ b/v2/tools/generator/internal/astmodel/interface_implementer.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/maps"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -104,11 +104,10 @@ func (i InterfaceImplementer) AsDeclarations(
 		}
 
 		if len(errs) > 0 {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				kerrors.NewAggregate(errs),
 				"generating declarations for interface %s",
-				iface.name.Name(),
-			)
+				iface.name.Name())
 		}
 	}
 

--- a/v2/tools/generator/internal/astmodel/interface_type.go
+++ b/v2/tools/generator/internal/astmodel/interface_type.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
@@ -115,7 +115,7 @@ func (i *InterfaceType) AsDeclarations(
 ) ([]dst.Decl, error) {
 	iExpr, err := i.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for interface %s", declContext.Name)
+		return nil, eris.Wrapf(err, "creating type expression for interface %s", declContext.Name)
 	}
 
 	declaration := &dst.GenDecl{
@@ -229,7 +229,7 @@ func functionToField(
 	// Populate Type
 	f, err := function.AsFunc(codeGenerationContext, InternalTypeName{}) // Empty typename here because we have no receiver
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to determiine type of function %s", function.Name())
+		return nil, eris.Wrapf(err, "unable to determiine type of function %s", function.Name())
 	}
 
 	result.Type = f.Type

--- a/v2/tools/generator/internal/astmodel/map_type.go
+++ b/v2/tools/generator/internal/astmodel/map_type.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 )
@@ -72,12 +72,12 @@ func (m *MapType) AsDeclarations(codeGenerationContext *CodeGenerationContext, d
 func (m *MapType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
 	keyExpr, err := m.key.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating map key type")
+		return nil, eris.Wrap(err, "creating map key type")
 	}
 
 	valueExpr, err := m.value.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating map value type")
+		return nil, eris.Wrap(err, "creating map value type")
 	}
 
 	return &dst.MapType{

--- a/v2/tools/generator/internal/astmodel/object_type.go
+++ b/v2/tools/generator/internal/astmodel/object_type.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -69,7 +69,7 @@ func (objectType *ObjectType) AsDeclarations(
 ) ([]dst.Decl, error) {
 	objectTypeExpr, err := objectType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating object type expression for %s", declContext.Name)
+		return nil, eris.Wrapf(err, "creating object type expression for %s", declContext.Name)
 	}
 
 	declaration := &dst.GenDecl{
@@ -93,12 +93,12 @@ func (objectType *ObjectType) AsDeclarations(
 
 	interfaceDeclarations, err := objectType.InterfaceImplementer.AsDeclarations(codeGenerationContext, declContext.Name, nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "generating interface declarations for %s", declContext.Name)
+		return nil, eris.Wrapf(err, "generating interface declarations for %s", declContext.Name)
 	}
 
 	methodDeclarations, err := objectType.generateMethodDecls(codeGenerationContext, declContext.Name)
 	if err != nil {
-		return nil, errors.Wrapf(err, "generating method declarations for %s", declContext.Name)
+		return nil, eris.Wrapf(err, "generating method declarations for %s", declContext.Name)
 	}
 
 	result := astbuilder.Declarations(
@@ -252,7 +252,7 @@ func (objectType *ObjectType) AsTypeExpr(codeGenerationContext *CodeGenerationCo
 	for _, f := range embedded {
 		field, err := f.AsField(codeGenerationContext)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "creating field for embedded property %s", f.PropertyName()))
+			errs = append(errs, eris.Wrapf(err, "creating field for embedded property %s", f.PropertyName()))
 			continue
 		}
 
@@ -262,7 +262,7 @@ func (objectType *ObjectType) AsTypeExpr(codeGenerationContext *CodeGenerationCo
 	for _, f := range objectType.properties.AsSlice() {
 		field, err := f.AsField(codeGenerationContext)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "creating field for property %s", f.PropertyName()))
+			errs = append(errs, eris.Wrapf(err, "creating field for property %s", f.PropertyName()))
 			continue
 		}
 
@@ -270,7 +270,7 @@ func (objectType *ObjectType) AsTypeExpr(codeGenerationContext *CodeGenerationCo
 	}
 
 	if len(errs) > 0 {
-		return nil, errors.Wrapf(kerrors.NewAggregate(errs), "creating fields for object type")
+		return nil, eris.Wrapf(kerrors.NewAggregate(errs), "creating fields for object type")
 	}
 
 	if len(fields) > 0 {
@@ -510,7 +510,7 @@ func (objectType *ObjectType) checkEmbeddedProperty(property *PropertyDefinition
 	// There are certain expectations about the shape of the provided property -- namely
 	// it must not have a name and its Type must be TypeName or Optional[TypeName]
 	if property.PropertyName() != "" {
-		return errors.Errorf("embedded property name must be empty, was: %s", property.PropertyName())
+		return eris.Errorf("embedded property name must be empty, was: %s", property.PropertyName())
 	}
 
 	return nil
@@ -631,7 +631,7 @@ func extractEmbeddedTypeName(t Type) (TypeName, error) {
 		return typeName, nil
 	}
 
-	return nil, errors.Errorf("embedded property type must be TypeName, was: %T", t)
+	return nil, eris.Errorf("embedded property type must be TypeName, was: %T", t)
 }
 
 // WriteDebugDescription adds a description of the current type to the passed builder.

--- a/v2/tools/generator/internal/astmodel/oneof_helpers.go
+++ b/v2/tools/generator/internal/astmodel/oneof_helpers.go
@@ -5,9 +5,7 @@
 
 package astmodel
 
-import (
-	"github.com/pkg/errors"
-)
+import "github.com/rotisserie/eris"
 
 type PropertyNameAndType struct {
 	PropertyName PropertyName
@@ -25,21 +23,21 @@ func resolveOneOfMemberToObjectType(
 	if !ok {
 		return InternalTypeName{},
 			nil,
-			errors.Errorf("expected oneOf member to be a TypeName, instead was %s", DebugDescription(t))
+			eris.Errorf("expected oneOf member to be a TypeName, instead was %s", DebugDescription(t))
 	}
 
 	propType, err := definitions.FullyResolve(tn)
 	if err != nil {
 		return InternalTypeName{},
 			nil,
-			errors.Wrapf(err, "unable to resolve oneOf member type %s", tn)
+			eris.Wrapf(err, "unable to resolve oneOf member type %s", tn)
 	}
 
 	propObjType, ok := AsObjectType(propType)
 	if !ok {
 		return InternalTypeName{},
 			nil,
-			errors.Errorf("OneOf %s referenced non-object type %s", t, DebugDescription(propType))
+			eris.Errorf("OneOf %s referenced non-object type %s", t, DebugDescription(propType))
 	}
 
 	return tn, propObjType, nil
@@ -104,7 +102,7 @@ func DetermineDiscriminantAndValues(
 	firstProp := oneOf.Properties().First()
 	_, firstMember, err := resolveOneOfMemberToObjectType(firstProp.PropertyType(), definitions)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "unable to resolve first member of OneOf")
+		return "", nil, eris.Wrap(err, "unable to resolve first member of OneOf")
 	}
 
 	// try to find a discriminator property out of the properties on the first member
@@ -122,5 +120,5 @@ func DetermineDiscriminantAndValues(
 		}
 	}
 
-	return "", nil, errors.Errorf("unable to determine a discriminator property for oneOf type")
+	return "", nil, eris.Errorf("unable to determine a discriminator property for oneOf type")
 }

--- a/v2/tools/generator/internal/astmodel/oneof_type.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 )
 
 // OneOfType represents something that can be any one of a number of selected types
@@ -152,7 +152,7 @@ var oneOFailureMsg = "OneOfType should have been replaced by generation time by 
 // AsType always panics; OneOf cannot be represented by the Go AST and must be
 // lowered to an object type
 func (oneOf *OneOfType) AsTypeExpr(codeGenerationContext *CodeGenerationContext) (dst.Expr, error) {
-	panic(errors.New(oneOFailureMsg))
+	panic(eris.New(oneOFailureMsg))
 }
 
 // AsDeclarations always panics; OneOf cannot be represented by the Go AST and must be
@@ -161,18 +161,18 @@ func (oneOf *OneOfType) AsDeclarations(
 	codeGenerationContext *CodeGenerationContext,
 	declContext DeclarationContext,
 ) ([]dst.Decl, error) {
-	panic(errors.New(oneOFailureMsg))
+	panic(eris.New(oneOFailureMsg))
 }
 
 // AsZero always panics; OneOf cannot be represented by the Go AST and must be
 // lowered to an object type
 func (oneOf *OneOfType) AsZero(_ TypeDefinitionSet, _ *CodeGenerationContext) dst.Expr {
-	panic(errors.New(oneOFailureMsg))
+	panic(eris.New(oneOFailureMsg))
 }
 
 // RequiredPackageReferences returns the union of the required imports of all the oneOf types
 func (oneOf *OneOfType) RequiredPackageReferences() *PackageReferenceSet {
-	panic(errors.New(oneOFailureMsg))
+	panic(eris.New(oneOFailureMsg))
 }
 
 // Equals returns true if the other Type is a OneOfType that contains

--- a/v2/tools/generator/internal/astmodel/optional_type.go
+++ b/v2/tools/generator/internal/astmodel/optional_type.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 )
@@ -130,7 +130,7 @@ func (optional *OptionalType) AsTypeExpr(codeGenerationContext *CodeGenerationCo
 	// Special case interface{} as it shouldn't be a pointer
 	elementExpr, err := optional.element.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating element for optional type")
+		return nil, eris.Wrapf(err, "creating element for optional type")
 	}
 
 	if optional.element == AnyType {

--- a/v2/tools/generator/internal/astmodel/package_definition.go
+++ b/v2/tools/generator/internal/astmodel/package_definition.go
@@ -13,9 +13,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-
-	"github.com/pkg/errors"
 )
 
 // PackageDefinition is the definition of a package
@@ -52,7 +51,7 @@ func (p *PackageDefinition) GetDefinition(typeName InternalTypeName) (TypeDefini
 		return def, nil
 	}
 
-	return TypeDefinition{}, errors.Errorf("no type with name %s found", typeName)
+	return TypeDefinition{}, eris.Errorf("no type with name %s found", typeName)
 }
 
 // AddDefinition adds a Definition to the PackageDefinition
@@ -154,7 +153,7 @@ func (p *PackageDefinition) writeCodeFile(
 	fileWriter := NewGoSourceFileWriter(genFile)
 	err := fileWriter.SaveToFile(outputFile)
 	if err != nil {
-		return errors.Wrapf(err, "saving definitions to file %q", outputFile)
+		return eris.Wrapf(err, "saving definitions to file %q", outputFile)
 	}
 
 	return nil
@@ -185,7 +184,7 @@ func (p *PackageDefinition) writeTestFile(
 	fileWriter := NewGoSourceFileWriter(genFile)
 	err := fileWriter.SaveToFile(outputFile)
 	if err != nil {
-		return errors.Wrapf(err, "writing test cases to file %q", outputFile)
+		return eris.Wrapf(err, "writing test cases to file %q", outputFile)
 	}
 
 	return nil
@@ -234,7 +233,7 @@ func (pkgDef *PackageDefinition) emitTemplateFile(template *template.Template, f
 
 	err = os.WriteFile(fileRef, buf.Bytes(), 0o600)
 	if err != nil {
-		return errors.Wrapf(err, "error writing file %q", fileRef)
+		return eris.Wrapf(err, "error writing file %q", fileRef)
 	}
 
 	return nil

--- a/v2/tools/generator/internal/astmodel/property_definition.go
+++ b/v2/tools/generator/internal/astmodel/property_definition.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
@@ -178,7 +178,7 @@ func (property *PropertyDefinition) WithType(
 	newType Type,
 ) *PropertyDefinition {
 	if newType == nil {
-		panic(errors.New("nil type provided to WithType"))
+		panic(eris.New("nil type provided to WithType"))
 	}
 
 	if TypeEquals(property.propertyType, newType) {
@@ -286,7 +286,7 @@ func (property *PropertyDefinition) MakeRequired() *PropertyDefinition {
 	}
 
 	if !isTypeOptional(property.PropertyType()) {
-		panic(errors.Errorf(
+		panic(eris.Errorf(
 			"property %s with non-optional type %T cannot be marked kubebuilder:validation:Required.",
 			property.PropertyName(),
 			property.PropertyType()))
@@ -413,7 +413,7 @@ func (property *PropertyDefinition) AsField(
 	codeGenerationContext *CodeGenerationContext,
 ) (*dst.Field, error) {
 	if property.flatten {
-		return nil, errors.Errorf("property %s marked for flattening was not flattened", property.propertyName)
+		return nil, eris.Errorf("property %s marked for flattening was not flattened", property.propertyName)
 	}
 
 	tags := property.renderedTags()
@@ -438,7 +438,7 @@ func (property *PropertyDefinition) AsField(
 	// Some types opt out of codegen by returning nil
 	propTypeExpr, err := propType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to generate field for property %s", property.propertyName)
+		return nil, eris.Wrapf(err, "unable to generate field for property %s", property.propertyName)
 	}
 
 	typeExpr := propTypeExpr

--- a/v2/tools/generator/internal/astmodel/property_injector.go
+++ b/v2/tools/generator/internal/astmodel/property_injector.go
@@ -5,7 +5,7 @@
 
 package astmodel
 
-import "github.com/pkg/errors"
+import "github.com/rotisserie/eris"
 
 // PropertyInjector is a utility for injecting property definitions into resources and objects
 type PropertyInjector struct {
@@ -28,7 +28,7 @@ func NewPropertyInjector() *PropertyInjector {
 func (pi *PropertyInjector) Inject(def TypeDefinition, prop *PropertyDefinition) (TypeDefinition, error) {
 	result, err := pi.visitor.VisitDefinition(def, prop)
 	if err != nil {
-		return TypeDefinition{}, errors.Wrapf(err, "failed to inject property %q into %q", prop.PropertyName(), def.Name())
+		return TypeDefinition{}, eris.Wrapf(err, "failed to inject property %q into %q", prop.PropertyName(), def.Name())
 	}
 
 	return result, nil
@@ -40,7 +40,7 @@ func (pi *PropertyInjector) injectPropertyIntoObject(
 ) (Type, error) {
 	// Ensure that we don't already have a property with the same name
 	if _, ok := ot.Property(prop.PropertyName()); ok {
-		return nil, errors.Errorf("already has property named %q", prop.PropertyName())
+		return nil, eris.Errorf("already has property named %q", prop.PropertyName())
 	}
 
 	return ot.WithProperty(prop), nil

--- a/v2/tools/generator/internal/astmodel/property_remover.go
+++ b/v2/tools/generator/internal/astmodel/property_remover.go
@@ -5,7 +5,7 @@
 
 package astmodel
 
-import "github.com/pkg/errors"
+import "github.com/rotisserie/eris"
 
 // PropertyRemover is a utility for removing property definitions from objects
 type PropertyRemover struct {
@@ -28,7 +28,7 @@ func NewPropertyRemover() *PropertyRemover {
 func (pi *PropertyRemover) Remove(def TypeDefinition, name PropertyName) (TypeDefinition, error) {
 	result, err := pi.visitor.VisitDefinition(def, name)
 	if err != nil {
-		return TypeDefinition{}, errors.Wrapf(err, "failed to remove property %q from %q", name, def.Name())
+		return TypeDefinition{}, eris.Wrapf(err, "failed to remove property %q from %q", name, def.Name())
 	}
 
 	return result, nil

--- a/v2/tools/generator/internal/astmodel/reference_graph.go
+++ b/v2/tools/generator/internal/astmodel/reference_graph.go
@@ -8,7 +8,7 @@ package astmodel
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 )
 
 // ReferenceGraph is a graph of references between types
@@ -23,13 +23,13 @@ func CollectARMSpecAndStatusDefinitions(definitions TypeDefinitionSet) TypeNameS
 	findARMType := func(t Type) (InternalTypeName, error) {
 		name, ok := AsInternalTypeName(t)
 		if !ok {
-			return InternalTypeName{}, errors.Errorf("type was not of type InternalTypeName, instead %T", t)
+			return InternalTypeName{}, eris.Errorf("type was not of type InternalTypeName, instead %T", t)
 		}
 
 		armName := CreateARMTypeName(name)
 
 		if _, ok = definitions[armName]; !ok {
-			return InternalTypeName{}, errors.Errorf("couldn't find ARM type %q", armName)
+			return InternalTypeName{}, eris.Errorf("couldn't find ARM type %q", armName)
 		}
 
 		return armName, nil

--- a/v2/tools/generator/internal/astmodel/renaming_visitor.go
+++ b/v2/tools/generator/internal/astmodel/renaming_visitor.go
@@ -6,7 +6,7 @@
 package astmodel
 
 import (
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
@@ -81,7 +81,7 @@ func (r *RenamingVisitor) RenameAll(definitions TypeDefinitionSet) (TypeDefiniti
 		}
 
 		if result.Contains(renamed.Name()) {
-			errs = append(errs, errors.Errorf("a definition for %s already exists", renamed.Name()))
+			errs = append(errs, eris.Errorf("a definition for %s already exists", renamed.Name()))
 			continue
 		}
 

--- a/v2/tools/generator/internal/astmodel/resource_type.go
+++ b/v2/tools/generator/internal/astmodel/resource_type.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/maps"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -599,7 +599,7 @@ func (resource *ResourceType) AsDeclarations(
 	for _, property := range resource.EmbeddedProperties() {
 		f, err := property.AsField(codeGenerationContext)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "creating embedded field for %s", property.PropertyName()))
+			errs = append(errs, eris.Wrapf(err, "creating embedded field for %s", property.PropertyName()))
 			continue
 		}
 
@@ -611,7 +611,7 @@ func (resource *ResourceType) AsDeclarations(
 	for _, property := range resource.Properties().AsSlice() {
 		f, err := property.AsField(codeGenerationContext)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "creating field for %s", property.PropertyName()))
+			errs = append(errs, eris.Wrapf(err, "creating field for %s", property.PropertyName()))
 			continue
 		}
 
@@ -621,7 +621,7 @@ func (resource *ResourceType) AsDeclarations(
 	}
 
 	if len(errs) > 0 {
-		return nil, errors.Wrapf(kerrors.NewAggregate(errs), "failed to generate fields for %s", declContext.Name)
+		return nil, eris.Wrapf(kerrors.NewAggregate(errs), "failed to generate fields for %s", declContext.Name)
 	}
 
 	if len(fields) > 0 {
@@ -685,17 +685,17 @@ func (resource *ResourceType) AsDeclarations(
 	resourceListDeclaration, err := resource.resourceListTypeDecls(
 		codeGenerationContext, declContext.Name, declContext.Description)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating resource list type for %s", declContext.Name)
+		return nil, eris.Wrapf(err, "creating resource list type for %s", declContext.Name)
 	}
 
 	interfaceDeclarations, err := resource.InterfaceImplementer.AsDeclarations(codeGenerationContext, declContext.Name, nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "generating interface declarations for %s", declContext.Name)
+		return nil, eris.Wrapf(err, "generating interface declarations for %s", declContext.Name)
 	}
 
 	methodDeclarations, err := resource.generateMethodDecls(codeGenerationContext, declContext.Name)
 	if err != nil {
-		return nil, errors.Wrapf(err, "generating method declarations for %s", declContext.Name)
+		return nil, eris.Wrapf(err, "generating method declarations for %s", declContext.Name)
 	}
 
 	return astbuilder.Declarations(
@@ -749,7 +749,7 @@ func (resource *ResourceType) resourceListTypeDecls(
 
 	itemTypeExpr, err := items.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", items)
+		return nil, eris.Wrapf(err, "creating type expression for %s", items)
 	}
 
 	fields := []*dst.Field{
@@ -864,13 +864,13 @@ func generateMethodDeclForFunction(
 	defer func() {
 		if r := recover(); r != nil {
 			if e, ok := r.(error); ok {
-				err = errors.Wrapf(
+				err = eris.Wrapf(
 					e,
 					"generating method declaration for %s.%s",
 					typeName.Name(),
 					f.Name())
 			} else {
-				err = errors.Errorf(
+				err = eris.Errorf(
 					"generating method declaration for %s.%s: %s",
 					typeName.Name(),
 					f.Name(),

--- a/v2/tools/generator/internal/astmodel/test_file_definition.go
+++ b/v2/tools/generator/internal/astmodel/test_file_definition.go
@@ -10,7 +10,7 @@ import (
 	"go/token"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 )
@@ -80,10 +80,9 @@ func (file *TestFileDefinition) AsAst() (*dst.File, error) {
 	}
 
 	if len(errs) > 0 {
-		return nil, errors.Wrap(
+		return nil, eris.Wrap(
 			kerrors.NewAggregate(errs),
-			"failed to generate test cases",
-		)
+			"failed to generate test cases")
 	}
 
 	var decls []dst.Decl

--- a/v2/tools/generator/internal/astmodel/type_definition.go
+++ b/v2/tools/generator/internal/astmodel/type_definition.go
@@ -10,7 +10,7 @@ import (
 	"go/token"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 )
@@ -97,7 +97,7 @@ func AsSimpleDeclarations(
 
 	theTypeExpr, err := theType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating simple declaration")
+		return nil, eris.Wrap(err, "creating simple declaration")
 	}
 
 	result := &dst.GenDecl{
@@ -169,11 +169,11 @@ func (def TypeDefinition) ApplyObjectTransformation(transform func(*ObjectType) 
 
 	newType, err := visitor.Visit(def.theType, nil)
 	if err != nil {
-		return TypeDefinition{}, errors.Wrapf(err, "transformation of %s failed", def.name)
+		return TypeDefinition{}, eris.Wrapf(err, "transformation of %s failed", def.name)
 	}
 
 	if !visited {
-		return TypeDefinition{}, errors.Errorf("transformation was not applied to %s (expected object type, found %s)", def.name, def.theType)
+		return TypeDefinition{}, eris.Errorf("transformation was not applied to %s (expected object type, found %s)", def.name, def.theType)
 	}
 
 	result := def.WithType(newType)
@@ -190,7 +190,7 @@ func (def TypeDefinition) ApplyObjectTransformations(transforms ...func(*ObjectT
 		for i, transform := range transforms {
 			rt, err := transform(result)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to apply object transformation %d", i)
+				return nil, eris.Wrapf(err, "failed to apply object transformation %d", i)
 			}
 
 			result = rt

--- a/v2/tools/generator/internal/astmodel/type_definition_set.go
+++ b/v2/tools/generator/internal/astmodel/type_definition_set.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/kr/pretty"
 	"github.com/kylelemons/godebug/diff"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/readonly"
 )
@@ -65,7 +65,7 @@ func (set TypeDefinitionSet) MustGetDefinition(name InternalTypeName) TypeDefini
 func (set TypeDefinitionSet) GetDefinition(name InternalTypeName) (TypeDefinition, error) {
 	result, ok := set[name]
 	if !ok {
-		return TypeDefinition{}, errors.Errorf("couldn't find type %q", name)
+		return TypeDefinition{}, eris.Errorf("couldn't find type %q", name)
 	}
 
 	return result, nil
@@ -91,13 +91,13 @@ func (set TypeDefinitionSet) FullyResolve(t Type) (Type, error) {
 
 		def, found := set[tn]
 		if !found {
-			return nil, errors.Errorf("couldn't find definition for %s", tn)
+			return nil, eris.Errorf("couldn't find definition for %s", tn)
 		}
 
 		t = def.Type()
 		tn, ok = t.(InternalTypeName)
 		if ok && seen.Contains(tn) {
-			return nil, errors.Errorf("cycle detected in type definition for %s", tn)
+			return nil, eris.Errorf("cycle detected in type definition for %s", tn)
 		}
 	}
 
@@ -115,12 +115,12 @@ func (set TypeDefinitionSet) FullyResolveDefinition(def TypeDefinition) (TypeDef
 		var found bool
 		def, found = set[tn]
 		if !found {
-			return TypeDefinition{}, errors.Errorf("couldn't find definition for %s", tn)
+			return TypeDefinition{}, eris.Errorf("couldn't find definition for %s", tn)
 		}
 
 		tn, ok = def.Type().(InternalTypeName)
 		if ok && seen.Contains(tn) {
-			return TypeDefinition{}, errors.Errorf("cycle detected in type definition for %s", tn)
+			return TypeDefinition{}, eris.Errorf("cycle detected in type definition for %s", tn)
 		}
 	}
 
@@ -167,7 +167,7 @@ func (set TypeDefinitionSet) AddAllowDuplicates(def TypeDefinition) error {
 	}
 
 	if !TypeEquals(def.Type(), existing.Type()) {
-		return errors.Errorf("type definition for %q has two shapes: \r\n%s", existing.Name(), DiffTypes(existing.Type(), def.Type()))
+		return eris.Errorf("type definition for %q has two shapes: \r\n%s", existing.Name(), DiffTypes(existing.Type(), def.Type()))
 	}
 
 	// Can safely skip this add
@@ -413,12 +413,12 @@ func ResolveResourceSpecDefinition(defs ReadonlyTypeDefinitions, resourceType *R
 	// The expectation is that the spec type is just a name
 	specName, ok := resourceType.SpecType().(InternalTypeName)
 	if !ok {
-		return TypeDefinition{}, errors.Errorf("spec was not of type InternalTypeName, instead: %T", resourceType.SpecType())
+		return TypeDefinition{}, eris.Errorf("spec was not of type InternalTypeName, instead: %T", resourceType.SpecType())
 	}
 
 	resourceSpecDef, err := defs.GetDefinition(specName)
 	if !ok {
-		return TypeDefinition{}, errors.Wrapf(err, "couldn't find spec")
+		return TypeDefinition{}, eris.Wrapf(err, "couldn't find spec")
 	}
 
 	return resourceSpecDef, nil
@@ -428,12 +428,12 @@ func ResolveResourceSpecDefinition(defs ReadonlyTypeDefinitions, resourceType *R
 func ResolveResourceStatusDefinition(defs ReadonlyTypeDefinitions, resourceType *ResourceType) (TypeDefinition, error) {
 	statusName, ok := resourceType.StatusType().(InternalTypeName)
 	if !ok {
-		return TypeDefinition{}, errors.Errorf("status was not of type InternalTypeName, instead: %T", resourceType.StatusType())
+		return TypeDefinition{}, eris.Errorf("status was not of type InternalTypeName, instead: %T", resourceType.StatusType())
 	}
 
 	resourceStatusDef, err := defs.GetDefinition(statusName)
 	if !ok {
-		return TypeDefinition{}, errors.Wrapf(err, "couldn't find status")
+		return TypeDefinition{}, eris.Wrapf(err, "couldn't find status")
 	}
 
 	// preserve outer spec name
@@ -445,7 +445,7 @@ func ResolveResourceStatusDefinition(defs ReadonlyTypeDefinitions, resourceType 
 func ResolveResourceSpecAndStatus(defs ReadonlyTypeDefinitions, resourceDef TypeDefinition) (*ResourceSpecAndStatusResult, error) {
 	resource, ok := AsResourceType(resourceDef.Type())
 	if !ok {
-		return nil, errors.Errorf("expected %q to be a Resource but instead it was a %T", resourceDef.Name(), resourceDef.Type())
+		return nil, eris.Errorf("expected %q to be a Resource but instead it was a %T", resourceDef.Name(), resourceDef.Type())
 	}
 
 	// Resolve the spec
@@ -455,7 +455,7 @@ func ResolveResourceSpecAndStatus(defs ReadonlyTypeDefinitions, resourceDef Type
 	}
 	spec, ok := AsObjectType(specDef.Type())
 	if !ok {
-		return nil, errors.Errorf("resource spec %q did not contain an object, instead %s", resource.SpecType().String(), specDef.Type())
+		return nil, eris.Errorf("resource spec %q did not contain an object, instead %s", resource.SpecType().String(), specDef.Type())
 	}
 
 	// Resolve the status if it's there (we need this because our golden file tests don't have status currently)
@@ -469,7 +469,7 @@ func ResolveResourceSpecAndStatus(defs ReadonlyTypeDefinitions, resourceDef Type
 		}
 		status, ok = AsObjectType(statusDef.Type())
 		if !ok {
-			return nil, errors.Errorf("resource status %q did not contain an object, instead %s", resource.StatusType().String(), statusDef.Type())
+			return nil, eris.Errorf("resource status %q did not contain an object, instead %s", resource.StatusType().String(), statusDef.Type())
 		}
 	}
 
@@ -574,7 +574,7 @@ func FindConnectedDefinitions(definitions TypeDefinitionSet, roots TypeDefinitio
 	for _, def := range roots {
 		types, err := walker.Walk(def)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed walking types")
+			return nil, eris.Wrapf(err, "failed walking types")
 		}
 
 		err = result.AddTypesAllowDuplicates(types)

--- a/v2/tools/generator/internal/astmodel/type_definition_test.go
+++ b/v2/tools/generator/internal/astmodel/type_definition_test.go
@@ -10,7 +10,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 )
 
 /*
@@ -119,7 +119,7 @@ func TestApplyObjectTransformation_GivenObjectAndTransformationReturningError_Re
 	original := MakeTypeDefinition(ref, NewObjectType())
 
 	_, err := original.ApplyObjectTransformation(func(objectType *ObjectType) (Type, error) {
-		return nil, errors.New("failed")
+		return nil, eris.New("failed")
 	})
 
 	g.Expect(err).NotTo(BeNil())
@@ -157,7 +157,7 @@ var (
 	}
 
 	failingTransform = func(objectType *ObjectType) (*ObjectType, error) {
-		return nil, errors.New("bang")
+		return nil, eris.New("bang")
 	}
 )
 

--- a/v2/tools/generator/internal/astmodel/type_merger.go
+++ b/v2/tools/generator/internal/astmodel/type_merger.go
@@ -8,7 +8,7 @@ package astmodel
 import (
 	"reflect"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 )
 
 // TypeMerger is like a visitor for 2 types.
@@ -162,7 +162,7 @@ func (m *TypeMerger) MergeWithContext(ctx interface{}, left, right Type) (Type, 
 
 		if leftTypeMatches && rightTypeMatches {
 			result, err := merger.merge(ctx, left, right)
-			if (result == nil && err == nil) || errors.Is(err, ContinueMerge) {
+			if (result == nil && err == nil) || eris.Is(err, ContinueMerge) {
 				// these conditions indicate that the merger was not actually applicable,
 				// despite having a type that matched
 				continue
@@ -175,4 +175,4 @@ func (m *TypeMerger) MergeWithContext(ctx interface{}, left, right Type) (Type, 
 	return m.fallback(ctx, left, right)
 }
 
-var ContinueMerge error = errors.New("special error that indicates that the merger was not applicable")
+var ContinueMerge error = eris.New("special error that indicates that the merger was not applicable")

--- a/v2/tools/generator/internal/astmodel/type_merger_test.go
+++ b/v2/tools/generator/internal/astmodel/type_merger_test.go
@@ -10,7 +10,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 )
 
 func TestCanMergeSameTypes(t *testing.T) {
@@ -18,7 +18,7 @@ func TestCanMergeSameTypes(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	merger := NewTypeMerger(func(_ interface{}, l, r Type) (Type, error) {
-		return nil, errors.New("reached fallback")
+		return nil, eris.New("reached fallback")
 	})
 
 	merger.Add(func(l, r *PrimitiveType) (Type, error) {

--- a/v2/tools/generator/internal/astmodel/type_visitor.go
+++ b/v2/tools/generator/internal/astmodel/type_visitor.go
@@ -8,7 +8,7 @@ package astmodel
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
@@ -94,12 +94,12 @@ func (tv *TypeVisitor[C]) VisitInternalTypeName(name InternalTypeName, ctx C) (I
 
 	t, err := tv.visitInternalTypeName(tv, name, ctx)
 	if err != nil {
-		return InternalTypeName{}, errors.Wrapf(err, "visit of InternalTypeName %q failed", name)
+		return InternalTypeName{}, eris.Wrapf(err, "visit of InternalTypeName %q failed", name)
 	}
 
 	n, ok := t.(InternalTypeName)
 	if !ok {
-		return InternalTypeName{}, errors.Errorf("expected visit of InternalTypeName %q to return InternalTypeName, not %T", name, t)
+		return InternalTypeName{}, eris.Errorf("expected visit of InternalTypeName %q to return InternalTypeName, not %T", name, t)
 	}
 
 	return n, nil
@@ -111,7 +111,7 @@ func (tv *TypeVisitor[C]) VisitDefinition(td TypeDefinition, ctx C) (TypeDefinit
 	name := td.Name()
 	visitedName, err := tv.VisitInternalTypeName(name, ctx)
 	if err != nil {
-		return TypeDefinition{}, errors.Wrapf(
+		return TypeDefinition{}, eris.Wrapf(
 			err,
 			"visit of %s/%s failed",
 			name.InternalPackageReference().FolderPath(),
@@ -120,7 +120,7 @@ func (tv *TypeVisitor[C]) VisitDefinition(td TypeDefinition, ctx C) (TypeDefinit
 
 	visitedType, err := tv.Visit(td.Type(), ctx)
 	if err != nil {
-		return TypeDefinition{}, errors.Wrapf(
+		return TypeDefinition{}, eris.Wrapf(
 			err,
 			"visit of type of %s/%s failed",
 			name.InternalPackageReference().FolderPath(),
@@ -158,7 +158,7 @@ func IdentityVisitOfTypeName[C any](_ *TypeVisitor[C], it TypeName, _ C) (Type, 
 func IdentityVisitOfArrayType[C any](this *TypeVisitor[C], it *ArrayType, ctx C) (Type, error) {
 	newElement, err := this.Visit(it.element, ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to visit type of array")
+		return nil, eris.Wrap(err, "failed to visit type of array")
 	}
 
 	return it.WithElement(newElement), nil
@@ -353,12 +353,12 @@ func orderedIdentityVisitOfObjectTypeWithPerPropertyContext[C any](
 func IdentityVisitOfMapType[C any](this *TypeVisitor[C], it *MapType, ctx C) (Type, error) {
 	visitedKey, err := this.Visit(it.key, ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to visit map key type %q", it.key)
+		return nil, eris.Wrapf(err, "failed to visit map key type %q", it.key)
 	}
 
 	visitedValue, err := this.Visit(it.value, ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to visit map value type %q", it.value)
+		return nil, eris.Wrapf(err, "failed to visit map value type %q", it.value)
 	}
 
 	return it.WithKeyType(visitedKey).WithValueType(visitedValue), nil
@@ -373,7 +373,7 @@ func IdentityVisitOfEnumType[C any](_ *TypeVisitor[C], it *EnumType, _ C) (Type,
 func IdentityVisitOfOptionalType[C any](this *TypeVisitor[C], it *OptionalType, ctx C) (Type, error) {
 	visitedElement, err := this.Visit(it.element, ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to visit optional element type %q", it.element)
+		return nil, eris.Wrapf(err, "failed to visit optional element type %q", it.element)
 	}
 
 	return it.WithElement(visitedElement), nil
@@ -382,12 +382,12 @@ func IdentityVisitOfOptionalType[C any](this *TypeVisitor[C], it *OptionalType, 
 func IdentityVisitOfResourceType[C any](this *TypeVisitor[C], it *ResourceType, ctx C) (Type, error) {
 	visitedSpec, err := this.Visit(it.spec, ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to visit resource spec type %q", it.spec)
+		return nil, eris.Wrapf(err, "failed to visit resource spec type %q", it.spec)
 	}
 
 	visitedStatus, err := this.Visit(it.status, ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to visit resource status type %q", it.status)
+		return nil, eris.Wrapf(err, "failed to visit resource status type %q", it.status)
 	}
 
 	changedAPIVersionName := false
@@ -395,7 +395,7 @@ func IdentityVisitOfResourceType[C any](this *TypeVisitor[C], it *ResourceType, 
 		originalAPIVersionTypeName := it.APIVersionTypeName()
 		newAPIVersion, err := this.VisitInternalTypeName(originalAPIVersionTypeName, ctx)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to visit resource API version name %q", originalAPIVersionTypeName)
+			return nil, eris.Wrapf(err, "failed to visit resource API version name %q", originalAPIVersionTypeName)
 		}
 
 		if !TypeEquals(originalAPIVersionTypeName, newAPIVersion) {
@@ -426,7 +426,7 @@ func IdentityVisitOfOneOfType[C any](this *TypeVisitor[C], it *OneOfType, ctx C)
 
 		obj, ok := newObj.(*ObjectType)
 		if !ok {
-			return nil, errors.Errorf("expected to visit oneof property object to result in object type, instead got %T", newObj)
+			return nil, eris.Errorf("expected to visit oneof property object to result in object type, instead got %T", newObj)
 		}
 
 		result = result.WithAdditionalPropertyObject(obj)
@@ -436,7 +436,7 @@ func IdentityVisitOfOneOfType[C any](this *TypeVisitor[C], it *OneOfType, ctx C)
 	err := it.Types().ForEachError(func(oneOf Type, _ int) error {
 		newType, err := this.Visit(oneOf, ctx)
 		if err != nil {
-			return errors.Wrapf(err, "failed to visit oneOf")
+			return eris.Wrapf(err, "failed to visit oneOf")
 		}
 
 		newTypes = append(newTypes, newType)
@@ -454,7 +454,7 @@ func IdentityVisitOfAllOfType[C any](this *TypeVisitor[C], it *AllOfType, ctx C)
 	err := it.Types().ForEachError(func(allOf Type, _ int) error {
 		newType, err := this.Visit(allOf, ctx)
 		if err != nil {
-			return errors.Wrapf(err, "failed to visit allOf")
+			return eris.Wrapf(err, "failed to visit allOf")
 		}
 
 		newTypes = append(newTypes, newType)
@@ -496,7 +496,7 @@ func typeSlicesFastEqual(t1 []Type, t2 []Type) bool {
 func IdentityVisitOfFlaggedType[C any](this *TypeVisitor[C], ft *FlaggedType, ctx C) (Type, error) {
 	nt, err := this.Visit(ft.element, ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to visit flagged type %q", ft.element)
+		return nil, eris.Wrapf(err, "failed to visit flagged type %q", ft.element)
 	}
 
 	if nt == ft.element {
@@ -509,7 +509,7 @@ func IdentityVisitOfFlaggedType[C any](this *TypeVisitor[C], ft *FlaggedType, ct
 func IdentityVisitOfValidatedType[C any](this *TypeVisitor[C], v *ValidatedType, ctx C) (Type, error) {
 	nt, err := this.Visit(v.element, ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to visit validated type %q", v.element)
+		return nil, eris.Wrapf(err, "failed to visit validated type %q", v.element)
 	}
 
 	if nt == v.element {
@@ -522,7 +522,7 @@ func IdentityVisitOfValidatedType[C any](this *TypeVisitor[C], v *ValidatedType,
 func IdentityVisitOfErroredType[C any](this *TypeVisitor[C], e *ErroredType, ctx C) (Type, error) {
 	nt, err := this.Visit(e.inner, ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to visit errored type %q", e.inner)
+		return nil, eris.Wrapf(err, "failed to visit errored type %q", e.inner)
 	}
 
 	if nt == e.inner {

--- a/v2/tools/generator/internal/astmodel/type_visitor_test.go
+++ b/v2/tools/generator/internal/astmodel/type_visitor_test.go
@@ -10,7 +10,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 )
 
 func Test_Visit_GivenCountingTypeVisitor_ReturnsExpectedCounts(t *testing.T) {
@@ -218,7 +218,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			StringType,
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitPrimitive = func(tv *TypeVisitor[any], p *PrimitiveType, _ interface{}) (Type, error) {
-					return p, errors.New(p.name)
+					return p, eris.New(p.name)
 				}
 			},
 			StringType,
@@ -229,7 +229,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			StringType,
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitPrimitive = func(p *PrimitiveType) (Type, error) {
-					return p, errors.New(p.name)
+					return p, eris.New(p.name)
 				}
 			},
 			StringType,
@@ -240,7 +240,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			OptionalIntType,
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitOptionalType = func(tv *TypeVisitor[any], ot *OptionalType, _ interface{}) (Type, error) {
-					return ot, errors.New(ot.String())
+					return ot, eris.New(ot.String())
 				}
 			},
 			OptionalIntType,
@@ -251,7 +251,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			OptionalIntType,
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitOptionalType = func(ot *OptionalType) (Type, error) {
-					return ot, errors.New(ot.String())
+					return ot, eris.New(ot.String())
 				}
 			},
 			OptionalIntType,
@@ -262,7 +262,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewEnumType(StringType),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitEnumType = func(tv *TypeVisitor[any], et *EnumType, _ interface{}) (Type, error) {
-					return et, errors.New(et.String())
+					return et, eris.New(et.String())
 				}
 			},
 			NewEnumType(StringType),
@@ -273,7 +273,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewEnumType(StringType),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitEnumType = func(et *EnumType) (Type, error) {
-					return et, errors.New(et.String())
+					return et, eris.New(et.String())
 				}
 			},
 			NewEnumType(StringType),
@@ -284,7 +284,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewObjectType(),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitObjectType = func(tv *TypeVisitor[any], ot *ObjectType, _ interface{}) (Type, error) {
-					return ot, errors.New(ot.String())
+					return ot, eris.New(ot.String())
 				}
 			},
 			NewObjectType(),
@@ -295,7 +295,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewObjectType(),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitObjectType = func(ot *ObjectType) (Type, error) {
-					return ot, errors.New(ot.String())
+					return ot, eris.New(ot.String())
 				}
 			},
 			NewObjectType(),
@@ -306,7 +306,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewOneOfType("x", BoolType, StringType),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitOneOfType = func(tv *TypeVisitor[any], ot *OneOfType, _ interface{}) (Type, error) {
-					return ot, errors.New(ot.String())
+					return ot, eris.New(ot.String())
 				}
 			},
 			NewOneOfType("x", BoolType, StringType),
@@ -317,7 +317,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewOneOfType("x", BoolType, StringType),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitOneOfType = func(ot *OneOfType) (Type, error) {
-					return ot, errors.New(ot.String())
+					return ot, eris.New(ot.String())
 				}
 			},
 			NewOneOfType("x", BoolType, StringType),
@@ -328,7 +328,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewErroredType(StringType, nil, nil),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitErroredType = func(tv *TypeVisitor[any], et *ErroredType, _ interface{}) (Type, error) {
-					return et, errors.New(et.String())
+					return et, eris.New(et.String())
 				}
 			},
 			NewErroredType(StringType, nil, nil),
@@ -339,7 +339,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewErroredType(StringType, nil, nil),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitErroredType = func(et *ErroredType) (Type, error) {
-					return et, errors.New(et.String())
+					return et, eris.New(et.String())
 				}
 			},
 			NewErroredType(StringType, nil, nil),
@@ -350,7 +350,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewValidatedType(StringType, StringValidations{}),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitValidatedType = func(tv *TypeVisitor[any], vt *ValidatedType, _ interface{}) (Type, error) {
-					return vt, errors.New(vt.String())
+					return vt, eris.New(vt.String())
 				}
 			},
 			NewValidatedType(StringType, StringValidations{}),
@@ -361,7 +361,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewValidatedType(StringType, StringValidations{}),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitValidatedType = func(vt *ValidatedType) (Type, error) {
-					return vt, errors.New(vt.String())
+					return vt, eris.New(vt.String())
 				}
 			},
 			NewValidatedType(StringType, StringValidations{}),
@@ -372,7 +372,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewResourceType(StringType, StringType),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitResourceType = func(tv *TypeVisitor[any], rt *ResourceType, _ interface{}) (Type, error) {
-					return rt, errors.New(rt.String())
+					return rt, eris.New(rt.String())
 				}
 			},
 			NewResourceType(StringType, StringType),
@@ -383,7 +383,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewResourceType(StringType, StringType),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitResourceType = func(rt *ResourceType) (Type, error) {
-					return rt, errors.New(rt.String())
+					return rt, eris.New(rt.String())
 				}
 			},
 			NewResourceType(StringType, StringType),
@@ -394,7 +394,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewAllOfType(),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitAllOfType = func(tv *TypeVisitor[any], at *AllOfType, _ interface{}) (Type, error) {
-					return at, errors.New(at.String())
+					return at, eris.New(at.String())
 				}
 			},
 			NewAllOfType(),
@@ -405,7 +405,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewAllOfType(),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitAllOfType = func(at *AllOfType) (Type, error) {
-					return at, errors.New(at.String())
+					return at, eris.New(at.String())
 				}
 			},
 			NewAllOfType(),
@@ -416,7 +416,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewMapType(StringType, IntType),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitMapType = func(tv *TypeVisitor[any], mt *MapType, _ interface{}) (Type, error) {
-					return mt, errors.New(mt.String())
+					return mt, eris.New(mt.String())
 				}
 			},
 			NewMapType(StringType, IntType),
@@ -427,7 +427,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewMapType(StringType, IntType),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitMapType = func(mt *MapType) (Type, error) {
-					return mt, errors.New(mt.String())
+					return mt, eris.New(mt.String())
 				}
 			},
 			NewMapType(StringType, IntType),
@@ -438,7 +438,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewArrayType(StringType),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitArrayType = func(tv *TypeVisitor[any], at *ArrayType, _ interface{}) (Type, error) {
-					return at, errors.New(at.String())
+					return at, eris.New(at.String())
 				}
 			},
 			NewArrayType(StringType),
@@ -449,7 +449,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			NewArrayType(StringType),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitArrayType = func(at *ArrayType) (Type, error) {
-					return at, errors.New(at.String())
+					return at, eris.New(at.String())
 				}
 			},
 			NewArrayType(StringType),
@@ -460,7 +460,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			StorageFlag.ApplyTo(StringType),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitFlaggedType = func(tv *TypeVisitor[any], ft *FlaggedType, _ interface{}) (Type, error) {
-					return ft, errors.New(ft.String())
+					return ft, eris.New(ft.String())
 				}
 			},
 			StorageFlag.ApplyTo(StringType),
@@ -471,7 +471,7 @@ func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
 			StorageFlag.ApplyTo(StringType),
 			func(builder *TypeVisitorBuilder[any]) {
 				builder.VisitFlaggedType = func(ft *FlaggedType) (Type, error) {
-					return ft, errors.New(ft.String())
+					return ft, eris.New(ft.String())
 				}
 			},
 			StorageFlag.ApplyTo(StringType),

--- a/v2/tools/generator/internal/astmodel/type_walker.go
+++ b/v2/tools/generator/internal/astmodel/type_walker.go
@@ -8,7 +8,7 @@ package astmodel
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 )
 
 // TODO: This is conceptually kinda close to ReferenceGraph except more powerful. We may be able to refactor ReferenceGraph to use this
@@ -69,13 +69,13 @@ func NewTypeWalker[C any](allDefs TypeDefinitionSet, visitor TypeVisitor[C]) *Ty
 func (t *TypeWalker[C]) visitInternalTypeName(this *TypeVisitor[C], it InternalTypeName, ctx C) (Type, error) {
 	updatedCtx, err := t.MakeContext(it, ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "MakeContext failed for name %q", it)
+		return nil, eris.Wrapf(err, "MakeContext failed for name %q", it)
 	}
 
 	if t.originalVisitInternalTypeName != nil {
 		visitedTypeName, terr := t.originalVisitInternalTypeName(this, it, updatedCtx)
 		if terr != nil {
-			return nil, errors.Wrapf(terr, "visitTypeName failed for name %q", it)
+			return nil, eris.Wrapf(terr, "visitTypeName failed for name %q", it)
 		}
 
 		itn, ok := visitedTypeName.(InternalTypeName)
@@ -103,7 +103,7 @@ func (t *TypeWalker[C]) visitInternalTypeName(this *TypeVisitor[C], it InternalT
 	if _, ok := t.state.processing[def.Name()]; ok {
 		remove, cycleErr := t.ShouldRemoveCycle(def, updatedCtx)
 		if cycleErr != nil {
-			return nil, errors.Wrapf(cycleErr, "ShouldRemoveCycle failed for def %q", def.Name())
+			return nil, eris.Wrapf(cycleErr, "ShouldRemoveCycle failed for def %q", def.Name())
 		}
 		if remove {
 			return typeWalkerRemoveType, nil
@@ -116,11 +116,11 @@ func (t *TypeWalker[C]) visitInternalTypeName(this *TypeVisitor[C], it InternalT
 
 	updatedType, err := this.Visit(def.Type(), updatedCtx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error visiting type %q", def.Name())
+		return nil, eris.Wrapf(err, "error visiting type %q", def.Name())
 	}
 	updatedDef, err := t.AfterVisit(def, def.WithType(updatedType), updatedCtx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "AfterVisit failed for def %q", def.Name())
+		return nil, eris.Wrapf(err, "AfterVisit failed for def %q", def.Name())
 	}
 
 	delete(t.state.processing, def.Name())

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/internal/version"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -62,7 +62,7 @@ func NewTargetedCodeGeneratorFromConfig(
 ) (*CodeGenerator, error) {
 	result, err := NewCodeGeneratorFromConfig(configuration, idFactory, log)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating pipeline targeting %s", target)
+		return nil, eris.Wrapf(err, "creating pipeline targeting %s", target)
 	}
 
 	// Filter stages to use only those appropriate for our target
@@ -278,7 +278,7 @@ func (generator *CodeGenerator) Generate(
 		diagram := pipeline.NewPipelineDiagram(generator.debugSettings)
 		err := diagram.WriteDiagram(generator.pipeline)
 		if err != nil {
-			return errors.Wrapf(err, "failed to generate diagram")
+			return eris.Wrapf(err, "failed to generate diagram")
 		}
 	}
 
@@ -291,7 +291,7 @@ func (generator *CodeGenerator) Generate(
 
 		newState, err := generator.executeStage(ctx, stageNumber, stage, state)
 		if err != nil {
-			return errors.Wrapf(err, "failed to execute stage %d: %s", stageNumber, stage.Description())
+			return eris.Wrapf(err, "failed to execute stage %d: %s", stageNumber, stage.Description())
 		}
 
 		generator.logStateChanges(start, newState, state, log, stageDescription)
@@ -343,9 +343,9 @@ func (generator *CodeGenerator) executeStage(
 	defer func() {
 		if r := recover(); r != nil {
 			if e, ok := r.(error); ok {
-				err = errors.Wrapf(e, "panic: %s", string(debug.Stack()))
+				err = eris.Wrapf(e, "panic: %s", string(debug.Stack()))
 			} else {
-				err = errors.Errorf("panic: %s\n%s", r, string(debug.Stack()))
+				err = eris.Errorf("panic: %s\n%s", r, string(debug.Stack()))
 			}
 		}
 	}()
@@ -359,26 +359,26 @@ func (generator *CodeGenerator) executeStage(
 
 	if ctx.Err() != nil {
 		// Cancelled - will be wrapped by our caller
-		return nil, errors.New("pipeline cancelled")
+		return nil, eris.New("pipeline cancelled")
 	}
 
 	// Fail fast if something goes awry
 	if len(newState.Definitions()) == 0 {
 		// Will be wrapped by our caller with details of the stage
-		return nil, errors.Errorf("all type definitions removed by stage")
+		return nil, eris.Errorf("all type definitions removed by stage")
 	}
 
 	if generator.debugReporter != nil {
 		err := generator.debugReporter.ReportStage(stageNumber, stage.Description(), newState)
 		if err != nil {
 			// Will be wrapped by our caller with details of the stage
-			return nil, errors.Wrapf(err, "failed to generate debug report for stage")
+			return nil, eris.Wrapf(err, "failed to generate debug report for stage")
 		}
 
 		err = stage.RunDiagnostic(generator.debugSettings, stageNumber, newState)
 		if err != nil {
 			// Will be wrapped by our caller with details of the stage
-			return nil, errors.Wrapf(err, "failed to generate diagnostic report for stage")
+			return nil, eris.Wrapf(err, "failed to generate diagnostic report for stage")
 		}
 	}
 

--- a/v2/tools/generator/internal/codegen/debug_reporter.go
+++ b/v2/tools/generator/internal/codegen/debug_reporter.go
@@ -8,7 +8,7 @@ package codegen
 import (
 	"strconv"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/pipeline"
@@ -40,5 +40,5 @@ func (dr *debugReporter) ReportStage(stage int, description string, state *pipel
 	filename := dr.settings.CreateFileName(name)
 
 	err := tcr.SaveTo(filename)
-	return errors.Wrapf(err, "failed to save type catalog to %s", filename)
+	return eris.Wrapf(err, "failed to save type catalog to %s", filename)
 }

--- a/v2/tools/generator/internal/codegen/embeddedresources/misbehaving_embedded_resources.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/misbehaving_embedded_resources.go
@@ -6,7 +6,7 @@
 package embeddedresources
 
 import (
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -47,7 +47,7 @@ func findMisbehavingResources(
 					// Expected that the property in question is a TypeName
 					propertyType, ok := astmodel.ExtractTypeName(prop.PropertyType())
 					if !ok {
-						return nil, errors.Errorf("property %s of %s doesn't look like a resource because it is not a TypeName", prop.PropertyName(), ctx.typeName.String())
+						return nil, eris.Errorf("property %s of %s doesn't look like a resource because it is not a TypeName", prop.PropertyName(), ctx.typeName.String())
 					}
 
 					if _, ok = resources[ctx.resourceName]; !ok {
@@ -84,7 +84,7 @@ func findMisbehavingResources(
 	for _, def := range astmodel.FindResourceDefinitions(defs) {
 		_, err := typeWalker.Walk(def)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to walk type %s", def.Name())
+			return nil, eris.Wrapf(err, "failed to walk type %s", def.Name())
 		}
 	}
 

--- a/v2/tools/generator/internal/codegen/embeddedresources/remove_empty_objects.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/remove_empty_objects.go
@@ -7,7 +7,7 @@ package embeddedresources
 
 import (
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -89,7 +89,7 @@ func removeReferencesToTypes(
 
 		updatedDef, err := visitor.VisitDefinition(def, nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "visiting definition %q", def.Name())
+			return nil, eris.Wrapf(err, "visiting definition %q", def.Name())
 		}
 		result.Add(updatedDef)
 	}
@@ -168,7 +168,7 @@ func makeRemovedTypeVisitor(
 		// Safety check that we're not overwriting typeName
 		if ctx != nil {
 			if !ctx.typeName.IsEmpty() {
-				return nil, errors.Errorf("would've overwritten ctx.typeName %q", ctx.typeName)
+				return nil, eris.Errorf("would've overwritten ctx.typeName %q", ctx.typeName)
 			}
 
 			ctx.typeName = it

--- a/v2/tools/generator/internal/codegen/embeddedresources/remover.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/remover.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -81,12 +81,12 @@ func MakeEmbeddedResourceRemover(configuration *config.Configuration, definition
 
 	resourcesEmbeddedInParent, err := findResourcesEmbeddedInParent(configuration, definitions)
 	if err != nil {
-		return EmbeddedResourceRemover{}, errors.Wrap(err, "couldn't find all resources embedded in parent")
+		return EmbeddedResourceRemover{}, eris.Wrap(err, "couldn't find all resources embedded in parent")
 	}
 
 	misbehavingResources, err := findMisbehavingResources(configuration, definitions)
 	if err != nil {
-		return EmbeddedResourceRemover{}, errors.Wrap(err, "couldn't find all misbehaving embedded resources")
+		return EmbeddedResourceRemover{}, eris.Wrap(err, "couldn't find all misbehaving embedded resources")
 	}
 
 	remover := EmbeddedResourceRemover{
@@ -367,13 +367,13 @@ func findResourcesEmbeddedInParent(
 
 		// Perform some validation that this annotation makes sense before we accept it
 		if !objectType.IsResource() {
-			errs = append(errs, errors.Errorf("%s is not labelled as a resource, so cannot be a resource embedded in a parent", name))
+			errs = append(errs, eris.Errorf("%s is not labelled as a resource, so cannot be a resource embedded in a parent", name))
 			continue
 		}
 
 		parentTypeName := name.WithName(parentResource)
 		if !defs.Contains(parentTypeName) {
-			errs = append(errs, errors.Errorf("cannot find %s parent %s", name, parentTypeName))
+			errs = append(errs, eris.Errorf("cannot find %s parent %s", name, parentTypeName))
 			continue
 		}
 

--- a/v2/tools/generator/internal/codegen/embeddedresources/renamer.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/renamer.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -62,7 +62,7 @@ func (r renamer) simplifyEmbeddedNameRemoveContextAndCount(
 	associated := associatedNames.Single()
 	embeddedName, ok := originalNames[associated]
 	if !ok {
-		return nil, errors.Errorf("could not find original name for %q", associated)
+		return nil, eris.Errorf("could not find original name for %q", associated)
 	}
 
 	embeddedName.context = ""
@@ -88,7 +88,7 @@ func (r renamer) simplifyEmbeddedNameRemoveContext(
 	for associated := range associatedNames {
 		embeddedName, ok := originalNames[associated]
 		if !ok {
-			return nil, errors.Errorf("could not find original name for %q", associated)
+			return nil, eris.Errorf("could not find original name for %q", associated)
 		}
 		associatedCountPerContext[embeddedName.context] = associatedCountPerContext[embeddedName.context] + 1
 	}
@@ -102,7 +102,7 @@ func (r renamer) simplifyEmbeddedNameRemoveContext(
 	for associated := range associatedNames {
 		embeddedName, ok := originalNames[associated]
 		if !ok {
-			return nil, errors.Errorf("could not find original name for %q", associated)
+			return nil, eris.Errorf("could not find original name for %q", associated)
 		}
 		embeddedName.context = ""
 		renames[associated] = embeddedName.ToSimplifiedTypeName()
@@ -128,7 +128,7 @@ func (r renamer) simplifyEmbeddedName(
 	for associated := range associatedNames {
 		embeddedName, ok := originalNames[associated]
 		if !ok {
-			return nil, errors.Errorf("could not find original name for %q", associated)
+			return nil, eris.Errorf("could not find original name for %q", associated)
 		}
 
 		possibleRename := embeddedName.ToSimplifiedTypeName()
@@ -186,7 +186,7 @@ func simplifyTypeNames(
 		if flag.IsOn(def.Type()) {
 			en, ok := originalNames[def.Name()]
 			if !ok {
-				return nil, errors.Errorf("failed to find original name for renamed type %s", def.Name())
+				return nil, eris.Errorf("failed to find original name for renamed type %s", def.Name())
 			}
 
 			if updatedNames[en.original] == nil {

--- a/v2/tools/generator/internal/codegen/pipeline/add_arm_conversion_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_arm_conversion_interface.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/armconversion"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -67,7 +67,7 @@ func (c *armConversionApplier) transformResourceSpecs() (astmodel.TypeDefinition
 	for _, td := range resources {
 		resource, ok := astmodel.AsResourceType(td.Type())
 		if !ok {
-			return nil, errors.Errorf("%q was not a resource, instead %T", td.Name(), td.Type())
+			return nil, eris.Errorf("%q was not a resource, instead %T", td.Name(), td.Type())
 		}
 
 		specDefinition, err := c.transformSpec(resource)
@@ -77,7 +77,7 @@ func (c *armConversionApplier) transformResourceSpecs() (astmodel.TypeDefinition
 
 		armSpecDefinition, ok := LookupARMTypeDefinition(specDefinition.Name(), c.definitions)
 		if !ok {
-			return nil, errors.Errorf("couldn't find ARM definition for spec %s", specDefinition.Name())
+			return nil, eris.Errorf("couldn't find ARM definition for spec %s", specDefinition.Name())
 		}
 
 		specDefinition, err = c.addARMConversionInterface(specDefinition, armSpecDefinition, armconversion.TypeKindSpec)
@@ -110,7 +110,7 @@ func (c *armConversionApplier) transformResourceStatuses() (astmodel.TypeDefinit
 
 		armStatusDefinition, ok := LookupARMTypeDefinition(td.Name(), c.definitions)
 		if !ok {
-			return nil, errors.Errorf("couldn't find ARM definition for status %s", td.Name())
+			return nil, eris.Errorf("couldn't find ARM definition for status %s", td.Name())
 		}
 
 		statusDefinition, err := c.addARMConversionInterface(td, armStatusDefinition, armconversion.TypeKindStatus)
@@ -158,12 +158,12 @@ func (c *armConversionApplier) transformTypes() (astmodel.TypeDefinitionSet, err
 
 		armDefinition, ok := LookupARMTypeDefinition(td.Name(), c.definitions)
 		if !ok {
-			return nil, errors.Errorf("couldn't find ARM definition for %s", td.Name())
+			return nil, eris.Errorf("couldn't find ARM definition for %s", td.Name())
 		}
 
 		modifiedDef, err := c.addARMConversionInterface(td, armDefinition, armconversion.TypeKindOrdinary)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to add ARM conversion interface to %q", td.Name())
+			return nil, eris.Wrapf(err, "failed to add ARM conversion interface to %q", td.Name())
 		}
 
 		result.Add(modifiedDef)
@@ -214,7 +214,7 @@ func (c *armConversionApplier) transformSpec(resourceType *astmodel.ResourceType
 
 	kubernetesDef, err := resourceSpecDef.ApplyObjectTransformations(remapProperties, injectOwnerProperty)
 	if err != nil {
-		return astmodel.TypeDefinition{}, errors.Wrapf(err, "remapping properties of Kubernetes definition")
+		return astmodel.TypeDefinition{}, eris.Wrapf(err, "remapping properties of Kubernetes definition")
 	}
 
 	return kubernetesDef, nil
@@ -228,7 +228,7 @@ func (c *armConversionApplier) addARMConversionInterface(
 	objectType, ok := astmodel.AsObjectType(armDef.Type())
 	emptyDef := astmodel.TypeDefinition{}
 	if !ok {
-		return emptyDef, errors.Errorf("ARM definition %q did not define an object type", armDef.Name())
+		return emptyDef, eris.Errorf("ARM definition %q did not define an object type", armDef.Name())
 	}
 
 	addInterfaceHandler := func(t *astmodel.ObjectType) (astmodel.Type, error) {
@@ -245,7 +245,7 @@ func (c *armConversionApplier) addARMConversionInterface(
 	if err != nil {
 		emptyDef := astmodel.TypeDefinition{}
 		return emptyDef,
-			errors.Errorf("failed to add ARM conversion interface to Kubenetes object definition %s", armDef.Name())
+			eris.Errorf("failed to add ARM conversion interface to Kubenetes object definition %s", armDef.Name())
 	}
 
 	return result, nil

--- a/v2/tools/generator/internal/codegen/pipeline/add_configmaps.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_configmaps.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -28,7 +28,7 @@ func AddConfigMaps(config *config.Configuration) *Stage {
 
 			updatedDefs, err := transformConfigMaps(config, defs)
 			if err != nil {
-				return nil, errors.Wrap(err, "transforming spec secrets")
+				return nil, eris.Wrap(err, "transforming spec secrets")
 			}
 
 			return state.WithDefinitions(updatedDefs), nil
@@ -43,7 +43,7 @@ func transformPropertyToConfigMapReference(prop *astmodel.PropertyDefinition, ne
 	// The expectation is that this is a string
 	propType := prop.PropertyType()
 	if !astmodel.Unwrap(propType).Equals(astmodel.StringType, astmodel.EqualityOverrides{}) {
-		return nil, errors.Errorf("expected property %q to be a string, but was: %T", prop.PropertyName(), propType)
+		return nil, eris.Errorf("expected property %q to be a string, but was: %T", prop.PropertyName(), propType)
 	}
 
 	// check if it's optional
@@ -63,12 +63,12 @@ func createNewConfigMapReference(
 	// The expectation is that this is a string
 	propType := prop.PropertyType()
 	if !astmodel.TypeEquals(astmodel.Unwrap(propType), astmodel.StringType) {
-		return nil, nil, errors.Errorf("expected property %q to be a string, but was: %s", prop.PropertyName(), astmodel.DebugDescription(propType))
+		return nil, nil, eris.Errorf("expected property %q to be a string, but was: %s", prop.PropertyName(), astmodel.DebugDescription(propType))
 	}
 
 	jsonName, ok := prop.JSONName()
 	if !ok {
-		return nil, nil, errors.Errorf("property %s didn't have a JSON name", prop.PropertyName())
+		return nil, nil, eris.Errorf("property %s didn't have a JSON name", prop.PropertyName())
 	}
 
 	// Neither property can be required anymore. That's a bit unfortunate from a fail-fast perspective.
@@ -106,18 +106,18 @@ func transformConfigMaps(cfg *config.Configuration, definitions astmodel.TypeDef
 			case config.ImportConfigMapModeRequired:
 				newProp, err := transformPropertyToConfigMapReference(prop, astmodel.ConfigMapReferenceType)
 				if err != nil {
-					return nil, errors.Wrapf(err, "failed to transform property to configmap on type %s", ctx)
+					return nil, eris.Wrapf(err, "failed to transform property to configmap on type %s", ctx)
 				}
 				it = it.WithProperty(newProp)
 			case config.ImportConfigMapModeOptional:
 				updatedProp, newProp, err := createNewConfigMapReference(prop, astmodel.ConfigMapReferenceType)
 				if err != nil {
-					return nil, errors.Wrapf(err, "failed to transform property to optional configmap on type %s", ctx)
+					return nil, eris.Wrapf(err, "failed to transform property to optional configmap on type %s", ctx)
 				}
 
 				// If the property we're about to add already exists, that's bad!
 				if _, ok := it.Property(newProp.PropertyName()); ok {
-					return nil, errors.Errorf(
+					return nil, eris.Errorf(
 						"failed to transform property to optional configmap on type %s. Property %s already exists",
 						ctx,
 						newProp.PropertyName())
@@ -139,7 +139,7 @@ func transformConfigMaps(cfg *config.Configuration, definitions astmodel.TypeDef
 	for _, def := range definitions {
 		updatedDef, err := visitor.VisitDefinition(def, def.Name())
 		if err != nil {
-			return nil, errors.Wrapf(err, "visiting type %q", def.Name())
+			return nil, eris.Wrapf(err, "visiting type %q", def.Name())
 		}
 
 		result.Add(updatedDef)

--- a/v2/tools/generator/internal/codegen/pipeline/add_cross_resource_references.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_cross_resource_references.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -41,7 +41,7 @@ func TransformCrossResourceReferences(configuration *config.Configuration, idFac
 
 				t, err := visitor.Visit(def.Type(), def.Name())
 				if err != nil {
-					return nil, errors.Wrapf(err, "visiting %q", def.Name())
+					return nil, eris.Wrapf(err, "visiting %q", def.Name())
 				}
 
 				updatedDefs.Add(def.WithType(t))
@@ -49,7 +49,7 @@ func TransformCrossResourceReferences(configuration *config.Configuration, idFac
 
 			resultDefs, err := stripARMIDPrimitiveTypes(updatedDefs)
 			if err != nil {
-				return nil, errors.Wrap(err, "failed to strip ARM ID primitive types")
+				return nil, eris.Wrap(err, "failed to strip ARM ID primitive types")
 			}
 
 			return state.WithDefinitions(resultDefs), nil
@@ -135,7 +135,7 @@ func (v *ARMIDToGenruntimeReferenceTypeVisitor) renamePropertiesWithARMIDReferen
 
 	ot, ok := result.(*astmodel.ObjectType)
 	if !ok {
-		return nil, errors.Errorf("result for visitObjectType of %s was not expected ObjectType, instead %T", ctx, result)
+		return nil, eris.Errorf("result for visitObjectType of %s was not expected ObjectType, instead %T", ctx, result)
 	}
 
 	// Now, check if any properties have been updated and if they have change their names to match
@@ -144,7 +144,7 @@ func (v *ARMIDToGenruntimeReferenceTypeVisitor) renamePropertiesWithARMIDReferen
 	ot.Properties().ForEach(func(prop *astmodel.PropertyDefinition) {
 		origProp, ok := it.Property(prop.PropertyName())
 		if !ok {
-			errs = append(errs, errors.Errorf("expected to find property %q on %s", prop.PropertyName(), ctx))
+			errs = append(errs, eris.Errorf("expected to find property %q on %s", prop.PropertyName(), ctx))
 			return
 		}
 
@@ -184,7 +184,7 @@ func (v *ARMIDToGenruntimeReferenceTypeVisitor) stripValidationForResourceRefere
 	// If they aren't equal, just return the element
 	validated, ok := result.(*astmodel.ValidatedType)
 	if !ok {
-		return nil, errors.Errorf("expected IdentityVisitOfValidatedType to return a ValidatedType, but it instead returned %T", result)
+		return nil, eris.Errorf("expected IdentityVisitOfValidatedType to return a ValidatedType, but it instead returned %T", result)
 	}
 	return validated.ElementType(), nil
 }

--- a/v2/tools/generator/internal/codegen/pipeline/add_kubernetes_exporter.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_kubernetes_exporter.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/functions"
@@ -26,13 +26,13 @@ func AddKubernetesExporter(idFactory astmodel.IdentifierFactory) *Stage {
 
 			mappings, err := GetStateData[*ExportedTypeNameProperties](state, ExportedConfigMaps)
 			if err != nil {
-				return nil, errors.Wrapf(err, "couldn't find exported config maps")
+				return nil, eris.Wrapf(err, "couldn't find exported config maps")
 			}
 
 			for _, def := range astmodel.FindResourceDefinitions(defs) {
 				resourceType, ok := astmodel.AsResourceType(def.Type())
 				if !ok {
-					return nil, errors.Errorf("%s definition type wasn't a resource", def.Name())
+					return nil, eris.Errorf("%s definition type wasn't a resource", def.Name())
 				}
 
 				configMapMappings, ok := mappings.Get(def.Name())

--- a/v2/tools/generator/internal/codegen/pipeline/add_serialization_type_tag.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_serialization_type_tag.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -40,7 +40,7 @@ func AddSerializationTypeTag(configuration *config.Configuration) *Stage {
 					config: configuration,
 				})
 				if err != nil {
-					return nil, errors.Wrapf(err, "visiting %q", def.Name())
+					return nil, eris.Wrapf(err, "visiting %q", def.Name())
 				}
 
 				updatedDefs.Add(def.WithType(t))

--- a/v2/tools/generator/internal/codegen/pipeline/add_simple_cross_resource_references.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_simple_cross_resource_references.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 )
 
 // TransformCrossResourceReferencesToStringStageID is the unique identifier for this pipeline stage
@@ -22,7 +22,7 @@ func TransformCrossResourceReferencesToString() *Stage {
 		func(ctx context.Context, state *State) (*State, error) {
 			updatedDefs, err := stripARMIDPrimitiveTypes(state.Definitions())
 			if err != nil {
-				return nil, errors.Wrap(err, "failed to strip ARM ID primitive types")
+				return nil, eris.Wrap(err, "failed to strip ARM ID primitive types")
 			}
 
 			return state.WithDefinitions(updatedDefs), nil

--- a/v2/tools/generator/internal/codegen/pipeline/add_status_conditions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_status_conditions.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/functions"
@@ -34,7 +34,7 @@ func AddStatusConditions(idFactory astmodel.IdentifierFactory) *Stage {
 				conditionsProp = conditionsProp.WithDescription("The observed state of the resource").MakeOptional()
 				updatedDef, err := propInjector.Inject(def, conditionsProp)
 				if err != nil {
-					return nil, errors.Wrapf(err, "couldn't add Conditions condition to status %q", def.Name())
+					return nil, eris.Wrapf(err, "couldn't add Conditions condition to status %q", def.Name())
 				}
 				result.Add(updatedDef)
 			}
@@ -45,7 +45,7 @@ func AddStatusConditions(idFactory astmodel.IdentifierFactory) *Stage {
 
 				conditionerImpl, err := NewConditionerInterfaceImpl(idFactory, resourceType)
 				if err != nil {
-					return nil, errors.Wrapf(err, "couldn't create genruntime.Conditioner implementation for %q", def.Name())
+					return nil, eris.Wrapf(err, "couldn't create genruntime.Conditioner implementation for %q", def.Name())
 				}
 				resourceType = resourceType.WithInterface(conditionerImpl)
 

--- a/v2/tools/generator/internal/codegen/pipeline/apply_cross_resource_references_from_config.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_cross_resource_references_from_config.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -56,9 +56,10 @@ func ApplyCrossResourceReferencesFromConfig(
 						// config. Record an error saying that the config entry is no longer needed
 						crossResourceReferenceErrs = append(
 							crossResourceReferenceErrs,
-							errors.Errorf("%s.%s marked as ARM reference, but value is not needed because Swagger already says it is an ARM reference",
+							eris.Errorf("%s.%s marked as ARM reference, but value is not needed because Swagger already says it is an ARM reference",
 								typeName.String(),
-								prop.PropertyName().String()))
+								prop.PropertyName().String()),
+						)
 					}
 				}
 
@@ -68,10 +69,11 @@ func ApplyCrossResourceReferencesFromConfig(
 					// trust the Swagger.
 					crossResourceReferenceErrs = append(
 						crossResourceReferenceErrs,
-						errors.Errorf(
+						eris.Errorf(
 							"%s.%s looks like a resource reference but was not labelled as one; You may need to add it to the 'objectModelConfiguration' section of the config file",
 							typeName,
-							prop.PropertyName()))
+							prop.PropertyName()),
+					)
 				}
 
 				if isReference {
@@ -92,7 +94,7 @@ func ApplyCrossResourceReferencesFromConfig(
 
 				t, err := visitor.Visit(def.Type(), def.Name())
 				if err != nil {
-					return nil, errors.Wrapf(err, "visiting %q", def.Name())
+					return nil, eris.Wrapf(err, "visiting %q", def.Name())
 				}
 
 				typesWithARMIDs.Add(def.WithType(t))
@@ -108,7 +110,7 @@ func ApplyCrossResourceReferencesFromConfig(
 
 			err = configuration.ObjectModelConfiguration.ARMReference.VerifyConsumed()
 			if err != nil {
-				return nil, errors.Wrap(
+				return nil, eris.Wrap(
 					err,
 					"Found unused $armReference configurations; these need to be fixed or removed.")
 			}

--- a/v2/tools/generator/internal/codegen/pipeline/apply_export_filters.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_export_filters.go
@@ -9,7 +9,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -55,7 +55,7 @@ func filterTypes(
 
 	typesToExport, err := astmodel.FindConnectedDefinitions(state.Definitions(), resourcesToExport)
 	if err != nil {
-		return nil, errors.Wrap(err, "finding types connected to resources marked for export")
+		return nil, eris.Wrap(err, "finding types connected to resources marked for export")
 	}
 
 	// Find and apply renames.

--- a/v2/tools/generator/internal/codegen/pipeline/apply_kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_kubernetes_resource_interface.go
@@ -9,7 +9,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/interfaces"
@@ -35,7 +35,7 @@ func ApplyKubernetesResourceInterface(
 					state.Definitions(),
 					log)
 				if err != nil {
-					return nil, errors.Wrapf(err, "couldn't implement Kubernetes resource interface for %q", typeName)
+					return nil, eris.Wrapf(err, "couldn't implement Kubernetes resource interface for %q", typeName)
 				}
 
 				updatedDefs.AddTypes(newDefs)

--- a/v2/tools/generator/internal/codegen/pipeline/apply_type_rewrites.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_type_rewrites.go
@@ -9,7 +9,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -29,7 +29,7 @@ func ApplyTypeRewrites(
 				// Apply type transformation, if any
 				newDef, err := transformDefinition(def, config, log)
 				if err != nil {
-					return nil, errors.Wrapf(err, "unable to transform type %q", name)
+					return nil, eris.Wrapf(err, "unable to transform type %q", name)
 				}
 
 				definitions.Add(newDef)

--- a/v2/tools/generator/internal/codegen/pipeline/check_for_anytype.go
+++ b/v2/tools/generator/internal/codegen/pipeline/check_for_anytype.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -66,11 +66,11 @@ func checkForAnyType(description string, packages []string) *Stage {
 
 			badPackages, err := collectBadPackages(badNames, expectedPackages)
 			if err != nil {
-				return nil, errors.Wrap(err, "summarising bad types")
+				return nil, eris.Wrap(err, "summarising bad types")
 			}
 
 			if len(badPackages) > 0 {
-				return nil, errors.Errorf("AnyTypes found - add exclusions for: %s", strings.Join(badPackages, ", "))
+				return nil, eris.Errorf("AnyTypes found - add exclusions for: %s", strings.Join(badPackages, ", "))
 			}
 
 			return output, nil
@@ -125,8 +125,9 @@ func collectBadPackages(
 			leftovers = append(leftovers, value)
 		}
 		sort.Strings(leftovers)
-		return nil, errors.Errorf(
+		return nil, eris.Errorf(
 			"no AnyTypes found in: %s", strings.Join(leftovers, ", "))
+
 	}
 
 	return groupNames, nil

--- a/v2/tools/generator/internal/codegen/pipeline/check_for_anytype_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/check_for_anytype_test.go
@@ -11,7 +11,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/test"
@@ -116,5 +116,5 @@ func TestComplainsAboutUnneededExclusions(t *testing.T) {
 	stage := FilterOutDefinitionsUsingAnyType(exclusions)
 	finalState, err := stage.Run(context.Background(), state)
 	g.Expect(finalState).To(BeNil())
-	g.Expect(errors.Cause(err)).To(MatchError("no AnyTypes found in: gamma.knife/v20200821, people.vultures/20200821"))
+	g.Expect(eris.Cause(err)).To(MatchError("no AnyTypes found in: gamma.knife/v20200821, people.vultures/20200821"))
 }

--- a/v2/tools/generator/internal/codegen/pipeline/collapse_cross_group_refs.go
+++ b/v2/tools/generator/internal/codegen/pipeline/collapse_cross_group_refs.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -30,7 +30,7 @@ func CollapseCrossGroupReferences(idFactory astmodel.IdentifierFactory) *Stage {
 				walker := newTypeWalker(idFactory, state.Definitions(), name)
 				updatedTypes, err := walker.Walk(def)
 				if err != nil {
-					return nil, errors.Wrapf(err, "failed walking definitions")
+					return nil, eris.Wrapf(err, "failed walking definitions")
 				}
 
 				for _, newDef := range updatedTypes {

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -49,7 +49,7 @@ func CreateConversionGraph(
 			graph, err := builder.Build()
 			if err != nil {
 				// Shouldn't have any non-local references, if we do, abort
-				return nil, errors.Wrapf(err, "creating conversion graph")
+				return nil, eris.Wrapf(err, "creating conversion graph")
 			}
 
 			return StateWithData(state, ConversionGraphInfo, graph), nil
@@ -64,14 +64,14 @@ func CreateConversionGraph(
 func exportConversionGraph(settings *DebugSettings, index int, state *State) error {
 	graph, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo)
 	if err != nil {
-		return errors.Wrapf(err, "conversion graph not found")
+		return eris.Wrapf(err, "conversion graph not found")
 	}
 
 	// Create our output folder
 	outputFolder := settings.CreateFileName(fmt.Sprintf("conversion-graph-%d", index))
 	err = os.Mkdir(outputFolder, 0o700)
 	if err != nil {
-		return errors.Wrapf(err, "creating output folder for conversion graph diagnostic")
+		return eris.Wrapf(err, "creating output folder for conversion graph diagnostic")
 	}
 
 	done := set.Make[string]()
@@ -106,7 +106,7 @@ func exportConversionGraph(settings *DebugSettings, index int, state *State) err
 		filename := filepath.Join(outputFolder, key)
 		err := graph.SaveTo(grp, name, filename)
 		if err != nil {
-			return errors.Wrapf(err, "writing conversion graph for %s", name)
+			return eris.Wrapf(err, "writing conversion graph for %s", name)
 		}
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/create_storage_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_storage_types.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/storage"
@@ -60,7 +60,7 @@ func CreateStorageTypes() *Stage {
 			for name, def := range typesToConvert {
 				storageDef, err := typeConverter.ConvertDefinition(def)
 				if err != nil {
-					return nil, errors.Wrapf(err, "creating storage variant of %q", name)
+					return nil, eris.Wrapf(err, "creating storage variant of %q", name)
 				}
 
 				storageDefs.Add(storageDef)

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_at_provider.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_at_provider.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -26,7 +26,7 @@ func AddCrossplaneAtProvider(idFactory astmodel.IdentifierFactory) *Stage {
 					atProviderTypes, err := nestStatusIntoAtProvider(
 						idFactory, definitions, typeDef)
 					if err != nil {
-						return nil, errors.Wrapf(err, "creating AtProvider definitions")
+						return nil, eris.Wrapf(err, "creating AtProvider definitions")
 					}
 
 					// Allow duplicates here because some resources share the same _Status type
@@ -55,7 +55,7 @@ func nestStatusIntoAtProvider(
 ) ([]astmodel.TypeDefinition, error) {
 	resource, ok := astmodel.AsResourceType(typeDef.Type())
 	if !ok {
-		return nil, errors.Errorf("provided typeDef was not a resourceType, instead %T", typeDef.Type())
+		return nil, eris.Errorf("provided typeDef was not a resourceType, instead %T", typeDef.Type())
 	}
 	resourceName := typeDef.Name()
 
@@ -66,7 +66,7 @@ func nestStatusIntoAtProvider(
 
 	statusName, ok := astmodel.AsInternalTypeName(resource.StatusType())
 	if !ok {
-		return nil, errors.Errorf("resource %q status was not of type TypeName, instead: %T", resourceName, resource.StatusType())
+		return nil, eris.Errorf("resource %q status was not of type TypeName, instead: %T", resourceName, resource.StatusType())
 	}
 
 	// In the case where a status type is reused across multiple resource definitions, we need to make sure

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_embedded_resource_spec.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_embedded_resource_spec.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -32,7 +32,7 @@ func AddCrossplaneEmbeddedResourceSpec(idFactory astmodel.IdentifierFactory) *St
 
 					specDef, err := definitions.ResolveResourceSpecDefinition(resource)
 					if err != nil {
-						return nil, errors.Wrapf(err, "getting resource spec definition")
+						return nil, eris.Wrapf(err, "getting resource spec definition")
 					}
 
 					// The assumption here is that specs are all Objects
@@ -40,7 +40,7 @@ func AddCrossplaneEmbeddedResourceSpec(idFactory astmodel.IdentifierFactory) *St
 						return o.WithEmbeddedProperty(embeddedSpec)
 					})
 					if err != nil {
-						return nil, errors.Wrapf(err, "adding embedded crossplane spec")
+						return nil, eris.Wrapf(err, "adding embedded crossplane spec")
 					}
 
 					result.Add(typeDef)

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_embedded_resource_status.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_embedded_resource_status.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -34,7 +34,7 @@ func AddCrossplaneEmbeddedResourceStatus(idFactory astmodel.IdentifierFactory) *
 
 					statusDef, err := definitions.ResolveResourceStatusDefinition(resource)
 					if err != nil {
-						return nil, errors.Wrapf(err, "getting resource status definition")
+						return nil, eris.Wrapf(err, "getting resource status definition")
 					}
 
 					// The assumption here is that specs are all Objects
@@ -42,7 +42,7 @@ func AddCrossplaneEmbeddedResourceStatus(idFactory astmodel.IdentifierFactory) *
 						return o.WithEmbeddedProperty(embeddedStatus)
 					})
 					if err != nil {
-						return nil, errors.Wrapf(err, "adding embedded crossplane status")
+						return nil, eris.Wrapf(err, "adding embedded crossplane status")
 					}
 
 					result.Add(typeDef)

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_for_provider.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_for_provider.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -27,7 +27,7 @@ func AddCrossplaneForProvider(idFactory astmodel.IdentifierFactory) *Stage {
 					forProviderTypes, err := nestSpecIntoForProvider(
 						idFactory, definitions, typeDef)
 					if err != nil {
-						return nil, errors.Wrapf(err, "creating 'ForProvider' definitions")
+						return nil, eris.Wrapf(err, "creating 'ForProvider' definitions")
 					}
 
 					result.AddAll(forProviderTypes...)
@@ -50,13 +50,13 @@ func nestSpecIntoForProvider(
 ) ([]astmodel.TypeDefinition, error) {
 	resource, ok := astmodel.AsResourceType(typeDef.Type())
 	if !ok {
-		return nil, errors.Errorf("provided typeDef was not a resourceType, instead %T", typeDef.Type())
+		return nil, eris.Errorf("provided typeDef was not a resourceType, instead %T", typeDef.Type())
 	}
 	resourceName := typeDef.Name()
 
 	specName, ok := astmodel.AsInternalTypeName(resource.SpecType())
 	if !ok {
-		return nil, errors.Errorf("resource %q spec was not of type TypeName, instead: %T", resourceName, resource.SpecType())
+		return nil, eris.Errorf("resource %q spec was not of type TypeName, instead: %T", resourceName, resource.SpecType())
 	}
 
 	// In the case where a spec type is reused across multiple resource definitions, we need to make sure
@@ -82,12 +82,12 @@ func nestType(
 ) ([]astmodel.TypeDefinition, error) {
 	outerType, ok := definitions[outerTypeName]
 	if !ok {
-		return nil, errors.Errorf("couldn't find type %q", outerTypeName)
+		return nil, eris.Errorf("couldn't find type %q", outerTypeName)
 	}
 
 	outerObject, ok := astmodel.AsObjectType(outerType.Type())
 	if !ok {
-		return nil, errors.Errorf("type %q was not of type ObjectType, instead %T", outerTypeName, outerType.Type())
+		return nil, eris.Errorf("type %q was not of type ObjectType, instead %T", outerTypeName, outerType.Type())
 	}
 
 	var result []astmodel.TypeDefinition

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_owner_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_owner_properties.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -34,7 +34,7 @@ func AddCrossplaneOwnerProperties(idFactory astmodel.IdentifierFactory) *Stage {
 
 					owners, err := lookupOwners(definitions, typeDef)
 					if err != nil {
-						return nil, errors.Wrapf(err, "failed to look up owners for %s", typeDef.Name())
+						return nil, eris.Wrapf(err, "failed to look up owners for %s", typeDef.Name())
 					}
 
 					// The right-most owner is this type, so remove it
@@ -48,7 +48,7 @@ func AddCrossplaneOwnerProperties(idFactory astmodel.IdentifierFactory) *Stage {
 
 					specDef, err := definitions.ResolveResourceSpecDefinition(resource)
 					if err != nil {
-						return nil, errors.Wrapf(err, "getting resource spec definition")
+						return nil, eris.Wrapf(err, "getting resource spec definition")
 					}
 
 					for _, owner := range owners {
@@ -75,7 +75,7 @@ func AddCrossplaneOwnerProperties(idFactory astmodel.IdentifierFactory) *Stage {
 							return result, nil
 						})
 						if err != nil {
-							return nil, errors.Wrapf(err, "adding ownership properties to spec")
+							return nil, eris.Wrapf(err, "adding ownership properties to spec")
 						}
 						specDef = updatedDef
 					}
@@ -98,7 +98,7 @@ func AddCrossplaneOwnerProperties(idFactory astmodel.IdentifierFactory) *Stage {
 func lookupOwners(defs astmodel.TypeDefinitionSet, resourceDef astmodel.TypeDefinition) ([]astmodel.TypeName, error) {
 	resourceType, ok := resourceDef.Type().(*astmodel.ResourceType)
 	if !ok {
-		return nil, errors.Errorf("type %s is not a resource", resourceDef.Name())
+		return nil, eris.Errorf("type %s is not a resource", resourceDef.Name())
 	}
 
 	if resourceType.Owner().IsEmpty() {
@@ -115,7 +115,7 @@ func lookupOwners(defs astmodel.TypeDefinitionSet, resourceDef astmodel.TypeDefi
 	owner := resourceType.Owner()
 	ownerDef, ok := defs[owner]
 	if !ok {
-		return nil, errors.Errorf("couldn't find definition for owner %s", owner)
+		return nil, eris.Errorf("couldn't find definition for owner %s", owner)
 	}
 
 	result, err := lookupOwners(defs, ownerDef)

--- a/v2/tools/generator/internal/codegen/pipeline/delete_generated_code.go
+++ b/v2/tools/generator/internal/codegen/pipeline/delete_generated_code.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -65,7 +65,7 @@ func deleteGeneratedCodeByPattern(ctx context.Context, globPattern string) error
 	// We use doublestar here rather than filepath.Glob because filepath.Glob doesn't support **
 	files, err := doublestar.Glob(globPattern)
 	if err != nil {
-		return errors.Wrapf(err, "error globbing files with pattern %q", globPattern)
+		return eris.Wrapf(err, "error globbing files with pattern %q", globPattern)
 	}
 
 	// We treat files as a queue of files needing deletion
@@ -84,7 +84,7 @@ func deleteGeneratedCodeByPattern(ctx context.Context, globPattern string) error
 
 		isGenerated, err := isFileGenerated(file)
 		if err != nil {
-			errorsSeen[file] = errors.Wrapf(err, "error determining if file was generated")
+			errorsSeen[file] = eris.Wrapf(err, "error determining if file was generated")
 			consecutiveDeleteFailures++
 			files = append(files, file) // requeue the file
 		}
@@ -92,7 +92,7 @@ func deleteGeneratedCodeByPattern(ctx context.Context, globPattern string) error
 		if isGenerated {
 			err := os.Remove(file)
 			if err != nil {
-				errorsSeen[file] = errors.Wrapf(err, "error determining if file was generated")
+				errorsSeen[file] = eris.Wrapf(err, "error determining if file was generated")
 				consecutiveDeleteFailures++
 				files = append(files, file) // requeue the file
 			} else {
@@ -135,7 +135,7 @@ func isFileGenerated(filename string) (bool, error) {
 	reader := bufio.NewReader(f)
 	for i := 0; i < maxLinesToCheck; i++ {
 		line, err := reader.ReadString('\n')
-		if errors.Is(err, io.EOF) {
+		if eris.Is(err, io.EOF) {
 			return false, nil
 		}
 
@@ -201,14 +201,14 @@ func deleteEmptyDirectories(ctx context.Context, path string) error {
 
 		files, err := os.ReadDir(dir)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "error reading directory %q", dir))
+			errs = append(errs, eris.Wrapf(err, "error reading directory %q", dir))
 		}
 
 		if len(files) == 0 {
 			// Directory is empty now, we can delete it
 			err := os.Remove(dir)
 			if err != nil {
-				errs = append(errs, errors.Wrapf(err, "error removing dir %q", dir))
+				errs = append(errs, eris.Wrapf(err, "error removing dir %q", dir))
 			}
 		}
 	}

--- a/v2/tools/generator/internal/codegen/pipeline/determine_resource_ownership.go
+++ b/v2/tools/generator/internal/codegen/pipeline/determine_resource_ownership.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -31,7 +31,7 @@ func DetermineResourceOwnership(
 			determiner := newOwnershipStage(configuration, state.Definitions())
 			defs, err := determiner.assignOwners()
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to determine resource ownership")
+				return nil, eris.Wrapf(err, "failed to determine resource ownership")
 			}
 
 			return state.WithOverlaidDefinitions(defs), nil
@@ -81,7 +81,7 @@ func (o *ownershipStage) assignOwners() (astmodel.TypeDefinitionSet, error) {
 	for _, def := range resources {
 		resolved, err := o.definitions.ResolveResourceSpecAndStatus(def)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to find resource %s spec and status", def.Name())
+			return nil, eris.Wrapf(err, "unable to find resource %s spec and status", def.Name())
 		}
 
 		childResourceTypeNames := o.findChildren(def)
@@ -90,7 +90,7 @@ func (o *ownershipStage) assignOwners() (astmodel.TypeDefinitionSet, error) {
 		if err != nil {
 			errs = append(
 				errs,
-				errors.Wrapf(err, "failed to update ownership for resource %s", def.Name()))
+				eris.Wrapf(err, "failed to update ownership for resource %s", def.Name()))
 			continue
 		}
 
@@ -103,7 +103,7 @@ func (o *ownershipStage) assignOwners() (astmodel.TypeDefinitionSet, error) {
 			if err != nil {
 				errs = append(
 					errs,
-					errors.Wrapf(err, "failed to remove resources property from resource %s", def.Name()))
+					eris.Wrapf(err, "failed to remove resources property from resource %s", def.Name()))
 				continue
 			}
 
@@ -112,7 +112,7 @@ func (o *ownershipStage) assignOwners() (astmodel.TypeDefinitionSet, error) {
 	}
 
 	if len(errs) > 0 {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			kerrors.NewAggregate(errs),
 			"failed to update ownership for some resources")
 	}
@@ -166,7 +166,7 @@ func (o *ownershipStage) updateChildResourceDefinitionsWithOwner(
 		// Confirm the type really exists
 		childResourceDef, ok := o.definitions[typeName]
 		if !ok {
-			return errors.Errorf("couldn't find child resource type %s", typeName)
+			return eris.Errorf("couldn't find child resource type %s", typeName)
 		}
 
 		// TODO: If it ever arises that we have a resource whose owner doesn't exist in the same API
@@ -181,7 +181,7 @@ func (o *ownershipStage) updateChildResourceDefinitionsWithOwner(
 		// Update the definition of the child resource type to point to its owner
 		childResource, ok := childResourceDef.Type().(*astmodel.ResourceType)
 		if !ok {
-			return errors.Errorf("child resource %s not of type *astmodel.ResourceType, instead %T", typeName, childResourceDef.Type())
+			return eris.Errorf("child resource %s not of type *astmodel.ResourceType, instead %T", typeName, childResourceDef.Type())
 		}
 
 		childResourceDef = childResourceDef.WithType(childResource.WithOwner(owningResourceName))
@@ -202,7 +202,7 @@ func (o *ownershipStage) updateChildResourceDefinitionsWithOwner(
 				}
 			}
 
-			return errors.Wrapf(err, "conflicting child resource already defined for %s [%s]", typeName, childResource.ARMURI())
+			return eris.Wrapf(err, "conflicting child resource already defined for %s [%s]", typeName, childResource.ARMURI())
 		}
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/ensure_type_has_arm_type.go
+++ b/v2/tools/generator/internal/codegen/pipeline/ensure_type_has_arm_type.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -31,13 +31,13 @@ func validateExpectedTypesHaveARMType(definitions astmodel.TypeDefinitionSet) er
 	findARMType := func(t astmodel.Type) error {
 		name, ok := astmodel.AsInternalTypeName(t)
 		if !ok {
-			return errors.Errorf("type was not of type TypeName, instead %T", t)
+			return eris.Errorf("type was not of type TypeName, instead %T", t)
 		}
 
 		armName := astmodel.CreateARMTypeName(name)
 
 		if _, ok = definitions[armName]; !ok {
-			return errors.Errorf("couldn't find ARM type %q", armName)
+			return eris.Errorf("couldn't find ARM type %q", armName)
 		}
 
 		return nil

--- a/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -45,12 +45,12 @@ func ExportControllerResourceRegistrations(idFactory astmodel.IdentifierFactory,
 
 						secretChains, err := catalogSecretPropertyChains(def, definitions)
 						if err != nil {
-							return nil, errors.Wrapf(err, "failed to catalog %s secret property chains", def.Name())
+							return nil, eris.Wrapf(err, "failed to catalog %s secret property chains", def.Name())
 						}
 
 						configMapChains, err := catalogConfigMapPropertyChains(def, definitions)
 						if err != nil {
-							return nil, errors.Wrapf(err, "failed to catalog %s configmap property chains", def.Name())
+							return nil, eris.Wrapf(err, "failed to catalog %s configmap property chains", def.Name())
 						}
 
 						resourceSecretIndexFunctions, resourceSecretPropertyKeys := transformChainsToIndexFunctionsAndKeys(secretChains, idFactory, def)
@@ -79,7 +79,7 @@ func ExportControllerResourceRegistrations(idFactory astmodel.IdentifierFactory,
 
 			err := fileWriter.SaveToFile(outputPath)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to write controller type registration file to %q", outputPath)
+				return nil, eris.Wrapf(err, "failed to write controller type registration file to %q", outputPath)
 			}
 
 			return definitions, nil
@@ -218,7 +218,7 @@ func catalogPropertyChains(
 
 	_, err := walker.Walk(def)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error cataloging secret properties")
+		return nil, eris.Wrapf(err, "error cataloging secret properties")
 	}
 
 	return indexBuilder.propChains, nil

--- a/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
@@ -37,12 +37,12 @@ func ExportPackages(
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
 			packages, err := CreatePackagesForDefinitions(definitions)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to assign generated definitions to packages")
+				return nil, eris.Wrapf(err, "failed to assign generated definitions to packages")
 			}
 
 			err = writeFiles(packages, outputPath, emitDocFiles, log)
 			if err != nil {
-				return nil, errors.Wrapf(err, "unable to write files into %q", outputPath)
+				return nil, eris.Wrapf(err, "unable to write files into %q", outputPath)
 			}
 
 			return definitions, nil
@@ -117,13 +117,13 @@ func writeFiles(
 			if _, err := os.Stat(outputDir); os.IsNotExist(err) {
 				err = os.MkdirAll(outputDir, 0o700)
 				if err != nil {
-					return errors.Wrapf(err, "unable to create directory %q", outputDir)
+					return eris.Wrapf(err, "unable to create directory %q", outputDir)
 				}
 			}
 
 			count, err := pkg.EmitDefinitions(outputDir, packages, emitDocFiles)
 			if err != nil {
-				return errors.Wrapf(err, "error writing definitions into %q", outputDir)
+				return eris.Wrapf(err, "error writing definitions into %q", outputDir)
 			}
 
 			globalProgress.LogProgress("", pkg.DefinitionCount(), count, log)

--- a/v2/tools/generator/internal/codegen/pipeline/fix_optional_collection_aliases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/fix_optional_collection_aliases.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -31,7 +31,7 @@ func FixOptionalCollectionAliases() *Stage {
 			for _, def := range state.Definitions() {
 				d, err := fixer.visitor.VisitDefinition(def, nil)
 				if err != nil {
-					return nil, errors.Wrapf(err, "visiting %q", def.Name())
+					return nil, eris.Wrapf(err, "visiting %q", def.Name())
 				}
 				results.Add(d)
 			}

--- a/v2/tools/generator/internal/codegen/pipeline/flatten_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/flatten_properties.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -181,7 +181,7 @@ func flattenProperty(
 ) ([]*astmodel.PropertyDefinition, error) {
 	props, err := flattenPropType(container, prop.PropertyType(), defs, log)
 	if err != nil {
-		return nil, errors.Wrapf(err, "flattening property %s", prop.PropertyName())
+		return nil, eris.Wrapf(err, "flattening property %s", prop.PropertyName())
 	}
 
 	for i, p := range props {
@@ -221,7 +221,7 @@ func flattenPropType(
 	case *astmodel.OptionalType:
 		innerProps, err := flattenPropType(container, propType.Element(), defs, log)
 		if err != nil {
-			return nil, errors.Wrap(err, "wrapping optional type")
+			return nil, eris.Wrap(err, "wrapping optional type")
 		}
 
 		for ix := range innerProps {
@@ -232,6 +232,6 @@ func flattenPropType(
 
 	default:
 		desc := astmodel.DebugDescription(propType)
-		return nil, errors.Errorf("flatten applied to non-object type: %s", desc)
+		return nil, eris.Errorf("flatten applied to non-object type: %s", desc)
 	}
 }

--- a/v2/tools/generator/internal/codegen/pipeline/flatten_resources.go
+++ b/v2/tools/generator/internal/codegen/pipeline/flatten_resources.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -48,7 +48,7 @@ func FlattenResources() *Stage {
 
 				result, err := v.VisitDefinition(def, nil)
 				if err != nil {
-					return nil, errors.Wrapf(err, "error processing type %s", def.Name())
+					return nil, eris.Wrapf(err, "error processing type %s", def.Name())
 				}
 
 				results.Add(result)
@@ -60,7 +60,7 @@ func FlattenResources() *Stage {
 
 func flattenResource(defs astmodel.TypeDefinitionSet, t astmodel.Type, depth int) (astmodel.Type, error) {
 	if depth > 10 {
-		return nil, errors.Errorf("too many levels of nesting while flattening resource")
+		return nil, eris.Errorf("too many levels of nesting while flattening resource")
 	}
 
 	if resource, ok := t.(*astmodel.ResourceType); ok {

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/storage"
@@ -31,12 +31,12 @@ func ImplementConvertibleInterface(idFactory astmodel.IdentifierFactory) *Stage 
 				func(def astmodel.TypeDefinition) (*astmodel.TypeDefinition, error) {
 					graph, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo)
 					if err != nil {
-						return nil, errors.Wrapf(err, "couldn't find conversion graph")
+						return nil, eris.Wrapf(err, "couldn't find conversion graph")
 					}
 
 					hub, err := graph.FindHub(def.Name(), state.Definitions())
 					if err != nil {
-						return nil, errors.Wrapf(
+						return nil, eris.Wrapf(
 							err,
 							"finding hub for %s",
 							def.Name())
@@ -63,13 +63,13 @@ func ImplementConvertibleInterface(idFactory astmodel.IdentifierFactory) *Stage 
 
 					modified, err := injector.Inject(def, impl)
 					if err != nil {
-						return nil, errors.Wrapf(err, "injecting conversions.Convertible interface into %s", def.Name())
+						return nil, eris.Wrapf(err, "injecting conversions.Convertible interface into %s", def.Name())
 					}
 
 					return &modified, nil
 				})
 			if err != nil {
-				return nil, errors.Wrap(err, "injecting conversions.Convertible implementations")
+				return nil, eris.Wrap(err, "injecting conversions.Convertible implementations")
 			}
 
 			return state.WithOverlaidDefinitions(modifiedTypes), nil

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_spec_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_spec_interface.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/conversions"
@@ -31,7 +31,7 @@ func ImplementConvertibleSpecInterface(idFactory astmodel.IdentifierFactory) *St
 				convertible := createConvertibleSpecInterfaceImplementation(def, idFactory)
 				modified, err := injector.Inject(def, convertible)
 				if err != nil {
-					return nil, errors.Wrapf(err, "injecting Convertible interface into %s", name)
+					return nil, eris.Wrapf(err, "injecting Convertible interface into %s", name)
 				}
 
 				modifiedDefinitions.Add(modified)

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_status_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_status_interface.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/conversions"
@@ -31,7 +31,7 @@ func ImplementConvertibleStatusInterface(idFactory astmodel.IdentifierFactory) *
 				convertible := createConvertibleStatusInterfaceImplementation(def, idFactory)
 				modified, err := injector.Inject(def, convertible)
 				if err != nil {
-					return nil, errors.Wrapf(err, "injecting Convertible interface into %s", name)
+					return nil, eris.Wrapf(err, "injecting Convertible interface into %s", name)
 				}
 
 				modifiedDefs.Add(modified)

--- a/v2/tools/generator/internal/codegen/pipeline/implement_importable_resource_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_importable_resource_interface.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -32,13 +32,13 @@ func ImplementImportableResourceInterface(
 			// Scan for the resources requiring the ImportableResource interface injected
 			graph, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo)
 			if err != nil {
-				return nil, errors.Wrapf(err, "couldn't find conversion graph")
+				return nil, eris.Wrapf(err, "couldn't find conversion graph")
 			}
 
 			scanner := newSpecInitializationScanner(state.Definitions(), graph, configuration)
 			rsrcs, err := scanner.findResources()
 			if err != nil {
-				return nil, errors.Wrapf(err, "unable to find resources that support import")
+				return nil, eris.Wrapf(err, "unable to find resources that support import")
 			}
 
 			injector := astmodel.NewInterfaceInjector()
@@ -67,7 +67,7 @@ func ImplementImportableResourceInterface(
 			}
 
 			if len(errs) > 0 {
-				return nil, errors.Wrap(
+				return nil, eris.Wrap(
 					kerrors.NewAggregate(errs),
 					"unable to implement ImportableResource interface")
 			}
@@ -89,18 +89,18 @@ func createImportableResourceImplementation(
 ) (*astmodel.InterfaceImplementation, error) {
 	rsrc, ok := astmodel.AsResourceType(def.Type())
 	if !ok {
-		return nil, errors.Errorf("expected %q to be a resource", def.Name())
+		return nil, eris.Errorf("expected %q to be a resource", def.Name())
 	}
 
 	// Find the InterfaceInitialization function on the Spec, so we can call it later
 	specDef, err := defs.ResolveResourceSpecDefinition(rsrc)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to resolve spec for %q", def.Name())
+		return nil, eris.Wrapf(err, "unable to resolve spec for %q", def.Name())
 	}
 
 	spec, ok := astmodel.AsFunctionContainer(specDef.Type())
 	if !ok {
-		return nil, errors.Errorf("expected %q to be a function container", specDef.Name())
+		return nil, eris.Errorf("expected %q to be a function container", specDef.Name())
 	}
 
 	var fnName string
@@ -118,7 +118,7 @@ func createImportableResourceImplementation(
 
 	fn, err := functions.NewInitializeSpecFunction(def, fnName, idFactory)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to create initialization function for %q", def.Name())
+		return nil, eris.Wrapf(err, "unable to create initialization function for %q", def.Name())
 	}
 
 	return astmodel.NewInterfaceImplementation(

--- a/v2/tools/generator/internal/codegen/pipeline/inject_hub_function.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_hub_function.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/functions"
@@ -31,14 +31,14 @@ func InjectHubFunction(idFactory astmodel.IdentifierFactory) *Stage {
 			for name, def := range resources {
 				rt, ok := astmodel.AsResourceType(def.Type())
 				if !ok {
-					return nil, errors.Errorf("expected %s to be a resource type (should never happen)", name)
+					return nil, eris.Errorf("expected %s to be a resource type (should never happen)", name)
 				}
 
 				if rt.IsStorageVersion() {
 					fn := functions.NewHubFunction(idFactory)
 					defWithFn, err := injector.Inject(def, fn)
 					if err != nil {
-						return nil, errors.Wrapf(err, "injecting Hub() into %s", name)
+						return nil, eris.Wrapf(err, "injecting Hub() into %s", name)
 					}
 
 					result[name] = defWithFn

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_gvk_function.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_gvk_function.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/functions"
@@ -39,7 +39,7 @@ func InjectOriginalGVKFunction(idFactory astmodel.IdentifierFactory) *Stage {
 
 				defWithFn, err := injector.Inject(def, fn)
 				if err != nil {
-					return nil, errors.Wrapf(err, "injecting OriginalGVK() into %s", name)
+					return nil, eris.Wrapf(err, "injecting OriginalGVK() into %s", name)
 				}
 
 				result[defWithFn.Name()] = defWithFn

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_version_function.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_version_function.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/functions"
@@ -34,7 +34,7 @@ func InjectOriginalVersionFunction(idFactory astmodel.IdentifierFactory) *Stage 
 				fn := functions.NewOriginalVersionFunction(idFactory)
 				defWithFn, err := injector.Inject(def, fn)
 				if err != nil {
-					return nil, errors.Wrapf(err, "injecting OriginalVersion() into %s", name)
+					return nil, eris.Wrapf(err, "injecting OriginalVersion() into %s", name)
 				}
 
 				result[defWithFn.Name()] = defWithFn

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_version_property.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_version_property.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -46,7 +46,7 @@ func InjectOriginalVersionProperty() *Stage {
 				prop.WithDescription("returns the original API version used to create the resource")
 				defWithProp, err := injector.Inject(def, prop)
 				if err != nil {
-					return nil, errors.Wrapf(err, "injecting OriginalVersion into %s", name)
+					return nil, eris.Wrapf(err, "injecting OriginalVersion into %s", name)
 				}
 
 				result[defWithProp.Name()] = defWithProp

--- a/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/dave/dst"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -37,7 +37,7 @@ func InjectPropertyAssignmentFunctions(
 		func(ctx context.Context, state *State) (*State, error) {
 			graph, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo)
 			if err != nil {
-				return nil, errors.Wrapf(err, "couldn't find conversion graph")
+				return nil, eris.Wrapf(err, "couldn't find conversion graph")
 			}
 
 			defs := state.Definitions()
@@ -57,7 +57,7 @@ func InjectPropertyAssignmentFunctions(
 				// Find the definition we want to convert to/from
 				nextName, err := graph.FindNextType(name, state.Definitions())
 				if err != nil {
-					return nil, errors.Wrapf(err, "finding next type after %s", name)
+					return nil, eris.Wrapf(err, "finding next type after %s", name)
 				}
 
 				if nextName.IsEmpty() {
@@ -101,7 +101,7 @@ func InjectPropertyAssignmentFunctions(
 
 				modified, err := factory.injectBetween(def, nextDef, augmentationInterface)
 				if err != nil {
-					return nil, errors.Wrapf(err, "injecting property assignment functions into %s", name)
+					return nil, eris.Wrapf(err, "injecting property assignment functions into %s", name)
 				}
 
 				result[modified.Name()] = modified
@@ -159,7 +159,7 @@ func (f propertyAssignmentFunctionsFactory) injectBetween(
 	assignFromFn, err := assignFromBuilder.Build(assignmentContext)
 	upstreamName := upstreamDef.Name()
 	if err != nil {
-		return astmodel.TypeDefinition{}, errors.Wrapf(err, "creating AssignFrom() function for %q", upstreamName)
+		return astmodel.TypeDefinition{}, eris.Wrapf(err, "creating AssignFrom() function for %q", upstreamName)
 	}
 
 	assignToBuilder := functions.NewPropertyAssignmentFunctionBuilder(upstreamDef, downstreamDef, conversions.ConvertTo)
@@ -169,17 +169,17 @@ func (f propertyAssignmentFunctionsFactory) injectBetween(
 
 	assignToFn, err := assignToBuilder.Build(assignmentContext)
 	if err != nil {
-		return astmodel.TypeDefinition{}, errors.Wrapf(err, "creating AssignTo() function for %q", upstreamName)
+		return astmodel.TypeDefinition{}, eris.Wrapf(err, "creating AssignTo() function for %q", upstreamName)
 	}
 
 	updatedDefinition, err := f.functionInjector.Inject(upstreamDef, assignFromFn)
 	if err != nil {
-		return astmodel.TypeDefinition{}, errors.Wrapf(err, "failed to inject %s function into %q", assignFromFn.Name(), upstreamName)
+		return astmodel.TypeDefinition{}, eris.Wrapf(err, "failed to inject %s function into %q", assignFromFn.Name(), upstreamName)
 	}
 
 	updatedDefinition, err = f.functionInjector.Inject(updatedDefinition, assignToFn)
 	if err != nil {
-		return astmodel.TypeDefinition{}, errors.Wrapf(err, "failed to inject %s function into %q", assignToFn.Name(), upstreamName)
+		return astmodel.TypeDefinition{}, eris.Wrapf(err, "failed to inject %s function into %q", assignToFn.Name(), upstreamName)
 	}
 
 	return updatedDefinition, nil
@@ -200,7 +200,7 @@ func createAssignPropertiesOverrideStub(
 		}
 		paramTypeExpr, err := paramType.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating parameter type expression for %s", paramName)
+			return nil, eris.Wrapf(err, "creating parameter type expression for %s", paramName)
 		}
 
 		funcDetails.AddParameter(paramName, paramTypeExpr)

--- a/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -95,7 +95,7 @@ func (s *objectSerializationTestCaseFactory) NeedsTest(def astmodel.TypeDefiniti
 func (s *objectSerializationTestCaseFactory) AddTestTo(def astmodel.TypeDefinition) (astmodel.TypeDefinition, error) {
 	container, ok := astmodel.AsPropertyContainer(def.Type())
 	if !ok {
-		return astmodel.TypeDefinition{}, errors.Errorf("expected %s to be a property container", def.Name())
+		return astmodel.TypeDefinition{}, eris.Errorf("expected %s to be a property container", def.Name())
 	}
 
 	isOneOf := astmodel.OneOfFlag.IsOn(def.Type()) // this is ugly but can’t do much better right now

--- a/v2/tools/generator/internal/codegen/pipeline/make_one_of_discriminant_required.go
+++ b/v2/tools/generator/internal/codegen/pipeline/make_one_of_discriminant_required.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -79,7 +79,7 @@ func makeOneOfDiscriminantTypeRequired(
 ) (astmodel.TypeDefinitionSet, error) {
 	objectType, ok := astmodel.AsObjectType(oneOf.Type())
 	if !ok {
-		return nil, errors.Errorf(
+		return nil, eris.Errorf(
 			"OneOf %s was not of type Object, instead was: %s",
 			oneOf.Name(),
 			astmodel.DebugDescription(oneOf.Type()))
@@ -101,7 +101,7 @@ func makeOneOfDiscriminantTypeRequired(
 		}
 		updatedDef, err := remover.visitor.VisitDefinition(def, nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error updating definition %s", def.Name())
+			return nil, eris.Wrapf(err, "error updating definition %s", def.Name())
 		}
 
 		result.Add(updatedDef)

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -25,7 +25,7 @@ func MarkLatestAPIVersionAsStorageVersion() *Stage {
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
 			updatedDefs, err := MarkLatestResourceVersionsForStorage(definitions)
 			if err != nil {
-				return nil, errors.Wrapf(err, "unable to mark latest resource version as storage version")
+				return nil, eris.Wrapf(err, "unable to mark latest resource version as storage version")
 			}
 
 			return updatedDefs, nil

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/storage"
@@ -26,7 +26,7 @@ func MarkLatestStorageVariantAsHubVersion() *Stage {
 		func(ctx context.Context, state *State) (*State, error) {
 			var graph *storage.ConversionGraph
 			if g, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo); err != nil {
-				return nil, errors.Wrapf(err, "couldn't find conversion graph")
+				return nil, eris.Wrapf(err, "couldn't find conversion graph")
 			} else {
 				graph = g
 			}
@@ -36,7 +36,7 @@ func MarkLatestStorageVariantAsHubVersion() *Stage {
 					rsrc := astmodel.MustBeResourceType(def.Type())
 					hub, err := graph.FindHub(def.Name(), state.Definitions())
 					if err != nil {
-						return nil, errors.Wrapf(err, "finding hub type for %s", def.Name())
+						return nil, eris.Wrapf(err, "finding hub type for %s", def.Name())
 					}
 
 					if astmodel.TypeEquals(def.Name(), hub) {
@@ -49,7 +49,7 @@ func MarkLatestStorageVariantAsHubVersion() *Stage {
 					return nil, nil
 				})
 			if err != nil {
-				return nil, errors.Wrap(err, "marking storage versions")
+				return nil, eris.Wrap(err, "marking storage versions")
 			}
 
 			return state.WithOverlaidDefinitions(updatedDefs), nil

--- a/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd.go
+++ b/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -36,7 +36,7 @@ func NameTypesForCRD(idFactory astmodel.IdentifierFactory) *Stage {
 
 				newDefs, err := nameInnerTypes(typeDef, getDescription)
 				if err != nil {
-					return nil, errors.Wrapf(err, "failed to name inner definitions")
+					return nil, eris.Wrapf(err, "failed to name inner definitions")
 				}
 
 				for _, def := range newDefs {
@@ -154,14 +154,14 @@ func nameInnerTypes(
 	builder.VisitResourceType = func(this *astmodel.TypeVisitor[nameHint], it *astmodel.ResourceType, ctx nameHint) (astmodel.Type, error) {
 		spec, err := this.Visit(it.SpecType(), ctx.WithSuffixPart(astmodel.SpecSuffix))
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to name spec type %s", it.SpecType())
+			return nil, eris.Wrapf(err, "failed to name spec type %s", it.SpecType())
 		}
 
 		var status astmodel.Type
 		if it.StatusType() != nil {
 			status, err = this.Visit(it.StatusType(), ctx.WithSuffixPart(astmodel.StatusSuffix))
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to name status type %s", it.StatusType())
+				return nil, eris.Wrapf(err, "failed to name status type %s", it.StatusType())
 			}
 		}
 
@@ -178,7 +178,7 @@ func nameInnerTypes(
 
 	_, err := visitor.Visit(def.Type(), newNameHint(def.Name()))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to name inner types of %s", def.Name())
+		return nil, eris.Wrapf(err, "failed to name inner types of %s", def.Name())
 	}
 
 	return resultTypes, nil

--- a/v2/tools/generator/internal/codegen/pipeline/pipeline_diagram.go
+++ b/v2/tools/generator/internal/codegen/pipeline/pipeline_diagram.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 )
@@ -37,7 +37,7 @@ func (diagram *PipelineDiagram) WriteDiagram(stages []*Stage) error {
 	dotsrc := diagram.createDiagram(stages)
 	filename := filepath.Join(diagram.debugDir, "pipeline.dot")
 	err := os.WriteFile(filename, dotsrc, 0o600)
-	return errors.Wrapf(err, "failed to write diagram to %s", filename)
+	return eris.Wrapf(err, "failed to write diagram to %s", filename)
 }
 
 // createDiagram creates a dot file for the pipeline

--- a/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases.go
@@ -6,7 +6,7 @@
 package pipeline
 
 import (
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/net/context"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -81,7 +81,7 @@ func (s *propertyAssignmentTestCaseFactory) NeedsTest(def astmodel.TypeDefinitio
 func (s *propertyAssignmentTestCaseFactory) AddTestTo(def astmodel.TypeDefinition) (astmodel.TypeDefinition, error) {
 	container, ok := astmodel.AsFunctionContainer(def.Type())
 	if !ok {
-		return astmodel.TypeDefinition{}, errors.Errorf("expected %s to be a function container", def.Name())
+		return astmodel.TypeDefinition{}, eris.Errorf("expected %s to be a function container", def.Name())
 	}
 
 	testCase := testcases.NewPropertyAssignmentTestCase(def.Name(), container, s.idFactory)

--- a/v2/tools/generator/internal/codegen/pipeline/prune_resources_with_lifecycle_owned_by_parent.go
+++ b/v2/tools/generator/internal/codegen/pipeline/prune_resources_with_lifecycle_owned_by_parent.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/armconversion"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -41,7 +41,7 @@ func PruneResourcesWithLifecycleOwnedByParent(configuration *config.Configuratio
 				if def.Name().Name() == "VirtualNetwork" {
 					subnetName := def.Name().WithName("VirtualNetworksSubnet")
 					if !state.Definitions().Contains(subnetName) {
-						return nil, errors.Errorf("Couldn't find subnet type matching %s. VirtualNetwork and VirtualNetworksSubnet must always be exported together", def.Name())
+						return nil, eris.Errorf("Couldn't find subnet type matching %s. VirtualNetwork and VirtualNetworksSubnet must always be exported together", def.Name())
 					}
 				}
 			}
@@ -60,7 +60,7 @@ func PruneResourcesWithLifecycleOwnedByParent(configuration *config.Configuratio
 
 				updatedDef, err := pruner.visitor.VisitDefinition(def, def.Name())
 				if err != nil {
-					return nil, errors.Wrapf(err, "failed to visit definition %s", def.Name())
+					return nil, eris.Wrapf(err, "failed to visit definition %s", def.Name())
 				}
 
 				updatedDefs.Add(updatedDef)
@@ -99,7 +99,7 @@ func flagPrunedEmptyProperties(
 		// we need to add the noConversion tag on ARM type for the empty pruned property to relax the validation for convertToARM function.
 		armDef, ok := LookupARMTypeDefinition(emptyPrunedProp, defs)
 		if !ok {
-			return nil, errors.Errorf("couldn't find ARM definition for %s", emptyPrunedProp)
+			return nil, eris.Errorf("couldn't find ARM definition for %s", emptyPrunedProp)
 		}
 
 		emptyPrunedPropertiesArm.Add(armDef.Name())

--- a/v2/tools/generator/internal/codegen/pipeline/recursivetypefixer/simple_recursive_type_fixer.go
+++ b/v2/tools/generator/internal/codegen/pipeline/recursivetypefixer/simple_recursive_type_fixer.go
@@ -7,7 +7,7 @@ package recursivetypefixer
 
 import (
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -94,7 +94,7 @@ func (s *SimpleRecursiveTypeFixer) unrollObjectTypeProperty(
 
 	err := s.newDefinitions.AddAllowDuplicates(unrolledDef)
 	if err != nil {
-		return simpleRecursiveTypeFixerContext{}, errors.Wrapf(err, "error adding unrolled type %q", name)
+		return simpleRecursiveTypeFixerContext{}, eris.Wrapf(err, "error adding unrolled type %q", name)
 	}
 
 	return ctx.WithUnrolledName(unrolledName), nil

--- a/v2/tools/generator/internal/codegen/pipeline/remove_armid_from_status.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_armid_from_status.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -53,7 +53,7 @@ func removeSpecIDField(defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinition
 
 	updatedDefs, err := removeIDVisitor.VisitDefinitions(astmodel.FindSpecDefinitions(defs), nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to remove spec.Id")
+		return nil, eris.Wrapf(err, "failed to remove spec.Id")
 	}
 
 	return updatedDefs, nil
@@ -72,7 +72,7 @@ func replaceStatusARMIDWithString(defs astmodel.TypeDefinitionSet) (astmodel.Typ
 
 	updatedDefs, err := replaceARMIDWithStringVisitor.VisitDefinitions(astmodel.FindStatusDefinitions(defs), nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to replace ARM ID with String on status types")
+		return nil, eris.Wrapf(err, "failed to replace ARM ID with String on status types")
 	}
 
 	return updatedDefs, nil

--- a/v2/tools/generator/internal/codegen/pipeline/remove_status_property_validations.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_status_property_validations.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -69,7 +69,7 @@ func removeStatusTypeValidations(definitions astmodel.TypeDefinitionSet) (astmod
 	for _, def := range statusDefinitions {
 		updatedTypes, err := walker.Walk(def)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "failed walking definitions"))
+			errs = append(errs, eris.Wrapf(err, "failed walking definitions"))
 		}
 
 		err = result.AddTypesAllowDuplicates(updatedTypes)
@@ -95,7 +95,7 @@ type overlapError struct {
 func errorIfSpecStatusOverlap(statusDefinitions astmodel.TypeDefinitionSet, definitions astmodel.TypeDefinitionSet) error {
 	allSpecTypes, err := astmodel.FindSpecConnectedDefinitions(definitions)
 	if err != nil {
-		return errors.Wrap(err, "couldn't find all spec definitions")
+		return eris.Wrap(err, "couldn't find all spec definitions")
 	}
 
 	// Verify that the set of spec definitions and the set of modified status definitions is totally disjoint
@@ -136,7 +136,7 @@ func errorIfSpecStatusOverlap(statusDefinitions astmodel.TypeDefinitionSet, defi
 			}
 		}
 
-		return errors.New(result.String())
+		return eris.New(result.String())
 	}
 
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/remove_type_aliases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_type_aliases.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -64,7 +64,7 @@ func resolveTypeName(
 
 	def, ok := definitions[name]
 	if !ok {
-		return nil, errors.Errorf("couldn't find definition for type name %s", name)
+		return nil, eris.Errorf("couldn't find definition for type name %s", name)
 	}
 
 	// If this typeName definition has a type of object, enum, validated, flagged, resource, or resourceList

--- a/v2/tools/generator/internal/codegen/pipeline/rename_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/rename_properties.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -53,7 +53,7 @@ func RenameProperties(cfg *config.ObjectModelConfiguration) *Stage {
 			}
 
 			if err := cfg.RenamePropertyTo.VerifyConsumed(); err != nil {
-				return nil, errors.Wrap(err, "verifying property rename configuration")
+				return nil, eris.Wrap(err, "verifying property rename configuration")
 			}
 
 			return state.WithOverlaidDefinitions(modified), nil
@@ -105,7 +105,7 @@ func renamePropertiesInObjectType(
 			return nil
 		})
 	if err != nil {
-		return nil, errors.Wrapf(err, "renaming properties for %s", typeName)
+		return nil, eris.Wrapf(err, "renaming properties for %s", typeName)
 	}
 
 	return ot.WithoutProperties().WithProperties(properties...), nil

--- a/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/repair_skipping_properties.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -50,7 +50,7 @@ func RepairSkippingProperties() *Stage {
 		func(ctx context.Context, state *State) (*State, error) {
 			var graph *storage.ConversionGraph
 			if g, err := GetStateData[*storage.ConversionGraph](state, ConversionGraphInfo); err != nil {
-				return nil, errors.Wrapf(err, "couldn't find conversion graph")
+				return nil, eris.Wrapf(err, "couldn't find conversion graph")
 			} else {
 				graph = g
 			}
@@ -123,7 +123,7 @@ func (repairer *skippingPropertyRepairer) AddProperties(
 
 	err := kerrors.NewAggregate(errs)
 	if err != nil {
-		return errors.Wrapf(err, "adding properties from %s", name)
+		return eris.Wrapf(err, "adding properties from %s", name)
 	}
 
 	return nil
@@ -136,7 +136,7 @@ func (repairer *skippingPropertyRepairer) AddProperty(
 ) error {
 	ref := astmodel.MakePropertyReference(name, property.PropertyName())
 	if err := repairer.establishPropertyChain(ref); err != nil {
-		return errors.Wrapf(err, "adding property %s", property.PropertyName())
+		return eris.Wrapf(err, "adding property %s", property.PropertyName())
 	}
 
 	repairer.propertyObserved(ref)
@@ -167,7 +167,7 @@ func (repairer *skippingPropertyRepairer) RepairSkippedProperties() (astmodel.Ty
 	}
 
 	if len(errs) > 0 {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			kerrors.NewAggregate(errs),
 			"failed to repair skipping properties")
 	}
@@ -192,7 +192,7 @@ func (repairer *skippingPropertyRepairer) establishPropertyChain(ref astmodel.Pr
 func (repairer *skippingPropertyRepairer) createPropertyChain(ref astmodel.PropertyReference) error {
 	next, err := repairer.conversionGraph.FindNextProperty(ref, repairer.definitions)
 	if err != nil {
-		return errors.Wrapf(err, "creating property chain link from %s", ref.String())
+		return eris.Wrapf(err, "creating property chain link from %s", ref.String())
 	}
 
 	repairer.addLink(ref, next)
@@ -275,7 +275,7 @@ func (repairer *skippingPropertyRepairer) repairChain(
 	// Find all the type definitions referenced by this definition (e.g. nested types)
 	defs, err := astmodel.FindConnectedDefinitions(repairer.definitions, astmodel.MakeTypeDefinitionSetFromDefinitions(def))
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"failed to find connected definitions from %s",
 			tn)
@@ -289,7 +289,7 @@ func (repairer *skippingPropertyRepairer) repairChain(
 		})
 	newDefs, err := renamer.RenameAll(defs)
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"failed to rename definitions from %s",
 			tn)

--- a/v2/tools/generator/internal/codegen/pipeline/replace_anytype_with_json.go
+++ b/v2/tools/generator/internal/codegen/pipeline/replace_anytype_with_json.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -59,7 +59,7 @@ func ReplaceAnyTypeWithJSON() *Stage {
 			for _, def := range definitions {
 				d, err := visitor.VisitDefinition(def, nil)
 				if err != nil {
-					return nil, errors.Wrapf(err, "visiting %q", def.Name())
+					return nil, eris.Wrapf(err, "visiting %q", def.Name())
 				}
 				results.Add(d)
 			}

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_structure.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_structure.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -74,5 +74,5 @@ func (report *ResourceStructureReport) saveReport(filePath string, defs astmodel
 	rpt := reporting.NewTypeCatalogReport(defs, reporting.InlineTypes)
 	rpt.AddHeader(astmodel.CodeGenerationComments...)
 	err := rpt.SaveTo(filePath)
-	return errors.Wrapf(err, "unable to save type catalog report to %q", filePath)
+	return eris.Wrapf(err, "unable to save type catalog report to %q", filePath)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
@@ -16,7 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -56,7 +56,7 @@ func ReportResourceVersions(configuration *config.Configuration) *Stage {
 				outputFile := configuration.SupportedResourcesReport.GroupFullOutputPath(grp)
 				err = report.SaveGroupResourcesReportTo(grp, outputFile)
 				if err != nil {
-					errs = append(errs, errors.Wrapf(err, "writing versions report to %s for group %s", outputFile, grp))
+					errs = append(errs, eris.Wrapf(err, "writing versions report to %s for group %s", outputFile, grp))
 				}
 			}
 
@@ -114,12 +114,12 @@ func NewResourceVersionsReport(
 
 	err := result.loadFragments()
 	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to load report fragments")
+		return nil, eris.Wrapf(err, "Unable to load report fragments")
 	}
 
 	err = result.summarize(definitions)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to summarize resources")
+		return nil, eris.Wrapf(err, "Unable to summarize resources")
 	}
 
 	return result, nil
@@ -149,7 +149,7 @@ func (report *ResourceVersionsReport) loadFragments() error {
 			// Load the file contents
 			content, err := os.ReadFile(path)
 			if err != nil {
-				return errors.Wrapf(err, "Unable to read fragment file %q", info.Name())
+				return eris.Wrapf(err, "Unable to read fragment file %q", info.Name())
 			}
 
 			// Strip the extension from the filename
@@ -159,7 +159,7 @@ func (report *ResourceVersionsReport) loadFragments() error {
 			return nil
 		})
 	if err != nil {
-		return errors.Wrapf(err, "Unable to load fragments from %q", fragmentsPath)
+		return eris.Wrapf(err, "Unable to load fragments from %q", fragmentsPath)
 	}
 
 	// We don't want our README to trigger an error
@@ -221,12 +221,12 @@ func (report *ResourceVersionsReport) SaveAllResourcesReportTo(outputFile string
 	var buffer strings.Builder
 	err := report.WriteAllResourcesReportToBuffer(frontMatter, &buffer)
 	if err != nil {
-		return errors.Wrapf(err, "writing versions report to %s", outputFile)
+		return eris.Wrapf(err, "writing versions report to %s", outputFile)
 	}
 
 	err = report.ensureFolderExists(outputFile)
 	if err != nil {
-		return errors.Wrapf(err, "writing versions report to %s", outputFile)
+		return eris.Wrapf(err, "writing versions report to %s", outputFile)
 	}
 
 	return os.WriteFile(outputFile, []byte(buffer.String()), 0o600)
@@ -237,7 +237,7 @@ func (report *ResourceVersionsReport) ensureFolderExists(outputFile string) erro
 	if _, err := os.Stat(outputFolder); os.IsNotExist(err) {
 		err = os.MkdirAll(outputFolder, 0o700)
 		if err != nil {
-			return errors.Wrapf(err, "unable to create directory %q", outputFile)
+			return eris.Wrapf(err, "unable to create directory %q", outputFile)
 		}
 	}
 
@@ -253,12 +253,12 @@ func (report *ResourceVersionsReport) SaveGroupResourcesReportTo(group string, o
 	var buffer strings.Builder
 	err := report.WriteGroupResourcesReportToBuffer(group, frontMatter, &buffer)
 	if err != nil {
-		return errors.Wrapf(err, "writing versions report to %s for group %s", outputFile, group)
+		return eris.Wrapf(err, "writing versions report to %s for group %s", outputFile, group)
 	}
 
 	err = report.ensureFolderExists(outputFile)
 	if err != nil {
-		return errors.Wrapf(err, "writing versions report to %s", outputFile)
+		return eris.Wrapf(err, "writing versions report to %s", outputFile)
 	}
 
 	return os.WriteFile(outputFile, []byte(buffer.String()), 0o600)
@@ -278,7 +278,7 @@ func (report *ResourceVersionsReport) WriteAllResourcesReportToBuffer(
 	// Include file header if found
 	err := report.writeFragment("all-resources-header", nil, buffer)
 	if err != nil {
-		return errors.Wrapf(err, "writing all-resources-header fragment")
+		return eris.Wrapf(err, "writing all-resources-header fragment")
 	}
 
 	// Sort groups into alphabetical order
@@ -294,7 +294,7 @@ func (report *ResourceVersionsReport) WriteAllResourcesReportToBuffer(
 		// Include our group fragment
 		err := report.writeFragment("group-header", info, buffer)
 		if err != nil {
-			return errors.Wrapf(err, "writing group-header fragment for group %s", info.Group)
+			return eris.Wrapf(err, "writing group-header fragment for group %s", info.Group)
 		}
 
 		// Include a custom fragment for this group if we have one
@@ -342,13 +342,13 @@ func (report *ResourceVersionsReport) WriteGroupResourcesReportToBuffer(
 	// Include our group fragment
 	err := report.writeFragment("group-header", info, buffer)
 	if err != nil {
-		return errors.Wrapf(err, "writing group-header fragment for group %s", group)
+		return eris.Wrapf(err, "writing group-header fragment for group %s", group)
 	}
 
 	// Include a fragment for this group if we have one
 	err = report.writeFragment(group, info, buffer)
 	if err != nil {
-		return errors.Wrapf(err, "writing fragment for group %s", group)
+		return eris.Wrapf(err, "writing fragment for group %s", group)
 	}
 
 	return report.writeGroupSections(info, items, buffer)
@@ -378,7 +378,7 @@ func (report *ResourceVersionsReport) writeGroupSections(
 		prereleaseResources,
 		buffer)
 	if err != nil {
-		return errors.Wrapf(err, "writing prerelease resources for group %s", group)
+		return eris.Wrapf(err, "writing prerelease resources for group %s", group)
 	}
 
 	// Prerelease may have no usage, but we don't want that to trigger an error
@@ -391,7 +391,7 @@ func (report *ResourceVersionsReport) writeGroupSections(
 		releasedResources,
 		buffer)
 	if err != nil {
-		return errors.Wrapf(err, "writing released resources for group %s", group)
+		return eris.Wrapf(err, "writing released resources for group %s", group)
 	}
 
 	err = report.writeSection(
@@ -401,7 +401,7 @@ func (report *ResourceVersionsReport) writeGroupSections(
 		deprecatedResources,
 		buffer)
 	if err != nil {
-		return errors.Wrapf(err, "writing deprecated resources for group %s", group)
+		return eris.Wrapf(err, "writing deprecated resources for group %s", group)
 	}
 
 	// Deprecated fragment may have no usage, but we don't want that to trigger an error
@@ -454,17 +454,17 @@ func (report *ResourceVersionsReport) writeSection(
 	// Write a generic description, then a specific one
 	err := report.writeFragment(fmt.Sprintf("%s-%s", info.Group, id), nil, buffer)
 	if err != nil {
-		return errors.Wrapf(err, "writing fragment for group %s", info.Group)
+		return eris.Wrapf(err, "writing fragment for group %s", info.Group)
 	}
 
 	err = report.writeFragment(id, nil, buffer)
 	if err != nil {
-		return errors.Wrapf(err, "writing fragment for group %s", info.Group)
+		return eris.Wrapf(err, "writing fragment for group %s", info.Group)
 	}
 
 	table, err := report.createTable(info, items)
 	if err != nil {
-		return errors.Wrapf(err, "creating table for group %s", info.Group)
+		return eris.Wrapf(err, "creating table for group %s", info.Group)
 	}
 
 	table.WriteTo(buffer)
@@ -542,7 +542,7 @@ func (report *ResourceVersionsReport) FindSampleLinks(group string) (map[string]
 	if report.rootUrl != "" {
 		parsedRootURL, err := url.Parse(report.rootUrl)
 		if err != nil {
-			return nil, errors.Wrapf(err, "parsing rootUrl %s", report.rootUrl)
+			return nil, eris.Wrapf(err, "parsing rootUrl %s", report.rootUrl)
 		}
 
 		// We look for samples within only the subfolder for this group - this avoids getting sample links wrong
@@ -564,7 +564,7 @@ func (report *ResourceVersionsReport) FindSampleLinks(group string) (map[string]
 			if !d.IsDir() && filepath.Base(filepath.Dir(filePath)) != "refs" {
 				filePath, err = filepath.Rel(filepath.Dir(report.samplesPath), filePath)
 				if err != nil {
-					return errors.Wrapf(err, "getting relative path for %s", filePath)
+					return eris.Wrapf(err, "getting relative path for %s", filePath)
 				}
 
 				filePath = filepath.ToSlash(filePath)
@@ -577,7 +577,7 @@ func (report *ResourceVersionsReport) FindSampleLinks(group string) (map[string]
 			return nil
 		})
 		if err != nil {
-			return nil, errors.Wrapf(err, "walking through samples directory %s", report.samplesPath)
+			return nil, eris.Wrapf(err, "walking through samples directory %s", report.samplesPath)
 		}
 	}
 
@@ -608,7 +608,7 @@ func (report *ResourceVersionsReport) generateAPILink(name astmodel.InternalType
 	}
 
 	docFile := report.resourceDocFile(name)
-	if _, err := os.Stat(docFile); errors.Is(err, fs.ErrNotExist) {
+	if _, err := os.Stat(docFile); eris.Is(err, fs.ErrNotExist) {
 		// docFile does not exist, don't build a link
 		return crdKind
 	}
@@ -729,13 +729,13 @@ func (report *ResourceVersionsReport) writeFragment(name string, data any, buffe
 	// Create a template based on the fragment
 	tmpl, err := template.New(name).Parse(fragment)
 	if err != nil {
-		return errors.Wrapf(err, "unable to parse template for %s", name)
+		return eris.Wrapf(err, "unable to parse template for %s", name)
 	}
 
 	// Render the template
 	err = tmpl.Execute(buffer, data)
 	if err != nil {
-		return errors.Wrapf(err, "unable to render template for %s", name)
+		return eris.Wrapf(err, "unable to render template for %s", name)
 	}
 
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/report_type_versions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_type_versions.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -95,7 +95,7 @@ func (report *PackagesMatrixReport) WriteTableTo(table *reporting.SparseTable, p
 	if _, err := os.Stat(outputFolder); os.IsNotExist(err) {
 		err = os.MkdirAll(outputFolder, 0o700)
 		if err != nil {
-			return errors.Wrapf(err, "Unable to create directory %q", outputFolder)
+			return eris.Wrapf(err, "Unable to create directory %q", outputFolder)
 		}
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
@@ -6,7 +6,7 @@
 package pipeline
 
 import (
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/net/context"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -81,12 +81,12 @@ func (_ *resourceConversionTestCaseFactory) NeedsTest(def astmodel.TypeDefinitio
 func (factory *resourceConversionTestCaseFactory) AddTestTo(def astmodel.TypeDefinition) (astmodel.TypeDefinition, error) {
 	resource, ok := astmodel.AsResourceType(def.Type())
 	if !ok {
-		return astmodel.TypeDefinition{}, errors.Errorf("expected %s to be a resourceType", def.Name())
+		return astmodel.TypeDefinition{}, eris.Errorf("expected %s to be a resourceType", def.Name())
 	}
 
 	testCase, err := testcases.NewResourceConversionTestCase(def.Name(), resource, factory.idFactory)
 	if err != nil {
-		return astmodel.TypeDefinition{}, errors.Wrapf(err, "adding resource conversion test case to %s", def.Name())
+		return astmodel.TypeDefinition{}, eris.Wrapf(err, "adding resource conversion test case to %s", def.Name())
 	}
 
 	return factory.injector.Inject(def, testCase)

--- a/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
@@ -82,7 +82,7 @@ func (r *ResourceRegistrationFile) AsAst() (*dst.File, error) {
 	// getKnownStorageTypes() function
 	knownStorageTypes, err := r.createGetKnownStorageTypesFunc(codeGenContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating %s function", "getKnownStorageTypes")
+		return nil, eris.Wrapf(err, "creating %s function", "getKnownStorageTypes")
 	}
 
 	decls = append(decls, knownStorageTypes)
@@ -97,7 +97,7 @@ func (r *ResourceRegistrationFile) AsAst() (*dst.File, error) {
 	// createScheme() function
 	createSchemeFunc, err := r.createCreateSchemeFunc(codeGenContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating getKnownResourceExtensions function")
+		return nil, eris.Wrap(err, "creating getKnownResourceExtensions function")
 	}
 
 	decls = append(decls, createSchemeFunc)
@@ -105,7 +105,7 @@ func (r *ResourceRegistrationFile) AsAst() (*dst.File, error) {
 	// Create Resource Extensions
 	resourceExtensionTypes, err := r.createGetResourceExtensions(codeGenContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating getKnownResourceExtensions function")
+		return nil, eris.Wrap(err, "creating getKnownResourceExtensions function")
 	}
 
 	decls = append(decls, resourceExtensionTypes)
@@ -113,7 +113,7 @@ func (r *ResourceRegistrationFile) AsAst() (*dst.File, error) {
 	// All the index functions
 	indexFunctionDecls, err := r.defineIndexFunctions(codeGenContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "defining index functions")
+		return nil, eris.Wrap(err, "defining index functions")
 	}
 
 	decls = append(decls, indexFunctionDecls...)
@@ -233,7 +233,7 @@ func createGetKnownTypesFunc(
 
 		typeNameExpr, err := typeName.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating type expression for %s", typeName.Name())
+			return nil, eris.Wrapf(err, "creating type expression for %s", typeName.Name())
 		}
 
 		batch = append(batch, astbuilder.CallFunc("new", typeNameExpr))
@@ -295,7 +295,7 @@ func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 			astmodel.StorageTypeRegistrationType))
 	resultTypeExpr, err := resultType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating type expression for StorageTypeRegistrationType")
+		return nil, eris.Wrap(err, "creating type expression for StorageTypeRegistrationType")
 	}
 
 	resultVar := astbuilder.LocalVariableDeclaration(
@@ -309,12 +309,12 @@ func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 	for _, typeName := range r.storageVersionResources {
 		typeNameExpr, err := typeName.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating type expression for %s", typeName.Name())
+			return nil, eris.Wrapf(err, "creating type expression for %s", typeName.Name())
 		}
 
 		registrationTypeExpr, err := astmodel.StorageTypeRegistrationType.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating type expression for StorageTypeRegistrationType")
+			return nil, eris.Wrap(err, "creating type expression for StorageTypeRegistrationType")
 		}
 
 		newStorageTypeBuilder := astbuilder.NewCompositeLiteralBuilder(registrationTypeExpr)
@@ -331,7 +331,7 @@ func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 			var indexRegistrationTypeExpr dst.Expr
 			indexRegistrationTypeExpr, err = astmodel.IndexRegistrationType.AsTypeExpr(codeGenerationContext)
 			if err != nil {
-				return nil, errors.Wrap(err, "creating type expression for IndexRegistrationType")
+				return nil, eris.Wrap(err, "creating type expression for IndexRegistrationType")
 			}
 
 			sliceBuilder := astbuilder.NewSliceLiteralBuilder(indexRegistrationTypeExpr, true)
@@ -357,7 +357,7 @@ func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(
 		//	}
 		watches, err := r.makeWatchesExpr(typeName, codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating watches expression for %s", typeName.Name())
+			return nil, eris.Wrapf(err, "creating watches expression for %s", typeName.Name())
 		}
 
 		if watches != nil {
@@ -401,7 +401,7 @@ func (r *ResourceRegistrationFile) createGetResourceExtensions(
 	resultType := astmodel.NewArrayType(astmodel.ResourceExtensionType)
 	resultTypeExpr, err := resultType.AsTypeExpr(context)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating type expression for ResourceExtensionType")
+		return nil, eris.Wrap(err, "creating type expression for ResourceExtensionType")
 	}
 
 	resultVar := astbuilder.LocalVariableDeclaration(
@@ -413,7 +413,7 @@ func (r *ResourceRegistrationFile) createGetResourceExtensions(
 	for _, typeName := range r.resourceExtensions {
 		typeNameExpr, err := typeName.AsTypeExpr(context)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating type expression for %s", typeName.Name())
+			return nil, eris.Wrapf(err, "creating type expression for %s", typeName.Name())
 		}
 
 		literalExpr := astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(typeNameExpr).Build())
@@ -557,7 +557,7 @@ func (r *ResourceRegistrationFile) makeWatchesExpr(
 		r.secretPropertyKeys,
 		codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating watches expression for secrets")
+		return nil, eris.Wrap(err, "creating watches expression for secrets")
 	}
 
 	configMapWatchesExpr, err := r.makeSimpleWatchesExpr(
@@ -567,7 +567,7 @@ func (r *ResourceRegistrationFile) makeWatchesExpr(
 		r.configMapPropertyKeys,
 		codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating watches expression for configmaps")
+		return nil, eris.Wrap(err, "creating watches expression for configmaps")
 	}
 
 	if secretWatchesExpr == nil && configMapWatchesExpr == nil {
@@ -576,7 +576,7 @@ func (r *ResourceRegistrationFile) makeWatchesExpr(
 
 	watchRegistrationTypeExpr, err := astmodel.WatchRegistrationType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating type expression for WatchRegistrationType")
+		return nil, eris.Wrap(err, "creating type expression for WatchRegistrationType")
 	}
 
 	sliceBuilder := astbuilder.NewSliceLiteralBuilder(watchRegistrationTypeExpr, true)
@@ -614,7 +614,7 @@ func (r *ResourceRegistrationFile) makeSimpleWatchesExpr(
 
 	watchRegistrationTypeExpr, err := astmodel.WatchRegistrationType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating type expression for WatchRegistrationType")
+		return nil, eris.Wrap(err, "creating type expression for WatchRegistrationType")
 	}
 
 	newWatchBuilder := astbuilder.NewCompositeLiteralBuilder(watchRegistrationTypeExpr)
@@ -622,7 +622,7 @@ func (r *ResourceRegistrationFile) makeSimpleWatchesExpr(
 
 	fieldTypeExpr, err := fieldType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", fieldType.Name())
+		return nil, eris.Wrapf(err, "creating type expression for %s", fieldType.Name())
 	}
 
 	objectType := astbuilder.AddrOf(&dst.CompositeLit{
@@ -638,7 +638,7 @@ func (r *ResourceRegistrationFile) makeSimpleWatchesExpr(
 	listType := typeName.WithName(typeName.Name() + "List")
 	listTypeExpr, err := listType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", listType.Name())
+		return nil, eris.Wrapf(err, "creating type expression for %s", listType.Name())
 	}
 
 	eventHandler := astbuilder.CallFunc(

--- a/v2/tools/generator/internal/codegen/pipeline/stage.go
+++ b/v2/tools/generator/internal/codegen/pipeline/stage.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
@@ -199,7 +199,7 @@ func (stage *Stage) Description() string {
 // Run is used to execute the action associated with this stage
 func (stage *Stage) Run(ctx context.Context, state *State) (*State, error) {
 	if err := stage.checkPreconditions(state); err != nil {
-		return nil, errors.Wrapf(err, "preconditions of stage %s not met", stage.id)
+		return nil, eris.Wrapf(err, "preconditions of stage %s not met", stage.id)
 	}
 
 	resultState, err := stage.action(ctx, state)
@@ -238,7 +238,7 @@ func (stage *Stage) checkPrerequisites(state *State) error {
 	for _, prereq := range stage.prerequisites {
 		satisfied := state.stagesSeen.Contains(prereq)
 		if !satisfied {
-			errs = append(errs, errors.Errorf("prerequisite %q of stage %q NOT satisfied.", prereq, stage.Id()))
+			errs = append(errs, eris.Errorf("prerequisite %q of stage %q NOT satisfied.", prereq, stage.Id()))
 		}
 	}
 
@@ -251,7 +251,7 @@ func (stage *Stage) checkPostrequisites(state *State) error {
 	for _, postreq := range stage.postrequisites {
 		early := state.stagesSeen.Contains(postreq)
 		if early {
-			errs = append(errs, errors.Errorf("postrequisite %q satisfied of stage %q early.", postreq, stage.Id()))
+			errs = append(errs, eris.Errorf("postrequisite %q satisfied of stage %q early.", postreq, stage.Id()))
 		}
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/stage_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/stage_test.go
@@ -11,7 +11,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 )
 
 // RunTestPipeline is used to run a sequence of stages as a part of a unit test
@@ -21,7 +21,7 @@ func RunTestPipeline(state *State, stages ...*Stage) (*State, error) {
 	for _, stage := range stages {
 		s, err := stage.Run(context.TODO(), resultState)
 		if err != nil {
-			return nil, errors.Wrapf(err, "running stage %q", stage.id)
+			return nil, eris.Wrapf(err, "running stage %q", stage.id)
 		}
 
 		resultState = s

--- a/v2/tools/generator/internal/codegen/pipeline/state.go
+++ b/v2/tools/generator/internal/codegen/pipeline/state.go
@@ -6,7 +6,7 @@
 package pipeline
 
 import (
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/maps"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -94,7 +94,7 @@ func (s *State) CheckFinalState() error {
 	var errs []error
 	for required, requiredBy := range s.stagesExpected {
 		for stageId := range requiredBy {
-			errs = append(errs, errors.Errorf("postrequisite %q of stage %q not satisfied", required, stageId))
+			errs = append(errs, eris.Errorf("postrequisite %q of stage %q not satisfied", required, stageId))
 		}
 	}
 
@@ -138,24 +138,25 @@ func GetStateData[I any](
 ) (I, error) {
 	if state.stateInfo == nil {
 		var zero I
-		return zero, errors.Errorf("no state information available")
+		return zero, eris.Errorf("no state information available")
 	}
 
 	value, ok := state.stateInfo[key]
 	if !ok {
 		var zero I
-		return zero, errors.Errorf("no state information found for key %s", key)
+		return zero, eris.Errorf("no state information found for key %s", key)
 	}
 
 	info, ok := value.(I)
 	if !ok {
 		var zero I
 		return zero,
-			errors.Errorf(
+			eris.Errorf(
 				"state information found for key %s of type %T, expected %T",
 				key,
 				value,
 				zero)
+
 	}
 
 	return info, nil

--- a/v2/tools/generator/internal/codegen/pipeline/strip_descriptions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/strip_descriptions.go
@@ -9,7 +9,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -65,7 +65,7 @@ func StripDocumentation(configuration *config.Configuration, log logr.Logger) *S
 
 			err := configuration.ObjectModelConfiguration.StripDocumentation.VerifyConsumed()
 			if err != nil {
-				return nil, errors.Wrap(
+				return nil, eris.Wrap(
 					err,
 					"Found unused $stripDocumentation configurations; these can only be specified on top-level resources.")
 			}

--- a/v2/tools/generator/internal/codegen/pipeline/target.go
+++ b/v2/tools/generator/internal/codegen/pipeline/target.go
@@ -8,7 +8,7 @@ package pipeline
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
 )
@@ -46,6 +46,6 @@ func TranslatePipelineToTarget(pipeline config.GenerationPipeline) (Target, erro
 	case config.GenerationPipelineCrossplane:
 		return CrossplaneTarget, nil
 	default:
-		return Target{}, errors.Errorf("unknown pipeline target kind %s", pipeline)
+		return Target{}, eris.Errorf("unknown pipeline target kind %s", pipeline)
 	}
 }

--- a/v2/tools/generator/internal/codegen/pipeline/unroll_recursive_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/unroll_recursive_types.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/pipeline/recursivetypefixer"
@@ -70,7 +70,7 @@ func UnrollRecursiveTypes(log logr.Logger) *Stage {
 				// we can't be sure it's safe to unroll, so we raise an error. This is fatal because controller-gen
 				// will error on recursive types when we run it later and we want to fail fast.
 				if !astmodel.TypeEquals(def.Type(), updatedDef.Type()) && !strings.Contains(def.Name().Name(), "Error") {
-					return nil, errors.Errorf("%q is directly recursive and cannot be unrolled because it doesn't contain 'Error'", def.Name())
+					return nil, eris.Errorf("%q is directly recursive and cannot be unrolled because it doesn't contain 'Error'", def.Name())
 				}
 
 				result.Add(updatedDef)

--- a/v2/tools/generator/internal/codegen/pipeline/verify_no_errored_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/verify_no_errored_types.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -29,7 +29,7 @@ func VerifyNoErroredTypes() *Stage {
 
 				_, err := visitor.visitor.Visit(def.Type(), erroredTypeVisitorContext{name: def.Name()})
 				if err != nil {
-					return nil, errors.Wrapf(err, "failed while visiting %q", def.Name())
+					return nil, eris.Wrapf(err, "failed while visiting %q", def.Name())
 				}
 			}
 
@@ -74,7 +74,7 @@ func (v *errorCollectingVisitor) catalogErrors(
 ) (astmodel.Type, error) {
 	if len(it.Errors()) > 0 {
 		errStrings := strings.Join(it.Errors(), ", ")
-		v.errs = append(v.errs, errors.Errorf("%q has property %q with errors: %q", ctx.name, ctx.property, errStrings))
+		v.errs = append(v.errs, eris.Errorf("%q has property %q with errors: %q", ctx.name, ctx.property, errStrings))
 	}
 
 	return astmodel.IdentityVisitOfErroredType(this, it, ctx)
@@ -87,12 +87,12 @@ func includeResourcePropertyContext(
 ) (astmodel.Type, error) {
 	_, err := this.Visit(it.SpecType(), ctx.WithProperty("Spec"))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to visit resource spec type %q", it.SpecType())
+		return nil, eris.Wrapf(err, "failed to visit resource spec type %q", it.SpecType())
 	}
 
 	_, err = this.Visit(it.StatusType(), ctx.WithProperty("Status"))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to visit resource status type %q", it.StatusType())
+		return nil, eris.Wrapf(err, "failed to visit resource status type %q", it.StatusType())
 	}
 
 	return it, nil

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -59,7 +59,7 @@ func (graph *ConversionGraph) FindNextType(
 	renamedType, err := subgraph.searchForRenamedType(name, definitions)
 	if err != nil {
 		// Something went wrong
-		return astmodel.InternalTypeName{}, errors.Wrapf(err, "searching for type renamed from %s", name)
+		return astmodel.InternalTypeName{}, eris.Wrapf(err, "searching for type renamed from %s", name)
 	}
 
 	// If we have no renamed type, return the next type (if any)
@@ -76,7 +76,7 @@ func (graph *ConversionGraph) FindNextType(
 	// If they're in the same package, the type-rename has been configured on the wrong version (or the wrong type)
 	if nextType.PackageReference().Equals(renamedType.PackageReference()) {
 		return astmodel.InternalTypeName{},
-			errors.Errorf("confict between rename of %s to %s and existing type %s", name, renamedType, nextType)
+			eris.Errorf("confict between rename of %s to %s and existing type %s", name, renamedType, nextType)
 	}
 
 	// Now we need to return the earlier type. We can do this by comparing the package paths.
@@ -120,7 +120,7 @@ func (graph *ConversionGraph) FindHubAndDistance(
 		if err != nil {
 			return astmodel.InternalTypeName{},
 				-1,
-				errors.Wrapf(err, "finding hub for %s",
+				eris.Wrapf(err, "finding hub for %s",
 					name)
 		}
 
@@ -186,7 +186,7 @@ func (graph *ConversionGraph) FindNextProperty(
 	if err != nil {
 		// Something went wrong
 		return astmodel.EmptyPropertyReference,
-			errors.Wrapf(err, "finding next property for %s", ref)
+			eris.Wrapf(err, "finding next property for %s", ref)
 	}
 
 	// If no next type, no next property either
@@ -203,7 +203,7 @@ func (graph *ConversionGraph) String(group string, kind string) (string, error) 
 	var content bytes.Buffer
 	err := graph.WriteTo(group, kind, &content)
 	if err != nil {
-		return "", errors.Wrapf(err, "writing conversion graph")
+		return "", eris.Wrapf(err, "writing conversion graph")
 	}
 
 	return content.String(), nil
@@ -212,14 +212,14 @@ func (graph *ConversionGraph) String(group string, kind string) (string, error) 
 func (graph *ConversionGraph) SaveTo(group string, kind string, filename string) error {
 	file, err := os.Create(filename)
 	if err != nil {
-		return errors.Wrapf(err, "creating %s", filename)
+		return eris.Wrapf(err, "creating %s", filename)
 	}
 
 	defer file.Close()
 
 	err = graph.WriteTo(group, kind, file)
 	if err != nil {
-		return errors.Wrapf(err, "writing conversion graph to %s", filename)
+		return eris.Wrapf(err, "writing conversion graph to %s", filename)
 	}
 
 	return nil

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph_builder.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph_builder.go
@@ -6,7 +6,7 @@
 package storage
 
 import (
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -53,7 +53,7 @@ func (b *ConversionGraphBuilder) Build() (*ConversionGraph, error) {
 	for group, builder := range b.subBuilders {
 		subgraph, err := builder.Build()
 		if err != nil {
-			return nil, errors.Wrapf(err, "building subgraph for group %s", group)
+			return nil, eris.Wrapf(err, "building subgraph for group %s", group)
 		}
 
 		subgraphs[group] = subgraph

--- a/v2/tools/generator/internal/codegen/storage/group_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/group_conversion_graph.go
@@ -8,7 +8,7 @@ package storage
 import (
 	"io"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -87,7 +87,7 @@ func (graph *GroupConversionGraph) searchForRenamedType(
 
 	// Didn't find the type we're looking for
 	return astmodel.InternalTypeName{},
-		errors.Errorf("rename of %s invalid because no type with name %s was found in any later version", name, rename)
+		eris.Errorf("rename of %s invalid because no type with name %s was found in any later version", name, rename)
 }
 
 // WriteTo gives a debug dump of the conversion graph for a particular type name

--- a/v2/tools/generator/internal/codegen/storage/group_conversion_graph_builder.go
+++ b/v2/tools/generator/internal/codegen/storage/group_conversion_graph_builder.go
@@ -6,7 +6,7 @@
 package storage
 
 import (
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -63,7 +63,7 @@ func (b *GroupConversionGraphBuilder) Build() (*GroupConversionGraph, error) {
 	for group, builder := range b.subBuilders {
 		subgraph, err := builder.Build()
 		if err != nil {
-			return nil, errors.Wrapf(err, "building subgraph for group %s", group)
+			return nil, eris.Wrapf(err, "building subgraph for group %s", group)
 		}
 
 		subGraphs[group] = subgraph

--- a/v2/tools/generator/internal/codegen/storage/property_converter.go
+++ b/v2/tools/generator/internal/codegen/storage/property_converter.go
@@ -8,7 +8,7 @@ package storage
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -181,7 +181,7 @@ func (p *PropertyConverter) defaultPropertyConversion(
 ) (*astmodel.PropertyDefinition, error) {
 	propertyType, err := p.visitor.Visit(property.PropertyType(), nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "converting property %q", property.PropertyName())
+		return nil, eris.Wrapf(err, "converting property %q", property.PropertyName())
 	}
 
 	newProperty := property.WithType(propertyType).

--- a/v2/tools/generator/internal/codegen/storage/resource_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/resource_conversion_graph.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
@@ -82,12 +82,12 @@ func (graph *ResourceConversionGraph) WriteTo(writer io.Writer) error {
 		"        node [shape=ellipse, style=dashed, penwidth=1, rankType=min, group=storage];",
 	)
 	if err != nil {
-		return errors.Wrapf(err, "writing graph header")
+		return eris.Wrapf(err, "writing graph header")
 	}
 
 	err = graph.WriteVersions(writer, apiVersions)
 	if err != nil {
-		return errors.Wrapf(err, "writing graph apiversions")
+		return eris.Wrapf(err, "writing graph apiversions")
 	}
 
 	err = graph.WriteLines(
@@ -99,12 +99,12 @@ func (graph *ResourceConversionGraph) WriteTo(writer io.Writer) error {
 		"        node [shape=ellipse, style=dashed, penwidth=1, rankType=min, group=storage];",
 	)
 	if err != nil {
-		return errors.Wrapf(err, "writing graph midsection")
+		return eris.Wrapf(err, "writing graph midsection")
 	}
 
 	err = graph.WriteVersions(writer, storageVersions)
 	if err != nil {
-		return errors.Wrapf(err, "writing graph storageversions")
+		return eris.Wrapf(err, "writing graph storageversions")
 	}
 
 	err = graph.WriteLines(
@@ -114,12 +114,12 @@ func (graph *ResourceConversionGraph) WriteTo(writer io.Writer) error {
 		"    edge [arrowhead=vee, arrowtail=vee, dir=forward];",
 	)
 	if err != nil {
-		return errors.Wrapf(err, "writing graph endsection")
+		return eris.Wrapf(err, "writing graph endsection")
 	}
 
 	err = graph.writeLinks(writer, linkStarts)
 	if err != nil {
-		return errors.Wrapf(err, "writing graph links")
+		return eris.Wrapf(err, "writing graph links")
 	}
 
 	err = graph.WriteLines(
@@ -127,7 +127,7 @@ func (graph *ResourceConversionGraph) WriteTo(writer io.Writer) error {
 		"}",
 	)
 	if err != nil {
-		return errors.Wrapf(err, "writing graph end")
+		return eris.Wrapf(err, "writing graph end")
 	}
 
 	return nil
@@ -152,7 +152,7 @@ func (graph *ResourceConversionGraph) WriteLines(writer io.Writer, lines ...stri
 	for _, line := range lines {
 		_, err := io.WriteString(writer, line+"\n")
 		if err != nil {
-			return errors.Wrapf(err, "writing %q to writer", line)
+			return eris.Wrapf(err, "writing %q to writer", line)
 		}
 	}
 

--- a/v2/tools/generator/internal/codegen/storage/resource_conversion_graph_builder.go
+++ b/v2/tools/generator/internal/codegen/storage/resource_conversion_graph_builder.go
@@ -8,7 +8,7 @@ package storage
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -69,7 +69,7 @@ func (b *ResourceConversionGraphBuilder) Build() (*ResourceConversionGraph, erro
 
 	// Expect to have only the hub reference left
 	if len(toProcess) != 1 {
-		return nil, errors.Errorf(
+		return nil, eris.Errorf(
 			"expected to have linked all references in with name %q, but have %d left",
 			b.name,
 			len(toProcess))

--- a/v2/tools/generator/internal/codegen/storage/type_converter.go
+++ b/v2/tools/generator/internal/codegen/storage/type_converter.go
@@ -8,7 +8,7 @@ package storage
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -82,7 +82,7 @@ func (t *TypeConverter) convertObjectType(
 	for name, prop := range properties {
 		p, err := t.propertyConverter.ConvertProperty(prop)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "property %s", name))
+			errs = append(errs, eris.Wrapf(err, "property %s", name))
 		} else {
 			properties[name] = p
 		}
@@ -116,7 +116,7 @@ func (t *TypeConverter) redirectTypeNamesToStoragePackage(name astmodel.Internal
 	}
 
 	// Failed to redirect into a storage package, return an error
-	return nil, errors.Errorf("unable to redirect %s into a storage package", name)
+	return nil, eris.Errorf("unable to redirect %s into a storage package", name)
 }
 
 // stripAllFlags removes all flags
@@ -178,5 +178,5 @@ func (t *TypeConverter) selectPropertyBagName(object *astmodel.ObjectType) (astm
 		return name, nil
 	}
 
-	return "", errors.Errorf("failed to find non-clashing name for PropertyBag (tried %q)", candidateNames)
+	return "", eris.Errorf("failed to find non-clashing name for PropertyBag (tried %q)", candidateNames)
 }

--- a/v2/tools/generator/internal/config/configurable.go
+++ b/v2/tools/generator/internal/config/configurable.go
@@ -5,9 +5,7 @@
 
 package config
 
-import (
-	"github.com/pkg/errors"
-)
+import "github.com/rotisserie/eris"
 
 // configurable represents a value that may be configured.
 // Includes tracking for whether we consume the configured value or not, allowing us to flag unnecessary configuration
@@ -34,7 +32,7 @@ func (c *configurable[T]) Lookup() (T, bool) {
 // VerifyConsumed returns an error if the value is configured but not consumed.
 func (c *configurable[T]) VerifyConsumed() error {
 	if c.isUnconsumed() {
-		return errors.Errorf("%s specified for %s but not consumed", c.tag, c.scope)
+		return eris.Errorf("%s specified for %s but not consumed", c.tag, c.scope)
 	}
 
 	return nil

--- a/v2/tools/generator/internal/config/configuration.go
+++ b/v2/tools/generator/internal/config/configuration.go
@@ -13,7 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/mod/modfile"
 	"gopkg.in/yaml.v3"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -112,7 +112,7 @@ func (config *Configuration) FullSamplesPath() string {
 func (config *Configuration) GetTypeFiltersError() error {
 	for _, filter := range config.TypeFilters {
 		if err := filter.RequiredTypesWereMatched(); err != nil {
-			return errors.Wrapf(err, "type filter action: %q", filter.Action)
+			return eris.Wrapf(err, "type filter action: %q", filter.Action)
 		}
 	}
 
@@ -122,12 +122,12 @@ func (config *Configuration) GetTypeFiltersError() error {
 func (config *Configuration) GetTransformersError() error {
 	for _, filter := range config.Transformers {
 		if err := filter.RequiredTypesWereMatched(); err != nil {
-			return errors.Wrap(err, "type transformer")
+			return eris.Wrap(err, "type transformer")
 		}
 
 		if filter.Property.IsRestrictive() {
 			if err := filter.RequiredTypesWereMatched(); err != nil {
-				return errors.Wrap(err, "type transformer property")
+				return eris.Wrap(err, "type transformer property")
 			}
 		}
 	}
@@ -166,12 +166,12 @@ func LoadConfiguration(configurationFile string) (*Configuration, error) {
 
 	err = decoder.Decode(result)
 	if err != nil {
-		return nil, errors.Wrapf(err, "configuration file loaded from %q is not valid YAML", configurationFile)
+		return nil, eris.Wrapf(err, "configuration file loaded from %q is not valid YAML", configurationFile)
 	}
 
 	err = result.initialize(configurationFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "configuration file loaded from %q is invalid", configurationFile)
+		return nil, eris.Wrapf(err, "configuration file loaded from %q is invalid", configurationFile)
 	}
 
 	return result, nil
@@ -191,12 +191,12 @@ const (
 // which need additional setup after json deserialization
 func (config *Configuration) initialize(configPath string) error {
 	if config.SchemaRoot == "" {
-		return errors.New("SchemaRoot missing")
+		return eris.New("SchemaRoot missing")
 	}
 
 	absConfigLocation, err := filepath.Abs(configPath)
 	if err != nil {
-		return errors.Wrapf(err, "unable to find absolute config file location")
+		return eris.Wrapf(err, "unable to find absolute config file location")
 	}
 
 	configDirectory := filepath.Dir(absConfigLocation)
@@ -224,12 +224,12 @@ func (config *Configuration) initialize(configPath string) error {
 		case string(GenerationPipelineCrossplane):
 			config.Pipeline = GenerationPipelineCrossplane
 		default:
-			errs = append(errs, errors.Errorf("unknown pipeline kind %s", config.Pipeline))
+			errs = append(errs, eris.Errorf("unknown pipeline kind %s", config.Pipeline))
 		}
 	}
 
 	if config.DestinationGoModuleFile == "" {
-		errs = append(errs, errors.Errorf("destination Go module must be specified"))
+		errs = append(errs, eris.Errorf("destination Go module must be specified"))
 	}
 
 	// Ensure config.DestinationGoModuleFile is a fully qualified path
@@ -272,7 +272,7 @@ func (config *Configuration) ShouldPrune(typeName astmodel.InternalTypeName) (re
 			case TypeFilterInclude:
 				return Include, f.Because
 			default:
-				panic(errors.Errorf("unknown typefilter directive: %s", f.Action))
+				panic(eris.Errorf("unknown typefilter directive: %s", f.Action))
 			}
 		}
 	}
@@ -306,7 +306,7 @@ func getModulePathFromModFile(modFilePath string) (string, error) {
 
 	modPath := modfile.ModulePath(modFileData)
 	if modPath == "" {
-		return "", errors.Errorf("couldn't find module path in mod file %s", modFilePath)
+		return "", eris.Errorf("couldn't find module path in mod file %s", modFilePath)
 	}
 
 	return modPath, nil

--- a/v2/tools/generator/internal/config/field_matcher.go
+++ b/v2/tools/generator/internal/config/field_matcher.go
@@ -6,7 +6,7 @@
 package config
 
 import (
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"gopkg.in/yaml.v3"
 
 	"github.com/Azure/azure-service-operator/v2/internal/util/match"
@@ -66,7 +66,7 @@ func (dm *FieldMatcher) IsRestrictive() bool {
 // We expect just a single string, which we use create an actual StringMatcher
 func (dm *FieldMatcher) UnmarshalYAML(value *yaml.Node) error {
 	if value.Kind != yaml.ScalarNode {
-		return errors.New("expected scalar value")
+		return eris.New("expected scalar value")
 	}
 
 	actual := match.NewStringMatcher(value.Value)

--- a/v2/tools/generator/internal/config/group_configuration.go
+++ b/v2/tools/generator/internal/config/group_configuration.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"gopkg.in/yaml.v3"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -86,7 +86,7 @@ func (gc *GroupConfiguration) visitVersion(
 
 	err := visitor.visitVersion(vc)
 	if err != nil {
-		return errors.Wrapf(err, "configuration of group %s", gc.name)
+		return eris.Wrapf(err, "configuration of group %s", gc.name)
 	}
 
 	return nil
@@ -111,7 +111,7 @@ func (gc *GroupConfiguration) visitVersions(visitor *configurationVisitor) error
 	}
 
 	// Both errors.Wrapf() and kerrors.NewAggregate() return nil if nothing went wrong
-	return errors.Wrapf(
+	return eris.Wrapf(
 		kerrors.NewAggregate(errs),
 		"group %s",
 		gc.name)
@@ -157,7 +157,7 @@ func (gc *GroupConfiguration) findVersionForLocalPackageReference(ref astmodel.L
 // The slice node.Content contains pairs of nodes, first one for an ID, then one for the value.
 func (gc *GroupConfiguration) UnmarshalYAML(value *yaml.Node) error {
 	if value.Kind != yaml.MappingNode {
-		return errors.New("expected mapping")
+		return eris.New("expected mapping")
 	}
 
 	gc.versions = make(map[string]*VersionConfiguration)
@@ -175,7 +175,7 @@ func (gc *GroupConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			v := NewVersionConfiguration(lastId)
 			err := c.Decode(&v)
 			if err != nil {
-				return errors.Wrapf(err, "decoding yaml for %q", lastId)
+				return eris.Wrapf(err, "decoding yaml for %q", lastId)
 			}
 
 			gc.addVersion(lastId, v)
@@ -194,15 +194,16 @@ func (gc *GroupConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			case string(ExplicitProperties):
 				gc.PayloadType.Set(ExplicitProperties)
 			default:
-				return errors.Errorf("unknown %s value: %s.", payloadTypeTag, c.Value)
+				return eris.Errorf("unknown %s value: %s.", payloadTypeTag, c.Value)
 			}
 
 			continue
 		}
 
 		// No handler for this value, return an error
-		return errors.Errorf(
+		return eris.Errorf(
 			"group configuration, unexpected yaml value %s: %s (line %d col %d)", lastId, c.Value, c.Line, c.Column)
+
 	}
 
 	return nil

--- a/v2/tools/generator/internal/config/object_model_configuration.go
+++ b/v2/tools/generator/internal/config/object_model_configuration.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"gopkg.in/yaml.v3"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -221,7 +221,7 @@ func (omc *ObjectModelConfiguration) FindHandCraftedTypeNames(localPath string) 
 
 	err := groupVisitor.visit(omc)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to find hand-crafted packages")
+		return nil, eris.Wrapf(err, "failed to find hand-crafted packages")
 	}
 
 	return result, nil
@@ -286,7 +286,7 @@ func (omc *ObjectModelConfiguration) findGroup(ref astmodel.InternalPackageRefer
 // The slice node.Content contains pairs of nodes, first one for an ID, then one for the value.
 func (omc *ObjectModelConfiguration) UnmarshalYAML(value *yaml.Node) error {
 	if value.Kind != yaml.MappingNode {
-		return errors.New("expected mapping")
+		return eris.New("expected mapping")
 	}
 
 	var lastId string
@@ -302,7 +302,7 @@ func (omc *ObjectModelConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			g := NewGroupConfiguration(lastId)
 			err := c.Decode(&g)
 			if err != nil {
-				return errors.Wrapf(err, "decoding yaml for %q", lastId)
+				return eris.Wrapf(err, "decoding yaml for %q", lastId)
 			}
 
 			omc.addGroup(lastId, g)
@@ -310,8 +310,9 @@ func (omc *ObjectModelConfiguration) UnmarshalYAML(value *yaml.Node) error {
 		}
 
 		// No handler for this value, return an error
-		return errors.Errorf(
+		return eris.Errorf(
 			"object model configuration, unexpected yaml value %s: %s (line %d col %d)", lastId, c.Value, c.Line, c.Column)
+
 	}
 
 	return nil

--- a/v2/tools/generator/internal/config/property_configuration.go
+++ b/v2/tools/generator/internal/config/property_configuration.go
@@ -8,7 +8,7 @@ package config
 import (
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"gopkg.in/yaml.v3"
 )
 
@@ -68,7 +68,7 @@ func NewPropertyConfiguration(name string) *PropertyConfiguration {
 // The slice node.Content contains pairs of nodes, first one for an ID, then one for the value.
 func (pc *PropertyConfiguration) UnmarshalYAML(value *yaml.Node) error {
 	if value.Kind != yaml.MappingNode {
-		return errors.New("expected mapping")
+		return eris.New("expected mapping")
 	}
 
 	var lastId string
@@ -90,7 +90,7 @@ func (pc *PropertyConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			var isSecret bool
 			err := c.Decode(&isSecret)
 			if err != nil {
-				return errors.Wrapf(err, "decoding %s", isSecretTag)
+				return eris.Wrapf(err, "decoding %s", isSecretTag)
 			}
 
 			pc.IsSecret.Set(isSecret)
@@ -102,7 +102,7 @@ func (pc *PropertyConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			var resourceLifecycleOwnedByParent string
 			err := c.Decode(&resourceLifecycleOwnedByParent)
 			if err != nil {
-				return errors.Wrapf(err, "decoding %s", resourceLifecycleOwnedByParentTag)
+				return eris.Wrapf(err, "decoding %s", resourceLifecycleOwnedByParentTag)
 			}
 
 			pc.ResourceLifecycleOwnedByParent.Set(resourceLifecycleOwnedByParent)
@@ -114,7 +114,7 @@ func (pc *PropertyConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			var isARMRef bool
 			err := c.Decode(&isARMRef)
 			if err != nil {
-				return errors.Wrapf(err, "decoding %s", armReferenceTag)
+				return eris.Wrapf(err, "decoding %s", armReferenceTag)
 			}
 
 			pc.ARMReference.Set(isARMRef)
@@ -129,7 +129,7 @@ func (pc *PropertyConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			case ImportConfigMapModeRequired:
 				pc.ImportConfigMapMode.Set(ImportConfigMapModeRequired)
 			default:
-				return errors.Errorf("unknown %s value: %s.", importConfigMapModeTag, c.Value)
+				return eris.Errorf("unknown %s value: %s.", importConfigMapModeTag, c.Value)
 			}
 
 			continue
@@ -140,7 +140,7 @@ func (pc *PropertyConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			var renameTo string
 			err := c.Decode(&renameTo)
 			if err != nil {
-				return errors.Wrapf(err, "decoding %s", renamePropertyToTag)
+				return eris.Wrapf(err, "decoding %s", renamePropertyToTag)
 			}
 
 			pc.RenameTo.Set(renameTo)
@@ -159,15 +159,16 @@ func (pc *PropertyConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			case string(ExplicitProperties):
 				pc.PayloadType.Set(ExplicitProperties)
 			default:
-				return errors.Errorf("unknown %s value: %s.", payloadTypeTag, c.Value)
+				return eris.Errorf("unknown %s value: %s.", payloadTypeTag, c.Value)
 			}
 
 			continue
 		}
 
 		// No handler for this value, return an error
-		return errors.Errorf(
+		return eris.Errorf(
 			"property configuration, unexpected yaml value %s: %s (line %d col %d)", lastId, c.Value, c.Line, c.Column)
+
 	}
 
 	return nil

--- a/v2/tools/generator/internal/config/transform_result.go
+++ b/v2/tools/generator/internal/config/transform_result.go
@@ -8,7 +8,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -40,7 +40,7 @@ func (tr *TransformResult) produceTargetType(
 	original astmodel.Type,
 ) (astmodel.Type, error) {
 	if err := tr.validate(); err != nil {
-		return nil, errors.Wrapf(err, "invalid transformation in %s", descriptor)
+		return nil, eris.Wrapf(err, "invalid transformation in %s", descriptor)
 	}
 
 	if tr == nil {
@@ -78,7 +78,7 @@ func (tr *TransformResult) produceTargetType(
 	}
 
 	if resultType == nil {
-		return nil, errors.Errorf("no target type found in %s", descriptor)
+		return nil, eris.Errorf("no target type found in %s", descriptor)
 	}
 
 	if tr.Optional {
@@ -91,11 +91,11 @@ func (tr *TransformResult) produceTargetType(
 func (tr *TransformResult) produceTargetNamedType(original astmodel.Type) (astmodel.Type, error) {
 	// Transform to name, ensure we have no other transformation
 	if tr.Map != nil {
-		return nil, errors.Errorf("cannot specify both Name transformation and Map transformation")
+		return nil, eris.Errorf("cannot specify both Name transformation and Map transformation")
 	}
 
 	if tr.Enum != nil {
-		return nil, errors.Errorf("cannot specify both Name transformation and Enum transformation")
+		return nil, eris.Errorf("cannot specify both Name transformation and Enum transformation")
 	}
 
 	// If we have *only* a name *and* that name represents a primitive type, we should use that
@@ -113,7 +113,7 @@ func (tr *TransformResult) produceTargetNamedType(original astmodel.Type) (astmo
 
 	tn, ok := astmodel.AsInternalTypeName(original)
 	if !ok {
-		return nil, errors.Errorf(
+		return nil, eris.Errorf(
 			"cannot apply type transformation; expected InternalTypeName, but have %s",
 			astmodel.DebugDescription(original))
 	}
@@ -133,11 +133,11 @@ func (tr *TransformResult) produceTargetMapType(
 ) (astmodel.Type, error) {
 	// Transform to map, ensure we have no other transformation
 	if tr.Name.IsRestrictive() {
-		return nil, errors.Errorf("cannot specify both Name transformation and Map transformation")
+		return nil, eris.Errorf("cannot specify both Name transformation and Map transformation")
 	}
 
 	if tr.Enum != nil {
-		return nil, errors.Errorf("cannot specify both Map transformation and Enum transformation")
+		return nil, eris.Errorf("cannot specify both Map transformation and Enum transformation")
 	}
 
 	keyType, err := tr.Map.Key.produceTargetType(descriptor+"/map/key", original)
@@ -158,15 +158,15 @@ func (tr *TransformResult) produceTargetEnumType(
 ) (astmodel.Type, error) {
 	// Transform to enum, ensure we have no other transformation
 	if tr.Name.IsRestrictive() {
-		return nil, errors.Errorf("cannot specify both Name transformation and Enum transformation")
+		return nil, eris.Errorf("cannot specify both Name transformation and Enum transformation")
 	}
 
 	if tr.Map != nil {
-		return nil, errors.Errorf("cannot specify both Map transformation and Enum transformation")
+		return nil, eris.Errorf("cannot specify both Map transformation and Enum transformation")
 	}
 
 	if tr.Enum.Base == "" {
-		return nil, errors.Errorf("enum transformation requires a base type")
+		return nil, eris.Errorf("enum transformation requires a base type")
 	}
 
 	baseType, err := tr.asPrimitiveType(tr.Enum.Base)
@@ -237,7 +237,7 @@ func (tr *TransformResult) asPrimitiveType(name string) (*astmodel.PrimitiveType
 	case "any":
 		return astmodel.AnyType, nil
 	default:
-		return nil, errors.Errorf("unknown primitive type transformation target: %s", name)
+		return nil, eris.Errorf("unknown primitive type transformation target: %s", name)
 	}
 }
 
@@ -246,7 +246,7 @@ func (tr *TransformResult) validate() error {
 		tr.Map == nil &&
 		tr.Enum == nil &&
 		tr.Optional == false {
-		return errors.Errorf("no result transformation specified")
+		return eris.Errorf("no result transformation specified")
 	}
 
 	return nil

--- a/v2/tools/generator/internal/config/type_configuration.go
+++ b/v2/tools/generator/internal/config/type_configuration.go
@@ -8,7 +8,7 @@ package config
 import (
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"gopkg.in/yaml.v3"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -112,7 +112,7 @@ func (tc *TypeConfiguration) visitProperty(
 
 	err := visitor.visitProperty(pc)
 	if err != nil {
-		return errors.Wrapf(err, "configuration of type %s", tc.name)
+		return eris.Wrapf(err, "configuration of type %s", tc.name)
 	}
 
 	return nil
@@ -128,7 +128,7 @@ func (tc *TypeConfiguration) visitProperties(visitor *configurationVisitor) erro
 	}
 
 	// Both errors.Wrapf() and kerrors.NewAggregate() return nil if nothing went wrong
-	return errors.Wrapf(
+	return eris.Wrapf(
 		kerrors.NewAggregate(errs),
 		"type %s",
 		tc.name)
@@ -152,7 +152,7 @@ func (tc *TypeConfiguration) findProperty(property astmodel.PropertyName) *Prope
 // The slice node.Content contains pairs of nodes, first one for an ID, then one for the value.
 func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 	if value.Kind != yaml.MappingNode {
-		return errors.New("expected mapping")
+		return eris.New("expected mapping")
 	}
 
 	tc.properties = make(map[string]*PropertyConfiguration)
@@ -175,7 +175,7 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 				if content.Kind == yaml.ScalarNode {
 					val = content.Value
 				} else {
-					return errors.Errorf(
+					return eris.Errorf(
 						"unexpected yam value for %s (line %d col %d)",
 						generatedConfigsTag,
 						content.Line,
@@ -188,7 +188,7 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 				}
 				if idx%2 == 1 {
 					if !strings.HasPrefix(val, "$.") {
-						return errors.Errorf("%s entry %q must begin with $.", generatedConfigsTag, val)
+						return eris.Errorf("%s entry %q must begin with $.", generatedConfigsTag, val)
 					}
 					azureGeneratedConfigs[key] = val
 
@@ -207,7 +207,7 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			p := NewPropertyConfiguration(lastId)
 			err := c.Decode(p)
 			if err != nil {
-				return errors.Wrapf(err, "decoding yaml for %q", lastId)
+				return eris.Wrapf(err, "decoding yaml for %q", lastId)
 			}
 
 			tc.addProperty(lastId, p)
@@ -225,7 +225,7 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			var export bool
 			err := c.Decode(&export)
 			if err != nil {
-				return errors.Wrapf(err, "decoding %s", exportTag)
+				return eris.Wrapf(err, "decoding %s", exportTag)
 			}
 
 			tc.Export.Set(export)
@@ -247,7 +247,7 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 				if content.Kind == yaml.ScalarNode {
 					azureGeneratedSecrets = append(azureGeneratedSecrets, content.Value)
 				} else {
-					return errors.Errorf(
+					return eris.Errorf(
 						"unexpected yam value for %s (line %d col %d)",
 						azureGeneratedSecretsTag,
 						content.Line,
@@ -268,7 +268,7 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 				if content.Kind == yaml.ScalarNode {
 					manualAzureGeneratedConfigs = append(manualAzureGeneratedConfigs, content.Value)
 				} else {
-					return errors.Errorf(
+					return eris.Errorf(
 						"unexpected yam value for %s (line %d col %d)",
 						manualConfigsTag,
 						content.Line,
@@ -285,7 +285,7 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			var stripDocs bool
 			err := c.Decode(&stripDocs)
 			if err != nil {
-				return errors.Wrapf(err, "decoding %s", stripDocumentationTag)
+				return eris.Wrapf(err, "decoding %s", stripDocumentationTag)
 			}
 
 			tc.StripDocumentation.Set(stripDocs)
@@ -303,7 +303,7 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			var renameTo string
 			err := c.Decode(&renameTo)
 			if err != nil {
-				return errors.Wrapf(err, "decoding %s", renameTo)
+				return eris.Wrapf(err, "decoding %s", renameTo)
 			}
 
 			tc.RenameTo.Set(renameTo)
@@ -315,7 +315,7 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			var resourceEmbeddedInParent string
 			err := c.Decode(&resourceEmbeddedInParent)
 			if err != nil {
-				return errors.Wrapf(err, "decoding %s", resourceEmbeddedInParentTag)
+				return eris.Wrapf(err, "decoding %s", resourceEmbeddedInParentTag)
 			}
 
 			tc.ResourceEmbeddedInParent.Set(resourceEmbeddedInParent)
@@ -327,7 +327,7 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			var isResource bool
 			err := c.Decode(&isResource)
 			if err != nil {
-				return errors.Wrapf(err, "decoding %s", isResourceTag)
+				return eris.Wrapf(err, "decoding %s", isResourceTag)
 			}
 
 			tc.IsResource.Set(isResource)
@@ -339,7 +339,7 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			var importable bool
 			err := c.Decode(&importable)
 			if err != nil {
-				return errors.Wrapf(err, "decoding %s", importableTag)
+				return eris.Wrapf(err, "decoding %s", importableTag)
 			}
 
 			tc.Importable.Set(importable)
@@ -351,7 +351,7 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 			var defaultAzureName bool
 			err := c.Decode(&defaultAzureName)
 			if err != nil {
-				return errors.Wrapf(err, "decoding %s", defaultAzureNameTag)
+				return eris.Wrapf(err, "decoding %s", defaultAzureNameTag)
 			}
 
 			tc.DefaultAzureName.Set(defaultAzureName)
@@ -371,12 +371,12 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 					var property OperatorSpecPropertyConfiguration
 					err := content.Decode(&property)
 					if err != nil {
-						return errors.Wrapf(err, "decoding %s", operatorSpecPropertiesTag)
+						return eris.Wrapf(err, "decoding %s", operatorSpecPropertiesTag)
 					}
 
 					properties = append(properties, property)
 				} else {
-					return errors.Errorf(
+					return eris.Errorf(
 						"unexpected yam value for %s (line %d col %d)",
 						operatorSpecPropertiesTag,
 						content.Line,
@@ -389,8 +389,9 @@ func (tc *TypeConfiguration) UnmarshalYAML(value *yaml.Node) error {
 		}
 
 		// No handler for this value, return an error
-		return errors.Errorf(
+		return eris.Errorf(
 			"type configuration, unexpected yaml value %s: %s (line %d col %d)", lastId, c.Value, c.Line, c.Column)
+
 	}
 
 	return nil

--- a/v2/tools/generator/internal/config/type_matcher.go
+++ b/v2/tools/generator/internal/config/type_matcher.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -64,28 +64,28 @@ func (t *TypeMatcher) WasMatched() error {
 	}
 
 	if err := t.Group.WasMatched(); err != nil {
-		return errors.Wrapf(
+		return eris.Wrapf(
 			err,
 			"type matcher [%s] matched no types; every group was excluded",
 			t.String())
 	}
 
 	if err := t.Version.WasMatched(); err != nil {
-		return errors.Wrapf(
+		return eris.Wrapf(
 			err,
 			"type matcher [%s] matched no types; groups matched, but every version was excluded",
 			t.String())
 	}
 
 	if err := t.Name.WasMatched(); err != nil {
-		return errors.Wrapf(
+		return eris.Wrapf(
 			err,
 			"type matcher [%s] matched no types; groups and versions matched, but every type was excluded",
 			t.String())
 	}
 
 	// Don't expect this case to ever be used, but be informative anyway
-	return errors.Errorf("Type matcher [%s] matched no types", t.String())
+	return eris.Errorf("Type matcher [%s] matched no types", t.String())
 }
 
 // String returns a description of this filter

--- a/v2/tools/generator/internal/conversions/property_bag_member_type.go
+++ b/v2/tools/generator/internal/conversions/property_bag_member_type.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -64,7 +64,7 @@ func (b *PropertyBagMemberType) References() astmodel.TypeNameSet {
 func (b *PropertyBagMemberType) AsTypeExpr(codeGenerationContext *astmodel.CodeGenerationContext) (dst.Expr, error) {
 	result, err := b.element.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating inner expression for property bag type")
+		return nil, eris.Wrapf(err, "creating inner expression for property bag type")
 	}
 
 	return result, nil
@@ -75,7 +75,7 @@ func (b *PropertyBagMemberType) AsDeclarations(
 	codeGenerationContext *astmodel.CodeGenerationContext,
 	declContext astmodel.DeclarationContext,
 ) ([]dst.Decl, error) {
-	panic(errors.New("should never try to render a PropertyBagMemberType into declarations"))
+	panic(eris.New("should never try to render a PropertyBagMemberType into declarations"))
 }
 
 // AsZero renders an expression for the "zero" value of the type

--- a/v2/tools/generator/internal/conversions/property_conversion_context.go
+++ b/v2/tools/generator/internal/conversions/property_conversion_context.go
@@ -6,7 +6,7 @@
 package conversions
 
 import (
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/storage"
@@ -247,7 +247,7 @@ func (c *PropertyConversionContext) validateTypeRename(
 	if !ok {
 		// No rename configured, but we can't proceed without one. Return an error - it'll be wrapped with property
 		// details by CreateTypeConversion() so we only need the specific details here
-		return errors.Errorf(
+		return eris.Errorf(
 			"no configuration to rename %s to %s",
 			earlier.Name(),
 			later.Name())
@@ -256,7 +256,7 @@ func (c *PropertyConversionContext) validateTypeRename(
 	if later.Name() != name {
 		// Configured rename doesn't match what we found. Return an error - it'll be wrapped with property details
 		// by CreateTypeConversion() so we only need the specific details here
-		return errors.Errorf(
+		return eris.Errorf(
 			"configuration includes rename of %s to %s, but found %s",
 			earlier.Name(),
 			name,

--- a/v2/tools/generator/internal/conversions/property_conversions.go
+++ b/v2/tools/generator/internal/conversions/property_conversions.go
@@ -10,7 +10,7 @@ import (
 	"go/token"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -196,9 +196,9 @@ func CreateTypeConversion(
 		describe(srcType, dstType))
 
 	if err != nil {
-		err = errors.Wrap(err, msg)
+		err = eris.Wrap(err, msg)
 	} else {
-		err = errors.New(msg)
+		err = eris.New(msg)
 	}
 
 	return nil, err
@@ -348,7 +348,7 @@ func writeToBagItem(
 			knownLocals,
 			generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"unable to convert %s to %s writing property bag",
 				sourceEndpoint.Name(),
@@ -523,7 +523,7 @@ func pullFromBagItem(
 		// var <local> <sourceBagItemType>
 		sourceBagItemExpr, err := sourceBagItem.AsTypeExpr(generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"converting %s to %s reading property bag",
 				sourceEndpoint.Name(),
@@ -575,7 +575,7 @@ func pullFromBagItem(
 		// Create the actual code to store the value
 		assignValue, err := conversion(reader, writer, knownLocals, generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"unable to convert %s to %s reading property bag",
 				sourceEndpoint.Name(),
@@ -678,7 +678,7 @@ func assignFromOptional(
 			knownLocals.Clone(),
 			generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"unable to convert %s to %s",
 				sourceEndpoint.Name(),
@@ -770,7 +770,7 @@ func assignToEnumeration(
 
 		dstNameExpr, err := dstName.AsTypeExpr(generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"unable to convert %s to %s",
 				sourceEndpoint.Name(),
@@ -796,7 +796,7 @@ func assignToEnumeration(
 				knownLocals,
 				generationContext)
 			if err != nil {
-				return nil, errors.Wrapf(
+				return nil, eris.Wrapf(
 					err,
 					"unable to convert %s to %s",
 					sourceEndpoint.Name(),
@@ -914,7 +914,7 @@ func assignAliasedPrimitiveFromAliasedPrimitive(
 	) ([]dst.Stmt, error) {
 		destinationNameExpr, err := destinationName.AsTypeExpr(generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating destination expression")
+			return nil, eris.Wrapf(err, "creating destination expression")
 		}
 
 		return writer(&dst.CallExpr{
@@ -972,7 +972,7 @@ func assignFromAliasedType(
 	) ([]dst.Stmt, error) {
 		sourceTypeExpr, err := sourceType.AsTypeExpr(generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating source expression")
+			return nil, eris.Wrapf(err, "creating source expression")
 		}
 
 		actualReader := &dst.CallExpr{
@@ -1034,7 +1034,7 @@ func assignToAliasedType(
 	) ([]dst.Stmt, error) {
 		destinationNameExpr, err := destinationName.AsTypeExpr(generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating destination expression")
+			return nil, eris.Wrapf(err, "creating destination expression")
 		}
 
 		actualWriter := func(expr dst.Expr) []dst.Stmt {
@@ -1274,7 +1274,7 @@ func assignArrayFromArray(
 		unwrappedDestinationEndpoint,
 		conversionContext)
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"finding array conversion from %s to %s",
 			astmodel.DebugDescription(sourceEndpoint.Type()),
@@ -1325,7 +1325,7 @@ func assignArrayFromArray(
 
 		destinationArrayExpr, err := destinationArray.AsTypeExpr(generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"converting %s to %s",
 				sourceEndpoint.Name(),
@@ -1353,7 +1353,7 @@ func assignArrayFromArray(
 
 		elemConv, err := conversion(dst.NewIdent(itemId), writeToElement, loopLocals, generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"creating conversion for array element from %s to %s",
 				astmodel.DebugDescription(sourceEndpoint.Type()),
@@ -1425,7 +1425,7 @@ func assignMapFromMap(
 		unwrappedDestinationEndpoint,
 		conversionContext)
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"finding map conversion from %s to %s",
 			astmodel.DebugDescription(sourceEndpoint.Type()),
@@ -1477,7 +1477,7 @@ func assignMapFromMap(
 
 		keyTypeExpr, err := destinationMap.KeyType().AsTypeExpr(generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"creating map key type expression for %s",
 				astmodel.DebugDescription(destinationMap.KeyType()))
@@ -1485,7 +1485,7 @@ func assignMapFromMap(
 
 		valueTypeExpr, err := destinationMap.ValueType().AsTypeExpr(generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"creating map value type expression for %s",
 				astmodel.DebugDescription(destinationMap.ValueType()))
@@ -1515,7 +1515,7 @@ func assignMapFromMap(
 
 		elemConv, err := conversion(dst.NewIdent(itemId), assignToItem, loopLocals, generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"creating map item conversion from %s to %s",
 				astmodel.DebugDescription(sourceMap.ValueType()),
@@ -1604,7 +1604,7 @@ func assignUserAssignedIdentityMapFromArray(
 		destinationEndpoint.WithType(astmodel.ResourceReferenceType),
 		conversionContext)
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"finding UserAssignedIdentities conversion from %s to %s",
 			astmodel.DebugDescription(astmodel.StringType),
@@ -1621,7 +1621,7 @@ func assignUserAssignedIdentityMapFromArray(
 		tempId := knownLocals.CreateSingularLocal(sourceEndpoint.Name(), "List")
 		destinationArrayExpr, err := destinationArray.AsTypeExpr(generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"creating UserAssignedIdentities conversion from %s to %s",
 				astmodel.DebugDescription(astmodel.StringType),
@@ -1638,7 +1638,7 @@ func assignUserAssignedIdentityMapFromArray(
 		intermediateDestination := loopLocals.CreateLocal(destinationEndpoint.Name(), "Ref")
 		destinationTypeExpr, err := destinationElement.AsTypeExpr(generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"creating UserAssignedIdentities conversion from %s to %s",
 				astmodel.DebugDescription(astmodel.StringType),
@@ -1660,7 +1660,7 @@ func assignUserAssignedIdentityMapFromArray(
 		//	}
 		elemConv, err := conversion(dst.NewIdent(keyID), writeToElement, loopLocals, generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"creating UserAssignedIdentities conversion from %s to %s",
 				astmodel.DebugDescription(astmodel.StringType),
@@ -1745,7 +1745,7 @@ func assignEnumFromEnum(
 
 	// Require enumerations to have the same base definitions
 	if !astmodel.TypeEquals(sourceEnum.BaseType(), destinationEnum.BaseType()) {
-		return nil, errors.Errorf(
+		return nil, eris.Errorf(
 			"no conversion from %s to %s",
 			astmodel.DebugDescription(sourceEnum.BaseType()),
 			astmodel.DebugDescription(destinationEnum.BaseType()))
@@ -1897,7 +1897,7 @@ func assignObjectDirectlyFromObject(
 		// If our two types are not adjacent in our conversion graph, this is not the conversion you're looking for
 		nextType, err := conversionContext.FindNextType(destinationName)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"looking up next type for %s",
 				astmodel.DebugDescription(destinationEndpoint.Type()))
@@ -2022,7 +2022,7 @@ func assignObjectDirectlyToObject(
 		// Check that
 		nextType, err := conversionContext.FindNextType(sourceName)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"looking up next type for %s",
 				astmodel.DebugDescription(sourceEndpoint.Type()))
@@ -2151,7 +2151,7 @@ func assignInlineObjectsViaIntermediateObject(
 		var err error
 		intermediateName, err = conversionContext.FindNextType(sourceName)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"looking up next type for %s",
 				astmodel.DebugDescription(destinationEndpoint.Type()))
@@ -2160,7 +2160,7 @@ func assignInlineObjectsViaIntermediateObject(
 		var err error
 		intermediateName, err = conversionContext.FindNextType(destinationName)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"looking up next type for %s",
 				astmodel.DebugDescription(destinationEndpoint.Type()))
@@ -2188,7 +2188,7 @@ func assignInlineObjectsViaIntermediateObject(
 		intermediateName.Name()+"Stash")
 	firstConversion, err := CreateTypeConversion(sourceEndpoint, intermediateEndpoint, conversionContext)
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"finding first intermediate conversion, from %s to %s",
 			astmodel.DebugDescription(sourceName),
@@ -2200,7 +2200,7 @@ func assignInlineObjectsViaIntermediateObject(
 
 	secondConversion, err := CreateTypeConversion(intermediateEndpoint, destinationEndpoint, conversionContext)
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"finding second intermediate conversion, from %s to %s",
 			astmodel.DebugDescription(intermediateName),
@@ -2229,7 +2229,7 @@ func assignInlineObjectsViaIntermediateObject(
 		// Capture the first step
 		firstStep, err := firstConversion(reader, capturingWriter, knownLocals, generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"converting from %s to %s",
 				astmodel.DebugDescription(sourceName),
@@ -2238,7 +2238,7 @@ func assignInlineObjectsViaIntermediateObject(
 
 		secondStep, err := secondConversion(capture, writer, knownLocals, generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"converting from %s to %s",
 				astmodel.DebugDescription(intermediateName),
@@ -2340,7 +2340,7 @@ func assignNonInlineObjectsViaPivotObject(
 		pivotEndpoint,
 		conversionContext.WithDirection(ConvertTo))
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"finding first intermediate conversion, from %s to %s",
 			astmodel.DebugDescription(sourceName),
@@ -2356,7 +2356,7 @@ func assignNonInlineObjectsViaPivotObject(
 		destinationEndpoint,
 		conversionContext.WithDirection(ConvertFrom))
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"finding second intermediate conversion, from %s to %s",
 			astmodel.DebugDescription(pivotName),
@@ -2385,7 +2385,7 @@ func assignNonInlineObjectsViaPivotObject(
 		// Capture the first step
 		firstStep, err := firstConversion(reader, capturingWriter, knownLocals, generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"converting from %s to %s",
 				astmodel.DebugDescription(sourceName),
@@ -2394,7 +2394,7 @@ func assignNonInlineObjectsViaPivotObject(
 
 		secondStep, err := secondConversion(capture, writer, knownLocals, generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"converting from %s to %s",
 				astmodel.DebugDescription(pivotName),

--- a/v2/tools/generator/internal/functions/chained_conversion_function.go
+++ b/v2/tools/generator/internal/functions/chained_conversion_function.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -131,7 +131,7 @@ func (fn *ChainedConversionFunction) AsFunc(
 	// We always use a pointer receiver, so we can modify it
 	receiverExpr, err := astmodel.NewOptionalType(receiver).AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating receiver type expression for %s", receiver)
+		return nil, eris.Wrapf(err, "creating receiver type expression for %s", receiver)
 	}
 
 	funcDetails := &astbuilder.FuncDetails{
@@ -143,7 +143,7 @@ func (fn *ChainedConversionFunction) AsFunc(
 	parameterName := fn.direction.SelectString("source", "destination")
 	parameterTypeExpr, err := fn.parameterType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating parameter type expression for %s", parameterName)
+		return nil, eris.Wrapf(err, "creating parameter type expression for %s", parameterName)
 	}
 
 	funcDetails.AddParameter(parameterName, parameterTypeExpr)

--- a/v2/tools/generator/internal/functions/common.go
+++ b/v2/tools/generator/internal/functions/common.go
@@ -7,7 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -50,7 +50,7 @@ func createBodyReturningValue(
 
 		receiverExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating receiver expression for %s", receiverType)
+			return nil, eris.Wrapf(err, "creating receiver expression for %s", receiverType)
 		}
 
 		fn := &astbuilder.FuncDetails{
@@ -64,7 +64,7 @@ func createBodyReturningValue(
 		fn.AddComments(comment)
 		returnTypeExpr, err := returnType.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating type expression for %s", returnType)
+			return nil, eris.Wrapf(err, "creating type expression for %s", returnType)
 		}
 
 		fn.AddReturn(returnTypeExpr)

--- a/v2/tools/generator/internal/functions/conditions_functions.go
+++ b/v2/tools/generator/internal/functions/conditions_functions.go
@@ -9,7 +9,7 @@ import (
 	"go/token"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -29,7 +29,7 @@ func GetConditionsFunction(
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+		return nil, eris.Wrapf(err, "creating type expression for %s", receiver)
 	}
 
 	status := astbuilder.Selector(dst.NewIdent(receiverIdent), "Status")
@@ -46,7 +46,7 @@ func GetConditionsFunction(
 	fn.AddComments("returns the conditions of the resource")
 	conditionsTypeExpr, err := astmodel.ConditionsType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", astmodel.ConditionsType)
+		return nil, eris.Wrapf(err, "creating type expression for %s", astmodel.ConditionsType)
 	}
 
 	fn.AddReturn(conditionsTypeExpr)
@@ -70,7 +70,7 @@ func SetConditionsFunction(
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+		return nil, eris.Wrapf(err, "creating type expression for %s", receiver)
 	}
 
 	status := astbuilder.Selector(dst.NewIdent(receiverIdent), "Status")
@@ -86,7 +86,7 @@ func SetConditionsFunction(
 
 	conditionsTypeExpr, err := astmodel.ConditionsType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to render type expression for %s", astmodel.ConditionsType)
+		return nil, eris.Wrapf(err, "unable to render type expression for %s", astmodel.ConditionsType)
 	}
 
 	fn.AddParameter(

--- a/v2/tools/generator/internal/functions/dynamic_exports.go
+++ b/v2/tools/generator/internal/functions/dynamic_exports.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -117,7 +117,7 @@ func (d *PropertyExporter) getPropertyFunction(
 	receiverType := astmodel.NewOptionalType(receiver)
 	receiverTypeExpr, err := receiverType.AsTypeExpr(genContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	nilChecks := make([]dst.Stmt, 0, len(d.nilChecks))
@@ -144,7 +144,7 @@ func (d *PropertyExporter) getPropertyFunction(
 
 	exportTypeExpr, err := d.exportType.AsTypeExpr(genContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating return type expression")
+		return nil, eris.Wrap(err, "creating return type expression")
 	}
 
 	fn.AddReturn(exportTypeExpr)

--- a/v2/tools/generator/internal/functions/empty_status_function.go
+++ b/v2/tools/generator/internal/functions/empty_status_function.go
@@ -7,7 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -37,7 +37,7 @@ func createNewEmptyStatusFunction(
 		receiverType := astmodel.NewOptionalType(receiver)
 		receiverTypeExpr, err := receiverType.AsTypeExpr(genContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating receiver expression for %s", receiverType)
+			return nil, eris.Wrapf(err, "creating receiver expression for %s", receiverType)
 		}
 
 		// When Storage variants are created from resources, any existing functions are copied across - which means
@@ -58,7 +58,7 @@ func createNewEmptyStatusFunction(
 
 		convertibleStatusInterfaceExpr, err := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(genContext)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to create ConvertibleStatusInterfaceType expression")
+			return nil, eris.Wrap(err, "unable to create ConvertibleStatusInterfaceType expression")
 		}
 
 		fn.AddReturn(convertibleStatusInterfaceExpr)

--- a/v2/tools/generator/internal/functions/get_extended_resources_function.go
+++ b/v2/tools/generator/internal/functions/get_extended_resources_function.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
@@ -99,7 +99,7 @@ func (ext *GetExtendedResourcesFunction) AsFunc(
 ) (*dst.FuncDecl, error) {
 	krType, err := astmodel.NewArrayType(astmodel.KubernetesResourceType).AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", astmodel.KubernetesResourceType)
+		return nil, eris.Wrapf(err, "creating type expression for %s", astmodel.KubernetesResourceType)
 	}
 
 	krLiteral := astbuilder.NewCompositeLiteralBuilder(krType).Build()
@@ -109,7 +109,7 @@ func (ext *GetExtendedResourcesFunction) AsFunc(
 		var resourceExpr dst.Expr
 		resourceExpr, err = resource.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating type expression for %s", resource)
+			return nil, eris.Wrapf(err, "creating type expression for %s", resource)
 		}
 
 		expr := astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(resourceExpr).Build())
@@ -120,7 +120,7 @@ func (ext *GetExtendedResourcesFunction) AsFunc(
 	receiverName := ext.idFactory.CreateReceiver(receiver.Name())
 	receiverType, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+		return nil, eris.Wrapf(err, "creating type expression for %s", receiver)
 	}
 
 	funcDetails := &astbuilder.FuncDetails{

--- a/v2/tools/generator/internal/functions/get_spec_function.go
+++ b/v2/tools/generator/internal/functions/get_spec_function.go
@@ -7,7 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -30,7 +30,7 @@ func createGetSpecFunction(
 	receiverType := astmodel.NewOptionalType(receiver)
 	receiverTypeExpr, err := receiverType.AsTypeExpr(genContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	ret := astbuilder.Returns(astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec")))
@@ -44,7 +44,7 @@ func createGetSpecFunction(
 
 	convertibleSpecInterfaceExpr, err := astmodel.ConvertibleSpecInterfaceType.AsTypeExpr(genContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating type expression for ConvertibleSpecInterface")
+		return nil, eris.Wrap(err, "creating type expression for ConvertibleSpecInterface")
 	}
 
 	fn.AddReturn(convertibleSpecInterfaceExpr)

--- a/v2/tools/generator/internal/functions/get_status_function.go
+++ b/v2/tools/generator/internal/functions/get_status_function.go
@@ -7,7 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -30,7 +30,7 @@ func createGetStatusFunction(
 	receiverType := astmodel.NewOptionalType(receiver)
 	receiverTypeExpr, err := receiverType.AsTypeExpr(genContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	fn := &astbuilder.FuncDetails{
@@ -44,7 +44,7 @@ func createGetStatusFunction(
 
 	convertibleStatusInterfaceExpr, err := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(genContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating type expression for ConvertibleStatusInterface")
+		return nil, eris.Wrap(err, "creating type expression for ConvertibleStatusInterface")
 	}
 
 	fn.AddReturn(convertibleStatusInterfaceExpr)

--- a/v2/tools/generator/internal/functions/hub_function.go
+++ b/v2/tools/generator/internal/functions/hub_function.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -38,7 +38,7 @@ func createHubFunctionBody(
 	receiverType := astmodel.NewOptionalType(receiver)
 	receiverTypeExpr, err := receiverType.AsTypeExpr(genContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	details := astbuilder.FuncDetails{

--- a/v2/tools/generator/internal/functions/index_registration_function.go
+++ b/v2/tools/generator/internal/functions/index_registration_function.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -87,7 +87,7 @@ func (f *IndexRegistrationFunction) AsFunc(
 	// obj, ok := rawObj.(*<type>)
 	resourceTypeNameExpr, err := f.resourceTypeName.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", f.resourceTypeName)
+		return nil, eris.Wrapf(err, "creating type expression for %s", f.resourceTypeName)
 	}
 
 	cast := astbuilder.TypeAssert(
@@ -105,7 +105,7 @@ func (f *IndexRegistrationFunction) AsFunc(
 	} else {
 		stmts, err = f.multipleValues(specSelector)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to generate multiple value index registration function for %s", f.resourceTypeName)
+			return nil, eris.Wrapf(err, "failed to generate multiple value index registration function for %s", f.resourceTypeName)
 		}
 	}
 
@@ -119,7 +119,7 @@ func (f *IndexRegistrationFunction) AsFunc(
 
 	controllerRuntimeObjectExpr, err := astmodel.ControllerRuntimeObjectType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating type expression for index registration function")
+		return nil, eris.Wrap(err, "creating type expression for index registration function")
 	}
 
 	fn.AddParameter(rawObjName, controllerRuntimeObjectExpr)
@@ -173,7 +173,7 @@ func (f *IndexRegistrationFunction) multipleValues(selector *dst.SelectorExpr) (
 		astbuilder.Returns(astbuilder.Nil()),
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to make statements for property chain %s", f.propertyChain)
+		return nil, eris.Wrapf(err, "failed to make statements for property chain %s", f.propertyChain)
 	}
 
 	ret := astbuilder.Returns(dst.NewIdent("result"))
@@ -221,7 +221,7 @@ func (f *IndexRegistrationFunction) makeStatements(
 		return f.handleMap(result, locals, ident, remainingChain)
 	}
 
-	return nil, errors.Errorf("can't produce index registration function for type %T", t)
+	return nil, eris.Errorf("can't produce index registration function for type %T", t)
 }
 
 func (f *IndexRegistrationFunction) handleArray(
@@ -236,7 +236,7 @@ func (f *IndexRegistrationFunction) handleArray(
 	nilHandler := astbuilder.Continue()
 	loopStatements, err := f.makeStatements(result, locals.Clone(), dst.NewIdent(local), remainingChain[1:], nilHandler)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to make loop statements for array property %s", p.PropertyName())
+		return nil, eris.Wrapf(err, "failed to make loop statements for array property %s", p.PropertyName())
 	}
 
 	loop := astbuilder.IterateOverSlice(
@@ -260,7 +260,7 @@ func (f *IndexRegistrationFunction) handleMap(
 	nilHandler := astbuilder.Continue()
 	loopStatements, err := f.makeStatements(result, locals.Clone(), dst.NewIdent(value), remainingChain[1:], nilHandler)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to make loop statements for map property %s", p.PropertyName())
+		return nil, eris.Wrapf(err, "failed to make loop statements for map property %s", p.PropertyName())
 	}
 
 	loop := astbuilder.IterateOverMapWithValue(

--- a/v2/tools/generator/internal/functions/initialize_spec_function.go
+++ b/v2/tools/generator/internal/functions/initialize_spec_function.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -27,12 +27,12 @@ func NewInitializeSpecFunction(
 ) (astmodel.Function, error) {
 	rsrc, ok := astmodel.AsResourceType(def.Type())
 	if !ok {
-		return nil, errors.Errorf("expected %q to be a resource", def.Name())
+		return nil, eris.Errorf("expected %q to be a resource", def.Name())
 	}
 
 	statusType, ok := astmodel.AsTypeName(rsrc.StatusType())
 	if !ok {
-		return nil, errors.Errorf("expected %q to be a TypeName", rsrc.StatusType())
+		return nil, eris.Errorf("expected %q to be a TypeName", rsrc.StatusType())
 	}
 
 	requiredPackages := astmodel.NewPackageReferenceSet(
@@ -50,7 +50,7 @@ func NewInitializeSpecFunction(
 
 		receiverType, err := receiver.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+			return nil, eris.Wrapf(err, "creating type expression for %s", receiver)
 		}
 
 		receiverName := idFactory.CreateReceiver(receiver.Name())
@@ -73,7 +73,7 @@ func NewInitializeSpecFunction(
 		// }
 		statusTypeExpr, err := statusType.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating type expression for status %s", statusType)
+			return nil, eris.Wrapf(err, "creating type expression for status %s", statusType)
 		}
 
 		initialize := astbuilder.IfType(
@@ -102,7 +102,7 @@ func NewInitializeSpecFunction(
 		funcDetails.AddComments("initializes the spec for this resource from the given status")
 		convertibleStatusInterfaceExpr, err := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating type expression for %s", astmodel.ConvertibleStatusInterfaceType)
+			return nil, eris.Wrapf(err, "creating type expression for %s", astmodel.ConvertibleStatusInterfaceType)
 		}
 
 		funcDetails.AddParameter(statusParam, convertibleStatusInterfaceExpr)

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
@@ -9,11 +9,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dave/dst"
-	"github.com/pkg/errors"
-
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+	"github.com/dave/dst"
+	"github.com/rotisserie/eris"
 )
 
 // DefaulterBuilder helps in building an interface implementation for admissions.Defaulter.
@@ -115,7 +114,7 @@ func (d *DefaulterBuilder) localDefault(
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	defaults := make([]dst.Stmt, 0, len(d.defaults))
@@ -145,7 +144,7 @@ func (d *DefaulterBuilder) defaultFunction(
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverType, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	tempVarIdent := "temp"
@@ -153,7 +152,7 @@ func (d *DefaulterBuilder) defaultFunction(
 
 	overrideInterfaceType, err := astmodel.GenRuntimeDefaulterInterfaceName.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating runtime defaulter interface type expression for method %s", methodName)
+		return nil, eris.Wrapf(err, "creating runtime defaulter interface type expression for method %s", methodName)
 	}
 
 	fn := &astbuilder.FuncDetails{

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaults.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaults.go
@@ -7,7 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -34,7 +34,7 @@ func defaultAzureNameFunction(
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	azureNameProp := astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec", astmodel.AzureNameProperty)

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validations.go
@@ -9,7 +9,7 @@ import (
 	"go/token"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -60,7 +60,7 @@ func validateResourceReferences(
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	fn := &astbuilder.FuncDetails{
@@ -119,7 +119,7 @@ func validateOwnerReferences(
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating receiver type expression for %s", receiver)
+		return nil, eris.Wrapf(err, "creating receiver type expression for %s", receiver)
 	}
 
 	admissionPkg := codeGenerationContext.MustGetImportedPackageName(astmodel.ControllerRuntimeAdmission)
@@ -165,14 +165,14 @@ func validateWriteOncePropertiesFunction(
 	receiverIdent := resourceFn.IdFactory().CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating receiver type expression for %s", receiver)
+		return nil, eris.Wrapf(err, "creating receiver type expression for %s", receiver)
 	}
 
 	runtimePackage := codeGenerationContext.MustGetImportedPackageName(astmodel.APIMachineryRuntimeReference)
 
 	body, err := validateWriteOncePropertiesFunctionBody(receiver, codeGenerationContext, receiverIdent)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating function body for %s", methodName)
+		return nil, eris.Wrapf(err, "creating function body for %s", methodName)
 	}
 
 	fn := &astbuilder.FuncDetails{
@@ -209,7 +209,7 @@ func validateWriteOncePropertiesFunctionBody(
 
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating receiver type expression for %s", receiver)
+		return nil, eris.Wrapf(err, "creating receiver type expression for %s", receiver)
 	}
 
 	cast := astbuilder.TypeAssert(obj, dst.NewIdent("old"), astbuilder.PointerTo(receiverExpr))
@@ -238,7 +238,7 @@ func validateOptionalConfigMapReferences(
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	fn := &astbuilder.FuncDetails{

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/dave/dst"
@@ -159,7 +159,7 @@ func (v *ValidatorBuilder) validateCreate(
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	body, err := v.validateBody(
@@ -170,7 +170,7 @@ func (v *ValidatorBuilder) validateCreate(
 		"ValidateCreate",
 		"")
 	if err != nil {
-		return nil, errors.Wrap(err, "creating validation body")
+		return nil, eris.Wrap(err, "creating validation body")
 	}
 
 	fn := &astbuilder.FuncDetails{
@@ -196,7 +196,7 @@ func (v *ValidatorBuilder) validateUpdate(
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	retType := getValidationFuncType(ValidationKindUpdate, codeGenerationContext)
@@ -209,7 +209,7 @@ func (v *ValidatorBuilder) validateUpdate(
 		"ValidateUpdate",
 		"old")
 	if err != nil {
-		return nil, errors.Wrap(err, "creating validation body")
+		return nil, eris.Wrap(err, "creating validation body")
 	}
 
 	fn := &astbuilder.FuncDetails{
@@ -235,7 +235,7 @@ func (v *ValidatorBuilder) validateDelete(
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	body, err := v.validateBody(
@@ -246,7 +246,7 @@ func (v *ValidatorBuilder) validateDelete(
 		"ValidateDelete",
 		"")
 	if err != nil {
-		return nil, errors.Wrap(err, "creating validation body")
+		return nil, eris.Wrap(err, "creating validation body")
 	}
 
 	fn := &astbuilder.FuncDetails{
@@ -282,7 +282,7 @@ func (v *ValidatorBuilder) validateBody(
 ) ([]dst.Stmt, error) {
 	overrideInterfaceType, err := astmodel.GenRuntimeValidatorInterfaceName.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", astmodel.GenRuntimeValidatorInterfaceName)
+		return nil, eris.Wrapf(err, "creating type expression for %s", astmodel.GenRuntimeValidatorInterfaceName)
 	}
 
 	validationsIdent := "validations"
@@ -375,12 +375,12 @@ func (v *ValidatorBuilder) makeLocalValidationFuncDetails(
 	receiverIdent := v.idFactory.CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	body, err := v.localValidationFuncBody(kind, codeGenerationContext, receiver)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create local validation function body for %s", methodName)
+		return nil, eris.Wrapf(err, "failed to create local validation function body for %s", methodName)
 	}
 
 	return &astbuilder.FuncDetails{
@@ -432,7 +432,7 @@ func (v *ValidatorBuilder) localValidationFuncBody(
 	}
 
 	if len(errs) > 0 {
-		return nil, errors.Wrap(
+		return nil, eris.Wrap(
 			kerrors.NewAggregate(errs),
 			"failed to create local validation function body")
 	}
@@ -477,7 +477,7 @@ func (v *ValidatorBuilder) makeLocalValidationElement(
 		// doesn't take any parameters, provide a wrapper
 		f, err := validation.asFunc(validation, codeGenerationContext, receiver, validation.name)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to create function for %s", validation.name)
+			return nil, eris.Wrapf(err, "unable to create function for %s", validation.name)
 		}
 
 		if f.Type.Params.NumFields() == 0 {

--- a/v2/tools/generator/internal/functions/kubernetes_config_exporter_function.go
+++ b/v2/tools/generator/internal/functions/kubernetes_config_exporter_function.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -88,7 +88,7 @@ func (d *KubernetesConfigExporterBuilder) exportKubernetesConfigMaps(
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	configMapsReference := codeGenerationContext.MustGetImportedPackageName(astmodel.GenRuntimeConfigMapsReference)
@@ -123,14 +123,14 @@ func (d *KubernetesConfigExporterBuilder) exportKubernetesConfigMaps(
 		for i := len(propertyPath) - 1; i >= 0; i -= 1 {
 			propType := propertyPath[i].PropertyType()
 			if _, ok := astmodel.AsMapType(propType); ok {
-				return nil, errors.Errorf(
+				return nil, eris.Errorf(
 					"Exporting Map elements as configmaps is not supported currently. Property %s has type %s",
 					propertyNames[i],
 					propType.String())
 			}
 
 			if _, ok := astmodel.AsArrayType(propType); ok {
-				return nil, errors.Errorf(
+				return nil, eris.Errorf(
 					"Exporting Slice elements as configmaps is not supported currently. Property %s has type %s",
 					propertyNames[i],
 					propType.String())
@@ -211,32 +211,32 @@ func (d *KubernetesConfigExporterBuilder) exportKubernetesConfigMaps(
 
 	contextTypeExpr, err := astmodel.ContextType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating context type expression")
+		return nil, eris.Wrap(err, "creating context type expression")
 	}
 	fn.AddParameter("_", contextTypeExpr)
 
 	metaObjectTypeExpr, err := astmodel.GenRuntimeMetaObjectType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating meta object type expression")
+		return nil, eris.Wrap(err, "creating meta object type expression")
 	}
 	fn.AddParameter("_", metaObjectTypeExpr)
 
 	clientTypeExpr, err := astmodel.NewOptionalType(astmodel.GenericClientType).AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating client type expression")
+		return nil, eris.Wrap(err, "creating client type expression")
 	}
 	fn.AddParameter("_", clientTypeExpr)
 
 	logrTypeExpr, err := astmodel.LogrType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating logr type expression")
+		return nil, eris.Wrap(err, "creating logr type expression")
 	}
 	fn.AddParameter("_", logrTypeExpr)
 
 	objectArrayType, err := astmodel.NewArrayType(astmodel.ControllerRuntimeObjectType).
 		AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating object array type expression")
+		return nil, eris.Wrap(err, "creating object array type expression")
 	}
 
 	fn.AddReturn(objectArrayType)

--- a/v2/tools/generator/internal/functions/locatable_resource_function.go
+++ b/v2/tools/generator/internal/functions/locatable_resource_function.go
@@ -7,7 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -37,7 +37,7 @@ func locatableResourceLocationFunc(
 	receiverIdent := k.idFactory.CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	locationSelector := astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec", "Location")
@@ -59,7 +59,7 @@ func locatableResourceLocationFunc(
 
 	stringTypeExpr, err := astmodel.StringType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating string type expression")
+		return nil, eris.Wrap(err, "creating string type expression")
 	}
 
 	fn.AddReturn(stringTypeExpr)

--- a/v2/tools/generator/internal/functions/new_empty_arm_value_function.go
+++ b/v2/tools/generator/internal/functions/new_empty_arm_value_function.go
@@ -7,7 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -39,14 +39,14 @@ func newEmptyARMValueBody(instanceType astmodel.InternalTypeName) ObjectFunction
 		receiverName := fn.IdFactory().CreateReceiver(receiver.Name())
 		receiverTypeExpr, err := receiver.AsTypeExpr(genContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+			return nil, eris.Wrapf(err, "creating type expression for %s", receiver)
 		}
 		receiverTypeExpr = astbuilder.PointerTo(receiverTypeExpr)
 
 		// return &<pkg.instanceType>{}
 		instanceTypeExpr, err := instanceType.AsTypeExpr(genContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating type expression for %s", instanceType)
+			return nil, eris.Wrapf(err, "creating type expression for %s", instanceType)
 		}
 
 		instance := astbuilder.NewCompositeLiteralBuilder(instanceTypeExpr)
@@ -61,7 +61,7 @@ func newEmptyARMValueBody(instanceType astmodel.InternalTypeName) ObjectFunction
 
 		armResourceStatusTypeExpr, err := astmodel.ARMResourceStatusType.AsTypeExpr(genContext)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating ARM resource status type expression")
+			return nil, eris.Wrap(err, "creating ARM resource status type expression")
 		}
 
 		details.AddReturn(armResourceStatusTypeExpr)

--- a/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
+++ b/v2/tools/generator/internal/functions/one_of_json_marshal_function.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -68,7 +68,7 @@ func (f *OneOfJSONMarshalFunction) AsFunc(
 	receiverName := f.idFactory.CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+		return nil, eris.Wrapf(err, "creating type expression for %s", receiver)
 	}
 
 	props := f.oneOfObject.Properties().AsSlice()

--- a/v2/tools/generator/internal/functions/one_of_json_unmarshal_function.go
+++ b/v2/tools/generator/internal/functions/one_of_json_unmarshal_function.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -62,14 +62,14 @@ func (f *OneOfJSONUnmarshalFunction) AsFunc(
 	receiverName := f.idFactory.CreateReceiver(receiver.Name())
 	receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+		return nil, eris.Wrapf(err, "creating type expression for %s", receiver)
 	}
 
 	allDefinitions := codeGenerationContext.GetAllReachableDefinitions()
 	discrimJSONName, valuesMapping, err := astmodel.DetermineDiscriminantAndValues(f.oneOfObject, allDefinitions)
 	if err != nil {
 		// Something went wrong; this late in the process we can't do anything about it
-		return nil, errors.Wrap(err, "unable to determine discriminant and values")
+		return nil, eris.Wrap(err, "unable to determine discriminant and values")
 	}
 
 	paramName := "data"

--- a/v2/tools/generator/internal/functions/original_gvk_function.go
+++ b/v2/tools/generator/internal/functions/original_gvk_function.go
@@ -7,7 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -74,7 +74,7 @@ func (o *OriginalGVKFunction) AsFunc(
 ) (*dst.FuncDecl, error) {
 	gvkType, err := astmodel.GroupVersionKindType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", astmodel.GroupVersionKindType)
+		return nil, eris.Wrapf(err, "creating type expression for %s", astmodel.GroupVersionKindType)
 	}
 
 	groupVersionPackageGlobal := dst.NewIdent("GroupVersion")
@@ -82,7 +82,7 @@ func (o *OriginalGVKFunction) AsFunc(
 	receiverName := o.idFactory.CreateReceiver(receiver.Name())
 	receiverTypeExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+		return nil, eris.Wrapf(err, "creating type expression for %s", receiver)
 	}
 
 	spec := astbuilder.Selector(dst.NewIdent(receiverName), "Spec")

--- a/v2/tools/generator/internal/functions/original_version_function.go
+++ b/v2/tools/generator/internal/functions/original_version_function.go
@@ -7,7 +7,7 @@ package functions
 
 import (
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -59,7 +59,7 @@ func (o *OriginalVersionFunction) AsFunc(
 	receiverName := o.idFactory.CreateReceiver(receiver.Name())
 	receiverTypeExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", receiver)
+		return nil, eris.Wrapf(err, "creating type expression for %s", receiver)
 	}
 
 	returnVersion := astbuilder.Returns(

--- a/v2/tools/generator/internal/functions/pivot_conversion_function.go
+++ b/v2/tools/generator/internal/functions/pivot_conversion_function.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -145,7 +145,7 @@ func (fn *PivotConversionFunction) AsFunc(
 	receiverType := astmodel.NewOptionalType(receiver)
 	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	funcDetails := &astbuilder.FuncDetails{
@@ -157,7 +157,7 @@ func (fn *PivotConversionFunction) AsFunc(
 	parameterName := fn.direction.SelectString("source", "destination")
 	parameterTypeExpr, err := fn.parameterType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating parameter type expression")
+		return nil, eris.Wrap(err, "creating parameter type expression")
 	}
 
 	funcDetails.AddParameter(parameterName, parameterTypeExpr)

--- a/v2/tools/generator/internal/functions/property_assignment_function.go
+++ b/v2/tools/generator/internal/functions/property_assignment_function.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/maps"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
@@ -138,12 +138,12 @@ func (fn *PropertyAssignmentFunction) AsFunc(
 	receiverType := astmodel.NewOptionalType(receiver)
 	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	body, err := fn.generateBody(fn.receiverName, fn.parameterName, codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to generate body for %s", fn.Name())
+		return nil, eris.Wrapf(err, "unable to generate body for %s", fn.Name())
 	}
 
 	funcDetails := &astbuilder.FuncDetails{
@@ -156,7 +156,7 @@ func (fn *PropertyAssignmentFunction) AsFunc(
 	parameterTypeExpr, err := astmodel.NewOptionalType(fn.ParameterType()).
 		AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating parameter type expression")
+		return nil, eris.Wrap(err, "creating parameter type expression")
 	}
 
 	funcDetails.AddParameter(fn.parameterName, parameterTypeExpr)
@@ -191,13 +191,13 @@ func (fn *PropertyAssignmentFunction) generateBody(
 	bagPrologue := fn.createPropertyBagPrologue(source, generationContext)
 	assignments, err := fn.generateAssignments(knownLocals, dst.NewIdent(source), dst.NewIdent(destination), generationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to generate assignments for %s", fn.Name())
+		return nil, eris.Wrapf(err, "unable to generate assignments for %s", fn.Name())
 	}
 
 	bagEpilogue := fn.propertyBagEpilogue(destination)
 	handleOverrideInterface, err := fn.handleAugmentationInterface(receiver, parameter, knownLocals, generationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "generating augmentation interface handling for %s", fn.Name())
+		return nil, eris.Wrapf(err, "generating augmentation interface handling for %s", fn.Name())
 	}
 
 	return astbuilder.Statements(
@@ -316,7 +316,7 @@ func (fn *PropertyAssignmentFunction) handleAugmentationInterface(
 
 	augmentationInterfaceExpr, err := fn.augmentationInterface.AsTypeExpr(generationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating augmentation interface type expression")
+		return nil, eris.Wrap(err, "creating augmentation interface type expression")
 	}
 
 	receiverAsAnyIdent := knownLocals.CreateLocal(receiver + "AsAny")
@@ -371,7 +371,7 @@ func (fn *PropertyAssignmentFunction) generateAssignments(
 		conversion := fn.conversions[prop]
 		block, err := conversion(source, destination, knownLocals, generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "property %s", prop)
+			return nil, eris.Wrapf(err, "property %s", prop)
 		}
 
 		if len(block) > 0 {

--- a/v2/tools/generator/internal/functions/property_assignment_function_builder.go
+++ b/v2/tools/generator/internal/functions/property_assignment_function_builder.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
@@ -175,7 +175,7 @@ func (builder *PropertyAssignmentFunctionBuilder) Build(
 			builder.receiverDefinition.Name().InternalPackageReference(),
 		)
 
-		return nil, errors.Wrapf(err, "creating '%s(%s)'", fnName, parameterType)
+		return nil, eris.Wrapf(err, "creating '%s(%s)'", fnName, parameterType)
 	}
 
 	result := &PropertyAssignmentFunction{
@@ -247,7 +247,7 @@ func (builder *PropertyAssignmentFunctionBuilder) createConversions(
 		conv, err := builder.createConversion(sourceEndpoint, destinationEndpoint, conversionContext)
 		if err != nil {
 			// An error was returned, we abort creating conversions for this object
-			return errors.Wrapf(
+			return eris.Wrapf(
 				err,
 				"creating conversion to %s by %s",
 				destinationEndpoint,
@@ -311,7 +311,7 @@ func (builder *PropertyAssignmentFunctionBuilder) createConversion(
 		destinationEndpoint.Endpoint(),
 		conversionContext)
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"trying to %s and %s",
 			sourceEndpoint, destinationEndpoint)
@@ -330,7 +330,7 @@ func (builder *PropertyAssignmentFunctionBuilder) createConversion(
 
 		stmts, err := conversion(reader, writer, knownLocals, generationContext)
 		if err != nil {
-			return nil, errors.Wrapf(
+			return nil, eris.Wrapf(
 				err,
 				"converting %s to %s",
 				sourceEndpoint, destinationEndpoint)
@@ -379,7 +379,7 @@ func (*PropertyAssignmentFunctionBuilder) selectIdenticallyNamedProperties(
 
 			err := assign(sourceEndpoint, destinationEndpoint)
 			if err != nil {
-				return errors.Wrapf(err, "assigning %s", destinationName)
+				return eris.Wrapf(err, "assigning %s", destinationName)
 			}
 		}
 	}
@@ -436,7 +436,7 @@ func (builder *PropertyAssignmentFunctionBuilder) selectPropertiesWithIdenticalP
 
 			if sourceEndpoint != nil {
 				// We've found multiple candidates - we can't handle this
-				return errors.Errorf(
+				return eris.Errorf(
 					"multiple source properties with path %s are compatible with destination %s, no way to select",
 					path,
 					destinationName)
@@ -449,7 +449,7 @@ func (builder *PropertyAssignmentFunctionBuilder) selectPropertiesWithIdenticalP
 		if sourceEndpoint != nil {
 			err := assign(sourceEndpoint, destinationEndpoint)
 			if err != nil {
-				return errors.Wrapf(err, "assigning %s", destinationName)
+				return eris.Wrapf(err, "assigning %s", destinationName)
 			}
 		}
 	}
@@ -502,7 +502,7 @@ func (builder *PropertyAssignmentFunctionBuilder) selectRenamedProperties(
 		if destinationEndpoint, ok := destinationProperties[destinationName]; ok {
 			err := assign(sourceEndpoint, destinationEndpoint)
 			if err != nil {
-				return errors.Wrapf(err, "assigning %s", destinationName)
+				return eris.Wrapf(err, "assigning %s", destinationName)
 			}
 		}
 	}
@@ -541,7 +541,7 @@ func (builder *PropertyAssignmentFunctionBuilder) readPropertiesFromPropertyBag(
 		sourceEndpoint := conversions.NewReadableConversionEndpointReadingPropertyBagMember(destinationName, typeToRead)
 		err := assign(sourceEndpoint, destinationEndpoint)
 		if err != nil {
-			return errors.Wrapf(err, "assigning %s from property bag", destinationName)
+			return eris.Wrapf(err, "assigning %s from property bag", destinationName)
 		}
 
 		builder.readsFromPropertyBag = true
@@ -581,7 +581,7 @@ func (builder *PropertyAssignmentFunctionBuilder) writePropertiesToPropertyBag(
 		destinationEndpoint := conversions.NewWritableConversionEndpointWritingPropertyBagMember(sourceName, typeToWrite)
 		err := assign(sourceEndpoint, destinationEndpoint)
 		if err != nil {
-			return errors.Wrapf(err, "assigning %s to property bag", sourceName)
+			return eris.Wrapf(err, "assigning %s to property bag", sourceName)
 		}
 
 		builder.writesToPropertyBag = true
@@ -610,7 +610,7 @@ func (builder *PropertyAssignmentFunctionBuilder) createSuffixMatchingAssignment
 			if sourceEndpoint, ok := sourceProperties[sourceName]; ok {
 				err := assign(sourceEndpoint, destinationEndpoint)
 				if err != nil {
-					return errors.Wrapf(err, "assigning %s", destinationName)
+					return eris.Wrapf(err, "assigning %s", destinationName)
 				}
 			}
 		}

--- a/v2/tools/generator/internal/functions/resource_conversion_function.go
+++ b/v2/tools/generator/internal/functions/resource_conversion_function.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -108,7 +108,7 @@ func (fn *ResourceConversionFunction) AsFunc(
 	receiverType := astmodel.NewOptionalType(receiver)
 	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	funcDetails := &astbuilder.FuncDetails{
@@ -127,7 +127,7 @@ func (fn *ResourceConversionFunction) AsFunc(
 		// Not using an intermediate step
 		body, err := fn.directConversion(receiverName, codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating direct conversion body")
+			return nil, eris.Wrap(err, "creating direct conversion body")
 		}
 
 		funcDetails.Body = body
@@ -138,7 +138,7 @@ func (fn *ResourceConversionFunction) AsFunc(
 			WhenFrom(func() { body, err = fn.indirectConversionFromHub(receiverName, codeGenerationContext) }).
 			WhenTo(func() { body, err = fn.indirectConversionToHub(receiverName, codeGenerationContext) })
 		if err != nil {
-			return nil, errors.Wrap(err, "creating indirect conversion body")
+			return nil, eris.Wrap(err, "creating indirect conversion body")
 		}
 
 		funcDetails.Body = body
@@ -178,7 +178,7 @@ func (fn *ResourceConversionFunction) directConversion(
 
 	hubExpr, err := fn.hub.AsTypeExpr(generationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", fn.hub)
+		return nil, eris.Wrapf(err, "creating type expression for %s", fn.hub)
 	}
 
 	assignLocal := astbuilder.TypeAssert(
@@ -229,7 +229,7 @@ func (fn *ResourceConversionFunction) indirectConversionFromHub(
 	intermediateType := fn.propertyFunction.ParameterType()
 	intermediateTypeExpr, err := intermediateType.AsTypeExpr(generationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating type expression for intermediate type")
+		return nil, eris.Wrap(err, "creating type expression for intermediate type")
 	}
 
 	declareLocal := astbuilder.LocalVariableDeclaration(
@@ -293,7 +293,7 @@ func (fn *ResourceConversionFunction) indirectConversionToHub(
 	intermediateType := fn.propertyFunction.ParameterType()
 	intermediateTypeExpr, err := intermediateType.AsTypeExpr(generationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating type expression for intermediate type")
+		return nil, eris.Wrap(err, "creating type expression for intermediate type")
 	}
 
 	declareLocal := astbuilder.LocalVariableDeclaration(

--- a/v2/tools/generator/internal/functions/resource_status_setter_function.go
+++ b/v2/tools/generator/internal/functions/resource_status_setter_function.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -65,7 +65,7 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 	receiverType := astmodel.NewOptionalType(receiver)
 	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	statusLocal := "st"
@@ -131,14 +131,14 @@ func (fn ResourceStatusSetterFunction) AsFunc(
 
 	convertibleStatusInterfaceTypeExpr, err := astmodel.ConvertibleStatusInterfaceType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating convertible status interface type expression")
+		return nil, eris.Wrap(err, "creating convertible status interface type expression")
 	}
 
 	builder.AddParameter(statusParameter, convertibleStatusInterfaceTypeExpr)
 
 	errorTypeExpr, err := astmodel.ErrorType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating error type expression")
+		return nil, eris.Wrap(err, "creating error type expression")
 	}
 
 	builder.AddReturn(errorTypeExpr)

--- a/v2/tools/generator/internal/interfaces/defaulter_interface.go
+++ b/v2/tools/generator/internal/interfaces/defaulter_interface.go
@@ -6,7 +6,7 @@
 package interfaces
 
 import (
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/functions"
@@ -19,7 +19,7 @@ func AddDefaulterInterface(
 ) (astmodel.TypeDefinition, error) {
 	resourceType, ok := resourceDef.Type().(*astmodel.ResourceType)
 	if !ok {
-		return astmodel.TypeDefinition{}, errors.Errorf("cannot add defaulter interface to non-resource type: %s %T", resourceDef.Name(), resourceDef.Type())
+		return astmodel.TypeDefinition{}, eris.Errorf("cannot add defaulter interface to non-resource type: %s %T", resourceDef.Name(), resourceDef.Type())
 	}
 
 	defaulterBuilder := functions.NewDefaulterBuilder(resourceDef.Name(), resourceType, idFactory)

--- a/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/interfaces/kubernetes_resource_interface.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/dave/dst"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
@@ -30,7 +30,7 @@ func AddKubernetesResourceInterfaceImpls(
 ) (astmodel.TypeDefinitionSet, error) {
 	resolved, err := definitions.ResolveResourceSpecAndStatus(resourceDef)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to resolve resource %s", resourceDef.Name())
+		return nil, eris.Wrapf(err, "unable to resolve resource %s", resourceDef.Name())
 	}
 
 	specDef := resolved.SpecDef
@@ -41,13 +41,13 @@ func AddKubernetesResourceInterfaceImpls(
 		ownerProperty := idFactory.CreatePropertyName(astmodel.OwnerProperty, astmodel.Exported)
 		_, ok := resolved.SpecType.Property(ownerProperty)
 		if !ok {
-			return nil, errors.Errorf("resource spec doesn't have %q property", ownerProperty)
+			return nil, eris.Errorf("resource spec doesn't have %q property", ownerProperty)
 		}
 	}
 
 	azureNameProp, ok := resolved.SpecType.Property(astmodel.AzureNameProperty)
 	if !ok {
-		return nil, errors.Errorf("resource spec doesn't have %q property", astmodel.AzureNameProperty)
+		return nil, eris.Errorf("resource spec doesn't have %q property", astmodel.AzureNameProperty)
 	}
 
 	nameFns, err := createAzureNameFunctionHandlersForType(azureNameProp.PropertyType(), definitions, log)
@@ -62,7 +62,7 @@ func AddKubernetesResourceInterfaceImpls(
 		var updated astmodel.TypeDefinition
 		updated, err = remover.Remove(resolved.SpecDef, astmodel.AzureNameProperty)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to remove AzureName property from resource %s", resourceDef.Name())
+			return nil, eris.Wrapf(err, "failed to remove AzureName property from resource %s", resourceDef.Name())
 		}
 
 		specDef = updated
@@ -116,7 +116,7 @@ func AddKubernetesResourceInterfaceImpls(
 				"Unable to create NewEmptyStatus() for resource %s (expected Status to be a TypeName but had %T)",
 				resourceDef.Name(),
 				r.StatusType())
-			return nil, errors.New(msg)
+			return nil, eris.New(msg)
 		}
 
 		emptyStatusFunction := functions.NewEmptyStatusFunction(status, idFactory)
@@ -131,7 +131,7 @@ func AddKubernetesResourceInterfaceImpls(
 	interfaceInjector := astmodel.NewInterfaceInjector()
 	updatedResource, err := interfaceInjector.Inject(resolved.ResourceDef, kubernetesResourceImplementation)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to inject KubernetesResource interface into resource %s", resourceDef.Name())
+		return nil, eris.Wrapf(err, "failed to inject KubernetesResource interface into resource %s", resourceDef.Name())
 	}
 
 	if nameFns.setNameFunction != nil {
@@ -143,7 +143,7 @@ func AddKubernetesResourceInterfaceImpls(
 
 		updated, err := functionInjector.Inject(specDef, setFn)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to inject SetAzureName function into resource %s", resourceDef.Name())
+			return nil, eris.Wrapf(err, "failed to inject SetAzureName function into resource %s", resourceDef.Name())
 		}
 
 		specDef = updated
@@ -171,7 +171,7 @@ func createAzureNameFunctionHandlersForType(
 	case *astmodel.ValidatedType:
 		if !astmodel.TypeEquals(azureNamePropType.ElementType(), astmodel.StringType) {
 			return createAzureNameFunctionsForTypeResult{},
-				errors.Errorf("unable to handle non-string validated definitions in AzureName property")
+				eris.Errorf("unable to handle non-string validated definitions in AzureName property")
 		}
 
 		validations := azureNamePropType.Validations().(astmodel.StringValidations)
@@ -205,13 +205,13 @@ func createAzureNameFunctionHandlersForType(
 		resolvedPropType, err := definitions.FullyResolve(azureNamePropType)
 		if err != nil {
 			return createAzureNameFunctionsForTypeResult{},
-				errors.Wrapf(err, "unable to resolve type of resource Name property: %s", azureNamePropType.String())
+				eris.Wrapf(err, "unable to resolve type of resource Name property: %s", azureNamePropType.String())
 		}
 
 		if t, ok := resolvedPropType.(*astmodel.EnumType); ok {
 			if !astmodel.TypeEquals(t.BaseType(), astmodel.StringType) {
 				return createAzureNameFunctionsForTypeResult{},
-					errors.Errorf("unable to handle non-string enum base type in Name property")
+					eris.Errorf("unable to handle non-string enum base type in Name property")
 			}
 
 			options := t.Options()
@@ -234,12 +234,12 @@ func createAzureNameFunctionHandlersForType(
 		}
 
 		return createAzureNameFunctionsForTypeResult{},
-			errors.Errorf("unable to produce AzureName()/SetAzureName() for Name property with type %s", resolvedPropType.String())
+			eris.Errorf("unable to produce AzureName()/SetAzureName() for Name property with type %s", resolvedPropType.String())
 
 	case *astmodel.PrimitiveType:
 		if !astmodel.TypeEquals(azureNamePropType, astmodel.StringType) {
 			return createAzureNameFunctionsForTypeResult{},
-				errors.Errorf("cannot use type %s as type of AzureName property", azureNamePropType.String())
+				eris.Errorf("cannot use type %s as type of AzureName property", azureNamePropType.String())
 		}
 
 		return createAzureNameFunctionsForTypeResult{
@@ -249,7 +249,7 @@ func createAzureNameFunctionHandlersForType(
 
 	default:
 		return createAzureNameFunctionsForTypeResult{},
-			errors.Errorf("unsupported type for AzureName property: %s", azureNamePropType.String())
+			eris.Errorf("unsupported type for AzureName property: %s", azureNamePropType.String())
 	}
 }
 
@@ -271,7 +271,7 @@ func getEnumAzureNameFunction(enumType astmodel.TypeName) functions.ObjectFuncti
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 		receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating receiver type expression")
+			return nil, eris.Wrap(err, "creating receiver type expression")
 		}
 
 		fn := &astbuilder.FuncDetails{
@@ -301,7 +301,7 @@ func setEnumAzureNameFunction(enumType astmodel.TypeName) functions.ObjectFuncti
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 		receiverTypeExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating receiver type expression")
+			return nil, eris.Wrap(err, "creating receiver type expression")
 		}
 
 		azureNameProp := astbuilder.Selector(dst.NewIdent(receiverIdent), astmodel.AzureNameProperty)
@@ -343,7 +343,7 @@ func fixedValueGetAzureNameFunction(fixedValue string) functions.ObjectFunctionH
 		receiverIdent := f.IdFactory().CreateReceiver(receiver.Name())
 		receiverExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating receiver type expression")
+			return nil, eris.Wrap(err, "creating receiver type expression")
 		}
 
 		fn := &astbuilder.FuncDetails{
@@ -384,7 +384,7 @@ func getOwnerFunction(
 	receiverType := astmodel.NewOptionalType(receiver)
 	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	specSelector := astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec")
@@ -396,7 +396,7 @@ func getOwnerFunction(
 	}
 	resourceReferenceTypeExpr, err := astmodel.ResourceReferenceType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating resource reference type expression")
+		return nil, eris.Wrap(err, "creating resource reference type expression")
 	}
 
 	fn.AddReturn(astbuilder.Dereference(resourceReferenceTypeExpr))
@@ -451,7 +451,7 @@ func getResourceScopeFunction(
 	receiverType := astmodel.NewOptionalType(receiver)
 	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	var resourceScope string
@@ -481,7 +481,7 @@ func getResourceScopeFunction(
 	fn.AddComments("returns the scope of the resource")
 	resourceScopeTypeExpr, err := astmodel.ResourceScopeType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating resource scope type expression")
+		return nil, eris.Wrap(err, "creating resource scope type expression")
 	}
 
 	fn.AddReturn(resourceScopeTypeExpr)
@@ -508,7 +508,7 @@ func getSupportedOperationsFunction(
 	receiverType := astmodel.NewOptionalType(receiver)
 	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	genruntimePackage := codeGenerationContext.MustGetImportedPackageName(astmodel.GenRuntimeReference)
@@ -533,7 +533,7 @@ func getSupportedOperationsFunction(
 
 	resourceOperationTypeExpr, err := astmodel.ResourceOperationType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating resource operation type expression")
+		return nil, eris.Wrap(err, "creating resource operation type expression")
 	}
 
 	sliceBuilder := astbuilder.NewSliceLiteralBuilder(resourceOperationTypeExpr, true)
@@ -554,7 +554,7 @@ func getSupportedOperationsFunction(
 	fn.AddComments("returns the operations supported by the resource")
 	resourceOperationTypeArrayExpr, err := astmodel.ResourceOperationTypeArray.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating resource operation type array expression")
+		return nil, eris.Wrap(err, "creating resource operation type array expression")
 	}
 
 	fn.AddReturn(resourceOperationTypeArrayExpr)
@@ -607,7 +607,7 @@ func setStringAzureNameFunction(
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverTypeExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	fn := &astbuilder.FuncDetails{
@@ -638,7 +638,7 @@ func getStringAzureNameFunction(
 	receiverIdent := k.IdFactory().CreateReceiver(receiver.Name())
 	receiverTypeExpr, err := receiver.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	fn := &astbuilder.FuncDetails{

--- a/v2/tools/generator/internal/interfaces/validator_interface.go
+++ b/v2/tools/generator/internal/interfaces/validator_interface.go
@@ -6,7 +6,7 @@
 package interfaces
 
 import (
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/functions"
@@ -20,7 +20,7 @@ func AddValidatorInterface(
 ) (astmodel.TypeDefinition, error) {
 	rt, ok := astmodel.AsResourceType(resourceDef.Type())
 	if !ok {
-		return astmodel.TypeDefinition{}, errors.Errorf("unable to resolve resource %s", resourceDef.Name())
+		return astmodel.TypeDefinition{}, eris.Errorf("unable to resolve resource %s", resourceDef.Name())
 	}
 
 	validatorBuilder := functions.NewValidatorBuilder(resourceDef.Name(), rt, idFactory)

--- a/v2/tools/generator/internal/jsonast/openapi_file_loader.go
+++ b/v2/tools/generator/internal/jsonast/openapi_file_loader.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/go-openapi/spec"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
@@ -74,12 +74,12 @@ func (fileCache CachingFileLoader) loadFile(absPath string) (PackageAndSwagger, 
 
 	fileContent, err := os.ReadFile(absPath)
 	if err != nil {
-		return result, errors.Wrapf(err, "unable to read swagger file %q", absPath)
+		return result, eris.Wrapf(err, "unable to read swagger file %q", absPath)
 	}
 
 	err = result.Swagger.UnmarshalJSON(fileContent)
 	if err != nil {
-		return result, errors.Wrapf(err, "unable to parse swagger file %q", absPath)
+		return result, eris.Wrapf(err, "unable to parse swagger file %q", absPath)
 	}
 
 	fileCache.files[key] = result

--- a/v2/tools/generator/internal/jsonast/schema_abstraction_gojson.go
+++ b/v2/tools/generator/internal/jsonast/schema_abstraction_gojson.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
@@ -290,7 +290,7 @@ func objectTypeOf(url *url.URL) (string, error) {
 	fragmentParts := strings.FieldsFunc(url.Fragment, isURLPathSeparator)
 
 	if len(fragmentParts) == 0 {
-		return "", errors.Errorf("unexpected URL format: no fragment parts extracted from %q", url.String())
+		return "", eris.Errorf("unexpected URL format: no fragment parts extracted from %q", url.String())
 	}
 
 	return fragmentParts[len(fragmentParts)-1], nil
@@ -305,7 +305,7 @@ func groupOf(url *url.URL) (string, error) {
 
 	file := pathParts[len(pathParts)-1]
 	if !strings.HasSuffix(file, ".json") {
-		return "", errors.Errorf("unexpected URL format (doesn't point to .json file)")
+		return "", eris.Errorf("unexpected URL format (doesn't point to .json file)")
 	}
 
 	return strings.TrimSuffix(file, ".json"), nil

--- a/v2/tools/generator/internal/jsonast/schema_abstraction_openapi.go
+++ b/v2/tools/generator/internal/jsonast/schema_abstraction_openapi.go
@@ -16,7 +16,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-openapi/jsonpointer"
 	"github.com/go-openapi/spec"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -370,13 +370,12 @@ func (schema *OpenAPISchema) refTypeName() (astmodel.InternalTypeName, error) {
 			// or is nil (so could be set to the pulling-in package)
 			if otherSchema.Package == nil || otherSchema.Package.Equals(schema.outputPackage) {
 				if _, ok := otherSchema.Swagger.Definitions[name]; ok {
-					return astmodel.InternalTypeName{}, errors.Errorf(
+					return astmodel.InternalTypeName{}, eris.Errorf(
 						"importing type %s from file %s into package %s could generate collision with type in %s",
 						name,
 						absRefPath,
 						pkg,
-						otherFile,
-					)
+						otherFile)
 				}
 			}
 		}
@@ -474,7 +473,7 @@ func objectNameFromPointer(ptr *jsonpointer.Pointer) string {
 // resolveAbsolutePath makes an absolute path by combining 'baseFileName' and 'url'
 func resolveAbsolutePath(baseFileName string, url *url.URL) (string, error) {
 	if url.IsAbs() {
-		return "", errors.Errorf("absolute path %q not supported (only relative URLs)", url)
+		return "", eris.Errorf("absolute path %q not supported (only relative URLs)", url)
 	}
 
 	dir := filepath.Dir(baseFileName)

--- a/v2/tools/generator/internal/kustomization/conversion_patch_file.go
+++ b/v2/tools/generator/internal/kustomization/conversion_patch_file.go
@@ -8,7 +8,7 @@ package kustomization
 import (
 	"os"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"gopkg.in/yaml.v3"
 )
 
@@ -82,12 +82,12 @@ func NewConversionPatchFile(resourceName string) *ConversionPatchFile {
 func (p *ConversionPatchFile) Save(destination string) error {
 	data, err := yaml.Marshal(*p)
 	if err != nil {
-		return errors.Wrap(err, "serializing to yaml")
+		return eris.Wrap(err, "serializing to yaml")
 	}
 
 	err = os.WriteFile(destination, data, 0o644) // #nosec G306
 	if err != nil {
-		return errors.Wrapf(err, "writing to %s", destination)
+		return eris.Wrapf(err, "writing to %s", destination)
 	}
 
 	return nil

--- a/v2/tools/generator/internal/kustomization/crd_kustomization_file.go
+++ b/v2/tools/generator/internal/kustomization/crd_kustomization_file.go
@@ -8,7 +8,7 @@ package kustomization
 import (
 	"os"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"gopkg.in/yaml.v3"
 )
 
@@ -54,12 +54,12 @@ func (k *CRDKustomizeFile) AddConfiguration(configFilePath string) {
 func (k *CRDKustomizeFile) Save(destination string) error {
 	data, err := yaml.Marshal(*k)
 	if err != nil {
-		return errors.Wrap(err, "serializing to yaml")
+		return eris.Wrap(err, "serializing to yaml")
 	}
 
 	err = os.WriteFile(destination, data, 0o644) // #nosec G306
 	if err != nil {
-		return errors.Wrapf(err, "writing to %s", destination)
+		return eris.Wrapf(err, "writing to %s", destination)
 	}
 
 	return nil

--- a/v2/tools/generator/internal/kustomization/resource_definition.go
+++ b/v2/tools/generator/internal/kustomization/resource_definition.go
@@ -8,7 +8,7 @@ package kustomization
 import (
 	"os"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"gopkg.in/yaml.v3"
 )
 
@@ -19,13 +19,13 @@ type ResourceDefinition struct {
 func LoadResourceDefinition(filePath string) (*ResourceDefinition, error) {
 	fileBytes, err := os.ReadFile(filePath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "reading resource definition from %s", filePath)
+		return nil, eris.Wrapf(err, "reading resource definition from %s", filePath)
 	}
 
 	result := &ResourceDefinition{}
 	err = yaml.Unmarshal(fileBytes, result)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unmarshalling resource definition from %s", filePath)
+		return nil, eris.Wrapf(err, "unmarshalling resource definition from %s", filePath)
 	}
 
 	return result, nil

--- a/v2/tools/generator/internal/reporting/type_catalog_report.go
+++ b/v2/tools/generator/internal/reporting/type_catalog_report.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 
 	"github.com/Azure/azure-service-operator/v2/internal/set"
@@ -131,7 +131,7 @@ func (tcr *TypeCatalogReport) WriteTo(writer io.Writer) error {
 
 		err := rpt.SaveTo(writer)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create type catalog report for %s", pkg.PackagePath())
+			return eris.Wrapf(err, "failed to create type catalog report for %s", pkg.PackagePath())
 		}
 	}
 

--- a/v2/tools/generator/internal/test/fake_function.go
+++ b/v2/tools/generator/internal/test/fake_function.go
@@ -7,7 +7,7 @@ package test
 
 import (
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -58,7 +58,7 @@ func (fake *FakeFunction) AsFunc(
 	receiverType := astmodel.NewOptionalType(receiver)
 	receiverTypeExpr, err := receiverType.AsTypeExpr(codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating receiver type expression")
+		return nil, eris.Wrap(err, "creating receiver type expression")
 	}
 
 	details := astbuilder.FuncDetails{
@@ -70,7 +70,7 @@ func (fake *FakeFunction) AsFunc(
 	if fake.TypeReturned != nil {
 		typeReturnedExpr, err := fake.TypeReturned.AsTypeExpr(codeGenerationContext)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating type returned expression")
+			return nil, eris.Wrap(err, "creating type returned expression")
 		}
 
 		details.AddReturn(typeReturnedExpr)

--- a/v2/tools/generator/internal/test/type_asserter.go
+++ b/v2/tools/generator/internal/test/type_asserter.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/kylelemons/godebug/diff"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"github.com/sebdah/goldie/v2"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -151,7 +151,7 @@ func (a *typeAsserter) renderDefs(
 	fileWriter := astmodel.NewGoSourceFileWriter(file)
 	err := fileWriter.SaveToWriter(buf)
 	if err != nil {
-		return "", errors.Wrap(err, "could not generate code file")
+		return "", eris.Wrap(err, "could not generate code file")
 	}
 
 	return buf.String(), nil

--- a/v2/tools/generator/internal/testcases/json_serialization_test_case.go
+++ b/v2/tools/generator/internal/testcases/json_serialization_test_case.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
@@ -103,7 +103,7 @@ func (o *JSONSerializationTestCase) AsFuncs(
 	// Write errors for any properties we don't handle
 	errs := make([]error, 0, len(properties))
 	for _, p := range properties {
-		errs = append(errs, errors.Errorf("no generator created for %s (%s)", p.PropertyName(), p.PropertyType()))
+		errs = append(errs, eris.Errorf("no generator created for %s (%s)", p.PropertyName(), p.PropertyType()))
 	}
 
 	err := kerrors.NewAggregate(errs)

--- a/v2/tools/generator/internal/testcases/property_assignment_test_case.go
+++ b/v2/tools/generator/internal/testcases/property_assignment_test_case.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -122,7 +122,7 @@ func (p *PropertyAssignmentTestCase) AsFuncs(
 	testRunner := p.createTestRunner(codeGenerationContext)
 	testMethod, err := p.createTestMethod(receiver, codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating test method for %s", p.testName)
+		return nil, eris.Wrapf(err, "creating test method for %s", p.testName)
 	}
 
 	return []dst.Decl{
@@ -260,7 +260,7 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 	// var other OtherType
 	parameterTypeExpr, err := p.toFn.ParameterType().AsTypeExpr(codegenContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", p.toFn.ParameterType())
+		return nil, eris.Wrapf(err, "creating type expression for %s", p.toFn.ParameterType())
 	}
 
 	declareOther := astbuilder.LocalVariableDeclaration(
@@ -285,7 +285,7 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 	// var result OurType
 	subjectExpr, err := subject.AsTypeExpr(codegenContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", subject)
+		return nil, eris.Wrapf(err, "creating type expression for %s", subject)
 	}
 
 	declareResult := astbuilder.LocalVariableDeclaration(
@@ -370,7 +370,7 @@ func (p *PropertyAssignmentTestCase) createTestMethod(
 
 	subjectExpr, err = p.subject.AsTypeExpr(codegenContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", p.subject)
+		return nil, eris.Wrapf(err, "creating type expression for %s", p.subject)
 	}
 
 	fn.AddParameter("subject", subjectExpr)

--- a/v2/tools/generator/internal/testcases/resource_conversion_test_case.go
+++ b/v2/tools/generator/internal/testcases/resource_conversion_test_case.go
@@ -10,7 +10,7 @@ import (
 	"go/token"
 
 	"github.com/dave/dst"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -44,7 +44,7 @@ func NewResourceConversionTestCase(
 
 	conversionImplementation, ok := resourceType.FindInterface(astmodel.ConvertibleInterface)
 	if !ok {
-		return nil, errors.Errorf("expected %s to implement conversions.Convertible including ConvertTo() and ConvertFrom()", name)
+		return nil, eris.Errorf("expected %s to implement conversions.Convertible including ConvertTo() and ConvertFrom()", name)
 	}
 
 	// Find ConvertTo and ConvertFrom functions from the implementation
@@ -60,15 +60,15 @@ func NewResourceConversionTestCase(
 
 	// Fail fast if something goes wrong
 	if result.fromFn == nil {
-		return nil, errors.Errorf("expected to find function ConvertFrom() on %s", name)
+		return nil, eris.Errorf("expected to find function ConvertFrom() on %s", name)
 	}
 
 	if result.toFn == nil {
-		return nil, errors.Errorf("expected to find function ConvertTo() on %s", name)
+		return nil, eris.Errorf("expected to find function ConvertTo() on %s", name)
 	}
 
 	if !astmodel.TypeEquals(result.fromFn.Hub(), result.toFn.Hub()) {
-		return nil, errors.Errorf(
+		return nil, eris.Errorf(
 			"expected ConvertFrom(%s) and ConvertTo(%s) on %s to have the same parameter type",
 			result.fromFn.Hub(),
 			result.toFn.Hub(),
@@ -126,7 +126,7 @@ func (tc *ResourceConversionTestCase) AsFuncs(
 	testRunner := tc.createTestRunner(codeGenerationContext)
 	testMethod, err := tc.createTestMethod(receiver, codeGenerationContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating test method for %s", tc.subject.Name())
+		return nil, eris.Wrapf(err, "creating test method for %s", tc.subject.Name())
 	}
 
 	return []dst.Decl{
@@ -296,7 +296,7 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 	// var hub OtherType
 	hubExpr, err := tc.toFn.Hub().AsTypeExpr(codegenContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", tc.toFn.Hub())
+		return nil, eris.Wrapf(err, "creating type expression for %s", tc.toFn.Hub())
 	}
 
 	declareOther := astbuilder.LocalVariableDeclaration(
@@ -321,7 +321,7 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 	// var result OurType
 	subjectExpr, err := subject.AsTypeExpr(codegenContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", subject)
+		return nil, eris.Wrapf(err, "creating type expression for %s", subject)
 	}
 
 	declareResult := astbuilder.LocalVariableDeclaration(
@@ -405,7 +405,7 @@ func (tc *ResourceConversionTestCase) createTestMethod(
 
 	subjectExpr, err = tc.subject.AsTypeExpr(codegenContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating type expression for %s", tc.subject)
+		return nil, eris.Wrapf(err, "creating type expression for %s", tc.subject)
 	}
 
 	fn.AddParameter("subject", subjectExpr)


### PR DESCRIPTION
## What this PR does

Migrates our code generator to use `github.com/rotisserie/eris`.

The code was changed using `gopatch`:

``` bash
$ gopatch --patch=../../../eris.patch --verbose .
```

and then cleaned up using `golangci-lint`:

``` bash
$ golangci-lint run --fix ./...
```

I've attached the [patch file](https://github.com/user-attachments/files/17808165/eris.patch) for reference.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/mUcRddsLnHbxu/giphy.gif?cid=790b7611zlkqrz82ksxk49g73wd5zlnzlsajsx4dzfl9igk3&ep=v1_gifs_search&rid=giphy.gif&ct=g)
