### PR TITLE
Fix bug where obj.AzureName was not used to create Azure URLs

### DIFF
--- a/v2/api/eventhub/customizations/namespaces_eventhubs_authorization_rule_extension.go
+++ b/v2/api/eventhub/customizations/namespaces_eventhubs_authorization_rule_extension.go
@@ -75,7 +75,7 @@ func (ext *NamespacesEventhubsAuthorizationRuleExtension) ExportKubernetesSecret
 			return nil, eris.Wrapf(err, "failed to create new EventHubsClient")
 		}
 
-		res, err = confClient.ListKeys(ctx, id.ResourceGroupName, id.Parent.Parent.Name, id.Parent.Name, typedObj.Name, nil)
+		res, err = confClient.ListKeys(ctx, id.ResourceGroupName, id.Parent.Parent.Name, id.Parent.Name, id.Name, nil)
 		if err != nil {
 			return nil, eris.Wrapf(err, "failed to retreive response")
 		}

--- a/v2/api/servicebus/customizations/namespaces_authorization_rule_extensions.go
+++ b/v2/api/servicebus/customizations/namespaces_authorization_rule_extensions.go
@@ -70,7 +70,7 @@ func (ext *NamespacesAuthorizationRuleExtension) ExportKubernetesSecrets(
 
 	client := clientFactory.NewNamespacesClient()
 	options := armservicebus.NamespacesClientListKeysOptions{}
-	response, err := client.ListKeys(ctx, id.ResourceGroupName, namespaceID.Name, rule.Name, &options)
+	response, err := client.ListKeys(ctx, id.ResourceGroupName, namespaceID.Name, id.Name, &options)
 	if err != nil {
 		return nil, eris.Wrapf(
 			err,


### PR DESCRIPTION
## What this PR does

obj.Name was mistakenly used when it should have been obj.AzureName (or id.Name, which is derived from the ARM ID which comes from obj.AzureName).

Fixes #4515.

