### PR TITLE
Set spec.owner on root resource of import

### DIFF
--- a/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
+++ b/v2/cmd/asoctl/pkg/importresources/importable_arm_resource.go
@@ -473,11 +473,7 @@ func (i *importableARMResource) getStatus(
 
 	o := genruntime.ArbitraryOwnerReference{}
 	if i.owner != nil {
-		o = genruntime.ArbitraryOwnerReference{
-			Group: i.owner.Group,
-			Kind:  i.owner.Kind,
-			Name:  i.owner.Name,
-		}
+		o = i.owner.AsArbitraryOwnerReference()
 	}
 
 	err = s.PopulateFromARM(o, reflecthelpers.ValueOfPtr(armStatus)) // TODO: PopulateFromArm expects a value... ick
@@ -569,22 +565,14 @@ func (i *importableARMResource) SetOwner(
 
 	// If the owner is an ArbitraryOwnerReference we need to synthesize one
 	if ownerField.Type() == reflect.PointerTo(reflect.TypeOf(genruntime.ArbitraryOwnerReference{})) {
-		aor := genruntime.ArbitraryOwnerReference{
-			Group: owner.Group,
-			Kind:  owner.Kind,
-			Name:  owner.Name,
-		}
-
+		aor := owner.AsArbitraryOwnerReference()
 		ownerField.Set(reflect.ValueOf(&aor))
 		return
 	}
 
 	// if the owner is a KnownResourceReference, we need to synthesize one
 	if ownerField.Type() == reflect.PointerTo(reflect.TypeOf(genruntime.KnownResourceReference{})) {
-		krr := genruntime.KnownResourceReference{
-			Name: owner.Name,
-		}
-
+		krr := owner.AsKnownResourceReference()
 		ownerField.Set(reflect.ValueOf(&krr))
 		return
 	}

--- a/v2/pkg/genruntime/resource_reference.go
+++ b/v2/pkg/genruntime/resource_reference.go
@@ -187,6 +187,23 @@ func (ref *ResourceReference) AsNamespacedRef(namespace string) NamespacedResour
 	}
 }
 
+// AsArbitraryOwnerReference creates an ArbitraryOwnerReference from this reference.
+func (ref *ResourceReference) AsArbitraryOwnerReference() ArbitraryOwnerReference {
+	// If this is a direct ARM reference, return just the ARM  ID
+	if ref.IsDirectARMReference() {
+		return ArbitraryOwnerReference{
+			ARMID: ref.ARMID,
+		}
+	}
+
+	// Otherwise return GVK
+	return ArbitraryOwnerReference{
+		Group: ref.Group,
+		Kind:  ref.Kind,
+		Name:  ref.Name,
+	}
+}
+
 // GroupKind returns the GroupKind of the resource reference
 func (ref *ResourceReference) GroupKind() schema.GroupKind {
 	return schema.GroupKind{

--- a/v2/pkg/genruntime/resource_reference.go
+++ b/v2/pkg/genruntime/resource_reference.go
@@ -204,6 +204,21 @@ func (ref *ResourceReference) AsArbitraryOwnerReference() ArbitraryOwnerReferenc
 	}
 }
 
+// AsKnownResourceReference creates a KnownResourceReference from this reference.
+func (ref *ResourceReference) AsKnownResourceReference() KnownResourceReference {
+	// If this is a direct ARM reference, return just the ARM  ID
+	if ref.IsDirectARMReference() {
+		return KnownResourceReference{
+			ARMID: ref.ARMID,
+		}
+	}
+
+	// Otherwise return just the name
+	return KnownResourceReference{
+		Name: ref.Name,
+	}
+}
+
 // GroupKind returns the GroupKind of the resource reference
 func (ref *ResourceReference) GroupKind() schema.GroupKind {
 	return schema.GroupKind{


### PR DESCRIPTION
## What this PR does

Sets the `spec.owner` of each root resource specified when importing existing Azure resources, using the ARM ID of the parent resource.

Closes #4564

Example: If you import a Storage Account:
```
/subscriptions/<subscriptionid>/resourceGroups/<resourcegroup>/providers/Microsoft.Storage/storageAccounts/storageacct
```

The owner will be set to the resource group
``` yaml
  owner:
    armId: /subscriptions/<subscriptionid>/resourceGroups/<resourcegroup>
```

## How does this PR make you feel?

![gif](https://media.giphy.com/media/3ohhweiVB36rAlqVCE/giphy.gif?cid=790b7611zwafqwkyiu9o6r2qmxyduqy2l8rt58425dkf7hsj&ep=v1_gifs_search&rid=giphy.gif&ct=g)

