### PR TITLE
Disable workflows in forks

### DIFF
--- a/.github/workflows/build-devcontainer-image.yml
+++ b/.github/workflows/build-devcontainer-image.yml
@@ -24,6 +24,9 @@ jobs:
       packages: write
       contents: read
 
+    # Only run this scheduled job on the main repo, it can't work elsewhere
+    if: ${{ github.repository == 'Azure/azure-service-operator' }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7

--- a/.github/workflows/scan-controller-image.yaml
+++ b/.github/workflows/scan-controller-image.yaml
@@ -18,8 +18,12 @@ on:
 jobs:
   scan-image:
     runs-on: ubuntu-latest
+    
     permissions:
       packages: read
+
+    # Only run this scheduled job on the main repo, it can't work elsewhere
+    if: ${{ github.repository == 'Azure/azure-service-operator' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What this PR does

The two workflows _Build Devcontainer image_ and _Scan controller image_ won't work in forks of ASO due to permissions or hard coded values. 

Here we disable them outside of the main repo so that contributors aren't spammed with failure emails.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/xULW8vRQrlIPRfiEog/giphy.gif?cid=790b7611nkw94xbg3hy6v1t5y3yd554lgp8th8trr2aoyob3&ep=v1_gifs_search&rid=giphy.gif&ct=g)
