### PR TITLE
Add description override codegenerator option

### DIFF
--- a/v2/api/network/v1api20201101/virtual_networks_subnet_types_gen.go
+++ b/v2/api/network/v1api20201101/virtual_networks_subnet_types_gen.go
@@ -1164,7 +1164,8 @@ type VirtualNetworksSubnet_STATUS struct {
 	// IpConfigurationProfiles: Array of IP configuration profiles which reference this subnet.
 	IpConfigurationProfiles []IPConfigurationProfile_STATUS `json:"ipConfigurationProfiles,omitempty"`
 
-	// IpConfigurations: An array of references to the network interface IP configurations using subnet.
+	// IpConfigurations: An array of references to the network interface IP configurations using subnet. This field is not
+	// included if there are more than 2000 entries.
 	IpConfigurations []IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded `json:"ipConfigurations,omitempty"`
 
 	// Name: The name of the resource that is unique within a resource group. This name can be used to access the resource.

--- a/v2/api/network/v1api20240301/virtual_networks_subnet_types_gen.go
+++ b/v2/api/network/v1api20240301/virtual_networks_subnet_types_gen.go
@@ -1409,7 +1409,8 @@ type VirtualNetworksSubnet_STATUS struct {
 	// IpConfigurationProfiles: Array of IP configuration profiles which reference this subnet.
 	IpConfigurationProfiles []IPConfigurationProfile_STATUS `json:"ipConfigurationProfiles,omitempty"`
 
-	// IpConfigurations: An array of references to the network interface IP configurations using subnet.
+	// IpConfigurations: An array of references to the network interface IP configurations using subnet. This field is not
+	// included if there are more than 2000 entries.
 	IpConfigurations []IPConfiguration_STATUS_VirtualNetworks_Subnet_SubResourceEmbedded `json:"ipConfigurations,omitempty"`
 
 	// Name: The name of the resource that is unique within a resource group. This name can be used to access the resource.

--- a/v2/azure-arm.yaml
+++ b/v2/azure-arm.yaml
@@ -895,6 +895,9 @@ status:
 #     Set to 'false' to disable our heuristics if a property is incorrectly 
 #     identified as an ARM reference.
 #
+# $description: <string>
+#     Overrides the property description with the provided value.
+#
 # $importConfigMapMode: <optional|required>
 #     Specifies that the property can be imported from a config map.
 #     Optional: The property may be specified as string or imported from a config map.
@@ -3104,6 +3107,9 @@ objectModelConfiguration:
       VirtualNetworks_Subnet: # TODO: There must always be a parent and child in the same API version. See https://github.com/Azure/azure-service-operator/issues/3002
         $exportAs: VirtualNetworksSubnet
         $supportedFrom: v2.0.0-alpha.1
+      VirtualNetworksSubnet_STATUS:
+        IpConfigurations:
+          $description: "An array of references to the network interface IP configurations using subnet. This field is not included if there are more than 2000 entries."
       VirtualNetworks_VirtualNetworkPeering:
         $exportAs: VirtualNetworksVirtualNetworkPeering
         $supportedFrom: v2.0.0-alpha.1
@@ -3409,6 +3415,9 @@ objectModelConfiguration:
       VirtualNetworks_Subnet: # TODO: There must always be a parent and child in the same API version. See https://github.com/Azure/azure-service-operator/issues/3002
         $exportAs: VirtualNetworksSubnet
         $supportedFrom: v2.11.0
+      VirtualNetworksSubnet_STATUS:
+        IpConfigurations:
+          $description: "An array of references to the network interface IP configurations using subnet. This field is not included if there are more than 2000 entries."
       VirtualNetworks_VirtualNetworkPeering:
         $exportAs: VirtualNetworksVirtualNetworkPeering
         $supportedFrom: v2.11.0

--- a/v2/cmd/asoctl/go.mod
+++ b/v2/cmd/asoctl/go.mod
@@ -103,7 +103,6 @@ require (
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/rotisserie/eris v0.5.4 // indirect
 	github.com/samber/lo v1.47.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -199,6 +199,7 @@ func createAllPipelineStages(
 		pipeline.StripUnreferencedTypeDefinitions(),
 
 		pipeline.RenameProperties(configuration.ObjectModelConfiguration),
+		pipeline.OverrideDescriptions(configuration), // After flatten and rename to make easier to use
 		pipeline.AddStatusConditions(idFactory).UsedFor(pipeline.ARMTarget),
 
 		pipeline.AddOperatorSpec(configuration, idFactory).UsedFor(pipeline.ARMTarget),

--- a/v2/tools/generator/internal/codegen/pipeline/override_descriptions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/override_descriptions.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package pipeline
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
+)
+
+// OverrideDescriptionsStageId is the unique identifier for this pipeline stage
+const OverrideDescriptionsStageId = "overrideDescriptions"
+
+// OverrideDescriptions overrides the specified property descriptions
+func OverrideDescriptions(configuration *config.Configuration) *Stage {
+	stage := NewStage(
+		OverrideDescriptionsStageId,
+		"Applies the configured description overrides",
+		func(ctx context.Context, state *State) (*State, error) {
+			visitor := createDescriptionOverrideVisitor(configuration)
+			result := make(astmodel.TypeDefinitionSet)
+			for _, def := range state.Definitions() {
+				newDef, err := visitor.VisitDefinition(def, def.Name())
+				if err != nil {
+					return nil, err
+				}
+
+				result.Add(newDef)
+			}
+
+			if err := configuration.ObjectModelConfiguration.Description.VerifyConsumed(); err != nil {
+				return nil, errors.Wrap(err, "verifying description augmentation")
+			}
+
+			return state.WithDefinitions(result), nil
+		})
+
+	stage.RequiresPrerequisiteStages(FlattenPropertiesStageId, RenamePropertiesStageID)
+	return stage
+}
+
+func createDescriptionOverrideVisitor(
+	configuration *config.Configuration,
+) astmodel.TypeVisitor[astmodel.InternalTypeName] {
+	visitor := astmodel.TypeVisitorBuilder[astmodel.InternalTypeName]{
+		VisitObjectType: func(
+			this *astmodel.TypeVisitor[astmodel.InternalTypeName],
+			it *astmodel.ObjectType,
+			ctx astmodel.InternalTypeName,
+		) (astmodel.Type, error) {
+			result := it
+			name := ctx
+			for _, prop := range it.Properties().AsSlice() {
+				// If the property has an overridden description, use it
+				description, ok := configuration.ObjectModelConfiguration.Description.Lookup(name, prop.PropertyName())
+				if !ok {
+					continue
+				}
+				prop = prop.WithDescription(description)
+				result = result.WithProperty(prop)
+			}
+
+			return result, nil
+		},
+	}
+
+	return visitor.Build()
+}

--- a/v2/tools/generator/internal/codegen/testdata/TestGolden_NewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/v2/tools/generator/internal/codegen/testdata/TestGolden_NewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -47,6 +47,7 @@ applyKubernetesResourceInterface                  azure      Add the KubernetesR
 flattenProperties                                            Apply flattening to properties marked for flattening
 stripUnreferenced                                            Strip unreferenced types
 renameProperties                                             Rename properties
+overrideDescriptions                                         Applies the configured description overrides
 addStatusConditions                               azure      Add the property 'Conditions' to all status types and implements genruntime.Conditioner on all resources
 addOperatorSpec                                   azure      Adds the property 'OperatorSpec' to all Spec types that require it
 addKubernetesExporter                             azure      Adds the KubernetesExporter interface to resources that need it

--- a/v2/tools/generator/internal/codegen/testdata/TestGolden_NewCrossplaneCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/v2/tools/generator/internal/codegen/testdata/TestGolden_NewCrossplaneCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -37,6 +37,7 @@ addSerializationTypeTag                                 Adds a property tag to p
 flattenProperties                                       Apply flattening to properties marked for flattening
 stripUnreferenced                                       Strip unreferenced types
 renameProperties                                        Rename properties
+overrideDescriptions                                    Applies the configured description overrides
 addCrossplaneOwnerProperties                 crossplane Add the 3-tuple of (xName, xNameRef, xNameSelector) for each owning resource
 addCrossplaneForProviderProperty             crossplane Add a 'ForProvider' property on every spec
 addCrossplaneAtProviderProperty              crossplane Add an 'AtProvider' property on every status

--- a/v2/tools/generator/internal/codegen/testdata/TestGolden_NewTestCodeGeneratorCreatesRightPipeline.golden
+++ b/v2/tools/generator/internal/codegen/testdata/TestGolden_NewTestCodeGeneratorCreatesRightPipeline.golden
@@ -39,6 +39,7 @@ applyKubernetesResourceInterface           azure      Add the KubernetesResource
 flattenProperties                                     Apply flattening to properties marked for flattening
 stripUnused                                           Strip unused types for test
 renameProperties                                      Rename properties
+overrideDescriptions                                  Applies the configured description overrides
 addStatusConditions                        azure      Add the property 'Conditions' to all status types and implements genruntime.Conditioner on all resources
 addOperatorSpec                            azure      Adds the property 'OperatorSpec' to all Spec types that require it
 addKubernetesExporter                      azure      Adds the KubernetesExporter interface to resources that need it

--- a/v2/tools/generator/internal/config/object_model_configuration.go
+++ b/v2/tools/generator/internal/config/object_model_configuration.go
@@ -50,6 +50,7 @@ type ObjectModelConfiguration struct {
 
 	// Property access fields here (alphabetical, please)
 	ARMReference                   propertyAccess[bool]
+	Description                    propertyAccess[string]
 	ImportConfigMapMode            propertyAccess[ImportConfigMapMode]
 	IsSecret                       propertyAccess[bool]
 	PropertyNameInNextVersion      propertyAccess[string]
@@ -110,6 +111,8 @@ func NewObjectModelConfiguration() *ObjectModelConfiguration {
 	// Initialize property access fields here (alphabetical, please)
 	result.ARMReference = makePropertyAccess[bool](
 		result, func(c *PropertyConfiguration) *configurable[bool] { return &c.ARMReference })
+	result.Description = makePropertyAccess[string](
+		result, func(c *PropertyConfiguration) *configurable[string] { return &c.Description })
 	result.ImportConfigMapMode = makePropertyAccess[ImportConfigMapMode](
 		result, func(c *PropertyConfiguration) *configurable[ImportConfigMapMode] { return &c.ImportConfigMapMode })
 	result.IsSecret = makePropertyAccess[bool](


### PR DESCRIPTION
Use this option to override the Subnet IPConfigurations field to explain that it is removed if it crosses 2000 entries.

- [x] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
