### PR TITLE
Fix "missing error information" error on 409s

### DIFF
--- a/v2/internal/genericarmclient/policy_register_rp.go
+++ b/v2/internal/genericarmclient/policy_register_rp.go
@@ -64,11 +64,16 @@ func (r *rpRegistrationPolicy) Do(req *azpolicy.Request) (*http.Response, error)
 		return resp, err
 	}
 	var reqErr requestError
-	if err = runtime.UnmarshalAsJSON(resp, &reqErr); err != nil {
-		return resp, err
+	if unmarshalErr := runtime.UnmarshalAsJSON(resp, &reqErr); unmarshalErr != nil {
+		return resp, unmarshalErr
 	}
 	if reqErr.ServiceError == nil {
-		return resp, errors.New("missing error information")
+		// This is unexpected and likely due to Azure RPs failing to adhere to the expected
+		// error shape contract. The good news is that if this happens we know this isn't
+		// an unregistered RP because that API will have the right shape. We just return
+		// the resp/err directly in this case to let the caller deal with whatever the problem
+		// was as we know it wasn't unregistered RP.
+		return resp, err
 	}
 	if !strings.EqualFold(reqErr.ServiceError.Code, unregisteredRPCode) {
 		// not a 409 due to unregistered RP


### PR DESCRIPTION
This can happen if the Azure RP being called returns a JSON error response payload that doesn't match the Azure contract. Instead of overwriting the underlying error, just return it as-is to aid in debugging.

- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
