### PR TITLE
Make reconcile-policy customizable for ASO operator (#4053)

### DIFF
--- a/docs/hugo/content/guide/aso-controller-settings-options.md
+++ b/docs/hugo/content/guide/aso-controller-settings-options.md
@@ -293,3 +293,15 @@ RATE_LIMIT_BUCKET_SIZE is the size of the bucket. This value only has an effect 
 **Required**: False
 
 **[Allowed scopes]( {{< relref "authentication#credential-scope" >}} )**: Global
+
+### DEFAULT_RECONCILE_POLICY
+
+DEFAULT_RECONCILE_POLICY specify which reconcile strategy to be used by the operator. If not specified, it is set to 'manage'.
+
+**Format:** `string`
+
+**Example:** `detach-on-delete`
+
+**Required**: False
+
+**[Allowed scopes]( {{< relref "authentication#credential-scope" >}} )**: Global

--- a/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
+++ b/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
@@ -186,6 +186,12 @@ spec:
               key: RATE_LIMIT_BUCKET_SIZE
               name: aso-controller-settings
               optional: true
+        - name: DEFAULT_RECONCILE_POLICY
+          valueFrom:
+            secretKeyRef:
+              key: DEFAULT_RECONCILE_POLICY
+              name: aso-controller-settings
+              optional: true
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/v2/config/manager/manager_image_patch.yaml
+++ b/v2/config/manager/manager_image_patch.yaml
@@ -132,6 +132,12 @@ spec:
                   key: RATE_LIMIT_BUCKET_SIZE
                   name: aso-controller-settings
                   optional: true
+            - name: DEFAULT_RECONCILE_POLICY
+              valueFrom:
+                secretKeyRef:
+                  key: DEFAULT_RECONCILE_POLICY
+                  name: aso-controller-settings
+                  optional: true
             # Used for setting the operator-namespace annotation (and
             # for aad-pod-identity once we support it).
             - name: POD_NAMESPACE

--- a/v2/internal/config/vars_test.go
+++ b/v2/internal/config/vars_test.go
@@ -80,3 +80,54 @@ func Test_Cloud_ResourceManagerAudienceSet(t *testing.T) {
 	g.Expect(cld.Services[cloud.ResourceManager].Endpoint).To(Equal(cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint))
 	g.Expect(cld.Services[cloud.ResourceManager].Audience).To(Equal(cfg.ResourceManagerAudience))
 }
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	vOk := config.Values{
+		PodNamespace:            "test-namespace",
+		MaxConcurrentReconciles: 1,
+		OperatorMode:            3,
+		TargetNamespaces:        []string{},
+		DefaultReconcilePolicy:  "detach-on-delete",
+	}
+
+	g.Expect(vOk.Validate()).NotTo(HaveOccurred())
+
+	vKoNamespace := config.Values{
+		PodNamespace: "",
+	}
+
+	err := vKoNamespace.Validate()
+	g.Expect(err).To(MatchError(ContainSubstring("POD_NAMESPACE")))
+	g.Expect(err).To(MatchError(ContainSubstring("missing value")))
+
+	g.Expect(vOk.Validate()).NotTo(HaveOccurred())
+
+	vKoConcurrentReconciles := config.Values{
+		PodNamespace:            "test-namespace",
+		MaxConcurrentReconciles: 0,
+		DefaultReconcilePolicy:  "detach-on-delete",
+	}
+
+	g.Expect(vKoConcurrentReconciles.Validate().Error()).Error().Should(Equal("MAX_CONCURRENT_RECONCILES must be at least 1"))
+
+	vKoDefaultReconcilePolicy := config.Values{
+		PodNamespace:            "test-namespace",
+		MaxConcurrentReconciles: 1,
+		DefaultReconcilePolicy:  "detach",
+	}
+
+	g.Expect(vKoDefaultReconcilePolicy.Validate().Error()).Error().Should(Equal("DEFAULT_RECONCILE_POLICY must be set to any of (detach-on-delete, manage, skip)"))
+
+	vKoOperatorMode := config.Values{
+		PodNamespace:            "test-namespace",
+		MaxConcurrentReconciles: 1,
+		DefaultReconcilePolicy:  "detach-on-delete",
+		TargetNamespaces:        []string{"to-be-watched"},
+		OperatorMode:            2,
+	}
+
+	g.Expect(vKoOperatorMode.Validate().Error()).Error().Should(Equal("AZURE_TARGET_NAMESPACES must include watchers to specify target namespaces"))
+}

--- a/v2/internal/reconcilers/generic/generic_reconciler.go
+++ b/v2/internal/reconcilers/generic/generic_reconciler.go
@@ -235,7 +235,7 @@ func (gr *GenericReconciler) createOrUpdate(ctx context.Context, log logr.Logger
 	}
 
 	// Check the reconcile-policy to ensure we're allowed to issue a CreateOrUpdate
-	reconcilePolicy := reconcilers.GetReconcilePolicy(metaObj, log)
+	reconcilePolicy := reconcilers.GetReconcilePolicy(metaObj, log, gr.Config.DefaultReconcilePolicy)
 	if !reconcilePolicy.AllowsModify() {
 		return ctrl.Result{}, gr.handleSkipReconcile(ctx, log, metaObj)
 	}
@@ -247,7 +247,7 @@ func (gr *GenericReconciler) createOrUpdate(ctx context.Context, log logr.Logger
 
 func (gr *GenericReconciler) delete(ctx context.Context, log logr.Logger, metaObj genruntime.MetaObject) (ctrl.Result, error) {
 	// Check the reconcile policy to ensure we're allowed to issue a delete
-	reconcilePolicy := reconcilers.GetReconcilePolicy(metaObj, log)
+	reconcilePolicy := reconcilers.GetReconcilePolicy(metaObj, log, gr.Config.DefaultReconcilePolicy)
 	if !reconcilePolicy.AllowsDelete() {
 		log.V(Info).Info("Bypassing delete of resource due to policy", "policy", reconcilePolicy)
 		controllerutil.RemoveFinalizer(metaObj, genruntime.ReconcilerFinalizer)
@@ -351,7 +351,7 @@ func (gr *GenericReconciler) CommitUpdate(
 }
 
 func (gr *GenericReconciler) handleSkipReconcile(ctx context.Context, log logr.Logger, obj genruntime.MetaObject) error {
-	reconcilePolicy := reconcilers.GetReconcilePolicy(obj, log) // TODO: Pull this whole method up here
+	reconcilePolicy := reconcilers.GetReconcilePolicy(obj, log, gr.Config.DefaultReconcilePolicy) // TODO: Pull this whole method up here
 	log.V(Status).Info(
 		"Skipping creation/update of resource due to policy",
 		annotations.ReconcilePolicy, reconcilePolicy)

--- a/v2/internal/reconcilers/predicates.go
+++ b/v2/internal/reconcilers/predicates.go
@@ -35,9 +35,9 @@ func ARMPerResourceSecretAnnotationChangedPredicate() predicate.Predicate {
 }
 
 // GetReconcilePolicy gets the reconcile-policy from the ReconcilePolicy
-func GetReconcilePolicy(obj genruntime.MetaObject, log logr.Logger) annotations.ReconcilePolicyValue {
+func GetReconcilePolicy(obj genruntime.MetaObject, log logr.Logger, defaultReconcilePolicy annotations.ReconcilePolicyValue) annotations.ReconcilePolicyValue {
 	policyStr := obj.GetAnnotations()[annotations.ReconcilePolicy]
-	policy, err := ParseReconcilePolicy(policyStr)
+	policy, err := ParseReconcilePolicy(policyStr, defaultReconcilePolicy)
 	if err != nil {
 		log.Error(
 			err,

--- a/v2/internal/reconcilers/reconcile_policy.go
+++ b/v2/internal/reconcilers/reconcile_policy.go
@@ -15,10 +15,12 @@ import (
 )
 
 // ParseReconcilePolicy parses the provided reconcile policy.
-func ParseReconcilePolicy(policy string) (annotations.ReconcilePolicyValue, error) {
+// defaultPolicyValue is read from DEFAULT_RECONCILE_POLICY env variable, it set to "manage" when not specified
+func ParseReconcilePolicy(policy string, defaultReconcilePolicy annotations.ReconcilePolicyValue) (annotations.ReconcilePolicyValue, error) {
+	// policy is read from CR annotation, if it's empty it being read from defaultReconcilePolicy
 	switch policy {
 	case "":
-		return annotations.ReconcilePolicyManage, nil
+		return defaultReconcilePolicy, nil
 	case string(annotations.ReconcilePolicyManage):
 		return annotations.ReconcilePolicyManage, nil
 	case string(annotations.ReconcilePolicySkip):

--- a/v2/internal/reconcilers/reconcile_policy_test.go
+++ b/v2/internal/reconcilers/reconcile_policy_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package reconcilers
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
+)
+
+func TestParseReconcilePolicy(t *testing.T) {
+	testingMap := map[string]annotations.ReconcilePolicyValue{
+		"manage":           annotations.ReconcilePolicyManage,
+		"skip":             annotations.ReconcilePolicySkip,
+		"detach-on-delete": annotations.ReconcilePolicyDetachOnDelete,
+	}
+
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	// test nominal case
+	for policyString, policyValue := range testingMap {
+		returnedPolicy, err := ParseReconcilePolicy(policyString, policyValue)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(returnedPolicy).Should(Equal(policyValue))
+	}
+
+	// test default value
+	returnedPolicy, err := ParseReconcilePolicy("", annotations.ReconcilePolicySkip)
+	g.Expect(err).ToNot((HaveOccurred()))
+	g.Expect(returnedPolicy).Should(Equal(annotations.ReconcilePolicySkip))
+
+	// test error in case of any other value
+	returnedPolicy, err = ParseReconcilePolicy("whatever", annotations.ReconcilePolicySkip)
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(returnedPolicy).Should(Equal(annotations.ReconcilePolicyManage))
+}

--- a/v2/pkg/common/config/config.go
+++ b/v2/pkg/common/config/config.go
@@ -98,4 +98,7 @@ const (
 	RateLimitQPS = "RATE_LIMIT_QPS"
 	// RateLimitBucketSize is the size of the bucket. This value only has an effect if RateLimitMode is 'bucket'.
 	RateLimitBucketSize = "RATE_LIMIT_BUCKET_SIZE"
+	// DefaultReconcilePolicy allows to change default reconciliation policy to use when serviceoperator.azure.com/reconcile-policy annotation
+	// is not explicitly defined. If omitted, it will be automatically set to "manage"
+	DefaultReconcilePolicy = "DEFAULT_RECONCILE_POLICY"
 )


### PR DESCRIPTION
## What this PR does

Extends ASO configuration to customize default reconcile policy for CRs when annotation `serviceoperator.azure.com/reconcile-policy` it not explicitly specified.
It keeps the same default behavior of today assuming that all CRs are in `manage` status, however this value can be overridden by setting DEFAULT_RECONCILE_POLICY environment variable.

closes #4562 
closes #4053 

I would appreciate to have your honest feedback on this code change; I'll add relevant unit tests and documentation if code looks correct on your side.

