### PR TITLE
Fix bugs in OneOf to Object conversion

### DIFF
--- a/docs/hugo/content/reference/_index.md
+++ b/docs/hugo/content/reference/_index.md
@@ -202,10 +202,10 @@ To install the CRDs for these resources, your ASO configuration must include `co
 
 Development of these new resources is complete and they will be available in the next release of ASO.
 
-| Resource            | ARM Version | CRD Version   | Supported From | Sample                                                                                                                                              |
-|---------------------|-------------|---------------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| Registry            | 2023-07-01  | v1api20230701 | v2.12.0        | [View](https://github.com/Azure/azure-service-operator/tree/main/v2/samples/containerregistry/v1api20230701/v1api20230701_registry.yaml)            |
-| RegistryReplication | 2023-07-01  | v1api20230701 | v2.12.0        | [View](https://github.com/Azure/azure-service-operator/tree/main/v2/samples/containerregistry/v1api20230701/v1api20230701_registryreplication.yaml) |
+| Resource                                                                                                                                                                       | ARM Version | CRD Version   | Supported From | Sample                                                                                                                                              |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|---------------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Registry](https://azure.github.io/azure-service-operator/reference/containerregistry/v1api20230701/#containerregistry.azure.com/v1api20230701.Registry)                       | 2023-07-01  | v1api20230701 | v2.12.0        | [View](https://github.com/Azure/azure-service-operator/tree/main/v2/samples/containerregistry/v1api20230701/v1api20230701_registry.yaml)            |
+| [RegistryReplication](https://azure.github.io/azure-service-operator/reference/containerregistry/v1api20230701/#containerregistry.azure.com/v1api20230701.RegistryReplication) | 2023-07-01  | v1api20230701 | v2.12.0        | [View](https://github.com/Azure/azure-service-operator/tree/main/v2/samples/containerregistry/v1api20230701/v1api20230701_registryreplication.yaml) |
 
 ### Released
 

--- a/docs/hugo/content/reference/containerregistry/_index.md
+++ b/docs/hugo/content/reference/containerregistry/_index.md
@@ -9,10 +9,10 @@ To install the CRDs for these resources, your ASO configuration must include `co
 
 Development of these new resources is complete and they will be available in the next release of ASO.
 
-| Resource            | ARM Version | CRD Version   | Supported From | Sample                                                                                                                                              |
-|---------------------|-------------|---------------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| Registry            | 2023-07-01  | v1api20230701 | v2.12.0        | [View](https://github.com/Azure/azure-service-operator/tree/main/v2/samples/containerregistry/v1api20230701/v1api20230701_registry.yaml)            |
-| RegistryReplication | 2023-07-01  | v1api20230701 | v2.12.0        | [View](https://github.com/Azure/azure-service-operator/tree/main/v2/samples/containerregistry/v1api20230701/v1api20230701_registryreplication.yaml) |
+| Resource                                                                                                                                                                       | ARM Version | CRD Version   | Supported From | Sample                                                                                                                                              |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|---------------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Registry](https://azure.github.io/azure-service-operator/reference/containerregistry/v1api20230701/#containerregistry.azure.com/v1api20230701.Registry)                       | 2023-07-01  | v1api20230701 | v2.12.0        | [View](https://github.com/Azure/azure-service-operator/tree/main/v2/samples/containerregistry/v1api20230701/v1api20230701_registry.yaml)            |
+| [RegistryReplication](https://azure.github.io/azure-service-operator/reference/containerregistry/v1api20230701/#containerregistry.azure.com/v1api20230701.RegistryReplication) | 2023-07-01  | v1api20230701 | v2.12.0        | [View](https://github.com/Azure/azure-service-operator/tree/main/v2/samples/containerregistry/v1api20230701/v1api20230701_registryreplication.yaml) |
 
 ### Released
 

--- a/v2/tools/generator/internal/astmodel/oneof_type.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type.go
@@ -187,7 +187,42 @@ func (oneOf *OneOfType) Equals(t Type, overrides EqualityOverrides) bool {
 		return false
 	}
 
-	return oneOf.types.Equals(other.types, overrides)
+	// Check for different properties
+	if oneOf.swaggerName != other.swaggerName {
+		return false
+	}
+
+	if oneOf.discriminatorProperty != other.discriminatorProperty {
+		return false
+	}
+
+	if oneOf.discriminatorValue != other.discriminatorValue {
+		return false
+	}
+
+	// Check for different options to select from
+	if !oneOf.types.Equals(other.types, overrides) {
+		return false
+	}
+
+	// Check for different common properties
+	if len(oneOf.propertyObjects) != len(other.propertyObjects) {
+		return false
+	}
+
+	// Requiring exactly the same property objects in the same order is overly
+	// strict as they're actually all merged together into a single object
+	// and the order is not significant. Moreover, two one-of types would be the
+	// same if the merge is the same, regardless of how many object types were there
+	// to start with. This is all too complex to handle here though, so we'll just
+	// use the strict check.
+	for i := range oneOf.propertyObjects {
+		if !oneOf.propertyObjects[i].Equals(other.propertyObjects[i], overrides) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // String implements fmt.Stringer

--- a/v2/tools/generator/internal/astmodel/oneof_type_test.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type_test.go
@@ -112,7 +112,7 @@ func TestOneOfType_WithoutAnyPropertyObjects_GivenProperties_ReturnsOneOfWithNon
 	g.Expect(result.PropertyObjects()).To(HaveLen(0))
 }
 
-func TestOneOfType_Equals_givenChange_recognisesDifference(t *testing.T) {
+func TestOneOfType_Equals_GivenChange_RecognisesDifference(t *testing.T) {
 	t.Parallel()
 
 	nameMixin := NewObjectType().WithProperties(

--- a/v2/tools/generator/internal/astmodel/oneof_type_test.go
+++ b/v2/tools/generator/internal/astmodel/oneof_type_test.go
@@ -15,33 +15,33 @@ func TestOneOfEqualityDoesNotCareAboutOrder(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	x := NewOneOfType("x", StringType, BoolType)
-	y := NewOneOfType("y", BoolType, StringType)
+	version1 := NewOneOfType("one", StringType, BoolType)
+	version2 := NewOneOfType("one", BoolType, StringType)
 
-	g.Expect(TypeEquals(x, y)).To(BeTrue())
-	g.Expect(TypeEquals(y, x)).To(BeTrue())
+	g.Expect(TypeEquals(version1, version2)).To(BeTrue())
+	g.Expect(TypeEquals(version2, version1)).To(BeTrue())
 }
 
 func TestOneOfMustHaveAllTypesToBeEqual(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	x := NewOneOfType("x", StringType, BoolType, FloatType)
-	y := NewOneOfType("y", BoolType, StringType)
+	version1 := NewOneOfType("one", StringType, BoolType, FloatType)
+	version2 := NewOneOfType("one", BoolType, StringType)
 
-	g.Expect(TypeEquals(x, y)).To(BeFalse())
-	g.Expect(TypeEquals(y, x)).To(BeFalse())
+	g.Expect(TypeEquals(version1, version2)).To(BeFalse())
+	g.Expect(TypeEquals(version2, version1)).To(BeFalse())
 }
 
 func TestOneOfsWithDifferentTypesAreNotEqual(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	x := NewOneOfType("x", StringType, FloatType)
-	y := NewOneOfType("y", BoolType, StringType)
+	version1 := NewOneOfType("one", StringType, FloatType)
+	version2 := NewOneOfType("one", BoolType, StringType)
 
-	g.Expect(TypeEquals(x, y)).To(BeFalse())
-	g.Expect(TypeEquals(y, x)).To(BeFalse())
+	g.Expect(TypeEquals(version1, version2)).To(BeFalse())
+	g.Expect(TypeEquals(version2, version1)).To(BeFalse())
 }
 
 var expectedOneOfPanic = "OneOfType should have been replaced by generation time by 'convertAllOfAndOneOf' phase"
@@ -110,4 +110,64 @@ func TestOneOfType_WithoutAnyPropertyObjects_GivenProperties_ReturnsOneOfWithNon
 	result := oneOf.WithoutAnyPropertyObjects()
 	g.Expect(result).NotTo(BeNil())
 	g.Expect(result.PropertyObjects()).To(HaveLen(0))
+}
+
+func TestOneOfType_Equals_givenChange_recognisesDifference(t *testing.T) {
+	t.Parallel()
+
+	nameMixin := NewObjectType().WithProperties(
+		NewPropertyDefinition("Name", "name", StringType))
+	locationMixin := NewObjectType().WithProperties(
+		NewPropertyDefinition("Location", "location", StringType))
+
+	cases := map[string]struct {
+		change         func(*OneOfType) *OneOfType
+		expectedEquals bool
+	}{
+		"adding a property object": {
+			change: func(oneOf *OneOfType) *OneOfType {
+				return oneOf.WithAdditionalPropertyObject(locationMixin)
+			},
+			expectedEquals: false,
+		},
+		"without property objects": {
+			change: func(oneOf *OneOfType) *OneOfType {
+				return oneOf.WithoutAnyPropertyObjects()
+			},
+			expectedEquals: false,
+		},
+		"with different property object": {
+			change: func(oneOf *OneOfType) *OneOfType {
+				return oneOf.WithoutAnyPropertyObjects().WithAdditionalPropertyObject(locationMixin)
+			},
+			expectedEquals: false,
+		},
+		"with option type already present": {
+			change: func(oneOf *OneOfType) *OneOfType {
+				return oneOf.WithType(StringType)
+			},
+			expectedEquals: true,
+		},
+		"with additional option type": {
+			change: func(oneOf *OneOfType) *OneOfType {
+				return oneOf.WithType(FloatType)
+			},
+			expectedEquals: false,
+		},
+	}
+
+	for n, c := range cases {
+		t.Run(n, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			oneOf := NewOneOfType("oneOf").
+				WithType(StringType).
+				WithType(BoolType).
+				WithAdditionalPropertyObject(nameMixin)
+
+			actual := c.change(oneOf)
+			g.Expect(oneOf.Equals(actual, EqualityOverrides{})).To(Equal(c.expectedEquals))
+		})
+	}
 }

--- a/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
+++ b/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
@@ -467,6 +467,7 @@ func init() {
 	i.AddUnordered(synthesizer.handleAnyType)
 	i.AddUnordered(synthesizer.handleAllOfType)
 	i.AddUnordered(synthesizer.handleTypeName)
+	i.AddUnordered(synthesizer.handleLeafOneOfWithObject)
 	i.AddUnordered(synthesizer.handleOneOf)
 	i.AddUnordered(synthesizer.handleARMIDAndString)
 	i.AddUnordered(synthesizer.handleFlaggedType)
@@ -696,6 +697,22 @@ func (s synthesizer) handleAllOfType(leftAllOf *astmodel.AllOfType, right astmod
 	}
 
 	return s.intersectTypes(result, right)
+}
+
+func (s synthesizer) handleLeafOneOfWithObject(
+	leaf *astmodel.OneOfType,
+	object *astmodel.ObjectType,
+) (astmodel.Type, error) {
+	if !leaf.HasDiscriminatorValue() {
+		// Not a leaf
+		return nil, nil
+	}
+
+	// We have a leaf with a discriminator value, so we need to merge the object into the leaf
+	result := leaf.WithAdditionalPropertyObject(object)
+
+	// Still have a OneOf, need to reprocess it
+	return s.oneOfToObject(result)
 }
 
 // if combining a type with a oneOf that contains that type, the result is that type

--- a/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
+++ b/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
@@ -266,7 +266,7 @@ func (s synthesizer) getOneOfName(t astmodel.Type, propIndex int) (propertyNames
 	switch concreteType := t.(type) {
 	case astmodel.InternalTypeName:
 
-		if def, ok := s.lookupType(concreteType); ok {
+		if def, ok := s.lookupDefinition(concreteType); ok {
 			// TypeName represents one of our definitions; if we can get a good name from the content
 			// (say, from a OneOf discriminator), we should use that
 			names, err := s.getOneOfName(def.Type(), propIndex)
@@ -747,7 +747,7 @@ func (s synthesizer) handleOneOf(leftOneOf *astmodel.OneOfType, right astmodel.T
 }
 
 func (s synthesizer) handleTypeName(leftName astmodel.InternalTypeName, right astmodel.Type) (astmodel.Type, error) {
-	found, ok := s.lookupType(leftName)
+	found, ok := s.lookupDefinition(leftName)
 	if !ok {
 		return nil, eris.Errorf("couldn't find type %s", leftName)
 	}
@@ -953,7 +953,7 @@ func (s synthesizer) simplifyAllOfTypeNames(types []astmodel.Type) []astmodel.Ty
 	result := make([]astmodel.Type, len(types))
 	for i, t := range types {
 		if tn, ok := astmodel.AsInternalTypeName(t); ok {
-			if def, ok := s.lookupType(tn); ok {
+			if def, ok := s.lookupDefinition(tn); ok {
 				result[i] = def.Type()
 				foundName = true
 				continue
@@ -1002,7 +1002,8 @@ func countTypeReferences(defs astmodel.TypeDefinitionSet) map[astmodel.TypeName]
 	return referenceCounts
 }
 
-func (s synthesizer) lookupType(name astmodel.InternalTypeName) (*astmodel.TypeDefinition, bool) {
+// lookupDefinition finds a type definition by name, first checking the updated definitions and then the original definitions.
+func (s synthesizer) lookupDefinition(name astmodel.InternalTypeName) (*astmodel.TypeDefinition, bool) {
 	if def, ok := s.updatedDefs[name]; ok {
 		return &def, true
 	}


### PR DESCRIPTION
## What this PR does

Fixes a few small errors that I uncovered while troubleshooting issues with Kusto resources.

### Leaf Merging

Previously we've always merged object properties into the root of a one-of, then pushed them down to the leaves. Due to the way Kusto resources are structured, we now also need to support merging object properties directly into leaves. (Instead of embedding a OneOf directly into an AllOff, the Kusto resources instead refer to a separate type definition, triggering the change in behaviour.)

### Avoid lost updates

In two locations, the synthesizer was looking up an unmodified type definition when that type had already been modified, resulting in the previous updates being lost. All type lookup now goes through a helper method (`lookupType`) that avoids this propblem.


### OneOf Equality

We hadn't updated equality of one-of types, causing lost object updates when additional properties were added. (Two one-of objects, one containing three object-property types, the other four, were comparing as equal.)

### Special notes

Also updates CRD documentation for ContainerRegistry - now that documentation has been merged, the code generator has introduced linkes.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdHEwYTZteDB3bXA0cWdvbTJma3pnNGkyNjBzeGcyZDdweGRkZjk0ZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/KX5nwoDX97AtPvKBF6/giphy.gif)

## Checklist

- [x] this PR contains tests
