### PR TITLE
Fix Taskfile ordering so that "task" command formats code

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,8 +62,9 @@ vars:
 
 tasks:
   default:
-    deps:
-      - quick-checks
+    cmds:
+      - task: format-code # Run before quick-checks to avoid racing with generated file creation
+      - task: quick-checks
 
   quick-checks:
     desc: Perform all fast local pre-commit tasks.
@@ -73,8 +74,6 @@ tasks:
       - asoctl:quick-checks
       - crossplane:quick-checks
       - mangle-test:quick-checks
-    cmds:
-      - task: format-code # Run after the deps to avoid racing with generated file creation
 
   setup:
     desc: Perform setup tasks
@@ -103,7 +102,7 @@ tasks:
     desc: Ensure all code is formatted
     dir: v2
     cmds:
-      - golangci-lint run --fix ./...
+      - golangci-lint run --fix ./... --timeout 5m  # I don't know why fix doesn't use the configured timeout
       - gofumpt -l -w .
 
   build-docs-site:


### PR DESCRIPTION
Previously, the format-code step was run AFTER the standard linting, so would always fail if there was incorrect format.

Move the step to run before linting in the default task command (only run locally).

No change for CI.

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
