### PR TITLE
Retry for explict Conflict, as we do already for 409

### DIFF
--- a/v2/internal/reconcilers/arm/error_classifier.go
+++ b/v2/internal/reconcilers/arm/error_classifier.go
@@ -49,6 +49,7 @@ func classifyCloudError(err *genericarmclient.CloudError) core.ErrorClassificati
 	case "AnotherOperationInProgress",
 		"AuthorizationFailed",
 		"AllocationFailed",
+		"Conflict",
 		"FailedIdentityOperation",
 		"InvalidResourceReference",
 		"InvalidSubscriptionRegistrationState",
@@ -65,7 +66,6 @@ func classifyCloudError(err *genericarmclient.CloudError) core.ErrorClassificati
 		"SubscriptionNotRegistered":
 		return core.ErrorRetryable
 	case "BadRequestFormat",
-		"Conflict",
 		"BadRequest",
 		"PublicIpForGatewayIsRequired", // TODO: There's not a great way to look at an arbitrary error returned by this API and determine if it's a 4xx or 5xx level... ugh
 		"InvalidParameter",
@@ -101,8 +101,10 @@ func classifyHTTPError(err *genericarmclient.CloudError) core.ErrorClassificatio
 	if !eris.As(err.Unwrap(), &httpError) {
 		return core.ErrorRetryable
 	}
+
 	if httpError.StatusCode == 400 {
 		return core.ErrorFatal
 	}
+
 	return core.ErrorRetryable
 }

--- a/v2/internal/reconcilers/arm/error_classifier_test.go
+++ b/v2/internal/reconcilers/arm/error_classifier_test.go
@@ -39,12 +39,12 @@ func Test_NilError_IsRetryable(t *testing.T) {
 	g.Expect(arm.ClassifyCloudError(nil)).To(Equal(expected))
 }
 
-func Test_Conflict_IsNotRetryable(t *testing.T) {
+func Test_Conflict_IsRetryable(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
 	expected := core.CloudErrorDetails{
-		Classification: core.ErrorFatal,
+		Classification: core.ErrorRetryable,
 		Code:           conflictError.Code(),
 		Message:        conflictError.Message(),
 	}


### PR DESCRIPTION
## What this PR does

Fixes an inconsistency where an HTTP conflict (409) was treated as retryable, but the explicit error code `Conflict` was treated as fatal.

Now both kinds of conflict will be treated as retryable.

Partial solution for #4668

## How does this PR make you feel?

![gif](https://media.giphy.com/media/R8MIGe47XWx68/giphy.gif?cid=790b76112cb82uw847gywz3jt2934iayoz7eyd23z2fexwi6&ep=v1_gifs_search&rid=giphy.gif&ct=g)
