### PR TITLE
Add fixes for make-mi-fic.py consistency

### DIFF
--- a/scripts/v2/create-kind-wi-storage.sh
+++ b/scripts/v2/create-kind-wi-storage.sh
@@ -88,7 +88,7 @@ cat <<EOF > "${DIR}/openid-configuration.json"
 }
 EOF
 
-CREATION_TIME="$(date --utc +"%Y-%m-%dT%H:%M:%SZ")"
+CREATION_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
 az group create -l westus -n "${RESOURCE_GROUP}" --tags "CreatedAt=${CREATION_TIME}"
 


### PR DESCRIPTION
## What this PR does

This PR fixes `make-mi-fic.py` script bug where once if identity is created and the process fails, re-running of script doesn't generate the artifacts. 
With this change, even if the identity already exists, the script re-run the rest of the steps and will ensure that the files `miclientid.txt` and `fix.txt` exist with the correct content.

Closes #4478 

