### PR TITLE
Adopt ASO-specific label to replace default control-plane: controller-manager

### DIFF
--- a/scripts/add-openshift-cert-handling.sh
+++ b/scripts/add-openshift-cert-handling.sh
@@ -19,7 +19,7 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: azure-service-operator
   sessionAffinity: None
   type: ClusterIP
 EOF

--- a/v2/charts/azure-service-operator/templates/_helpers.tpl
+++ b/v2/charts/azure-service-operator/templates/_helpers.tpl
@@ -1,4 +1,39 @@
 {{/*
+Expand the name of the chart.
+*/}}
+{{- define "azure-service-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "azure-service-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "azure-service-operator.labels" -}}
+helm.sh/chart: {{ include "azure-service-operator.chart" . }}
+{{ include "azure-service-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "azure-service-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "azure-service-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "azure-service-operator.serviceAccountName" -}}

--- a/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
+++ b/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
@@ -6,9 +6,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.11.0
-    control-plane: controller-manager
+    {{- include "azure-service-operator.labels" . | nindent 4 }}
   name: azureserviceoperator-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:
@@ -16,7 +14,7 @@ spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
-      control-plane: controller-manager
+      {{- include "azure-service-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -28,12 +26,7 @@ spec:
         {{- if .Values.aadPodIdentity.enable }}
         aadpodidbinding: aso-manager-binding
         {{- end }}
-        app.kubernetes.io/name: azure-service-operator
-        app.kubernetes.io/version: v2.11.0
-        control-plane: controller-manager
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "azure-service-operator.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.tolerations }}
       tolerations:

--- a/v2/charts/azure-service-operator/templates/networkpolicies.yaml
+++ b/v2/charts/azure-service-operator/templates/networkpolicies.yaml
@@ -11,7 +11,7 @@ spec:
   - {}
   podSelector:
     matchLabels:
-      control-plane: controller-manager
+      {{- include "azure-service-operator.selectorLabels" . | nindent 6 }}
   policyTypes:
   - Ingress
 ---
@@ -62,7 +62,7 @@ spec:
           cidr: {{ .Values.networkPolicies.sqlCIDR }}
   podSelector:
     matchLabels:
-      control-plane: controller-manager
+      {{- include "azure-service-operator.selectorLabels" . | nindent 6 }}
   policyTypes:
   - Egress
 {{- end }}

--- a/v2/charts/azure-service-operator/templates/v1_service_azureserviceoperator-controller-manager-metrics-service.yaml
+++ b/v2/charts/azure-service-operator/templates/v1_service_azureserviceoperator-controller-manager-metrics-service.yaml
@@ -4,9 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.11.0
-    control-plane: controller-manager
+    {{- include "azure-service-operator.labels" . | nindent 4 }}
   name: azureserviceoperator-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,6 +12,6 @@ spec:
   - name: metrics
     port: 8443
   selector:
-    control-plane: controller-manager
+    {{- include "azure-service-operator.selectorLabels" . | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/v2/charts/azure-service-operator/templates/v1_service_azureserviceoperator-webhook-service.yaml
+++ b/v2/charts/azure-service-operator/templates/v1_service_azureserviceoperator-webhook-service.yaml
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.11.0
+    {{- include "azure-service-operator.labels" . | nindent 4 }}
   name: azureserviceoperator-webhook-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -12,5 +11,5 @@ spec:
   - port: 443
     targetPort: {{ .Values.webhook.port }}
   selector:
-    control-plane: controller-manager
+    {{- include "azure-service-operator.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/v2/config/manager/manager.yaml
+++ b/v2/config/manager/manager.yaml
@@ -17,21 +17,17 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: ${VERSION}
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: azure-service-operator
   replicas: 1
   revisionHistoryLimit: 10
   template:
     metadata:
       labels:
-        control-plane: controller-manager
         app.kubernetes.io/name: azure-service-operator
-        app.kubernetes.io/version: ${VERSION}
       annotations:
         kubectl.kubernetes.io/default-container: manager
     spec:

--- a/v2/config/manager/manager_metrics_service.yaml
+++ b/v2/config/manager/manager_metrics_service.yaml
@@ -2,9 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: ${VERSION}
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -12,4 +10,4 @@ spec:
     - name: metrics
       port: 8443
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: azure-service-operator

--- a/v2/config/webhook/service.yaml
+++ b/v2/config/webhook/service.yaml
@@ -5,10 +5,9 @@ metadata:
   namespace: system
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: ${VERSION}
 spec:
   ports:
     - port: 443
       targetPort: 9443
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: azure-service-operator


### PR DESCRIPTION


## What this PR does

Closes https://github.com/Azure/azure-service-operator/issues/4277

**Current Behavior**:
The kubebuilder default label `control-plane: controller-manager` is currently used. This label is common across many projects, which can lead to potential conflicts, especially when multiple deployments or webhooks exist in the same namespace. Such conflicts may cause misrouting of resources and selectors, impacting functionality.

**Improvement**:
This PR introduces a unique label specific to ASO, ensuring better namespace coexistence and reducing the risk of conflicts with other deployments. By aligning with best practices, this change improves ASO's compatibility and coexistence within shared Kubernetes environments.

**Impact**:

- Avoids label conflicts with other projects.
- Supports installation alongside other controllers in the same namespace.
- Enhances stability and maintainability of deployments using ASO.

This update addresses potential selector misconfigurations and promotes more robust operations in multi-controller setups.

<!--  

Here are some tips:

If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. 
Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

Closes #[issue number]
-->

<!--
### Special notes

_If there's anything complex or unusual about this PR that would help us review it, let us know here. Otherwise delete this section._
-->

## How does this PR make you feel?

![gif](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExeTcwY3FrNWxraWFuNzIyMzM1NXk1cmdjMm1tOXppc214MHJzdHZmOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/25Fd0NooYZjZrGnVcN/giphy.gif)

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
