### PR TITLE
Retry on DNS Zone targetResource lookup not found

### DIFF
--- a/v2/api/network/customizations/dns_zones_a_record_extension.go
+++ b/v2/api/network/customizations/dns_zones_a_record_extension.go
@@ -1,0 +1,34 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package customizations
+
+import (
+	"github.com/go-logr/logr"
+
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
+)
+
+var _ extensions.ErrorClassifier = &DnsZonesARecordExtension{}
+
+func (extension *DnsZonesARecordExtension) ClassifyError(
+	cloudError *genericarmclient.CloudError,
+	apiVersion string,
+	log logr.Logger,
+	next extensions.ErrorClassifierFunc,
+) (core.CloudErrorDetails, error) {
+	details, err := next(cloudError)
+	if err != nil {
+		return core.CloudErrorDetails{}, err
+	}
+
+	if isRetryableDNSZoneRecordError(cloudError) {
+		details.Classification = core.ErrorRetryable
+	}
+
+	return details, nil
+}

--- a/v2/api/network/customizations/dns_zones_aaaa_record_extension.go
+++ b/v2/api/network/customizations/dns_zones_aaaa_record_extension.go
@@ -1,0 +1,34 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package customizations
+
+import (
+	"github.com/go-logr/logr"
+
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
+)
+
+var _ extensions.ErrorClassifier = &DnsZonesAAAARecordExtension{}
+
+func (extension *DnsZonesAAAARecordExtension) ClassifyError(
+	cloudError *genericarmclient.CloudError,
+	apiVersion string,
+	log logr.Logger,
+	next extensions.ErrorClassifierFunc,
+) (core.CloudErrorDetails, error) {
+	details, err := next(cloudError)
+	if err != nil {
+		return core.CloudErrorDetails{}, err
+	}
+
+	if isRetryableDNSZoneRecordError(cloudError) {
+		details.Classification = core.ErrorRetryable
+	}
+
+	return details, nil
+}

--- a/v2/api/network/customizations/dns_zones_cname_record_extension.go
+++ b/v2/api/network/customizations/dns_zones_cname_record_extension.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package customizations
+
+import (
+	"regexp"
+
+	"github.com/go-logr/logr"
+
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
+)
+
+var _ extensions.ErrorClassifier = &DnsZonesCNAMERecordExtension{}
+
+var referencedResourceNotFound = regexp.MustCompile("The referenced resource.*was not found")
+
+func (extension *DnsZonesCNAMERecordExtension) ClassifyError(
+	cloudError *genericarmclient.CloudError,
+	apiVersion string,
+	log logr.Logger,
+	next extensions.ErrorClassifierFunc,
+) (core.CloudErrorDetails, error) {
+	details, err := next(cloudError)
+	if err != nil {
+		return core.CloudErrorDetails{}, err
+	}
+
+	if isRetryableDNSZoneRecordError(cloudError) {
+		details.Classification = core.ErrorRetryable
+	}
+
+	return details, nil
+}
+
+// isRetryableDNSZoneRecordError determines if the error is a retryable DNS Zone Record error.
+// This should be generic across all DNS Zone Record types.
+func isRetryableDNSZoneRecordError(err *genericarmclient.CloudError) bool {
+	if err == nil {
+		return false
+	}
+
+	// If a referenced resource is not yet provisioned, it may be coming soon
+	if err.Code() == "BadRequest" && referencedResourceNotFound.MatchString(err.Message()) {
+		return true
+	}
+
+	return false
+}

--- a/v2/api/network/customizations/dns_zones_cname_record_extension_test.go
+++ b/v2/api/network/customizations/dns_zones_cname_record_extension_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package customizations
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+)
+
+func Test_IsRetryableDNSZoneRecordError_NotFound(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	err := genericarmclient.NewTestCloudError("BadRequest", "The referenced resource '/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Network/trafficManagerProfiles/test' was not found")
+	g.Expect(isRetryableDNSZoneRecordError(err)).To(BeTrue())
+}
+
+func Test_IsRetryableDNSZoneRecordError_BadRequest(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	err := genericarmclient.NewTestCloudError("BadRequest", "Invalid value specified for field")
+	g.Expect(isRetryableDNSZoneRecordError(err)).To(BeFalse())
+}


### PR DESCRIPTION
This error is likely transient and can be retried on.

Closes #4645 

- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
