### PR TITLE
Fix bug where PostgreSQL create user couldn't add roles with caps

### DIFF
--- a/v2/internal/util/postgresql/role_option.go
+++ b/v2/internal/util/postgresql/role_option.go
@@ -144,7 +144,7 @@ func setRoleOptions(ctx context.Context, db *sql.DB, user SQLUser, options set.S
 type RoleOption string
 
 // see https://www.postgresql.org/docs/current/sql-createrole.html
-var (
+const (
 	Login         = RoleOption("LOGIN")
 	CreateRole    = RoleOption("CREATEROLE")
 	CreateDb      = RoleOption("CREATEDB")

--- a/v2/internal/util/postgresql/roles.go
+++ b/v2/internal/util/postgresql/roles.go
@@ -121,7 +121,7 @@ func addRoles(ctx context.Context, db *sql.DB, user SQLUser, roles set.Set[strin
 		}
 	}
 	toAdd := strings.Join(roles.Values(), ",")
-	_, err := db.ExecContext(ctx, fmt.Sprintf("GRANT %s TO \"%s\"", toAdd, user.Name))
+	_, err := db.ExecContext(ctx, fmt.Sprintf("GRANT %q TO %q", toAdd, user.Name))
 	if err != nil {
 		errorStrings = append(errorStrings, err.Error())
 	}
@@ -138,7 +138,7 @@ func deleteRoles(ctx context.Context, db *sql.DB, user SQLUser, roles set.Set[st
 	}
 
 	toDelete := strings.Join(roles.Values(), ",")
-	_, err := db.ExecContext(ctx, fmt.Sprintf("REVOKE %s FROM \"%s\"", toDelete, user.Name))
+	_, err := db.ExecContext(ctx, fmt.Sprintf("REVOKE %q FROM %q", toDelete, user.Name))
 
 	return err
 }


### PR DESCRIPTION
This is due to PostgreSQL lowercasing role names when they are not double-quoted. This behavior is mentioned here:
https://stackoverflow.com/questions/31694518/how-can-i-create-a-capitalized-postgres-role-name

Closes #4334.

- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
