### PR TITLE
Migrate `customizations` to eris

### DIFF
--- a/v2/api/apimanagement/customizations/product_extensions.go
+++ b/v2/api/apimanagement/customizations/product_extensions.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -32,7 +32,7 @@ func (extension *ProductExtension) Delete(
 ) (ctrl.Result, error) {
 	typedObj, ok := obj.(*storage.Product)
 	if !ok {
-		return ctrl.Result{}, errors.Errorf("cannot run on unknown resource type %T, expected *apiManagement.Product", obj)
+		return ctrl.Result{}, eris.Errorf("cannot run on unknown resource type %T, expected *apiManagement.Product", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -42,11 +42,11 @@ func (extension *ProductExtension) Delete(
 	productName := typedObj.GetName()
 	id, err := genruntime.GetAndParseResourceID(typedObj)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to get the ARM ResourceId for %s", productName)
+		return ctrl.Result{}, eris.Wrapf(err, "failed to get the ARM ResourceId for %s", productName)
 	}
 
 	if id.Parent == nil {
-		return ctrl.Result{}, errors.Wrapf(err, ". APIM Product had no parent ID: %s", id.String())
+		return ctrl.Result{}, eris.Wrapf(err, ". APIM Product had no parent ID: %s", id.String())
 	}
 	parentName := id.Parent.Name
 
@@ -54,7 +54,7 @@ func (extension *ProductExtension) Delete(
 	// connection each time through
 	clientFactory, err := armapimanagement.NewClientFactory(id.SubscriptionID, armClient.Creds(), armClient.ClientOptions())
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to create new apimClient")
+		return ctrl.Result{}, eris.Wrapf(err, "failed to create new apimClient")
 	}
 
 	// This is a synchronous operation
@@ -68,7 +68,7 @@ func (extension *ProductExtension) Delete(
 			DeleteSubscriptions: to.Ptr(true),
 		})
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to delete product %q", productName)
+		return ctrl.Result{}, eris.Wrapf(err, "failed to delete product %q", productName)
 	}
 
 	return next(ctx, log, resolver, armClient, obj)

--- a/v2/api/apimanagement/customizations/subscription_extensions.go
+++ b/v2/api/apimanagement/customizations/subscription_extensions.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -42,7 +42,7 @@ func (ext *SubscriptionExtension) ExportKubernetesSecrets(
 	// if the hub storage version changes.
 	typedObj, ok := obj.(*apimanagement.Subscription)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *apimanagement.Subscription", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *apimanagement.Subscription", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -62,7 +62,7 @@ func (ext *SubscriptionExtension) ExportKubernetesSecrets(
 	}
 
 	if id.Parent == nil {
-		return nil, errors.Errorf("APIM subscription had no parent ID: %s", id.String())
+		return nil, eris.Errorf("APIM subscription had no parent ID: %s", id.String())
 	}
 	parentName := id.Parent.Name
 
@@ -75,13 +75,13 @@ func (ext *SubscriptionExtension) ExportKubernetesSecrets(
 		var subClient *armapimanagement.SubscriptionClient
 		subClient, err = armapimanagement.NewSubscriptionClient(subscription, armClient.Creds(), armClient.ClientOptions())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create new SubscriptionClient")
+			return nil, eris.Wrapf(err, "failed to create new SubscriptionClient")
 		}
 
 		var resp armapimanagement.SubscriptionClientListSecretsResponse
 		resp, err = subClient.ListSecrets(ctx, id.ResourceGroupName, parentName, typedObj.AzureName(), nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed listing secrets")
+			return nil, eris.Wrapf(err, "failed listing secrets")
 		}
 
 		s = resp.SubscriptionKeysContract

--- a/v2/api/appconfiguration/customizations/configuration_store_extensions.go
+++ b/v2/api/appconfiguration/customizations/configuration_store_extensions.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appconfiguration/armappconfiguration"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -53,7 +53,7 @@ func (ext *ConfigurationStoreExtension) ExportKubernetesSecrets(
 	// if the hub storage version changes.
 	typedObj, ok := obj.(*storage.ConfigurationStore)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *appconfiguration.ConfigurationStore", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *appconfiguration.ConfigurationStore", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -81,7 +81,7 @@ func (ext *ConfigurationStoreExtension) ExportKubernetesSecrets(
 		var confClient *armappconfiguration.ConfigurationStoresClient
 		confClient, err = armappconfiguration.NewConfigurationStoresClient(subscription, armClient.Creds(), armClient.ClientOptions())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create new ConfigurationStoresClient")
+			return nil, eris.Wrapf(err, "failed to create new ConfigurationStoresClient")
 		}
 
 		var pager *runtime.Pager[armappconfiguration.ConfigurationStoresClientListKeysResponse]
@@ -90,7 +90,7 @@ func (ext *ConfigurationStoreExtension) ExportKubernetesSecrets(
 		for pager.More() {
 			resp, err = pager.NextPage(ctx)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to retreive response")
+				return nil, eris.Wrapf(err, "failed to retreive response")
 			}
 			addSecretsToMap(resp.Value, keys)
 		}

--- a/v2/api/cache/customizations/redis_extensions.go
+++ b/v2/api/cache/customizations/redis_extensions.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -43,7 +43,7 @@ func (ext *RedisExtension) ExportKubernetesSecrets(
 	// if the hub storage version changes.
 	typedObj, ok := obj.(*redis.Redis)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *redis.Redis", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *redis.Redis", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -71,13 +71,13 @@ func (ext *RedisExtension) ExportKubernetesSecrets(
 		var redisClient *armredis.Client
 		redisClient, err = armredis.NewClient(subscription, armClient.Creds(), armClient.ClientOptions())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create new new RedisClient")
+			return nil, eris.Wrapf(err, "failed to create new new RedisClient")
 		}
 
 		var resp armredis.ClientListKeysResponse
 		resp, err = redisClient.ListKeys(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed listing keys")
+			return nil, eris.Wrapf(err, "failed listing keys")
 		}
 		accessKeys = resp.AccessKeys
 	}

--- a/v2/api/compute/customizations/vmss_extensions.go
+++ b/v2/api/compute/customizations/vmss_extensions.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	compute "github.com/Azure/azure-service-operator/v2/api/compute/v1api20220301/storage"
@@ -70,7 +70,7 @@ func (e *VirtualMachineScaleSetExtension) ModifyARMResource(
 ) (genruntime.ARMResource, error) {
 	typedObj, ok := obj.(*compute.VirtualMachineScaleSet)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *compute.VirtualMachineScaleSet", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *compute.VirtualMachineScaleSet", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -85,7 +85,7 @@ func (e *VirtualMachineScaleSetExtension) ModifyARMResource(
 
 	apiVersion, err := genruntime.GetAPIVersion(typedObj, kubeClient.Scheme())
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting api version for resource %s while getting status", obj.GetName())
+		return nil, eris.Wrapf(err, "error getting api version for resource %s while getting status", obj.GetName())
 	}
 
 	// Get the raw resource
@@ -94,15 +94,15 @@ func (e *VirtualMachineScaleSetExtension) ModifyARMResource(
 	if err != nil {
 		// If the error is NotFound, the resource we're trying to Create doesn't exist and so no modification is needed
 		var responseError *azcore.ResponseError
-		if errors.As(err, &responseError) && responseError.StatusCode == http.StatusNotFound {
+		if eris.As(err, &responseError) && responseError.StatusCode == http.StatusNotFound {
 			return armObj, nil
 		}
-		return nil, errors.Wrapf(err, "getting resource with ID: %q", resourceID)
+		return nil, eris.Wrapf(err, "getting resource with ID: %q", resourceID)
 	}
 
 	azureExtensions, err := getRawChildCollection(raw, rawChildCollectionPath...)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get VMSS Extensions")
+		return nil, eris.Wrapf(err, "failed to get VMSS Extensions")
 	}
 
 	// If the child collection is not defined, We return the arm object as is here.
@@ -115,7 +115,7 @@ func (e *VirtualMachineScaleSetExtension) ModifyARMResource(
 
 	err = setChildCollection(armObj.Spec(), azureExtensions, childCollectionPathARM...)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to set VMSS Extensions")
+		return nil, eris.Wrapf(err, "failed to set VMSS Extensions")
 	}
 
 	return armObj, nil
@@ -130,7 +130,7 @@ func getExactParentRecursively(parentValue reflect.Value, childFieldName []strin
 	fieldName := childFieldName[i]
 	field := parentValue.FieldByName(fieldName)
 	if !field.IsValid() {
-		return reflect.Value{}, errors.Errorf("couldn't find %s field", fieldName)
+		return reflect.Value{}, eris.Errorf("couldn't find %s field", fieldName)
 	}
 
 	propertiesValue := reflect.Indirect(field)
@@ -147,7 +147,7 @@ func getExactParentRecursively(parentValue reflect.Value, childFieldName []strin
 func getChildCollectionField(parent any, fieldPath []string) (ret reflect.Value, err error) {
 	defer func() {
 		if x := recover(); x != nil {
-			err = errors.Errorf("caught panic: %s", x)
+			err = eris.Errorf("caught panic: %s", x)
 		}
 	}()
 
@@ -155,7 +155,7 @@ func getChildCollectionField(parent any, fieldPath []string) (ret reflect.Value,
 	parentValue := reflect.ValueOf(parent)
 	parentValue = reflect.Indirect(parentValue)
 	if !parentValue.IsValid() {
-		return reflect.Value{}, errors.Errorf("cannot assign to nil parent")
+		return reflect.Value{}, eris.Errorf("cannot assign to nil parent")
 	}
 
 	exactParent, err := getExactParentRecursively(parentValue, fieldPath, 0)
@@ -166,11 +166,11 @@ func getChildCollectionField(parent any, fieldPath []string) (ret reflect.Value,
 	childFieldName := fieldPath[len(fieldPath)-1]
 	childField := exactParent.FieldByName(childFieldName)
 	if !childField.IsValid() {
-		return reflect.Value{}, errors.Errorf("couldn't find %q field", fieldPath)
+		return reflect.Value{}, eris.Errorf("couldn't find %q field", fieldPath)
 	}
 
 	if childField.Type().Kind() != reflect.Slice {
-		return reflect.Value{}, errors.Errorf("%q field was not of kind Slice", fieldPath)
+		return reflect.Value{}, eris.Errorf("%q field was not of kind Slice", fieldPath)
 	}
 
 	return childField, nil
@@ -192,7 +192,7 @@ func getRawExactParentRecursively(parent map[string]any, fieldSlice []string, i 
 
 	propsMap, ok := props.(map[string]any)
 	if !ok {
-		return nil, errors.Errorf("%s field wasn't a map", prop)
+		return nil, eris.Errorf("%s field wasn't a map", prop)
 	}
 
 	return getRawExactParentRecursively(propsMap, fieldSlice, i+1)
@@ -211,12 +211,12 @@ func getRawChildCollection(parent map[string]any, fieldSlice ...string) ([]any, 
 	childFieldName := fieldSlice[len(fieldSlice)-1]
 	childField, ok := exactParent[childFieldName]
 	if !ok {
-		return nil, errors.Errorf("couldn't find %q field", fieldSlice)
+		return nil, eris.Errorf("couldn't find %q field", fieldSlice)
 	}
 
 	childSlice, ok := childField.([]any)
 	if !ok {
-		return nil, errors.Errorf("%q field wasn't a slice", fieldSlice)
+		return nil, eris.Errorf("%q field wasn't a slice", fieldSlice)
 	}
 
 	return childSlice, nil
@@ -225,7 +225,7 @@ func getRawChildCollection(parent map[string]any, fieldSlice ...string) ([]any, 
 func setChildCollection(parent genruntime.ARMResourceSpec, childCollectionFromAzure []any, childFieldPath ...string) (err error) {
 	defer func() {
 		if x := recover(); x != nil {
-			err = errors.Errorf("caught panic: %s", x)
+			err = eris.Errorf("caught panic: %s", x)
 		}
 	}()
 
@@ -256,12 +256,12 @@ func setChildCollection(parent genruntime.ARMResourceSpec, childCollectionFromAz
 func fuzzySetResource(resource any, embeddedResource reflect.Value) error {
 	resourceJSON, err := json.Marshal(resource)
 	if err != nil {
-		return errors.Wrap(err, "failed to marshal resource JSON")
+		return eris.Wrap(err, "failed to marshal resource JSON")
 	}
 
 	err = json.Unmarshal(resourceJSON, embeddedResource.Interface())
 	if err != nil {
-		return errors.Wrap(err, "failed to unmarshal resource JSON")
+		return eris.Wrap(err, "failed to unmarshal resource JSON")
 	}
 
 	// TODO: Can't do a trivial fuzzyEqualityComparison here because we don't know which fields are readonly
@@ -288,7 +288,7 @@ func mergeExtensions(extensionField reflect.Value, azureExtensionsSlice reflect.
 		azureExtension := azureExtensionsSlice.Index(i)
 		newExtensionName, err := getNameField(azureExtension)
 		if err != nil {
-			return reflect.Value{}, errors.Wrapf(err, "failed to get name for new extension")
+			return reflect.Value{}, eris.Wrapf(err, "failed to get name for new extension")
 		}
 		foundExistingExtension := false
 
@@ -297,7 +297,7 @@ func mergeExtensions(extensionField reflect.Value, azureExtensionsSlice reflect.
 			var existingName reflect.Value
 			existingName, err = getNameField(existingExtension)
 			if err != nil {
-				return reflect.Value{}, errors.Wrapf(err, "failed to get name for existing extension")
+				return reflect.Value{}, eris.Wrapf(err, "failed to get name for existing extension")
 			}
 
 			if existingName.String() == newExtensionName.String() {
@@ -317,13 +317,13 @@ func mergeExtensions(extensionField reflect.Value, azureExtensionsSlice reflect.
 func getNameField(natValue reflect.Value) (ret reflect.Value, err error) {
 	defer func() {
 		if x := recover(); x != nil {
-			err = errors.Errorf("caught panic: %s", x)
+			err = eris.Errorf("caught panic: %s", x)
 		}
 	}()
 
 	nameField := natValue.FieldByName("Name")
 	if !nameField.IsValid() {
-		return nameField, errors.Errorf("couldn't find name field")
+		return nameField, eris.Errorf("couldn't find name field")
 	}
 
 	nameField = reflect.Indirect(nameField)

--- a/v2/api/containerservice/customizations/managed_cluster_extensions.go
+++ b/v2/api/containerservice/customizations/managed_cluster_extensions.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -46,7 +46,7 @@ func (ext *ManagedClusterExtension) ExportKubernetesSecrets(
 	// if the hub storage version changes.
 	typedObj, ok := obj.(*containerservice.ManagedCluster)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *containerservice.ManagedCluster", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *containerservice.ManagedCluster", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -72,7 +72,7 @@ func (ext *ManagedClusterExtension) ExportKubernetesSecrets(
 	var mcClient *armcontainerservice.ManagedClustersClient
 	mcClient, err = armcontainerservice.NewManagedClustersClient(subscription, armClient.Creds(), armClient.ClientOptions())
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create new ManagedClustersClient")
+		return nil, eris.Wrapf(err, "failed to create new ManagedClustersClient")
 	}
 
 	// TODO: In the future we may need variants of these secret properties that configure usage of the public FQDN rather than the private one, see:
@@ -82,7 +82,7 @@ func (ext *ManagedClusterExtension) ExportKubernetesSecrets(
 		var resp armcontainerservice.ManagedClustersClientListClusterAdminCredentialsResponse
 		resp, err = mcClient.ListClusterAdminCredentials(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed listing admin credentials")
+			return nil, eris.Wrapf(err, "failed listing admin credentials")
 		}
 		if len(resp.CredentialResults.Kubeconfigs) > 0 {
 			// It's awkward that we're ignoring the other possible responses here, but that's what the AZ CLI does too:
@@ -96,7 +96,7 @@ func (ext *ManagedClusterExtension) ExportKubernetesSecrets(
 		var resp armcontainerservice.ManagedClustersClientListClusterUserCredentialsResponse
 		resp, err = mcClient.ListClusterUserCredentials(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed listing admin credentials")
+			return nil, eris.Wrapf(err, "failed listing admin credentials")
 		}
 		if len(resp.CredentialResults.Kubeconfigs) > 0 {
 			// It's awkward that we're ignoring the other possible responses here, but that's what the AZ CLI does too:
@@ -179,7 +179,7 @@ func (ext *ManagedClusterExtension) PreReconcileCheck(
 	managedCluster, ok := obj.(*containerservice.ManagedCluster)
 	if !ok {
 		return extensions.PreReconcileCheckResult{},
-			errors.Errorf("cannot run on unknown resource type %T, expected *containerservice.ManagedCluster", obj)
+			eris.Errorf("cannot run on unknown resource type %T, expected *containerservice.ManagedCluster", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if

--- a/v2/api/containerservice/customizations/managed_clusters_agent_pool_extensions.go
+++ b/v2/api/containerservice/customizations/managed_clusters_agent_pool_extensions.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	containerservice "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240901/storage"
@@ -48,7 +48,7 @@ func (ext *ManagedClustersAgentPoolExtension) PreReconcileCheck(
 	agentPool, ok := obj.(*containerservice.ManagedClustersAgentPool)
 	if !ok {
 		return extensions.PreReconcileCheckResult{},
-			errors.Errorf("cannot run on unknown resource type %T, expected *containerservice.ManagedCluster", obj)
+			eris.Errorf("cannot run on unknown resource type %T, expected *containerservice.ManagedCluster", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if

--- a/v2/api/dataprotection/customizations/backup_vaults_backup_instance_extensions.go
+++ b/v2/api/dataprotection/customizations/backup_vaults_backup_instance_extensions.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dataprotection/armdataprotection/v3"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	dataprotection "github.com/Azure/azure-service-operator/v2/api/dataprotection/v1api20231101/storage"
@@ -79,7 +79,7 @@ func (extension *BackupVaultsBackupInstanceExtension) PostReconcileCheck(
 	backupInstance, ok := obj.(*dataprotection.BackupVaultsBackupInstance)
 	if !ok {
 		return extensions.PostReconcileCheckResult{},
-			errors.Errorf("cannot run on unknown resource type %T, expected *dataprotection.BackupVaultsBackupInstance", obj)
+			eris.Errorf("cannot run on unknown resource type %T, expected *dataprotection.BackupVaultsBackupInstance", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if

--- a/v2/api/dbformariadb/customizations/server_extensions.go
+++ b/v2/api/dbformariadb/customizations/server_extensions.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -36,7 +36,7 @@ func (ext *ServerExtension) ExportKubernetesSecrets(
 	// if the storage version changes.
 	typedObj, ok := obj.(*mariadb.Server)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if

--- a/v2/api/dbformysql/customizations/flexible_server_extensions.go
+++ b/v2/api/dbformysql/customizations/flexible_server_extensions.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -36,7 +36,7 @@ func (ext *FlexibleServerExtension) ExportKubernetesSecrets(
 	// if the hub storage version changes.
 	typedObj, ok := obj.(*mysql.FlexibleServer)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *mysql.FlexibleServer", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *mysql.FlexibleServer", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if

--- a/v2/api/dbformysql/v1/user_types.go
+++ b/v2/api/dbformysql/v1/user_types.go
@@ -3,7 +3,7 @@
 package v1
 
 import (
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -155,10 +155,11 @@ func (user *User) validateWriteOncePropertiesNotChanged(oldObj runtime.Object) (
 	}
 
 	if oldUser.Spec.AzureName != user.Spec.AzureName {
-		err := errors.Errorf(
+		err := eris.Errorf(
 			"updating 'AzureName' is not allowed for '%s : %s",
 			oldObj.GetObjectKind().GroupVersionKind(),
 			oldUser.GetName())
+
 		errs = append(errs, err)
 	}
 
@@ -171,16 +172,18 @@ func (user *User) validateWriteOncePropertiesNotChanged(oldObj runtime.Object) (
 	ownerRemoved := oldOwner != nil && newOwner == nil
 
 	if (bothHaveOwner && oldOwner.Name != newOwner.Name) || ownerAdded {
-		err := errors.Errorf(
+		err := eris.Errorf(
 			"updating 'Owner.Name' is not allowed for '%s : %s",
 			oldObj.GetObjectKind().GroupVersionKind(),
 			oldUser.GetName())
+
 		errs = append(errs, err)
 	} else if ownerRemoved {
-		err := errors.Errorf(
+		err := eris.Errorf(
 			"removing 'Owner' is not allowed for '%s : %s",
 			oldObj.GetObjectKind().GroupVersionKind(),
 			oldUser.GetName())
+
 		errs = append(errs, err)
 	}
 
@@ -202,7 +205,7 @@ func (user *User) validateUserAADAliasNotChanged(oldObj runtime.Object) (admissi
 	newAlias := user.Spec.AADUser.Alias
 
 	if oldAlias != newAlias {
-		return nil, errors.Errorf("cannot change AAD user 'alias' from %q to %q", oldAlias, newAlias)
+		return nil, eris.Errorf("cannot change AAD user 'alias' from %q to %q", oldAlias, newAlias)
 	}
 
 	return nil, nil
@@ -217,12 +220,12 @@ func (user *User) validateUserTypeNotChanged(oldObj runtime.Object) (admission.W
 
 	// Prevent change from AAD -> Local
 	if oldUser.Spec.AADUser != nil && user.Spec.AADUser == nil {
-		return nil, errors.Errorf("cannot change from AAD User to local user")
+		return nil, eris.Errorf("cannot change from AAD User to local user")
 	}
 
 	// Prevent change from Local -> AAD
 	if oldUser.Spec.LocalUser != nil && user.Spec.LocalUser == nil {
-		return nil, errors.Errorf("cannot change from local user to AAD user")
+		return nil, eris.Errorf("cannot change from local user to AAD user")
 	}
 
 	return nil, nil
@@ -230,11 +233,11 @@ func (user *User) validateUserTypeNotChanged(oldObj runtime.Object) (admission.W
 
 func (user *User) validateIsLocalOrAAD() (admission.Warnings, error) {
 	if user.Spec.LocalUser == nil && user.Spec.AADUser == nil {
-		return nil, errors.Errorf("exactly one of spec.localuser or spec.aadUser must be set")
+		return nil, eris.Errorf("exactly one of spec.localuser or spec.aadUser must be set")
 	}
 
 	if user.Spec.LocalUser != nil && user.Spec.AADUser != nil {
-		return nil, errors.Errorf("exactly one of spec.localuser or spec.aadUser must be set")
+		return nil, eris.Errorf("exactly one of spec.localuser or spec.aadUser must be set")
 	}
 
 	return nil, nil

--- a/v2/api/dbforpostgresql/customizations/flexible_server_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_server_extensions.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -40,7 +40,7 @@ func (ext *FlexibleServerExtension) ExportKubernetesSecrets(
 	// if the hub storage version changes.
 	typedObj, ok := obj.(*postgresql.FlexibleServer)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *postgresql.FlexibleServer", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *postgresql.FlexibleServer", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -112,7 +112,7 @@ func (ext *FlexibleServerExtension) PreReconcileCheck(
 	server, ok := obj.(*postgresql.FlexibleServer)
 	if !ok {
 		return extensions.PreReconcileCheckResult{},
-			errors.Errorf("cannot run on unknown resource type %T, expected *postgresql.FlexibleServer", obj)
+			eris.Errorf("cannot run on unknown resource type %T, expected *postgresql.FlexibleServer", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if

--- a/v2/api/devices/customizations/iot_hub_extensions.go
+++ b/v2/api/devices/customizations/iot_hub_extensions.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -51,7 +51,7 @@ func (ext *IotHubExtension) ExportKubernetesSecrets(
 	// if the hub devices version changes.
 	typedObj, ok := obj.(*devices.IotHub)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *devices.IotHub", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *devices.IotHub", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -79,7 +79,7 @@ func (ext *IotHubExtension) ExportKubernetesSecrets(
 		var resClient *armiothub.ResourceClient
 		resClient, err = armiothub.NewResourceClient(subscription, armClient.Creds(), armClient.ClientOptions())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create new DevicesClient")
+			return nil, eris.Wrapf(err, "failed to create new DevicesClient")
 		}
 
 		var pager *runtime.Pager[armiothub.ResourceClientListKeysResponse]
@@ -88,7 +88,7 @@ func (ext *IotHubExtension) ExportKubernetesSecrets(
 		for pager.More() {
 			resp, err = pager.NextPage(ctx)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed listing keys")
+				return nil, eris.Wrapf(err, "failed listing keys")
 			}
 			addSecretsToMap(resp.Value, keys)
 		}

--- a/v2/api/documentdb/customizations/database_account_extensions.go
+++ b/v2/api/documentdb/customizations/database_account_extensions.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -48,7 +48,7 @@ func (ext *DatabaseAccountExtension) ExportKubernetesSecrets(
 	// if the hub storage version changes.
 	typedObj, ok := obj.(*documentdb.DatabaseAccount)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *documentdb.DatabaseAccount", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *documentdb.DatabaseAccount", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -76,7 +76,7 @@ func (ext *DatabaseAccountExtension) ExportKubernetesSecrets(
 		var acctClient *armcosmos.DatabaseAccountsClient
 		acctClient, err = armcosmos.NewDatabaseAccountsClient(subscription, armClient.Creds(), armClient.ClientOptions())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create new DatabaseAccountClient")
+			return nil, eris.Wrapf(err, "failed to create new DatabaseAccountClient")
 		}
 
 		// TODO: There is a ListReadOnlyKeys API that requires less permissions. We should consider determining
@@ -84,7 +84,7 @@ func (ext *DatabaseAccountExtension) ExportKubernetesSecrets(
 		var resp armcosmos.DatabaseAccountsClientListKeysResponse
 		resp, err = acctClient.ListKeys(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed listing keys")
+			return nil, eris.Wrapf(err, "failed listing keys")
 		}
 
 		keys = resp.DatabaseAccountListKeysResult
@@ -223,7 +223,7 @@ func (ext *DatabaseAccountExtension) PreReconcileCheck(
 	// It will need to be updated if the hub storage version changes.
 	account, ok := obj.(*documentdb.DatabaseAccount)
 	if !ok {
-		return extensions.PreReconcileCheckResult{}, errors.Errorf("cannot run on unknown resource type %T, expected *documentdb.DatabaseAccount", obj)
+		return extensions.PreReconcileCheckResult{}, eris.Errorf("cannot run on unknown resource type %T, expected *documentdb.DatabaseAccount", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if

--- a/v2/api/eventgrid/customizations/topic_extension.go
+++ b/v2/api/eventgrid/customizations/topic_extension.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -41,7 +41,7 @@ func (ext *TopicExtension) ExportKubernetesSecrets(
 	// if the hub storage version changes.
 	typedObj, ok := obj.(*storage.Topic)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *eventgrid.Topic", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *eventgrid.Topic", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -67,13 +67,13 @@ func (ext *TopicExtension) ExportKubernetesSecrets(
 	var confClient *armeventgrid.TopicsClient
 	confClient, err = armeventgrid.NewTopicsClient(subscription, armClient.Creds(), armClient.ClientOptions())
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create new TopicsClient")
+		return nil, eris.Wrapf(err, "failed to create new TopicsClient")
 	}
 
 	var resp armeventgrid.TopicsClientListSharedAccessKeysResponse
 	resp, err = confClient.ListSharedAccessKeys(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed listing keys")
+		return nil, eris.Wrapf(err, "failed listing keys")
 	}
 
 	secretSlice, err := secretsToWrite(typedObj, resp)

--- a/v2/api/eventhub/customizations/namespace_extension.go
+++ b/v2/api/eventhub/customizations/namespace_extension.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -37,7 +37,7 @@ func (ext *NamespaceExtension) ExportKubernetesSecrets(
 	// if the hub storage version changes.
 	typedObj, ok := obj.(*storage.Namespace)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *eventhub.Namespace", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *eventhub.Namespace", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -66,14 +66,14 @@ func (ext *NamespaceExtension) ExportKubernetesSecrets(
 		var confClient *armeventhub.NamespacesClient
 		confClient, err = armeventhub.NewNamespacesClient(subscription, armClient.Creds(), armClient.ClientOptions())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create new NamespaceClient")
+			return nil, eris.Wrapf(err, "failed to create new NamespaceClient")
 		}
 
 		// RootManageSharedAccessKey is the default auth rule for namespace.
 		// See https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string
 		res, err = confClient.ListKeys(ctx, id.ResourceGroupName, typedObj.AzureName(), "RootManageSharedAccessKey", nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to retreive response")
+			return nil, eris.Wrapf(err, "failed to retreive response")
 		}
 	}
 

--- a/v2/api/eventhub/customizations/namespaces_authorization_rule_extension.go
+++ b/v2/api/eventhub/customizations/namespaces_authorization_rule_extension.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -37,7 +37,7 @@ func (ext *NamespacesAuthorizationRuleExtension) ExportKubernetesSecrets(
 	// if the hub storage version changes.
 	typedObj, ok := obj.(*storage.NamespacesAuthorizationRule)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *eventhub.NamespacesAuthorizationRule", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *eventhub.NamespacesAuthorizationRule", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -65,12 +65,12 @@ func (ext *NamespacesAuthorizationRuleExtension) ExportKubernetesSecrets(
 		var confClient *armeventhub.NamespacesClient
 		confClient, err = armeventhub.NewNamespacesClient(subscription, armClient.Creds(), armClient.ClientOptions())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create new NamespaceClient")
+			return nil, eris.Wrapf(err, "failed to create new NamespaceClient")
 		}
 
 		res, err = confClient.ListKeys(ctx, id.ResourceGroupName, id.Parent.Name, typedObj.AzureName(), nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to retreive response")
+			return nil, eris.Wrapf(err, "failed to retreive response")
 		}
 	}
 

--- a/v2/api/eventhub/customizations/namespaces_eventhubs_authorization_rule_extension.go
+++ b/v2/api/eventhub/customizations/namespaces_eventhubs_authorization_rule_extension.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -44,7 +44,7 @@ func (ext *NamespacesEventhubsAuthorizationRuleExtension) ExportKubernetesSecret
 	// if the hub storage version changes.
 	typedObj, ok := obj.(*storage.NamespacesEventhubsAuthorizationRule)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *eventhub.NamespacesEventhubsAuthorizationRule", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *eventhub.NamespacesEventhubsAuthorizationRule", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -72,12 +72,12 @@ func (ext *NamespacesEventhubsAuthorizationRuleExtension) ExportKubernetesSecret
 		var confClient *armeventhub.EventHubsClient
 		confClient, err = armeventhub.NewEventHubsClient(subscription, armClient.Creds(), armClient.ClientOptions())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create new EventHubsClient")
+			return nil, eris.Wrapf(err, "failed to create new EventHubsClient")
 		}
 
 		res, err = confClient.ListKeys(ctx, id.ResourceGroupName, id.Parent.Parent.Name, id.Parent.Name, typedObj.Name, nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to retreive response")
+			return nil, eris.Wrapf(err, "failed to retreive response")
 		}
 	}
 

--- a/v2/api/keyvault/customizations/vault_extensions.go
+++ b/v2/api/keyvault/customizations/vault_extensions.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	keyvault "github.com/Azure/azure-service-operator/v2/api/keyvault/v1api20230701/storage"
@@ -52,7 +52,7 @@ func (ex *VaultExtension) ModifyARMResource(
 ) (genruntime.ARMResource, error) {
 	kv, ok := obj.(*keyvault.Vault)
 	if !ok {
-		return nil, errors.Errorf(
+		return nil, eris.Errorf(
 			"Cannot run VaultExtension.ModifyARMResource() with unexpected resource type %T",
 			obj)
 	}
@@ -71,26 +71,26 @@ func (ex *VaultExtension) ModifyARMResource(
 	// (Can't use the KeyVault as we do this before the KV exists)
 	id, err := ex.getOwner(ctx, kv, resolver)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get and parse resource ID from KeyVault owner")
+		return nil, eris.Wrap(err, "failed to get and parse resource ID from KeyVault owner")
 	}
 
 	vc, err := armkeyvault.NewVaultsClient(id.SubscriptionID, armClient.Creds(), armClient.ClientOptions())
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create new VaultsClient")
+		return nil, eris.Wrap(err, "failed to create new VaultsClient")
 	}
 
 	createMode := *kv.Spec.Properties.CreateMode
 	if createMode == CreateMode_CreateOrRecover {
 		createMode, err = ex.handleCreateOrRecover(ctx, kv, vc, id, log)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error checking for existence of soft-deleted KeyVault")
+			return nil, eris.Wrapf(err, "error checking for existence of soft-deleted KeyVault")
 		}
 	}
 
 	if createMode == CreateMode_PurgeThenCreate {
 		err = ex.handlePurgeThenCreate(ctx, kv, vc, log)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error purging soft-deleted KeyVault")
+			return nil, eris.Wrapf(err, "error purging soft-deleted KeyVault")
 		}
 
 		createMode = CreateMode_Default
@@ -100,7 +100,7 @@ func (ex *VaultExtension) ModifyARMResource(
 	spec := armObj.Spec()
 	err = reflecthelpers.SetProperty(spec, "Properties.CreateMode", &createMode)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error setting CreateMode to %s", createMode)
+		return nil, eris.Wrapf(err, "error setting CreateMode to %s", createMode)
 	}
 
 	return armObj, nil
@@ -115,7 +115,7 @@ func (ex *VaultExtension) handleCreateOrRecover(
 ) (string, error) {
 	deletedKeyVault, err := ex.checkForExistenceOfDeletedKeyVault(ctx, kv, vc, log)
 	if err != nil {
-		return "", errors.Wrapf(err, "error checking for existence of soft-deleted KeyVault %s", kv.Name)
+		return "", eris.Wrapf(err, "error checking for existence of soft-deleted KeyVault %s", kv.Name)
 	}
 
 	result := CreateMode_Default
@@ -125,7 +125,7 @@ func (ex *VaultExtension) handleCreateOrRecover(
 			var id *arm.ResourceID
 			id, err = arm.ParseResourceID(to.Value(deletedKeyVault.DeletedVault.Properties.VaultID))
 			if err != nil {
-				return "", errors.Wrapf(err, "error parsing KeyVault ID %s", to.Value(deletedKeyVault.DeletedVault.Properties.VaultID))
+				return "", eris.Wrapf(err, "error parsing KeyVault ID %s", to.Value(deletedKeyVault.DeletedVault.Properties.VaultID))
 			}
 
 			err = checkResourceGroupsMatch(ownerID, id)
@@ -169,17 +169,17 @@ func (ex *VaultExtension) handlePurgeThenCreate(
 	if deletedKeyVault.Exists {
 		location := to.Value(kv.Spec.Location)
 		if location == "" {
-			return errors.Errorf("unable to determine location of KeyVault %s", kv.Name)
+			return eris.Errorf("unable to determine location of KeyVault %s", kv.Name)
 		}
 
 		poller, err := vc.BeginPurgeDeleted(ctx, kv.Name, location, &armkeyvault.VaultsClientBeginPurgeDeletedOptions{})
 		if err != nil {
-			return errors.Wrapf(err, "failed to begin purging deleted KeyVault %s", kv.Name)
+			return eris.Wrapf(err, "failed to begin purging deleted KeyVault %s", kv.Name)
 		}
 
 		_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: 10 * time.Second})
 		if err != nil {
-			return errors.Wrapf(err, "failed to purge deleted KeyVault %s", kv.Name)
+			return eris.Wrapf(err, "failed to purge deleted KeyVault %s", kv.Name)
 		}
 	}
 
@@ -215,7 +215,7 @@ func (ex *VaultExtension) checkForExistenceOfDeletedKeyVault(
 	// Get the location of the KeyVault
 	location := to.Value(kv.Spec.Location)
 	if location == "" {
-		return deletedKeyVaultNotFound(), errors.Errorf("unable to determine location of KeyVault %s", kv.Name)
+		return deletedKeyVaultNotFound(), eris.Errorf("unable to determine location of KeyVault %s", kv.Name)
 	}
 
 	// Get the name of the KeyVault
@@ -231,9 +231,9 @@ func (ex *VaultExtension) checkForExistenceOfDeletedKeyVault(
 	deletedDetails, err := vaultsClient.GetDeleted(ctx, vaultName, location, &armkeyvault.VaultsClientGetDeletedOptions{})
 	if err != nil {
 		var responseError *azcore.ResponseError
-		if errors.As(err, &responseError) {
+		if eris.As(err, &responseError) {
 			if responseError.StatusCode != http.StatusNotFound {
-				return deletedKeyVaultNotFound(), errors.Wrapf(err, "failed to get deleted KeyVault %s, error %d", kv.Name, responseError.StatusCode)
+				return deletedKeyVaultNotFound(), eris.Wrapf(err, "failed to get deleted KeyVault %s, error %d", kv.Name, responseError.StatusCode)
 			}
 
 			// KeyVault doesn't exist,
@@ -267,7 +267,7 @@ func (*VaultExtension) getOwner(
 ) (*arm.ResourceID, error) {
 	owner, err := reslv.ResolveOwner(ctx, kv)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to resolve owner of KeyVault %s", kv.Name)
+		return nil, eris.Wrapf(err, "unable to resolve owner of KeyVault %s", kv.Name)
 	}
 
 	var id *arm.ResourceID
@@ -277,7 +277,7 @@ func (*VaultExtension) getOwner(
 	case resolver.OwnerFoundKubernetes:
 		rg, ok := owner.Owner.(*resources.ResourceGroup)
 		if !ok {
-			return nil, errors.Errorf("expected owner of KeyVault %s to be a ResourceGroup", kv.Name)
+			return nil, eris.Errorf("expected owner of KeyVault %s to be a ResourceGroup", kv.Name)
 		}
 
 		// Type assert that the ResourceGroup is the hub type. This will fail to compile if
@@ -289,15 +289,15 @@ func (*VaultExtension) getOwner(
 
 		id, err = genruntime.GetAndParseResourceID(rg)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to get and parse resource ID from KeyVault owner")
+			return nil, eris.Wrap(err, "failed to get and parse resource ID from KeyVault owner")
 		}
 	case resolver.OwnerFoundARM:
 		id, err = arm.ParseResourceID(owner.ARMID)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse resource ID from KeyVault owner")
+			return nil, eris.Wrap(err, "failed to parse resource ID from KeyVault owner")
 		}
 	default:
-		return nil, errors.Errorf("unexpected owner type of KeyVault, type: %s", owner.Result)
+		return nil, eris.Errorf("unexpected owner type of KeyVault, type: %s", owner.Result)
 	}
 
 	return id, nil
@@ -307,10 +307,11 @@ func checkResourceGroupsMatch(new *arm.ResourceID, old *arm.ResourceID) error {
 	if !strings.EqualFold(new.ResourceGroupName, old.ResourceGroupName) {
 		// This error is fatal
 		return conditions.NewReadyConditionImpactingError(
-			errors.Errorf(
+			eris.Errorf(
 				"cannot recover KeyVault: new resourceGroup %s does not match old resource group %s",
 				new.ResourceGroupName,
 				old.ResourceGroupName),
+
 			conditions.ConditionSeverityError,
 			conditions.ReasonFailed,
 		)

--- a/v2/api/machinelearningservices/customizations/workspace_extension.go
+++ b/v2/api/machinelearningservices/customizations/workspace_extension.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -50,7 +50,7 @@ func (ext *WorkspaceExtension) ExportKubernetesSecrets(
 	// if the hub storage version changes.
 	typedObj, ok := obj.(*storage.Workspace)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *storage.Workspace", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *storage.Workspace", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -78,13 +78,13 @@ func (ext *WorkspaceExtension) ExportKubernetesSecrets(
 		var workspacesClient *armmachinelearning.WorkspacesClient
 		workspacesClient, err = armmachinelearning.NewWorkspacesClient(subscription, armClient.Creds(), armClient.ClientOptions())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create new workspaceClient")
+			return nil, eris.Wrapf(err, "failed to create new workspaceClient")
 		}
 
 		var resp armmachinelearning.WorkspacesClientListKeysResponse
 		resp, err = workspacesClient.ListKeys(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed listing keys")
+			return nil, eris.Wrapf(err, "failed listing keys")
 		}
 		keys = resp.ListWorkspaceKeysResult
 	}

--- a/v2/api/network/customizations/load_balancer_extension.go
+++ b/v2/api/network/customizations/load_balancer_extension.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	network "github.com/Azure/azure-service-operator/v2/api/network/v1api20240301/storage"
@@ -38,7 +38,7 @@ func (extension *LoadBalancerExtension) ModifyARMResource(
 ) (genruntime.ARMResource, error) {
 	typedObj, ok := obj.(*network.LoadBalancer)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *network.LoadBalancer", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *network.LoadBalancer", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -53,7 +53,7 @@ func (extension *LoadBalancerExtension) ModifyARMResource(
 
 	apiVersion, err := genruntime.GetAPIVersion(typedObj, kubeClient.Scheme())
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting api version for resource %s while getting status", obj.GetName())
+		return nil, eris.Wrapf(err, "error getting api version for resource %s while getting status", obj.GetName())
 	}
 
 	// Get the raw resource
@@ -62,22 +62,22 @@ func (extension *LoadBalancerExtension) ModifyARMResource(
 	if err != nil {
 		// If the error is NotFound, the resource we're trying to Create doesn't exist and so no modification is needed
 		var responseError *azcore.ResponseError
-		if errors.As(err, &responseError) && responseError.StatusCode == http.StatusNotFound {
+		if eris.As(err, &responseError) && responseError.StatusCode == http.StatusNotFound {
 			return armObj, nil
 		}
-		return nil, errors.Wrapf(err, "getting resource with ID: %q", resourceID)
+		return nil, eris.Wrapf(err, "getting resource with ID: %q", resourceID)
 	}
 
 	azureInboundNatRules, err := getRawChildCollection(raw, "inboundNatRules")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get inboundNatRules")
+		return nil, eris.Wrapf(err, "failed to get inboundNatRules")
 	}
 
 	log.V(Info).Info("Found InboundNatRules to include on LoadBalancer", "count", len(azureInboundNatRules), "names", genruntime.RawNames(azureInboundNatRules))
 
 	err = setInboundNatRules(armObj.Spec(), azureInboundNatRules)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to set inboundNatRules")
+		return nil, eris.Wrapf(err, "failed to set inboundNatRules")
 	}
 
 	return armObj, nil
@@ -86,13 +86,13 @@ func (extension *LoadBalancerExtension) ModifyARMResource(
 func getNameField(natValue reflect.Value) (ret reflect.Value, err error) {
 	defer func() {
 		if x := recover(); x != nil {
-			err = errors.Errorf("caught panic: %s", x)
+			err = eris.Errorf("caught panic: %s", x)
 		}
 	}()
 
 	nameField := natValue.FieldByName("Name")
 	if !nameField.IsValid() {
-		return nameField, errors.Errorf("couldn't find name field")
+		return nameField, eris.Errorf("couldn't find name field")
 	}
 
 	nameField = reflect.Indirect(nameField)
@@ -103,7 +103,7 @@ func getNameField(natValue reflect.Value) (ret reflect.Value, err error) {
 func setInboundNatRules(lb genruntime.ARMResourceSpec, azureInboundNatRules []any) (err error) {
 	defer func() {
 		if x := recover(); x != nil {
-			err = errors.Errorf("caught panic: %s", x)
+			err = eris.Errorf("caught panic: %s", x)
 		}
 	}()
 
@@ -127,7 +127,7 @@ func setInboundNatRules(lb genruntime.ARMResourceSpec, azureInboundNatRules []an
 
 	inboundNatRulesSlice, err = mergeNatRules(inboundNatRulesField, inboundNatRulesSlice)
 	if err != nil {
-		return errors.Wrapf(err, "failed to merge NAT rules")
+		return eris.Wrapf(err, "failed to merge NAT rules")
 	}
 
 	inboundNatRulesField.Set(inboundNatRulesSlice)
@@ -153,7 +153,7 @@ func mergeNatRules(inboundNatRulesField reflect.Value, azureInboundNatRules refl
 		inboundNatRule := azureInboundNatRules.Index(i)
 		newRuleName, err := getNameField(inboundNatRule)
 		if err != nil {
-			return reflect.Value{}, errors.Wrapf(err, "failed to get name for new rule")
+			return reflect.Value{}, eris.Wrapf(err, "failed to get name for new rule")
 		}
 		foundExistingRule := false
 
@@ -162,7 +162,7 @@ func mergeNatRules(inboundNatRulesField reflect.Value, azureInboundNatRules refl
 			var existingName reflect.Value
 			existingName, err = getNameField(existingInboundNatRule)
 			if err != nil {
-				return reflect.Value{}, errors.Wrapf(err, "failed to get name for existing rule")
+				return reflect.Value{}, eris.Wrapf(err, "failed to get name for existing rule")
 			}
 
 			if existingName.String() == newRuleName.String() {

--- a/v2/api/network/customizations/network_security_group_extension.go
+++ b/v2/api/network/customizations/network_security_group_extension.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	network "github.com/Azure/azure-service-operator/v2/api/network/v1api20240301/storage"
@@ -37,7 +37,7 @@ func (extension *NetworkSecurityGroupExtension) ModifyARMResource(
 ) (genruntime.ARMResource, error) {
 	typedObj, ok := obj.(*network.NetworkSecurityGroup)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *network.NetworkSecurityGroup", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *network.NetworkSecurityGroup", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -52,7 +52,7 @@ func (extension *NetworkSecurityGroupExtension) ModifyARMResource(
 
 	apiVersion, err := genruntime.GetAPIVersion(typedObj, kubeClient.Scheme())
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting api version for resource %s while getting status", obj.GetName())
+		return nil, eris.Wrapf(err, "error getting api version for resource %s while getting status", obj.GetName())
 	}
 
 	// Get the raw resource
@@ -61,22 +61,22 @@ func (extension *NetworkSecurityGroupExtension) ModifyARMResource(
 	if err != nil {
 		// If the error is NotFound, the resource we're trying to Create doesn't exist and so no modification is needed
 		var responseError *azcore.ResponseError
-		if errors.As(err, &responseError) && responseError.StatusCode == http.StatusNotFound {
+		if eris.As(err, &responseError) && responseError.StatusCode == http.StatusNotFound {
 			return armObj, nil
 		}
-		return nil, errors.Wrapf(err, "getting resource with ID: %q", resourceID)
+		return nil, eris.Wrapf(err, "getting resource with ID: %q", resourceID)
 	}
 
 	azureSecurityRules, err := getRawChildCollection(raw, "securityRules")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get SecurityRules")
+		return nil, eris.Wrapf(err, "failed to get SecurityRules")
 	}
 
 	log.V(Info).Info("Found security rules to include on NSG", "count", len(azureSecurityRules), "names", genruntime.RawNames(azureSecurityRules))
 
 	err = setChildCollection(armObj.Spec(), azureSecurityRules, "SecurityRules")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to set SecurityRules")
+		return nil, eris.Wrapf(err, "failed to set SecurityRules")
 	}
 
 	return armObj, nil

--- a/v2/api/network/customizations/private_endpoints_extensions.go
+++ b/v2/api/network/customizations/private_endpoints_extensions.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
@@ -40,7 +40,7 @@ func (extension *PrivateEndpointExtension) PostReconcileCheck(
 	endpoint, ok := obj.(*network.PrivateEndpoint)
 	if !ok {
 		return extensions.PostReconcileCheckResult{},
-			errors.Errorf("cannot run on unknown resource type %T, expected *network.PrivateEndpoint", obj)
+			eris.Errorf("cannot run on unknown resource type %T, expected *network.PrivateEndpoint", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -80,7 +80,7 @@ func (extension *PrivateEndpointExtension) ExportKubernetesConfigMaps(
 	// if the hub storage version changes.
 	endpoint, ok := obj.(*network.PrivateEndpoint)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *network.PrivateEndpoint", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *network.PrivateEndpoint", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -112,13 +112,13 @@ func (extension *PrivateEndpointExtension) ExportKubernetesConfigMaps(
 	var interfacesClient *armnetwork.InterfacesClient
 	interfacesClient, err = armnetwork.NewInterfacesClient(nicID.SubscriptionID, armClient.Creds(), armClient.ClientOptions())
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create new NetworkInterfacesClient")
+		return nil, eris.Wrapf(err, "failed to create new NetworkInterfacesClient")
 	}
 
 	var resp armnetwork.InterfacesClientGetResponse
 	resp, err = interfacesClient.Get(ctx, nicID.ResourceGroupName, nicID.Name, nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed getting NetworkInterfaceController")
+		return nil, eris.Wrapf(err, "failed getting NetworkInterfaceController")
 	}
 
 	configsByName := configByName(log, resp.Interface)
@@ -156,7 +156,7 @@ func configByName(log logr.Logger, nic armnetwork.Interface) map[string]string {
 func configMapToWrite(obj *network.PrivateEndpoint, configs map[string]string) ([]*v1.ConfigMap, error) {
 	operatorSpecConfigs := obj.Spec.OperatorSpec.ConfigMaps
 	if operatorSpecConfigs == nil {
-		return nil, errors.Errorf("unexpected nil operatorspec")
+		return nil, eris.Errorf("unexpected nil operatorspec")
 	}
 
 	collector := configmaps.NewCollector(obj.Namespace)

--- a/v2/api/network/customizations/route_table_extensions.go
+++ b/v2/api/network/customizations/route_table_extensions.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	network "github.com/Azure/azure-service-operator/v2/api/network/v1api20240301/storage"
@@ -38,7 +38,7 @@ func (extension *RouteTableExtension) ModifyARMResource(
 ) (genruntime.ARMResource, error) {
 	typedObj, ok := obj.(*network.RouteTable)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -53,7 +53,7 @@ func (extension *RouteTableExtension) ModifyARMResource(
 
 	apiVersion, err := genruntime.GetAPIVersion(typedObj, kubeClient.Scheme())
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting api version for resource %s while getting status", obj.GetName())
+		return nil, eris.Wrapf(err, "error getting api version for resource %s while getting status", obj.GetName())
 	}
 
 	// Get the raw resource
@@ -62,22 +62,22 @@ func (extension *RouteTableExtension) ModifyARMResource(
 	if err != nil {
 		// If the error is NotFound, the resource we're trying to Create doesn't exist and so no modification is needed
 		var responseError *azcore.ResponseError
-		if errors.As(err, &responseError) && responseError.StatusCode == http.StatusNotFound {
+		if eris.As(err, &responseError) && responseError.StatusCode == http.StatusNotFound {
 			return armObj, nil
 		}
-		return nil, errors.Wrapf(err, "getting resource with ID: %q", resourceID)
+		return nil, eris.Wrapf(err, "getting resource with ID: %q", resourceID)
 	}
 
 	azureRoutes, err := getRawChildCollection(raw, "routes")
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get routes")
+		return nil, eris.Wrap(err, "failed to get routes")
 	}
 
 	log.V(Info).Info("Found routes to include on RouteTable", "count", len(azureRoutes), "names", genruntime.RawNames(azureRoutes))
 
 	err = setChildCollection(armObj.Spec(), azureRoutes, "Routes")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to set routes")
+		return nil, eris.Wrapf(err, "failed to set routes")
 	}
 
 	return armObj, nil

--- a/v2/api/network/customizations/virtual_network_extensions.go
+++ b/v2/api/network/customizations/virtual_network_extensions.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	network "github.com/Azure/azure-service-operator/v2/api/network/v1api20240301/storage"
@@ -39,7 +39,7 @@ func (extension *VirtualNetworkExtension) ModifyARMResource(
 ) (genruntime.ARMResource, error) {
 	typedObj, ok := obj.(*network.VirtualNetwork)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *network.VirtualNetwork", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *network.VirtualNetwork", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -54,7 +54,7 @@ func (extension *VirtualNetworkExtension) ModifyARMResource(
 
 	apiVersion, err := genruntime.GetAPIVersion(typedObj, kubeClient.Scheme())
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting api version for resource %s while getting status", obj.GetName())
+		return nil, eris.Wrapf(err, "error getting api version for resource %s while getting status", obj.GetName())
 	}
 
 	// Get the raw resource
@@ -63,22 +63,22 @@ func (extension *VirtualNetworkExtension) ModifyARMResource(
 	if err != nil {
 		// If the error is NotFound, the resource we're trying to Create doesn't exist and so no modification is needed
 		var responseError *azcore.ResponseError
-		if errors.As(err, &responseError) && responseError.StatusCode == http.StatusNotFound {
+		if eris.As(err, &responseError) && responseError.StatusCode == http.StatusNotFound {
 			return armObj, nil
 		}
-		return nil, errors.Wrapf(err, "getting resource with ID: %q", resourceID)
+		return nil, eris.Wrapf(err, "getting resource with ID: %q", resourceID)
 	}
 
 	azureSubnets, err := getRawChildCollection(raw, "subnets")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get subnets")
+		return nil, eris.Wrapf(err, "failed to get subnets")
 	}
 
 	log.V(Info).Info("Found subnets to include on VNET", "count", len(azureSubnets), "names", genruntime.RawNames(azureSubnets))
 
 	err = setChildCollection(armObj.Spec(), azureSubnets, "Subnets")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to set subnets")
+		return nil, eris.Wrapf(err, "failed to set subnets")
 	}
 
 	return armObj, nil
@@ -87,7 +87,7 @@ func (extension *VirtualNetworkExtension) ModifyARMResource(
 func getChildCollectionField(parent any, childFieldName string) (ret reflect.Value, err error) {
 	defer func() {
 		if x := recover(); x != nil {
-			err = errors.Errorf("caught panic: %s", x)
+			err = eris.Errorf("caught panic: %s", x)
 		}
 	}()
 
@@ -95,12 +95,12 @@ func getChildCollectionField(parent any, childFieldName string) (ret reflect.Val
 	parentValue := reflect.ValueOf(parent)
 	parentValue = reflect.Indirect(parentValue)
 	if !parentValue.IsValid() {
-		return reflect.Value{}, errors.Errorf("cannot assign to nil parent")
+		return reflect.Value{}, eris.Errorf("cannot assign to nil parent")
 	}
 
 	propertiesField := parentValue.FieldByName("Properties")
 	if !propertiesField.IsValid() {
-		return reflect.Value{}, errors.Errorf("couldn't find properties field")
+		return reflect.Value{}, eris.Errorf("couldn't find properties field")
 	}
 
 	propertiesValue := reflect.Indirect(propertiesField)
@@ -113,11 +113,11 @@ func getChildCollectionField(parent any, childFieldName string) (ret reflect.Val
 
 	childField := propertiesValue.FieldByName(childFieldName)
 	if !childField.IsValid() {
-		return reflect.Value{}, errors.Errorf("couldn't find %q field", childFieldName)
+		return reflect.Value{}, eris.Errorf("couldn't find %q field", childFieldName)
 	}
 
 	if childField.Type().Kind() != reflect.Slice {
-		return reflect.Value{}, errors.Errorf("%q field was not of kind Slice", childFieldName)
+		return reflect.Value{}, eris.Errorf("%q field was not of kind Slice", childFieldName)
 	}
 
 	return childField, nil
@@ -126,22 +126,22 @@ func getChildCollectionField(parent any, childFieldName string) (ret reflect.Val
 func getRawChildCollection(parent map[string]any, childJSONName string) ([]any, error) {
 	props, ok := parent["properties"]
 	if !ok {
-		return nil, errors.Errorf("couldn't find properties field")
+		return nil, eris.Errorf("couldn't find properties field")
 	}
 
 	propsMap, ok := props.(map[string]any)
 	if !ok {
-		return nil, errors.Errorf("properties field wasn't a map")
+		return nil, eris.Errorf("properties field wasn't a map")
 	}
 
 	childField, ok := propsMap[childJSONName]
 	if !ok {
-		return nil, errors.Errorf("couldn't find %q field", childJSONName)
+		return nil, eris.Errorf("couldn't find %q field", childJSONName)
 	}
 
 	childSlice, ok := childField.([]any)
 	if !ok {
-		return nil, errors.Errorf("%q field wasn't a slice", childJSONName)
+		return nil, eris.Errorf("%q field wasn't a slice", childJSONName)
 	}
 
 	return childSlice, nil
@@ -150,7 +150,7 @@ func getRawChildCollection(parent map[string]any, childJSONName string) ([]any, 
 func setChildCollection(parent genruntime.ARMResourceSpec, childCollectionFromAzure []any, childFieldName string) (err error) {
 	defer func() {
 		if x := recover(); x != nil {
-			err = errors.Errorf("caught panic: %s", x)
+			err = eris.Errorf("caught panic: %s", x)
 		}
 	}()
 
@@ -180,12 +180,12 @@ func setChildCollection(parent genruntime.ARMResourceSpec, childCollectionFromAz
 func fuzzySetResource(resource any, embeddedResource reflect.Value) error {
 	resourceJSON, err := json.Marshal(resource)
 	if err != nil {
-		return errors.Wrap(err, "failed to marshal resource JSON")
+		return eris.Wrap(err, "failed to marshal resource JSON")
 	}
 
 	err = json.Unmarshal(resourceJSON, embeddedResource.Interface())
 	if err != nil {
-		return errors.Wrap(err, "failed to unmarshal resource JSON")
+		return eris.Wrap(err, "failed to unmarshal resource JSON")
 	}
 
 	// TODO: Can't do a trivial fuzzyEqualityComparison here because we don't know which fields are readonly

--- a/v2/api/network/customizations/virtual_network_subnet_extensions.go
+++ b/v2/api/network/customizations/virtual_network_subnet_extensions.go
@@ -6,7 +6,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	network "github.com/Azure/azure-service-operator/v2/api/network/v1api20240301/storage"
@@ -30,7 +30,7 @@ func (extension *VirtualNetworksSubnetExtension) PostReconcileCheck(
 	subnet, ok := obj.(*network.VirtualNetworksSubnet)
 	if !ok {
 		return extensions.PostReconcileCheckResult{},
-			errors.Errorf("cannot run on unknown resource type %T, expected *network.VirtualNetworksSubnet", obj)
+			eris.Errorf("cannot run on unknown resource type %T, expected *network.VirtualNetworksSubnet", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if

--- a/v2/api/search/customizations/search_service_extension.go
+++ b/v2/api/search/customizations/search_service_extension.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -44,7 +44,7 @@ func (ext *SearchServiceExtension) ExportKubernetesSecrets(
 	// if the hub devices version changes.
 	typedObj, ok := obj.(*search.SearchService)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *devices.IotHub", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *devices.IotHub", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -74,7 +74,7 @@ func (ext *SearchServiceExtension) ExportKubernetesSecrets(
 		var queryKeysClient *armsearch.QueryKeysClient
 		queryKeysClient, err = armsearch.NewQueryKeysClient(subscription, armClient.Creds(), armClient.ClientOptions())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create new SeachServiceQueryClient")
+			return nil, eris.Wrapf(err, "failed to create new SeachServiceQueryClient")
 		}
 
 		var pager *runtime.Pager[armsearch.QueryKeysClientListBySearchServiceResponse]
@@ -83,7 +83,7 @@ func (ext *SearchServiceExtension) ExportKubernetesSecrets(
 		for pager.More() {
 			resp, err = pager.NextPage(ctx)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed listing query keys")
+				return nil, eris.Wrapf(err, "failed listing query keys")
 			}
 			addSecretsToMap(resp.Value, queryKeys)
 		}
@@ -91,7 +91,7 @@ func (ext *SearchServiceExtension) ExportKubernetesSecrets(
 		var adminKeysClient *armsearch.AdminKeysClient
 		adminKeysClient, err = armsearch.NewAdminKeysClient(subscription, armClient.Creds(), armClient.ClientOptions())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create new SeachServiceAdminClient")
+			return nil, eris.Wrapf(err, "failed to create new SeachServiceAdminClient")
 		}
 
 		adminKeys, err = adminKeysClient.Get(ctx, id.ResourceGroupName, typedObj.AzureName(), nil, nil)

--- a/v2/api/servicebus/customizations/namespace_extensions.go
+++ b/v2/api/servicebus/customizations/namespace_extensions.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -45,7 +45,7 @@ func (ext *NamespaceExtension) ExportKubernetesSecrets(
 	// if the hub storage version changes.
 	namespace, ok := obj.(*servicebus.Namespace)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *servicebus.Namespace", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *servicebus.Namespace", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -72,7 +72,7 @@ func (ext *NamespaceExtension) ExportKubernetesSecrets(
 		armClient.Creds(),
 		armClient.ClientOptions())
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create ARM servicebus client factory")
+		return nil, eris.Wrapf(err, "failed to create ARM servicebus client factory")
 	}
 
 	// This access rule always exists and provides management access to the namespace
@@ -88,7 +88,7 @@ func (ext *NamespaceExtension) ExportKubernetesSecrets(
 		rootRuleName,
 		&options)
 	if err != nil {
-		return nil, errors.Wrapf(
+		return nil, eris.Wrapf(
 			err,
 			"failed to retrieve namespace management keys from authorization rule %q",
 			rootRuleName)

--- a/v2/api/signalrservice/customizations/signal_r_extension_authorization.go
+++ b/v2/api/signalrservice/customizations/signal_r_extension_authorization.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/signalr/armsignalr"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -44,7 +44,7 @@ func (ext *SignalRExtension) ExportKubernetesSecrets(
 	// This will need to be updated if the hub version changes
 	typedObj, ok := obj.(*signalr.SignalR)
 	if !ok {
-		return nil, errors.Errorf(
+		return nil, eris.Errorf(
 			"cannot run on unknown resource type %T, expected *signalr.SignalR", obj)
 	}
 
@@ -69,12 +69,12 @@ func (ext *SignalRExtension) ExportKubernetesSecrets(
 	// connection each time through
 	clientFactory, err := armsignalr.NewClientFactory(id.SubscriptionID, armClient.Creds(), armClient.ClientOptions())
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create ARM signalR client factory")
+		return nil, eris.Wrapf(err, "failed to create ARM signalR client factory")
 	}
 
 	res, err := clientFactory.NewClient().ListKeys(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list keys")
+		return nil, eris.Wrapf(err, "failed to list keys")
 	}
 
 	secretSlice, err := secretsToWrite(typedObj, res.Keys)

--- a/v2/api/sql/v1/user_types.go
+++ b/v2/api/sql/v1/user_types.go
@@ -3,7 +3,7 @@
 package v1
 
 import (
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -154,10 +154,11 @@ func (user *User) validateWriteOncePropertiesNotChanged(oldObj runtime.Object) (
 	}
 
 	if oldUser.Spec.AzureName != user.Spec.AzureName {
-		err := errors.Errorf(
+		err := eris.Errorf(
 			"updating 'AzureName' is not allowed for '%s : %s",
 			oldObj.GetObjectKind().GroupVersionKind(),
 			oldUser.GetName())
+
 		errs = append(errs, err)
 	}
 
@@ -170,16 +171,18 @@ func (user *User) validateWriteOncePropertiesNotChanged(oldObj runtime.Object) (
 	ownerRemoved := oldOwner != nil && newOwner == nil
 
 	if (bothHaveOwner && oldOwner.Name != newOwner.Name) || ownerAdded {
-		err := errors.Errorf(
+		err := eris.Errorf(
 			"updating 'Owner.Name' is not allowed for '%s : %s",
 			oldObj.GetObjectKind().GroupVersionKind(),
 			oldUser.GetName())
+
 		errs = append(errs, err)
 	} else if ownerRemoved {
-		err := errors.Errorf(
+		err := eris.Errorf(
 			"removing 'Owner' is not allowed for '%s : %s",
 			oldObj.GetObjectKind().GroupVersionKind(),
 			oldUser.GetName())
+
 		errs = append(errs, err)
 	}
 

--- a/v2/api/storage/customizations/storage_account_extensions.go
+++ b/v2/api/storage/customizations/storage_account_extensions.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	"github.com/rotisserie/eris"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -42,7 +42,7 @@ func (ext *StorageAccountExtension) ExportKubernetesSecrets(
 	// if the hub storage version changes.
 	typedObj, ok := obj.(*storage.StorageAccount)
 	if !ok {
-		return nil, errors.Errorf("cannot run on unknown resource type %T, expected *storage.StorageAccount", obj)
+		return nil, eris.Errorf("cannot run on unknown resource type %T, expected *storage.StorageAccount", obj)
 	}
 
 	// Type assert that we are the hub type. This will fail to compile if
@@ -70,13 +70,13 @@ func (ext *StorageAccountExtension) ExportKubernetesSecrets(
 		var acctClient *armstorage.AccountsClient
 		acctClient, err = armstorage.NewAccountsClient(subscription, armClient.Creds(), armClient.ClientOptions())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create new AccountsClient")
+			return nil, eris.Wrapf(err, "failed to create new AccountsClient")
 		}
 
 		var resp armstorage.AccountsClientListKeysResponse
 		resp, err = acctClient.ListKeys(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed listing keys")
+			return nil, eris.Wrapf(err, "failed listing keys")
 		}
 
 		keys = secretsByName(resp.Keys)


### PR DESCRIPTION
## What this PR does

Migrates `v2/api/*/customizations` to use `github.com/rotisserie/eris`.

The code was changed using gopatch:

``` bash
$ gopatch --patch=../../../eris.patch --verbose .
```
and then cleaned up using golangci-lint:

``` bash
$ golangci-lint run --fix ./...
```

See #4454 for the patch file used.