### PR TITLE
Fix linting in Taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -168,7 +168,6 @@ tasks:
     desc: Ensure all code for asoctl is formatted
     dir: v2/cmd/asoctl/
     cmds:
-      - golangci-lint run --fix ./... --timeout 5m  --verbose
       - gofumpt -l -w .
 
   asoctl:lint:
@@ -258,7 +257,6 @@ tasks:
     desc: Ensure all code for the code generator is formatted
     dir: v2/tools/generator
     cmds:
-      - golangci-lint run --fix ./... --timeout 5m  --verbose
       - gofumpt -l -w .
 
   generator:lint:
@@ -316,7 +314,6 @@ tasks:
     desc: Ensure all code for the controller is formatted
     dir: v2
     cmds:
-      - golangci-lint run --fix ./... --timeout 5m --verbose
       - gofumpt -l -w .
 
   controller:lint:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -174,7 +174,7 @@ tasks:
     desc: Run {{.ASOCTL_APP}} fast lint checks.
     dir: '{{.ASOCTL_ROOT}}'
     cmds:
-      - golangci-lint run --verbose --fast=false --timeout 5m ./...
+      - golangci-lint run --verbose --fix --fast=false --timeout 5m ./...
 
   asoctl:build:
     desc: Generate the {{.ASOCTL_APP}} binary.
@@ -263,7 +263,7 @@ tasks:
     desc: Run {{.GENERATOR_APP}} fast lint checks.
     dir: '{{.GENERATOR_ROOT}}'
     cmds:
-      - golangci-lint run --verbose --fast=false
+      - golangci-lint run --verbose --fix --fast=false
 
   generator:build:
     desc: Generate the {{.GENERATOR_APP}} binary.
@@ -323,7 +323,7 @@ tasks:
     dir: "{{.CONTROLLER_ROOT}}"
     cmds:
       # Setting GOGC to increase how much debris is tolerated before running GC
-      - GOGC=200 golangci-lint run --verbose --fast=false --timeout 20m ./...
+      - GOGC=200 golangci-lint run --verbose --fix --fast=false --timeout 20m ./...
 
   controller:verify-samples:
     desc: Verify that a sample exists for each supported resource
@@ -1141,7 +1141,7 @@ tasks:
     desc: Run mangle-test fast lint checks.
     dir: '{{.MANGLE_ROOT}}'
     cmds:
-      - golangci-lint run --verbose --fast=false --timeout 5m ./...  
+      - golangci-lint run --verbose --fix --fast=false --timeout 5m ./...  
 
   ############### Crossplane targets ###############
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -260,7 +260,7 @@ tasks:
       - gofumpt -l -w .
 
   generator:lint:
-    desc: Run {{.GENERATOR_APP}} fast lint checks.
+    desc: Run {{.GENERATOR_APP}} lint checks.
     dir: '{{.GENERATOR_ROOT}}'
     cmds:
       - golangci-lint run --verbose --fix --fast=false
@@ -317,7 +317,7 @@ tasks:
       - gofumpt -l -w .
 
   controller:lint:
-    desc: Run fast lint checks.
+    desc: Run lint checks.
     deps: 
       - controller:generate-crds
     dir: "{{.CONTROLLER_ROOT}}"


### PR DESCRIPTION
## What this PR does

Including lint fixes in `format-code` has caused problems, as the linter requires the code to fully compile before a fix can be applied. 

We can easily end up in a situation where running `task` doesn't fix things because a linter failure blocks code generation.

This PR removes the linters from `format-code` and instead puts the `--fix` flag into the lint tasks.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/vjfXRyY4S05HfI2Zj5/giphy.gif?cid=790b761119mw66m8k8d2mcbbtz8i8ygc1ji1a9f2bwwswntp&ep=v1_gifs_search&rid=giphy.gif&ct=g)
