### PR TITLE
Fix: Ensure asoctl simple logger shuts down properly

### DIFF
--- a/v2/cmd/asoctl/pkg/importreporter/log.go
+++ b/v2/cmd/asoctl/pkg/importreporter/log.go
@@ -47,9 +47,14 @@ func newLogProgress(
 			total += int64(delta.pending)
 
 			// If we're done, finish up
-			if parent == nil && total > 0 && completed >= total {
-				// We're the root importreporter log, so we also need to handle the done channel
-				close(done)
+			if total > 0 && completed >= total {
+				close(result.updates)
+
+				if parent == nil {
+					// We're the root importreporter log, so we also need to handle the done channel
+					close(done)
+				}
+
 				break
 			}
 


### PR DESCRIPTION
## What this PR does

If using the simple logger for asoctl (rather than the progress bars), nested loggers were not shutting down properly when the resource was completed. 
