### PR TITLE
Reuse predefined value conversion functions

### DIFF
--- a/v2/api/apimanagement/v1api20220801/api_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/api_types_gen.go
@@ -872,28 +872,13 @@ func (api *Api_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error
 func (api *Api_Spec) AssignProperties_From_Api_Spec(source *storage.Api_Spec) error {
 
 	// APIVersion
-	if source.APIVersion != nil {
-		apiVersion := *source.APIVersion
-		api.APIVersion = &apiVersion
-	} else {
-		api.APIVersion = nil
-	}
+	api.APIVersion = genruntime.ClonePointerToString(source.APIVersion)
 
 	// ApiRevision
-	if source.ApiRevision != nil {
-		apiRevision := *source.ApiRevision
-		api.ApiRevision = &apiRevision
-	} else {
-		api.ApiRevision = nil
-	}
+	api.ApiRevision = genruntime.ClonePointerToString(source.ApiRevision)
 
 	// ApiRevisionDescription
-	if source.ApiRevisionDescription != nil {
-		apiRevisionDescription := *source.ApiRevisionDescription
-		api.ApiRevisionDescription = &apiRevisionDescription
-	} else {
-		api.ApiRevisionDescription = nil
-	}
+	api.ApiRevisionDescription = genruntime.ClonePointerToString(source.ApiRevisionDescription)
 
 	// ApiType
 	if source.ApiType != nil {
@@ -905,12 +890,7 @@ func (api *Api_Spec) AssignProperties_From_Api_Spec(source *storage.Api_Spec) er
 	}
 
 	// ApiVersionDescription
-	if source.ApiVersionDescription != nil {
-		apiVersionDescription := *source.ApiVersionDescription
-		api.ApiVersionDescription = &apiVersionDescription
-	} else {
-		api.ApiVersionDescription = nil
-	}
+	api.ApiVersionDescription = genruntime.ClonePointerToString(source.ApiVersionDescription)
 
 	// ApiVersionSet
 	if source.ApiVersionSet != nil {
@@ -963,12 +943,7 @@ func (api *Api_Spec) AssignProperties_From_Api_Spec(source *storage.Api_Spec) er
 	api.Description = genruntime.ClonePointerToString(source.Description)
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		api.DisplayName = &displayName
-	} else {
-		api.DisplayName = nil
-	}
+	api.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// Format
 	if source.Format != nil {
@@ -1020,12 +995,7 @@ func (api *Api_Spec) AssignProperties_From_Api_Spec(source *storage.Api_Spec) er
 	}
 
 	// Path
-	if source.Path != nil {
-		path := *source.Path
-		api.Path = &path
-	} else {
-		api.Path = nil
-	}
+	api.Path = genruntime.ClonePointerToString(source.Path)
 
 	// Protocols
 	if source.Protocols != nil {
@@ -1041,12 +1011,7 @@ func (api *Api_Spec) AssignProperties_From_Api_Spec(source *storage.Api_Spec) er
 	}
 
 	// ServiceUrl
-	if source.ServiceUrl != nil {
-		serviceUrl := *source.ServiceUrl
-		api.ServiceUrl = &serviceUrl
-	} else {
-		api.ServiceUrl = nil
-	}
+	api.ServiceUrl = genruntime.ClonePointerToString(source.ServiceUrl)
 
 	// SourceApiReference
 	if source.SourceApiReference != nil {
@@ -1122,28 +1087,13 @@ func (api *Api_Spec) AssignProperties_To_Api_Spec(destination *storage.Api_Spec)
 	propertyBag := genruntime.NewPropertyBag()
 
 	// APIVersion
-	if api.APIVersion != nil {
-		apiVersion := *api.APIVersion
-		destination.APIVersion = &apiVersion
-	} else {
-		destination.APIVersion = nil
-	}
+	destination.APIVersion = genruntime.ClonePointerToString(api.APIVersion)
 
 	// ApiRevision
-	if api.ApiRevision != nil {
-		apiRevision := *api.ApiRevision
-		destination.ApiRevision = &apiRevision
-	} else {
-		destination.ApiRevision = nil
-	}
+	destination.ApiRevision = genruntime.ClonePointerToString(api.ApiRevision)
 
 	// ApiRevisionDescription
-	if api.ApiRevisionDescription != nil {
-		apiRevisionDescription := *api.ApiRevisionDescription
-		destination.ApiRevisionDescription = &apiRevisionDescription
-	} else {
-		destination.ApiRevisionDescription = nil
-	}
+	destination.ApiRevisionDescription = genruntime.ClonePointerToString(api.ApiRevisionDescription)
 
 	// ApiType
 	if api.ApiType != nil {
@@ -1154,12 +1104,7 @@ func (api *Api_Spec) AssignProperties_To_Api_Spec(destination *storage.Api_Spec)
 	}
 
 	// ApiVersionDescription
-	if api.ApiVersionDescription != nil {
-		apiVersionDescription := *api.ApiVersionDescription
-		destination.ApiVersionDescription = &apiVersionDescription
-	} else {
-		destination.ApiVersionDescription = nil
-	}
+	destination.ApiVersionDescription = genruntime.ClonePointerToString(api.ApiVersionDescription)
 
 	// ApiVersionSet
 	if api.ApiVersionSet != nil {
@@ -1212,12 +1157,7 @@ func (api *Api_Spec) AssignProperties_To_Api_Spec(destination *storage.Api_Spec)
 	destination.Description = genruntime.ClonePointerToString(api.Description)
 
 	// DisplayName
-	if api.DisplayName != nil {
-		displayName := *api.DisplayName
-		destination.DisplayName = &displayName
-	} else {
-		destination.DisplayName = nil
-	}
+	destination.DisplayName = genruntime.ClonePointerToString(api.DisplayName)
 
 	// Format
 	if api.Format != nil {
@@ -1271,12 +1211,7 @@ func (api *Api_Spec) AssignProperties_To_Api_Spec(destination *storage.Api_Spec)
 	}
 
 	// Path
-	if api.Path != nil {
-		path := *api.Path
-		destination.Path = &path
-	} else {
-		destination.Path = nil
-	}
+	destination.Path = genruntime.ClonePointerToString(api.Path)
 
 	// Protocols
 	if api.Protocols != nil {
@@ -1292,12 +1227,7 @@ func (api *Api_Spec) AssignProperties_To_Api_Spec(destination *storage.Api_Spec)
 	}
 
 	// ServiceUrl
-	if api.ServiceUrl != nil {
-		serviceUrl := *api.ServiceUrl
-		destination.ServiceUrl = &serviceUrl
-	} else {
-		destination.ServiceUrl = nil
-	}
+	destination.ServiceUrl = genruntime.ClonePointerToString(api.ServiceUrl)
 
 	// SourceApiReference
 	if api.SourceApiReference != nil {
@@ -1376,36 +1306,16 @@ func (api *Api_Spec) AssignProperties_To_Api_Spec(destination *storage.Api_Spec)
 func (api *Api_Spec) Initialize_From_Api_STATUS(source *Api_STATUS) error {
 
 	// APIVersion
-	if source.APIVersion != nil {
-		apiVersion := *source.APIVersion
-		api.APIVersion = &apiVersion
-	} else {
-		api.APIVersion = nil
-	}
+	api.APIVersion = genruntime.ClonePointerToString(source.APIVersion)
 
 	// ApiRevision
-	if source.ApiRevision != nil {
-		apiRevision := *source.ApiRevision
-		api.ApiRevision = &apiRevision
-	} else {
-		api.ApiRevision = nil
-	}
+	api.ApiRevision = genruntime.ClonePointerToString(source.ApiRevision)
 
 	// ApiRevisionDescription
-	if source.ApiRevisionDescription != nil {
-		apiRevisionDescription := *source.ApiRevisionDescription
-		api.ApiRevisionDescription = &apiRevisionDescription
-	} else {
-		api.ApiRevisionDescription = nil
-	}
+	api.ApiRevisionDescription = genruntime.ClonePointerToString(source.ApiRevisionDescription)
 
 	// ApiVersionDescription
-	if source.ApiVersionDescription != nil {
-		apiVersionDescription := *source.ApiVersionDescription
-		api.ApiVersionDescription = &apiVersionDescription
-	} else {
-		api.ApiVersionDescription = nil
-	}
+	api.ApiVersionDescription = genruntime.ClonePointerToString(source.ApiVersionDescription)
 
 	// ApiVersionSet
 	if source.ApiVersionSet != nil {
@@ -1455,12 +1365,7 @@ func (api *Api_Spec) Initialize_From_Api_STATUS(source *Api_STATUS) error {
 	api.Description = genruntime.ClonePointerToString(source.Description)
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		api.DisplayName = &displayName
-	} else {
-		api.DisplayName = nil
-	}
+	api.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// IsCurrent
 	if source.IsCurrent != nil {
@@ -1483,12 +1388,7 @@ func (api *Api_Spec) Initialize_From_Api_STATUS(source *Api_STATUS) error {
 	}
 
 	// Path
-	if source.Path != nil {
-		path := *source.Path
-		api.Path = &path
-	} else {
-		api.Path = nil
-	}
+	api.Path = genruntime.ClonePointerToString(source.Path)
 
 	// Protocols
 	if source.Protocols != nil {
@@ -1505,12 +1405,7 @@ func (api *Api_Spec) Initialize_From_Api_STATUS(source *Api_STATUS) error {
 	}
 
 	// ServiceUrl
-	if source.ServiceUrl != nil {
-		serviceUrl := *source.ServiceUrl
-		api.ServiceUrl = &serviceUrl
-	} else {
-		api.ServiceUrl = nil
-	}
+	api.ServiceUrl = genruntime.ClonePointerToString(source.ServiceUrl)
 
 	// SourceApiReference
 	if source.SourceApiId != nil {

--- a/v2/api/apimanagement/v1api20220801/api_version_set_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/api_version_set_types_gen.go
@@ -467,12 +467,7 @@ func (versionSet *ApiVersionSet_Spec) AssignProperties_From_ApiVersionSet_Spec(s
 	versionSet.Description = genruntime.ClonePointerToString(source.Description)
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		versionSet.DisplayName = &displayName
-	} else {
-		versionSet.DisplayName = nil
-	}
+	versionSet.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -495,20 +490,10 @@ func (versionSet *ApiVersionSet_Spec) AssignProperties_From_ApiVersionSet_Spec(s
 	}
 
 	// VersionHeaderName
-	if source.VersionHeaderName != nil {
-		versionHeaderName := *source.VersionHeaderName
-		versionSet.VersionHeaderName = &versionHeaderName
-	} else {
-		versionSet.VersionHeaderName = nil
-	}
+	versionSet.VersionHeaderName = genruntime.ClonePointerToString(source.VersionHeaderName)
 
 	// VersionQueryName
-	if source.VersionQueryName != nil {
-		versionQueryName := *source.VersionQueryName
-		versionSet.VersionQueryName = &versionQueryName
-	} else {
-		versionSet.VersionQueryName = nil
-	}
+	versionSet.VersionQueryName = genruntime.ClonePointerToString(source.VersionQueryName)
 
 	// VersioningScheme
 	if source.VersioningScheme != nil {
@@ -535,12 +520,7 @@ func (versionSet *ApiVersionSet_Spec) AssignProperties_To_ApiVersionSet_Spec(des
 	destination.Description = genruntime.ClonePointerToString(versionSet.Description)
 
 	// DisplayName
-	if versionSet.DisplayName != nil {
-		displayName := *versionSet.DisplayName
-		destination.DisplayName = &displayName
-	} else {
-		destination.DisplayName = nil
-	}
+	destination.DisplayName = genruntime.ClonePointerToString(versionSet.DisplayName)
 
 	// OperatorSpec
 	if versionSet.OperatorSpec != nil {
@@ -566,20 +546,10 @@ func (versionSet *ApiVersionSet_Spec) AssignProperties_To_ApiVersionSet_Spec(des
 	}
 
 	// VersionHeaderName
-	if versionSet.VersionHeaderName != nil {
-		versionHeaderName := *versionSet.VersionHeaderName
-		destination.VersionHeaderName = &versionHeaderName
-	} else {
-		destination.VersionHeaderName = nil
-	}
+	destination.VersionHeaderName = genruntime.ClonePointerToString(versionSet.VersionHeaderName)
 
 	// VersionQueryName
-	if versionSet.VersionQueryName != nil {
-		versionQueryName := *versionSet.VersionQueryName
-		destination.VersionQueryName = &versionQueryName
-	} else {
-		destination.VersionQueryName = nil
-	}
+	destination.VersionQueryName = genruntime.ClonePointerToString(versionSet.VersionQueryName)
 
 	// VersioningScheme
 	if versionSet.VersioningScheme != nil {
@@ -607,28 +577,13 @@ func (versionSet *ApiVersionSet_Spec) Initialize_From_ApiVersionSet_STATUS(sourc
 	versionSet.Description = genruntime.ClonePointerToString(source.Description)
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		versionSet.DisplayName = &displayName
-	} else {
-		versionSet.DisplayName = nil
-	}
+	versionSet.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// VersionHeaderName
-	if source.VersionHeaderName != nil {
-		versionHeaderName := *source.VersionHeaderName
-		versionSet.VersionHeaderName = &versionHeaderName
-	} else {
-		versionSet.VersionHeaderName = nil
-	}
+	versionSet.VersionHeaderName = genruntime.ClonePointerToString(source.VersionHeaderName)
 
 	// VersionQueryName
-	if source.VersionQueryName != nil {
-		versionQueryName := *source.VersionQueryName
-		versionSet.VersionQueryName = &versionQueryName
-	} else {
-		versionSet.VersionQueryName = nil
-	}
+	versionSet.VersionQueryName = genruntime.ClonePointerToString(source.VersionQueryName)
 
 	// VersioningScheme
 	if source.VersioningScheme != nil {

--- a/v2/api/apimanagement/v1api20220801/authorization_provider_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/authorization_provider_types_gen.go
@@ -428,12 +428,7 @@ func (provider *AuthorizationProvider_Spec) AssignProperties_From_AuthorizationP
 	provider.AzureName = source.AzureName
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		provider.DisplayName = &displayName
-	} else {
-		provider.DisplayName = nil
-	}
+	provider.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// IdentityProvider
 	provider.IdentityProvider = genruntime.ClonePointerToString(source.IdentityProvider)
@@ -483,12 +478,7 @@ func (provider *AuthorizationProvider_Spec) AssignProperties_To_AuthorizationPro
 	destination.AzureName = provider.AzureName
 
 	// DisplayName
-	if provider.DisplayName != nil {
-		displayName := *provider.DisplayName
-		destination.DisplayName = &displayName
-	} else {
-		destination.DisplayName = nil
-	}
+	destination.DisplayName = genruntime.ClonePointerToString(provider.DisplayName)
 
 	// IdentityProvider
 	destination.IdentityProvider = genruntime.ClonePointerToString(provider.IdentityProvider)
@@ -543,12 +533,7 @@ func (provider *AuthorizationProvider_Spec) AssignProperties_To_AuthorizationPro
 func (provider *AuthorizationProvider_Spec) Initialize_From_AuthorizationProvider_STATUS(source *AuthorizationProvider_STATUS) error {
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		provider.DisplayName = &displayName
-	} else {
-		provider.DisplayName = nil
-	}
+	provider.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// IdentityProvider
 	provider.IdentityProvider = genruntime.ClonePointerToString(source.IdentityProvider)

--- a/v2/api/apimanagement/v1api20220801/backend_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/backend_types_gen.go
@@ -577,12 +577,7 @@ func (backend *Backend_Spec) AssignProperties_From_Backend_Spec(source *storage.
 	}
 
 	// Description
-	if source.Description != nil {
-		description := *source.Description
-		backend.Description = &description
-	} else {
-		backend.Description = nil
-	}
+	backend.Description = genruntime.ClonePointerToString(source.Description)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -646,12 +641,7 @@ func (backend *Backend_Spec) AssignProperties_From_Backend_Spec(source *storage.
 	}
 
 	// Title
-	if source.Title != nil {
-		title := *source.Title
-		backend.Title = &title
-	} else {
-		backend.Title = nil
-	}
+	backend.Title = genruntime.ClonePointerToString(source.Title)
 
 	// Tls
 	if source.Tls != nil {
@@ -666,12 +656,7 @@ func (backend *Backend_Spec) AssignProperties_From_Backend_Spec(source *storage.
 	}
 
 	// Url
-	if source.Url != nil {
-		url := *source.Url
-		backend.Url = &url
-	} else {
-		backend.Url = nil
-	}
+	backend.Url = genruntime.ClonePointerToString(source.Url)
 
 	// No error
 	return nil
@@ -698,12 +683,7 @@ func (backend *Backend_Spec) AssignProperties_To_Backend_Spec(destination *stora
 	}
 
 	// Description
-	if backend.Description != nil {
-		description := *backend.Description
-		destination.Description = &description
-	} else {
-		destination.Description = nil
-	}
+	destination.Description = genruntime.ClonePointerToString(backend.Description)
 
 	// OperatorSpec
 	if backend.OperatorSpec != nil {
@@ -769,12 +749,7 @@ func (backend *Backend_Spec) AssignProperties_To_Backend_Spec(destination *stora
 	}
 
 	// Title
-	if backend.Title != nil {
-		title := *backend.Title
-		destination.Title = &title
-	} else {
-		destination.Title = nil
-	}
+	destination.Title = genruntime.ClonePointerToString(backend.Title)
 
 	// Tls
 	if backend.Tls != nil {
@@ -789,12 +764,7 @@ func (backend *Backend_Spec) AssignProperties_To_Backend_Spec(destination *stora
 	}
 
 	// Url
-	if backend.Url != nil {
-		url := *backend.Url
-		destination.Url = &url
-	} else {
-		destination.Url = nil
-	}
+	destination.Url = genruntime.ClonePointerToString(backend.Url)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -823,12 +793,7 @@ func (backend *Backend_Spec) Initialize_From_Backend_STATUS(source *Backend_STAT
 	}
 
 	// Description
-	if source.Description != nil {
-		description := *source.Description
-		backend.Description = &description
-	} else {
-		backend.Description = nil
-	}
+	backend.Description = genruntime.ClonePointerToString(source.Description)
 
 	// Properties
 	if source.Properties != nil {
@@ -871,12 +836,7 @@ func (backend *Backend_Spec) Initialize_From_Backend_STATUS(source *Backend_STAT
 	}
 
 	// Title
-	if source.Title != nil {
-		title := *source.Title
-		backend.Title = &title
-	} else {
-		backend.Title = nil
-	}
+	backend.Title = genruntime.ClonePointerToString(source.Title)
 
 	// Tls
 	if source.Tls != nil {
@@ -891,12 +851,7 @@ func (backend *Backend_Spec) Initialize_From_Backend_STATUS(source *Backend_STAT
 	}
 
 	// Url
-	if source.Url != nil {
-		url := *source.Url
-		backend.Url = &url
-	} else {
-		backend.Url = nil
-	}
+	backend.Url = genruntime.ClonePointerToString(source.Url)
 
 	// No error
 	return nil
@@ -1507,30 +1462,10 @@ func (contract *BackendCredentialsContract) AssignProperties_From_BackendCredent
 	}
 
 	// Certificate
-	if source.Certificate != nil {
-		certificateList := make([]string, len(source.Certificate))
-		for certificateIndex, certificateItem := range source.Certificate {
-			// Shadow the loop variable to avoid aliasing
-			certificateItem := certificateItem
-			certificateList[certificateIndex] = certificateItem
-		}
-		contract.Certificate = certificateList
-	} else {
-		contract.Certificate = nil
-	}
+	contract.Certificate = genruntime.CloneSliceOfString(source.Certificate)
 
 	// CertificateIds
-	if source.CertificateIds != nil {
-		certificateIdList := make([]string, len(source.CertificateIds))
-		for certificateIdIndex, certificateIdItem := range source.CertificateIds {
-			// Shadow the loop variable to avoid aliasing
-			certificateIdItem := certificateIdItem
-			certificateIdList[certificateIdIndex] = certificateIdItem
-		}
-		contract.CertificateIds = certificateIdList
-	} else {
-		contract.CertificateIds = nil
-	}
+	contract.CertificateIds = genruntime.CloneSliceOfString(source.CertificateIds)
 
 	// Header
 	if source.Header != nil {
@@ -1580,30 +1515,10 @@ func (contract *BackendCredentialsContract) AssignProperties_To_BackendCredentia
 	}
 
 	// Certificate
-	if contract.Certificate != nil {
-		certificateList := make([]string, len(contract.Certificate))
-		for certificateIndex, certificateItem := range contract.Certificate {
-			// Shadow the loop variable to avoid aliasing
-			certificateItem := certificateItem
-			certificateList[certificateIndex] = certificateItem
-		}
-		destination.Certificate = certificateList
-	} else {
-		destination.Certificate = nil
-	}
+	destination.Certificate = genruntime.CloneSliceOfString(contract.Certificate)
 
 	// CertificateIds
-	if contract.CertificateIds != nil {
-		certificateIdList := make([]string, len(contract.CertificateIds))
-		for certificateIdIndex, certificateIdItem := range contract.CertificateIds {
-			// Shadow the loop variable to avoid aliasing
-			certificateIdItem := certificateIdItem
-			certificateIdList[certificateIdIndex] = certificateIdItem
-		}
-		destination.CertificateIds = certificateIdList
-	} else {
-		destination.CertificateIds = nil
-	}
+	destination.CertificateIds = genruntime.CloneSliceOfString(contract.CertificateIds)
 
 	// Header
 	if contract.Header != nil {
@@ -1658,30 +1573,10 @@ func (contract *BackendCredentialsContract) Initialize_From_BackendCredentialsCo
 	}
 
 	// Certificate
-	if source.Certificate != nil {
-		certificateList := make([]string, len(source.Certificate))
-		for certificateIndex, certificateItem := range source.Certificate {
-			// Shadow the loop variable to avoid aliasing
-			certificateItem := certificateItem
-			certificateList[certificateIndex] = certificateItem
-		}
-		contract.Certificate = certificateList
-	} else {
-		contract.Certificate = nil
-	}
+	contract.Certificate = genruntime.CloneSliceOfString(source.Certificate)
 
 	// CertificateIds
-	if source.CertificateIds != nil {
-		certificateIdList := make([]string, len(source.CertificateIds))
-		for certificateIdIndex, certificateIdItem := range source.CertificateIds {
-			// Shadow the loop variable to avoid aliasing
-			certificateIdItem := certificateIdItem
-			certificateIdList[certificateIdIndex] = certificateIdItem
-		}
-		contract.CertificateIds = certificateIdList
-	} else {
-		contract.CertificateIds = nil
-	}
+	contract.CertificateIds = genruntime.CloneSliceOfString(source.CertificateIds)
 
 	// Header
 	if source.Header != nil {
@@ -2302,12 +2197,7 @@ func (contract *BackendProxyContract) AssignProperties_From_BackendProxyContract
 	}
 
 	// Url
-	if source.Url != nil {
-		url := *source.Url
-		contract.Url = &url
-	} else {
-		contract.Url = nil
-	}
+	contract.Url = genruntime.ClonePointerToString(source.Url)
 
 	// Username
 	contract.Username = genruntime.ClonePointerToString(source.Username)
@@ -2330,12 +2220,7 @@ func (contract *BackendProxyContract) AssignProperties_To_BackendProxyContract(d
 	}
 
 	// Url
-	if contract.Url != nil {
-		url := *contract.Url
-		destination.Url = &url
-	} else {
-		destination.Url = nil
-	}
+	destination.Url = genruntime.ClonePointerToString(contract.Url)
 
 	// Username
 	destination.Username = genruntime.ClonePointerToString(contract.Username)
@@ -2355,12 +2240,7 @@ func (contract *BackendProxyContract) AssignProperties_To_BackendProxyContract(d
 func (contract *BackendProxyContract) Initialize_From_BackendProxyContract_STATUS(source *BackendProxyContract_STATUS) error {
 
 	// Url
-	if source.Url != nil {
-		url := *source.Url
-		contract.Url = &url
-	} else {
-		contract.Url = nil
-	}
+	contract.Url = genruntime.ClonePointerToString(source.Url)
 
 	// Username
 	contract.Username = genruntime.ClonePointerToString(source.Username)
@@ -2750,20 +2630,10 @@ func (credentials *BackendAuthorizationHeaderCredentials) PopulateFromARM(owner 
 func (credentials *BackendAuthorizationHeaderCredentials) AssignProperties_From_BackendAuthorizationHeaderCredentials(source *storage.BackendAuthorizationHeaderCredentials) error {
 
 	// Parameter
-	if source.Parameter != nil {
-		parameter := *source.Parameter
-		credentials.Parameter = &parameter
-	} else {
-		credentials.Parameter = nil
-	}
+	credentials.Parameter = genruntime.ClonePointerToString(source.Parameter)
 
 	// Scheme
-	if source.Scheme != nil {
-		scheme := *source.Scheme
-		credentials.Scheme = &scheme
-	} else {
-		credentials.Scheme = nil
-	}
+	credentials.Scheme = genruntime.ClonePointerToString(source.Scheme)
 
 	// No error
 	return nil
@@ -2775,20 +2645,10 @@ func (credentials *BackendAuthorizationHeaderCredentials) AssignProperties_To_Ba
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Parameter
-	if credentials.Parameter != nil {
-		parameter := *credentials.Parameter
-		destination.Parameter = &parameter
-	} else {
-		destination.Parameter = nil
-	}
+	destination.Parameter = genruntime.ClonePointerToString(credentials.Parameter)
 
 	// Scheme
-	if credentials.Scheme != nil {
-		scheme := *credentials.Scheme
-		destination.Scheme = &scheme
-	} else {
-		destination.Scheme = nil
-	}
+	destination.Scheme = genruntime.ClonePointerToString(credentials.Scheme)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -2805,20 +2665,10 @@ func (credentials *BackendAuthorizationHeaderCredentials) AssignProperties_To_Ba
 func (credentials *BackendAuthorizationHeaderCredentials) Initialize_From_BackendAuthorizationHeaderCredentials_STATUS(source *BackendAuthorizationHeaderCredentials_STATUS) error {
 
 	// Parameter
-	if source.Parameter != nil {
-		parameter := *source.Parameter
-		credentials.Parameter = &parameter
-	} else {
-		credentials.Parameter = nil
-	}
+	credentials.Parameter = genruntime.ClonePointerToString(source.Parameter)
 
 	// Scheme
-	if source.Scheme != nil {
-		scheme := *source.Scheme
-		credentials.Scheme = &scheme
-	} else {
-		credentials.Scheme = nil
-	}
+	credentials.Scheme = genruntime.ClonePointerToString(source.Scheme)
 
 	// No error
 	return nil

--- a/v2/api/apimanagement/v1api20220801/named_value_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/named_value_types_gen.go
@@ -465,12 +465,7 @@ func (value *NamedValue_Spec) AssignProperties_From_NamedValue_Spec(source *stor
 	value.AzureName = source.AzureName
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		value.DisplayName = &displayName
-	} else {
-		value.DisplayName = nil
-	}
+	value.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// KeyVault
 	if source.KeyVault != nil {
@@ -513,25 +508,10 @@ func (value *NamedValue_Spec) AssignProperties_From_NamedValue_Spec(source *stor
 	}
 
 	// Tags
-	if source.Tags != nil {
-		tagList := make([]string, len(source.Tags))
-		for tagIndex, tagItem := range source.Tags {
-			// Shadow the loop variable to avoid aliasing
-			tagItem := tagItem
-			tagList[tagIndex] = tagItem
-		}
-		value.Tags = tagList
-	} else {
-		value.Tags = nil
-	}
+	value.Tags = genruntime.CloneSliceOfString(source.Tags)
 
 	// Value
-	if source.Value != nil {
-		valueTemp := *source.Value
-		value.Value = &valueTemp
-	} else {
-		value.Value = nil
-	}
+	value.Value = genruntime.ClonePointerToString(source.Value)
 
 	// No error
 	return nil
@@ -546,12 +526,7 @@ func (value *NamedValue_Spec) AssignProperties_To_NamedValue_Spec(destination *s
 	destination.AzureName = value.AzureName
 
 	// DisplayName
-	if value.DisplayName != nil {
-		displayName := *value.DisplayName
-		destination.DisplayName = &displayName
-	} else {
-		destination.DisplayName = nil
-	}
+	destination.DisplayName = genruntime.ClonePointerToString(value.DisplayName)
 
 	// KeyVault
 	if value.KeyVault != nil {
@@ -597,25 +572,10 @@ func (value *NamedValue_Spec) AssignProperties_To_NamedValue_Spec(destination *s
 	}
 
 	// Tags
-	if value.Tags != nil {
-		tagList := make([]string, len(value.Tags))
-		for tagIndex, tagItem := range value.Tags {
-			// Shadow the loop variable to avoid aliasing
-			tagItem := tagItem
-			tagList[tagIndex] = tagItem
-		}
-		destination.Tags = tagList
-	} else {
-		destination.Tags = nil
-	}
+	destination.Tags = genruntime.CloneSliceOfString(value.Tags)
 
 	// Value
-	if value.Value != nil {
-		valueTemp := *value.Value
-		destination.Value = &valueTemp
-	} else {
-		destination.Value = nil
-	}
+	destination.Value = genruntime.ClonePointerToString(value.Value)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -632,12 +592,7 @@ func (value *NamedValue_Spec) AssignProperties_To_NamedValue_Spec(destination *s
 func (value *NamedValue_Spec) Initialize_From_NamedValue_STATUS(source *NamedValue_STATUS) error {
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		value.DisplayName = &displayName
-	} else {
-		value.DisplayName = nil
-	}
+	value.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// KeyVault
 	if source.KeyVault != nil {
@@ -660,25 +615,10 @@ func (value *NamedValue_Spec) Initialize_From_NamedValue_STATUS(source *NamedVal
 	}
 
 	// Tags
-	if source.Tags != nil {
-		tagList := make([]string, len(source.Tags))
-		for tagIndex, tagItem := range source.Tags {
-			// Shadow the loop variable to avoid aliasing
-			tagItem := tagItem
-			tagList[tagIndex] = tagItem
-		}
-		value.Tags = tagList
-	} else {
-		value.Tags = nil
-	}
+	value.Tags = genruntime.CloneSliceOfString(source.Tags)
 
 	// Value
-	if source.Value != nil {
-		valueTemp := *source.Value
-		value.Value = &valueTemp
-	} else {
-		value.Value = nil
-	}
+	value.Value = genruntime.ClonePointerToString(source.Value)
 
 	// No error
 	return nil

--- a/v2/api/apimanagement/v1api20220801/policy_fragment_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/policy_fragment_types_gen.go
@@ -425,12 +425,7 @@ func (fragment *PolicyFragment_Spec) AssignProperties_From_PolicyFragment_Spec(s
 	fragment.AzureName = source.AzureName
 
 	// Description
-	if source.Description != nil {
-		description := *source.Description
-		fragment.Description = &description
-	} else {
-		fragment.Description = nil
-	}
+	fragment.Description = genruntime.ClonePointerToString(source.Description)
 
 	// Format
 	if source.Format != nil {
@@ -477,12 +472,7 @@ func (fragment *PolicyFragment_Spec) AssignProperties_To_PolicyFragment_Spec(des
 	destination.AzureName = fragment.AzureName
 
 	// Description
-	if fragment.Description != nil {
-		description := *fragment.Description
-		destination.Description = &description
-	} else {
-		destination.Description = nil
-	}
+	destination.Description = genruntime.ClonePointerToString(fragment.Description)
 
 	// Format
 	if fragment.Format != nil {
@@ -533,12 +523,7 @@ func (fragment *PolicyFragment_Spec) AssignProperties_To_PolicyFragment_Spec(des
 func (fragment *PolicyFragment_Spec) Initialize_From_PolicyFragment_STATUS(source *PolicyFragment_STATUS) error {
 
 	// Description
-	if source.Description != nil {
-		description := *source.Description
-		fragment.Description = &description
-	} else {
-		fragment.Description = nil
-	}
+	fragment.Description = genruntime.ClonePointerToString(source.Description)
 
 	// Format
 	if source.Format != nil {

--- a/v2/api/apimanagement/v1api20220801/product_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/product_types_gen.go
@@ -513,20 +513,10 @@ func (product *Product_Spec) AssignProperties_From_Product_Spec(source *storage.
 	product.AzureName = source.AzureName
 
 	// Description
-	if source.Description != nil {
-		description := *source.Description
-		product.Description = &description
-	} else {
-		product.Description = nil
-	}
+	product.Description = genruntime.ClonePointerToString(source.Description)
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		product.DisplayName = &displayName
-	} else {
-		product.DisplayName = nil
-	}
+	product.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -592,20 +582,10 @@ func (product *Product_Spec) AssignProperties_To_Product_Spec(destination *stora
 	destination.AzureName = product.AzureName
 
 	// Description
-	if product.Description != nil {
-		description := *product.Description
-		destination.Description = &description
-	} else {
-		destination.Description = nil
-	}
+	destination.Description = genruntime.ClonePointerToString(product.Description)
 
 	// DisplayName
-	if product.DisplayName != nil {
-		displayName := *product.DisplayName
-		destination.DisplayName = &displayName
-	} else {
-		destination.DisplayName = nil
-	}
+	destination.DisplayName = genruntime.ClonePointerToString(product.DisplayName)
 
 	// OperatorSpec
 	if product.OperatorSpec != nil {
@@ -675,20 +655,10 @@ func (product *Product_Spec) Initialize_From_Product_STATUS(source *Product_STAT
 	}
 
 	// Description
-	if source.Description != nil {
-		description := *source.Description
-		product.Description = &description
-	} else {
-		product.Description = nil
-	}
+	product.Description = genruntime.ClonePointerToString(source.Description)
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		product.DisplayName = &displayName
-	} else {
-		product.DisplayName = nil
-	}
+	product.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// State
 	if source.State != nil {

--- a/v2/api/apimanagement/v1api20220801/service_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/service_types_gen.go
@@ -932,12 +932,7 @@ func (service *Service_Spec) AssignProperties_From_Service_Spec(source *storage.
 	}
 
 	// NotificationSenderEmail
-	if source.NotificationSenderEmail != nil {
-		notificationSenderEmail := *source.NotificationSenderEmail
-		service.NotificationSenderEmail = &notificationSenderEmail
-	} else {
-		service.NotificationSenderEmail = nil
-	}
+	service.NotificationSenderEmail = genruntime.ClonePointerToString(source.NotificationSenderEmail)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -977,20 +972,10 @@ func (service *Service_Spec) AssignProperties_From_Service_Spec(source *storage.
 	}
 
 	// PublisherEmail
-	if source.PublisherEmail != nil {
-		publisherEmail := *source.PublisherEmail
-		service.PublisherEmail = &publisherEmail
-	} else {
-		service.PublisherEmail = nil
-	}
+	service.PublisherEmail = genruntime.ClonePointerToString(source.PublisherEmail)
 
 	// PublisherName
-	if source.PublisherName != nil {
-		publisherName := *source.PublisherName
-		service.PublisherName = &publisherName
-	} else {
-		service.PublisherName = nil
-	}
+	service.PublisherName = genruntime.ClonePointerToString(source.PublisherName)
 
 	// Restore
 	if source.Restore != nil {
@@ -1160,12 +1145,7 @@ func (service *Service_Spec) AssignProperties_To_Service_Spec(destination *stora
 	}
 
 	// NotificationSenderEmail
-	if service.NotificationSenderEmail != nil {
-		notificationSenderEmail := *service.NotificationSenderEmail
-		destination.NotificationSenderEmail = &notificationSenderEmail
-	} else {
-		destination.NotificationSenderEmail = nil
-	}
+	destination.NotificationSenderEmail = genruntime.ClonePointerToString(service.NotificationSenderEmail)
 
 	// OperatorSpec
 	if service.OperatorSpec != nil {
@@ -1207,20 +1187,10 @@ func (service *Service_Spec) AssignProperties_To_Service_Spec(destination *stora
 	}
 
 	// PublisherEmail
-	if service.PublisherEmail != nil {
-		publisherEmail := *service.PublisherEmail
-		destination.PublisherEmail = &publisherEmail
-	} else {
-		destination.PublisherEmail = nil
-	}
+	destination.PublisherEmail = genruntime.ClonePointerToString(service.PublisherEmail)
 
 	// PublisherName
-	if service.PublisherName != nil {
-		publisherName := *service.PublisherName
-		destination.PublisherName = &publisherName
-	} else {
-		destination.PublisherName = nil
-	}
+	destination.PublisherName = genruntime.ClonePointerToString(service.PublisherName)
 
 	// Restore
 	if service.Restore != nil {
@@ -1391,12 +1361,7 @@ func (service *Service_Spec) Initialize_From_Service_STATUS(source *Service_STAT
 	}
 
 	// NotificationSenderEmail
-	if source.NotificationSenderEmail != nil {
-		notificationSenderEmail := *source.NotificationSenderEmail
-		service.NotificationSenderEmail = &notificationSenderEmail
-	} else {
-		service.NotificationSenderEmail = nil
-	}
+	service.NotificationSenderEmail = genruntime.ClonePointerToString(source.NotificationSenderEmail)
 
 	// PublicIpAddressReference
 	if source.PublicIpAddressId != nil {
@@ -1415,20 +1380,10 @@ func (service *Service_Spec) Initialize_From_Service_STATUS(source *Service_STAT
 	}
 
 	// PublisherEmail
-	if source.PublisherEmail != nil {
-		publisherEmail := *source.PublisherEmail
-		service.PublisherEmail = &publisherEmail
-	} else {
-		service.PublisherEmail = nil
-	}
+	service.PublisherEmail = genruntime.ClonePointerToString(source.PublisherEmail)
 
 	// PublisherName
-	if source.PublisherName != nil {
-		publisherName := *source.PublisherName
-		service.PublisherName = &publisherName
-	} else {
-		service.PublisherName = nil
-	}
+	service.PublisherName = genruntime.ClonePointerToString(source.PublisherName)
 
 	// Restore
 	if source.Restore != nil {

--- a/v2/api/apimanagement/v1api20220801/subscription_types_gen.go
+++ b/v2/api/apimanagement/v1api20220801/subscription_types_gen.go
@@ -497,12 +497,7 @@ func (subscription *Subscription_Spec) AssignProperties_From_Subscription_Spec(s
 	subscription.AzureName = source.AzureName
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		subscription.DisplayName = &displayName
-	} else {
-		subscription.DisplayName = nil
-	}
+	subscription.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -581,12 +576,7 @@ func (subscription *Subscription_Spec) AssignProperties_To_Subscription_Spec(des
 	destination.AzureName = subscription.AzureName
 
 	// DisplayName
-	if subscription.DisplayName != nil {
-		displayName := *subscription.DisplayName
-		destination.DisplayName = &displayName
-	} else {
-		destination.DisplayName = nil
-	}
+	destination.DisplayName = genruntime.ClonePointerToString(subscription.DisplayName)
 
 	// OperatorSpec
 	if subscription.OperatorSpec != nil {
@@ -669,12 +659,7 @@ func (subscription *Subscription_Spec) Initialize_From_Subscription_STATUS(sourc
 	}
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		subscription.DisplayName = &displayName
-	} else {
-		subscription.DisplayName = nil
-	}
+	subscription.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// OwnerReference
 	if source.OwnerId != nil {

--- a/v2/api/apimanagement/v1api20230501preview/api_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/api_types_gen.go
@@ -876,28 +876,13 @@ func (api *Api_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error
 func (api *Api_Spec) AssignProperties_From_Api_Spec(source *storage.Api_Spec) error {
 
 	// APIVersion
-	if source.APIVersion != nil {
-		apiVersion := *source.APIVersion
-		api.APIVersion = &apiVersion
-	} else {
-		api.APIVersion = nil
-	}
+	api.APIVersion = genruntime.ClonePointerToString(source.APIVersion)
 
 	// ApiRevision
-	if source.ApiRevision != nil {
-		apiRevision := *source.ApiRevision
-		api.ApiRevision = &apiRevision
-	} else {
-		api.ApiRevision = nil
-	}
+	api.ApiRevision = genruntime.ClonePointerToString(source.ApiRevision)
 
 	// ApiRevisionDescription
-	if source.ApiRevisionDescription != nil {
-		apiRevisionDescription := *source.ApiRevisionDescription
-		api.ApiRevisionDescription = &apiRevisionDescription
-	} else {
-		api.ApiRevisionDescription = nil
-	}
+	api.ApiRevisionDescription = genruntime.ClonePointerToString(source.ApiRevisionDescription)
 
 	// ApiType
 	if source.ApiType != nil {
@@ -909,12 +894,7 @@ func (api *Api_Spec) AssignProperties_From_Api_Spec(source *storage.Api_Spec) er
 	}
 
 	// ApiVersionDescription
-	if source.ApiVersionDescription != nil {
-		apiVersionDescription := *source.ApiVersionDescription
-		api.ApiVersionDescription = &apiVersionDescription
-	} else {
-		api.ApiVersionDescription = nil
-	}
+	api.ApiVersionDescription = genruntime.ClonePointerToString(source.ApiVersionDescription)
 
 	// ApiVersionSet
 	if source.ApiVersionSet != nil {
@@ -967,12 +947,7 @@ func (api *Api_Spec) AssignProperties_From_Api_Spec(source *storage.Api_Spec) er
 	api.Description = genruntime.ClonePointerToString(source.Description)
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		api.DisplayName = &displayName
-	} else {
-		api.DisplayName = nil
-	}
+	api.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// Format
 	if source.Format != nil {
@@ -1024,12 +999,7 @@ func (api *Api_Spec) AssignProperties_From_Api_Spec(source *storage.Api_Spec) er
 	}
 
 	// Path
-	if source.Path != nil {
-		path := *source.Path
-		api.Path = &path
-	} else {
-		api.Path = nil
-	}
+	api.Path = genruntime.ClonePointerToString(source.Path)
 
 	// Protocols
 	if source.Protocols != nil {
@@ -1045,12 +1015,7 @@ func (api *Api_Spec) AssignProperties_From_Api_Spec(source *storage.Api_Spec) er
 	}
 
 	// ServiceUrl
-	if source.ServiceUrl != nil {
-		serviceUrl := *source.ServiceUrl
-		api.ServiceUrl = &serviceUrl
-	} else {
-		api.ServiceUrl = nil
-	}
+	api.ServiceUrl = genruntime.ClonePointerToString(source.ServiceUrl)
 
 	// SourceApiReference
 	if source.SourceApiReference != nil {
@@ -1126,28 +1091,13 @@ func (api *Api_Spec) AssignProperties_To_Api_Spec(destination *storage.Api_Spec)
 	propertyBag := genruntime.NewPropertyBag()
 
 	// APIVersion
-	if api.APIVersion != nil {
-		apiVersion := *api.APIVersion
-		destination.APIVersion = &apiVersion
-	} else {
-		destination.APIVersion = nil
-	}
+	destination.APIVersion = genruntime.ClonePointerToString(api.APIVersion)
 
 	// ApiRevision
-	if api.ApiRevision != nil {
-		apiRevision := *api.ApiRevision
-		destination.ApiRevision = &apiRevision
-	} else {
-		destination.ApiRevision = nil
-	}
+	destination.ApiRevision = genruntime.ClonePointerToString(api.ApiRevision)
 
 	// ApiRevisionDescription
-	if api.ApiRevisionDescription != nil {
-		apiRevisionDescription := *api.ApiRevisionDescription
-		destination.ApiRevisionDescription = &apiRevisionDescription
-	} else {
-		destination.ApiRevisionDescription = nil
-	}
+	destination.ApiRevisionDescription = genruntime.ClonePointerToString(api.ApiRevisionDescription)
 
 	// ApiType
 	if api.ApiType != nil {
@@ -1158,12 +1108,7 @@ func (api *Api_Spec) AssignProperties_To_Api_Spec(destination *storage.Api_Spec)
 	}
 
 	// ApiVersionDescription
-	if api.ApiVersionDescription != nil {
-		apiVersionDescription := *api.ApiVersionDescription
-		destination.ApiVersionDescription = &apiVersionDescription
-	} else {
-		destination.ApiVersionDescription = nil
-	}
+	destination.ApiVersionDescription = genruntime.ClonePointerToString(api.ApiVersionDescription)
 
 	// ApiVersionSet
 	if api.ApiVersionSet != nil {
@@ -1216,12 +1161,7 @@ func (api *Api_Spec) AssignProperties_To_Api_Spec(destination *storage.Api_Spec)
 	destination.Description = genruntime.ClonePointerToString(api.Description)
 
 	// DisplayName
-	if api.DisplayName != nil {
-		displayName := *api.DisplayName
-		destination.DisplayName = &displayName
-	} else {
-		destination.DisplayName = nil
-	}
+	destination.DisplayName = genruntime.ClonePointerToString(api.DisplayName)
 
 	// Format
 	if api.Format != nil {
@@ -1275,12 +1215,7 @@ func (api *Api_Spec) AssignProperties_To_Api_Spec(destination *storage.Api_Spec)
 	}
 
 	// Path
-	if api.Path != nil {
-		path := *api.Path
-		destination.Path = &path
-	} else {
-		destination.Path = nil
-	}
+	destination.Path = genruntime.ClonePointerToString(api.Path)
 
 	// Protocols
 	if api.Protocols != nil {
@@ -1296,12 +1231,7 @@ func (api *Api_Spec) AssignProperties_To_Api_Spec(destination *storage.Api_Spec)
 	}
 
 	// ServiceUrl
-	if api.ServiceUrl != nil {
-		serviceUrl := *api.ServiceUrl
-		destination.ServiceUrl = &serviceUrl
-	} else {
-		destination.ServiceUrl = nil
-	}
+	destination.ServiceUrl = genruntime.ClonePointerToString(api.ServiceUrl)
 
 	// SourceApiReference
 	if api.SourceApiReference != nil {

--- a/v2/api/apimanagement/v1api20230501preview/api_version_set_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/api_version_set_types_gen.go
@@ -470,12 +470,7 @@ func (versionSet *ApiVersionSet_Spec) AssignProperties_From_ApiVersionSet_Spec(s
 	versionSet.Description = genruntime.ClonePointerToString(source.Description)
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		versionSet.DisplayName = &displayName
-	} else {
-		versionSet.DisplayName = nil
-	}
+	versionSet.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -498,20 +493,10 @@ func (versionSet *ApiVersionSet_Spec) AssignProperties_From_ApiVersionSet_Spec(s
 	}
 
 	// VersionHeaderName
-	if source.VersionHeaderName != nil {
-		versionHeaderName := *source.VersionHeaderName
-		versionSet.VersionHeaderName = &versionHeaderName
-	} else {
-		versionSet.VersionHeaderName = nil
-	}
+	versionSet.VersionHeaderName = genruntime.ClonePointerToString(source.VersionHeaderName)
 
 	// VersionQueryName
-	if source.VersionQueryName != nil {
-		versionQueryName := *source.VersionQueryName
-		versionSet.VersionQueryName = &versionQueryName
-	} else {
-		versionSet.VersionQueryName = nil
-	}
+	versionSet.VersionQueryName = genruntime.ClonePointerToString(source.VersionQueryName)
 
 	// VersioningScheme
 	if source.VersioningScheme != nil {
@@ -538,12 +523,7 @@ func (versionSet *ApiVersionSet_Spec) AssignProperties_To_ApiVersionSet_Spec(des
 	destination.Description = genruntime.ClonePointerToString(versionSet.Description)
 
 	// DisplayName
-	if versionSet.DisplayName != nil {
-		displayName := *versionSet.DisplayName
-		destination.DisplayName = &displayName
-	} else {
-		destination.DisplayName = nil
-	}
+	destination.DisplayName = genruntime.ClonePointerToString(versionSet.DisplayName)
 
 	// OperatorSpec
 	if versionSet.OperatorSpec != nil {
@@ -569,20 +549,10 @@ func (versionSet *ApiVersionSet_Spec) AssignProperties_To_ApiVersionSet_Spec(des
 	}
 
 	// VersionHeaderName
-	if versionSet.VersionHeaderName != nil {
-		versionHeaderName := *versionSet.VersionHeaderName
-		destination.VersionHeaderName = &versionHeaderName
-	} else {
-		destination.VersionHeaderName = nil
-	}
+	destination.VersionHeaderName = genruntime.ClonePointerToString(versionSet.VersionHeaderName)
 
 	// VersionQueryName
-	if versionSet.VersionQueryName != nil {
-		versionQueryName := *versionSet.VersionQueryName
-		destination.VersionQueryName = &versionQueryName
-	} else {
-		destination.VersionQueryName = nil
-	}
+	destination.VersionQueryName = genruntime.ClonePointerToString(versionSet.VersionQueryName)
 
 	// VersioningScheme
 	if versionSet.VersioningScheme != nil {

--- a/v2/api/apimanagement/v1api20230501preview/authorization_provider_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/authorization_provider_types_gen.go
@@ -431,12 +431,7 @@ func (provider *AuthorizationProvider_Spec) AssignProperties_From_AuthorizationP
 	provider.AzureName = source.AzureName
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		provider.DisplayName = &displayName
-	} else {
-		provider.DisplayName = nil
-	}
+	provider.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// IdentityProvider
 	provider.IdentityProvider = genruntime.ClonePointerToString(source.IdentityProvider)
@@ -486,12 +481,7 @@ func (provider *AuthorizationProvider_Spec) AssignProperties_To_AuthorizationPro
 	destination.AzureName = provider.AzureName
 
 	// DisplayName
-	if provider.DisplayName != nil {
-		displayName := *provider.DisplayName
-		destination.DisplayName = &displayName
-	} else {
-		destination.DisplayName = nil
-	}
+	destination.DisplayName = genruntime.ClonePointerToString(provider.DisplayName)
 
 	// IdentityProvider
 	destination.IdentityProvider = genruntime.ClonePointerToString(provider.IdentityProvider)

--- a/v2/api/apimanagement/v1api20230501preview/backend_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/backend_types_gen.go
@@ -665,12 +665,7 @@ func (backend *Backend_Spec) AssignProperties_From_Backend_Spec(source *storage.
 	}
 
 	// Description
-	if source.Description != nil {
-		description := *source.Description
-		backend.Description = &description
-	} else {
-		backend.Description = nil
-	}
+	backend.Description = genruntime.ClonePointerToString(source.Description)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -746,12 +741,7 @@ func (backend *Backend_Spec) AssignProperties_From_Backend_Spec(source *storage.
 	}
 
 	// Title
-	if source.Title != nil {
-		title := *source.Title
-		backend.Title = &title
-	} else {
-		backend.Title = nil
-	}
+	backend.Title = genruntime.ClonePointerToString(source.Title)
 
 	// Tls
 	if source.Tls != nil {
@@ -775,12 +765,7 @@ func (backend *Backend_Spec) AssignProperties_From_Backend_Spec(source *storage.
 	}
 
 	// Url
-	if source.Url != nil {
-		url := *source.Url
-		backend.Url = &url
-	} else {
-		backend.Url = nil
-	}
+	backend.Url = genruntime.ClonePointerToString(source.Url)
 
 	// No error
 	return nil
@@ -819,12 +804,7 @@ func (backend *Backend_Spec) AssignProperties_To_Backend_Spec(destination *stora
 	}
 
 	// Description
-	if backend.Description != nil {
-		description := *backend.Description
-		destination.Description = &description
-	} else {
-		destination.Description = nil
-	}
+	destination.Description = genruntime.ClonePointerToString(backend.Description)
 
 	// OperatorSpec
 	if backend.OperatorSpec != nil {
@@ -902,12 +882,7 @@ func (backend *Backend_Spec) AssignProperties_To_Backend_Spec(destination *stora
 	}
 
 	// Title
-	if backend.Title != nil {
-		title := *backend.Title
-		destination.Title = &title
-	} else {
-		destination.Title = nil
-	}
+	destination.Title = genruntime.ClonePointerToString(backend.Title)
 
 	// Tls
 	if backend.Tls != nil {
@@ -930,12 +905,7 @@ func (backend *Backend_Spec) AssignProperties_To_Backend_Spec(destination *stora
 	}
 
 	// Url
-	if backend.Url != nil {
-		url := *backend.Url
-		destination.Url = &url
-	} else {
-		destination.Url = nil
-	}
+	destination.Url = genruntime.ClonePointerToString(backend.Url)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -1898,30 +1868,10 @@ func (contract *BackendCredentialsContract) AssignProperties_From_BackendCredent
 	}
 
 	// Certificate
-	if source.Certificate != nil {
-		certificateList := make([]string, len(source.Certificate))
-		for certificateIndex, certificateItem := range source.Certificate {
-			// Shadow the loop variable to avoid aliasing
-			certificateItem := certificateItem
-			certificateList[certificateIndex] = certificateItem
-		}
-		contract.Certificate = certificateList
-	} else {
-		contract.Certificate = nil
-	}
+	contract.Certificate = genruntime.CloneSliceOfString(source.Certificate)
 
 	// CertificateIds
-	if source.CertificateIds != nil {
-		certificateIdList := make([]string, len(source.CertificateIds))
-		for certificateIdIndex, certificateIdItem := range source.CertificateIds {
-			// Shadow the loop variable to avoid aliasing
-			certificateIdItem := certificateIdItem
-			certificateIdList[certificateIdIndex] = certificateIdItem
-		}
-		contract.CertificateIds = certificateIdList
-	} else {
-		contract.CertificateIds = nil
-	}
+	contract.CertificateIds = genruntime.CloneSliceOfString(source.CertificateIds)
 
 	// Header
 	if source.Header != nil {
@@ -1971,30 +1921,10 @@ func (contract *BackendCredentialsContract) AssignProperties_To_BackendCredentia
 	}
 
 	// Certificate
-	if contract.Certificate != nil {
-		certificateList := make([]string, len(contract.Certificate))
-		for certificateIndex, certificateItem := range contract.Certificate {
-			// Shadow the loop variable to avoid aliasing
-			certificateItem := certificateItem
-			certificateList[certificateIndex] = certificateItem
-		}
-		destination.Certificate = certificateList
-	} else {
-		destination.Certificate = nil
-	}
+	destination.Certificate = genruntime.CloneSliceOfString(contract.Certificate)
 
 	// CertificateIds
-	if contract.CertificateIds != nil {
-		certificateIdList := make([]string, len(contract.CertificateIds))
-		for certificateIdIndex, certificateIdItem := range contract.CertificateIds {
-			// Shadow the loop variable to avoid aliasing
-			certificateIdItem := certificateIdItem
-			certificateIdList[certificateIdIndex] = certificateIdItem
-		}
-		destination.CertificateIds = certificateIdList
-	} else {
-		destination.CertificateIds = nil
-	}
+	destination.CertificateIds = genruntime.CloneSliceOfString(contract.CertificateIds)
 
 	// Header
 	if contract.Header != nil {
@@ -2808,12 +2738,7 @@ func (contract *BackendProxyContract) AssignProperties_From_BackendProxyContract
 	}
 
 	// Url
-	if source.Url != nil {
-		url := *source.Url
-		contract.Url = &url
-	} else {
-		contract.Url = nil
-	}
+	contract.Url = genruntime.ClonePointerToString(source.Url)
 
 	// Username
 	contract.Username = genruntime.ClonePointerToString(source.Username)
@@ -2836,12 +2761,7 @@ func (contract *BackendProxyContract) AssignProperties_To_BackendProxyContract(d
 	}
 
 	// Url
-	if contract.Url != nil {
-		url := *contract.Url
-		destination.Url = &url
-	} else {
-		destination.Url = nil
-	}
+	destination.Url = genruntime.ClonePointerToString(contract.Url)
 
 	// Username
 	destination.Username = genruntime.ClonePointerToString(contract.Username)
@@ -3215,20 +3135,10 @@ func (credentials *BackendAuthorizationHeaderCredentials) PopulateFromARM(owner 
 func (credentials *BackendAuthorizationHeaderCredentials) AssignProperties_From_BackendAuthorizationHeaderCredentials(source *storage.BackendAuthorizationHeaderCredentials) error {
 
 	// Parameter
-	if source.Parameter != nil {
-		parameter := *source.Parameter
-		credentials.Parameter = &parameter
-	} else {
-		credentials.Parameter = nil
-	}
+	credentials.Parameter = genruntime.ClonePointerToString(source.Parameter)
 
 	// Scheme
-	if source.Scheme != nil {
-		scheme := *source.Scheme
-		credentials.Scheme = &scheme
-	} else {
-		credentials.Scheme = nil
-	}
+	credentials.Scheme = genruntime.ClonePointerToString(source.Scheme)
 
 	// No error
 	return nil
@@ -3240,20 +3150,10 @@ func (credentials *BackendAuthorizationHeaderCredentials) AssignProperties_To_Ba
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Parameter
-	if credentials.Parameter != nil {
-		parameter := *credentials.Parameter
-		destination.Parameter = &parameter
-	} else {
-		destination.Parameter = nil
-	}
+	destination.Parameter = genruntime.ClonePointerToString(credentials.Parameter)
 
 	// Scheme
-	if credentials.Scheme != nil {
-		scheme := *credentials.Scheme
-		destination.Scheme = &scheme
-	} else {
-		destination.Scheme = nil
-	}
+	destination.Scheme = genruntime.ClonePointerToString(credentials.Scheme)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4753,20 +4653,10 @@ func (codeRange *FailureStatusCodeRange) PopulateFromARM(owner genruntime.Arbitr
 func (codeRange *FailureStatusCodeRange) AssignProperties_From_FailureStatusCodeRange(source *storage.FailureStatusCodeRange) error {
 
 	// Max
-	if source.Max != nil {
-		max := *source.Max
-		codeRange.Max = &max
-	} else {
-		codeRange.Max = nil
-	}
+	codeRange.Max = genruntime.ClonePointerToInt(source.Max)
 
 	// Min
-	if source.Min != nil {
-		min := *source.Min
-		codeRange.Min = &min
-	} else {
-		codeRange.Min = nil
-	}
+	codeRange.Min = genruntime.ClonePointerToInt(source.Min)
 
 	// No error
 	return nil
@@ -4778,20 +4668,10 @@ func (codeRange *FailureStatusCodeRange) AssignProperties_To_FailureStatusCodeRa
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Max
-	if codeRange.Max != nil {
-		max := *codeRange.Max
-		destination.Max = &max
-	} else {
-		destination.Max = nil
-	}
+	destination.Max = genruntime.ClonePointerToInt(codeRange.Max)
 
 	// Min
-	if codeRange.Min != nil {
-		min := *codeRange.Min
-		destination.Min = &min
-	} else {
-		destination.Min = nil
-	}
+	destination.Min = genruntime.ClonePointerToInt(codeRange.Min)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4851,20 +4731,10 @@ func (codeRange *FailureStatusCodeRange_STATUS) PopulateFromARM(owner genruntime
 func (codeRange *FailureStatusCodeRange_STATUS) AssignProperties_From_FailureStatusCodeRange_STATUS(source *storage.FailureStatusCodeRange_STATUS) error {
 
 	// Max
-	if source.Max != nil {
-		max := *source.Max
-		codeRange.Max = &max
-	} else {
-		codeRange.Max = nil
-	}
+	codeRange.Max = genruntime.ClonePointerToInt(source.Max)
 
 	// Min
-	if source.Min != nil {
-		min := *source.Min
-		codeRange.Min = &min
-	} else {
-		codeRange.Min = nil
-	}
+	codeRange.Min = genruntime.ClonePointerToInt(source.Min)
 
 	// No error
 	return nil
@@ -4876,20 +4746,10 @@ func (codeRange *FailureStatusCodeRange_STATUS) AssignProperties_To_FailureStatu
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Max
-	if codeRange.Max != nil {
-		max := *codeRange.Max
-		destination.Max = &max
-	} else {
-		destination.Max = nil
-	}
+	destination.Max = genruntime.ClonePointerToInt(codeRange.Max)
 
 	// Min
-	if codeRange.Min != nil {
-		min := *codeRange.Min
-		destination.Min = &min
-	} else {
-		destination.Min = nil
-	}
+	destination.Min = genruntime.ClonePointerToInt(codeRange.Min)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/apimanagement/v1api20230501preview/named_value_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/named_value_types_gen.go
@@ -468,12 +468,7 @@ func (value *NamedValue_Spec) AssignProperties_From_NamedValue_Spec(source *stor
 	value.AzureName = source.AzureName
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		value.DisplayName = &displayName
-	} else {
-		value.DisplayName = nil
-	}
+	value.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// KeyVault
 	if source.KeyVault != nil {
@@ -516,25 +511,10 @@ func (value *NamedValue_Spec) AssignProperties_From_NamedValue_Spec(source *stor
 	}
 
 	// Tags
-	if source.Tags != nil {
-		tagList := make([]string, len(source.Tags))
-		for tagIndex, tagItem := range source.Tags {
-			// Shadow the loop variable to avoid aliasing
-			tagItem := tagItem
-			tagList[tagIndex] = tagItem
-		}
-		value.Tags = tagList
-	} else {
-		value.Tags = nil
-	}
+	value.Tags = genruntime.CloneSliceOfString(source.Tags)
 
 	// Value
-	if source.Value != nil {
-		valueTemp := *source.Value
-		value.Value = &valueTemp
-	} else {
-		value.Value = nil
-	}
+	value.Value = genruntime.ClonePointerToString(source.Value)
 
 	// No error
 	return nil
@@ -549,12 +529,7 @@ func (value *NamedValue_Spec) AssignProperties_To_NamedValue_Spec(destination *s
 	destination.AzureName = value.AzureName
 
 	// DisplayName
-	if value.DisplayName != nil {
-		displayName := *value.DisplayName
-		destination.DisplayName = &displayName
-	} else {
-		destination.DisplayName = nil
-	}
+	destination.DisplayName = genruntime.ClonePointerToString(value.DisplayName)
 
 	// KeyVault
 	if value.KeyVault != nil {
@@ -600,25 +575,10 @@ func (value *NamedValue_Spec) AssignProperties_To_NamedValue_Spec(destination *s
 	}
 
 	// Tags
-	if value.Tags != nil {
-		tagList := make([]string, len(value.Tags))
-		for tagIndex, tagItem := range value.Tags {
-			// Shadow the loop variable to avoid aliasing
-			tagItem := tagItem
-			tagList[tagIndex] = tagItem
-		}
-		destination.Tags = tagList
-	} else {
-		destination.Tags = nil
-	}
+	destination.Tags = genruntime.CloneSliceOfString(value.Tags)
 
 	// Value
-	if value.Value != nil {
-		valueTemp := *value.Value
-		destination.Value = &valueTemp
-	} else {
-		destination.Value = nil
-	}
+	destination.Value = genruntime.ClonePointerToString(value.Value)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/apimanagement/v1api20230501preview/policy_fragment_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/policy_fragment_types_gen.go
@@ -428,12 +428,7 @@ func (fragment *PolicyFragment_Spec) AssignProperties_From_PolicyFragment_Spec(s
 	fragment.AzureName = source.AzureName
 
 	// Description
-	if source.Description != nil {
-		description := *source.Description
-		fragment.Description = &description
-	} else {
-		fragment.Description = nil
-	}
+	fragment.Description = genruntime.ClonePointerToString(source.Description)
 
 	// Format
 	if source.Format != nil {
@@ -480,12 +475,7 @@ func (fragment *PolicyFragment_Spec) AssignProperties_To_PolicyFragment_Spec(des
 	destination.AzureName = fragment.AzureName
 
 	// Description
-	if fragment.Description != nil {
-		description := *fragment.Description
-		destination.Description = &description
-	} else {
-		destination.Description = nil
-	}
+	destination.Description = genruntime.ClonePointerToString(fragment.Description)
 
 	// Format
 	if fragment.Format != nil {

--- a/v2/api/apimanagement/v1api20230501preview/product_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/product_types_gen.go
@@ -516,20 +516,10 @@ func (product *Product_Spec) AssignProperties_From_Product_Spec(source *storage.
 	product.AzureName = source.AzureName
 
 	// Description
-	if source.Description != nil {
-		description := *source.Description
-		product.Description = &description
-	} else {
-		product.Description = nil
-	}
+	product.Description = genruntime.ClonePointerToString(source.Description)
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		product.DisplayName = &displayName
-	} else {
-		product.DisplayName = nil
-	}
+	product.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -595,20 +585,10 @@ func (product *Product_Spec) AssignProperties_To_Product_Spec(destination *stora
 	destination.AzureName = product.AzureName
 
 	// Description
-	if product.Description != nil {
-		description := *product.Description
-		destination.Description = &description
-	} else {
-		destination.Description = nil
-	}
+	destination.Description = genruntime.ClonePointerToString(product.Description)
 
 	// DisplayName
-	if product.DisplayName != nil {
-		displayName := *product.DisplayName
-		destination.DisplayName = &displayName
-	} else {
-		destination.DisplayName = nil
-	}
+	destination.DisplayName = genruntime.ClonePointerToString(product.DisplayName)
 
 	// OperatorSpec
 	if product.OperatorSpec != nil {

--- a/v2/api/apimanagement/v1api20230501preview/service_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/service_types_gen.go
@@ -1033,12 +1033,7 @@ func (service *Service_Spec) AssignProperties_From_Service_Spec(source *storage.
 	}
 
 	// NotificationSenderEmail
-	if source.NotificationSenderEmail != nil {
-		notificationSenderEmail := *source.NotificationSenderEmail
-		service.NotificationSenderEmail = &notificationSenderEmail
-	} else {
-		service.NotificationSenderEmail = nil
-	}
+	service.NotificationSenderEmail = genruntime.ClonePointerToString(source.NotificationSenderEmail)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -1078,20 +1073,10 @@ func (service *Service_Spec) AssignProperties_From_Service_Spec(source *storage.
 	}
 
 	// PublisherEmail
-	if source.PublisherEmail != nil {
-		publisherEmail := *source.PublisherEmail
-		service.PublisherEmail = &publisherEmail
-	} else {
-		service.PublisherEmail = nil
-	}
+	service.PublisherEmail = genruntime.ClonePointerToString(source.PublisherEmail)
 
 	// PublisherName
-	if source.PublisherName != nil {
-		publisherName := *source.PublisherName
-		service.PublisherName = &publisherName
-	} else {
-		service.PublisherName = nil
-	}
+	service.PublisherName = genruntime.ClonePointerToString(source.PublisherName)
 
 	// Restore
 	if source.Restore != nil {
@@ -1289,12 +1274,7 @@ func (service *Service_Spec) AssignProperties_To_Service_Spec(destination *stora
 	}
 
 	// NotificationSenderEmail
-	if service.NotificationSenderEmail != nil {
-		notificationSenderEmail := *service.NotificationSenderEmail
-		destination.NotificationSenderEmail = &notificationSenderEmail
-	} else {
-		destination.NotificationSenderEmail = nil
-	}
+	destination.NotificationSenderEmail = genruntime.ClonePointerToString(service.NotificationSenderEmail)
 
 	// OperatorSpec
 	if service.OperatorSpec != nil {
@@ -1336,20 +1316,10 @@ func (service *Service_Spec) AssignProperties_To_Service_Spec(destination *stora
 	}
 
 	// PublisherEmail
-	if service.PublisherEmail != nil {
-		publisherEmail := *service.PublisherEmail
-		destination.PublisherEmail = &publisherEmail
-	} else {
-		destination.PublisherEmail = nil
-	}
+	destination.PublisherEmail = genruntime.ClonePointerToString(service.PublisherEmail)
 
 	// PublisherName
-	if service.PublisherName != nil {
-		publisherName := *service.PublisherName
-		destination.PublisherName = &publisherName
-	} else {
-		destination.PublisherName = nil
-	}
+	destination.PublisherName = genruntime.ClonePointerToString(service.PublisherName)
 
 	// Restore
 	if service.Restore != nil {

--- a/v2/api/apimanagement/v1api20230501preview/subscription_types_gen.go
+++ b/v2/api/apimanagement/v1api20230501preview/subscription_types_gen.go
@@ -500,12 +500,7 @@ func (subscription *Subscription_Spec) AssignProperties_From_Subscription_Spec(s
 	subscription.AzureName = source.AzureName
 
 	// DisplayName
-	if source.DisplayName != nil {
-		displayName := *source.DisplayName
-		subscription.DisplayName = &displayName
-	} else {
-		subscription.DisplayName = nil
-	}
+	subscription.DisplayName = genruntime.ClonePointerToString(source.DisplayName)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -584,12 +579,7 @@ func (subscription *Subscription_Spec) AssignProperties_To_Subscription_Spec(des
 	destination.AzureName = subscription.AzureName
 
 	// DisplayName
-	if subscription.DisplayName != nil {
-		displayName := *subscription.DisplayName
-		destination.DisplayName = &displayName
-	} else {
-		destination.DisplayName = nil
-	}
+	destination.DisplayName = genruntime.ClonePointerToString(subscription.DisplayName)
 
 	// OperatorSpec
 	if subscription.OperatorSpec != nil {

--- a/v2/api/cache/v1api20201201/redis_types_gen.go
+++ b/v2/api/cache/v1api20201201/redis_types_gen.go
@@ -746,12 +746,7 @@ func (redis *Redis_Spec) AssignProperties_From_Redis_Spec(source *storage.Redis_
 	}
 
 	// StaticIP
-	if source.StaticIP != nil {
-		staticIP := *source.StaticIP
-		redis.StaticIP = &staticIP
-	} else {
-		redis.StaticIP = nil
-	}
+	redis.StaticIP = genruntime.ClonePointerToString(source.StaticIP)
 
 	// SubnetReference
 	if source.SubnetReference != nil {
@@ -869,12 +864,7 @@ func (redis *Redis_Spec) AssignProperties_To_Redis_Spec(destination *storage.Red
 	}
 
 	// StaticIP
-	if redis.StaticIP != nil {
-		staticIP := *redis.StaticIP
-		destination.StaticIP = &staticIP
-	} else {
-		destination.StaticIP = nil
-	}
+	destination.StaticIP = genruntime.ClonePointerToString(redis.StaticIP)
 
 	// SubnetReference
 	if redis.SubnetReference != nil {

--- a/v2/api/cache/v1api20230401/redis_types_gen.go
+++ b/v2/api/cache/v1api20230401/redis_types_gen.go
@@ -783,12 +783,7 @@ func (redis *Redis_Spec) AssignProperties_From_Redis_Spec(source *storage.Redis_
 	}
 
 	// StaticIP
-	if source.StaticIP != nil {
-		staticIP := *source.StaticIP
-		redis.StaticIP = &staticIP
-	} else {
-		redis.StaticIP = nil
-	}
+	redis.StaticIP = genruntime.ClonePointerToString(source.StaticIP)
 
 	// SubnetReference
 	if source.SubnetReference != nil {
@@ -918,12 +913,7 @@ func (redis *Redis_Spec) AssignProperties_To_Redis_Spec(destination *storage.Red
 	}
 
 	// StaticIP
-	if redis.StaticIP != nil {
-		staticIP := *redis.StaticIP
-		destination.StaticIP = &staticIP
-	} else {
-		destination.StaticIP = nil
-	}
+	destination.StaticIP = genruntime.ClonePointerToString(redis.StaticIP)
 
 	// SubnetReference
 	if redis.SubnetReference != nil {

--- a/v2/api/cache/v1api20230801/redis_types_gen.go
+++ b/v2/api/cache/v1api20230801/redis_types_gen.go
@@ -802,12 +802,7 @@ func (redis *Redis_Spec) AssignProperties_From_Redis_Spec(source *storage.Redis_
 	}
 
 	// StaticIP
-	if source.StaticIP != nil {
-		staticIP := *source.StaticIP
-		redis.StaticIP = &staticIP
-	} else {
-		redis.StaticIP = nil
-	}
+	redis.StaticIP = genruntime.ClonePointerToString(source.StaticIP)
 
 	// SubnetReference
 	if source.SubnetReference != nil {
@@ -946,12 +941,7 @@ func (redis *Redis_Spec) AssignProperties_To_Redis_Spec(destination *storage.Red
 	}
 
 	// StaticIP
-	if redis.StaticIP != nil {
-		staticIP := *redis.StaticIP
-		destination.StaticIP = &staticIP
-	} else {
-		destination.StaticIP = nil
-	}
+	destination.StaticIP = genruntime.ClonePointerToString(redis.StaticIP)
 
 	// SubnetReference
 	if redis.SubnetReference != nil {
@@ -1068,12 +1058,7 @@ func (redis *Redis_Spec) Initialize_From_Redis_STATUS(source *Redis_STATUS) erro
 	}
 
 	// StaticIP
-	if source.StaticIP != nil {
-		staticIP := *source.StaticIP
-		redis.StaticIP = &staticIP
-	} else {
-		redis.StaticIP = nil
-	}
+	redis.StaticIP = genruntime.ClonePointerToString(source.StaticIP)
 
 	// SubnetReference
 	if source.SubnetId != nil {

--- a/v2/api/cdn/v1api20210601/profile_types_gen.go
+++ b/v2/api/cdn/v1api20210601/profile_types_gen.go
@@ -466,12 +466,7 @@ func (profile *Profile_Spec) AssignProperties_From_Profile_Spec(source *storage.
 	}
 
 	// OriginResponseTimeoutSeconds
-	if source.OriginResponseTimeoutSeconds != nil {
-		originResponseTimeoutSecond := *source.OriginResponseTimeoutSeconds
-		profile.OriginResponseTimeoutSeconds = &originResponseTimeoutSecond
-	} else {
-		profile.OriginResponseTimeoutSeconds = nil
-	}
+	profile.OriginResponseTimeoutSeconds = genruntime.ClonePointerToInt(source.OriginResponseTimeoutSeconds)
 
 	// Owner
 	if source.Owner != nil {
@@ -524,12 +519,7 @@ func (profile *Profile_Spec) AssignProperties_To_Profile_Spec(destination *stora
 	}
 
 	// OriginResponseTimeoutSeconds
-	if profile.OriginResponseTimeoutSeconds != nil {
-		originResponseTimeoutSecond := *profile.OriginResponseTimeoutSeconds
-		destination.OriginResponseTimeoutSeconds = &originResponseTimeoutSecond
-	} else {
-		destination.OriginResponseTimeoutSeconds = nil
-	}
+	destination.OriginResponseTimeoutSeconds = genruntime.ClonePointerToInt(profile.OriginResponseTimeoutSeconds)
 
 	// OriginalVersion
 	destination.OriginalVersion = profile.OriginalVersion()

--- a/v2/api/cdn/v1api20210601/profiles_endpoint_types_gen.go
+++ b/v2/api/cdn/v1api20210601/profiles_endpoint_types_gen.go
@@ -2597,20 +2597,10 @@ func (origin *DeepCreatedOrigin) AssignProperties_From_DeepCreatedOrigin(source 
 	origin.HostName = genruntime.ClonePointerToString(source.HostName)
 
 	// HttpPort
-	if source.HttpPort != nil {
-		httpPort := *source.HttpPort
-		origin.HttpPort = &httpPort
-	} else {
-		origin.HttpPort = nil
-	}
+	origin.HttpPort = genruntime.ClonePointerToInt(source.HttpPort)
 
 	// HttpsPort
-	if source.HttpsPort != nil {
-		httpsPort := *source.HttpsPort
-		origin.HttpsPort = &httpsPort
-	} else {
-		origin.HttpsPort = nil
-	}
+	origin.HttpsPort = genruntime.ClonePointerToInt(source.HttpsPort)
 
 	// Name
 	origin.Name = genruntime.ClonePointerToString(source.Name)
@@ -2619,12 +2609,7 @@ func (origin *DeepCreatedOrigin) AssignProperties_From_DeepCreatedOrigin(source 
 	origin.OriginHostHeader = genruntime.ClonePointerToString(source.OriginHostHeader)
 
 	// Priority
-	if source.Priority != nil {
-		priority := *source.Priority
-		origin.Priority = &priority
-	} else {
-		origin.Priority = nil
-	}
+	origin.Priority = genruntime.ClonePointerToInt(source.Priority)
 
 	// PrivateLinkAlias
 	origin.PrivateLinkAlias = genruntime.ClonePointerToString(source.PrivateLinkAlias)
@@ -2649,12 +2634,7 @@ func (origin *DeepCreatedOrigin) AssignProperties_From_DeepCreatedOrigin(source 
 	}
 
 	// Weight
-	if source.Weight != nil {
-		weight := *source.Weight
-		origin.Weight = &weight
-	} else {
-		origin.Weight = nil
-	}
+	origin.Weight = genruntime.ClonePointerToInt(source.Weight)
 
 	// No error
 	return nil
@@ -2677,20 +2657,10 @@ func (origin *DeepCreatedOrigin) AssignProperties_To_DeepCreatedOrigin(destinati
 	destination.HostName = genruntime.ClonePointerToString(origin.HostName)
 
 	// HttpPort
-	if origin.HttpPort != nil {
-		httpPort := *origin.HttpPort
-		destination.HttpPort = &httpPort
-	} else {
-		destination.HttpPort = nil
-	}
+	destination.HttpPort = genruntime.ClonePointerToInt(origin.HttpPort)
 
 	// HttpsPort
-	if origin.HttpsPort != nil {
-		httpsPort := *origin.HttpsPort
-		destination.HttpsPort = &httpsPort
-	} else {
-		destination.HttpsPort = nil
-	}
+	destination.HttpsPort = genruntime.ClonePointerToInt(origin.HttpsPort)
 
 	// Name
 	destination.Name = genruntime.ClonePointerToString(origin.Name)
@@ -2699,12 +2669,7 @@ func (origin *DeepCreatedOrigin) AssignProperties_To_DeepCreatedOrigin(destinati
 	destination.OriginHostHeader = genruntime.ClonePointerToString(origin.OriginHostHeader)
 
 	// Priority
-	if origin.Priority != nil {
-		priority := *origin.Priority
-		destination.Priority = &priority
-	} else {
-		destination.Priority = nil
-	}
+	destination.Priority = genruntime.ClonePointerToInt(origin.Priority)
 
 	// PrivateLinkAlias
 	destination.PrivateLinkAlias = genruntime.ClonePointerToString(origin.PrivateLinkAlias)
@@ -2729,12 +2694,7 @@ func (origin *DeepCreatedOrigin) AssignProperties_To_DeepCreatedOrigin(destinati
 	}
 
 	// Weight
-	if origin.Weight != nil {
-		weight := *origin.Weight
-		destination.Weight = &weight
-	} else {
-		destination.Weight = nil
-	}
+	destination.Weight = genruntime.ClonePointerToInt(origin.Weight)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -2762,20 +2722,10 @@ func (origin *DeepCreatedOrigin) Initialize_From_DeepCreatedOrigin_STATUS(source
 	origin.HostName = genruntime.ClonePointerToString(source.HostName)
 
 	// HttpPort
-	if source.HttpPort != nil {
-		httpPort := *source.HttpPort
-		origin.HttpPort = &httpPort
-	} else {
-		origin.HttpPort = nil
-	}
+	origin.HttpPort = genruntime.ClonePointerToInt(source.HttpPort)
 
 	// HttpsPort
-	if source.HttpsPort != nil {
-		httpsPort := *source.HttpsPort
-		origin.HttpsPort = &httpsPort
-	} else {
-		origin.HttpsPort = nil
-	}
+	origin.HttpsPort = genruntime.ClonePointerToInt(source.HttpsPort)
 
 	// Name
 	origin.Name = genruntime.ClonePointerToString(source.Name)
@@ -2784,12 +2734,7 @@ func (origin *DeepCreatedOrigin) Initialize_From_DeepCreatedOrigin_STATUS(source
 	origin.OriginHostHeader = genruntime.ClonePointerToString(source.OriginHostHeader)
 
 	// Priority
-	if source.Priority != nil {
-		priority := *source.Priority
-		origin.Priority = &priority
-	} else {
-		origin.Priority = nil
-	}
+	origin.Priority = genruntime.ClonePointerToInt(source.Priority)
 
 	// PrivateLinkAlias
 	origin.PrivateLinkAlias = genruntime.ClonePointerToString(source.PrivateLinkAlias)
@@ -2806,12 +2751,7 @@ func (origin *DeepCreatedOrigin) Initialize_From_DeepCreatedOrigin_STATUS(source
 	}
 
 	// Weight
-	if source.Weight != nil {
-		weight := *source.Weight
-		origin.Weight = &weight
-	} else {
-		origin.Weight = nil
-	}
+	origin.Weight = genruntime.ClonePointerToInt(source.Weight)
 
 	// No error
 	return nil
@@ -3320,12 +3260,7 @@ func (group *DeepCreatedOriginGroup) AssignProperties_From_DeepCreatedOriginGrou
 	}
 
 	// TrafficRestorationTimeToHealedOrNewEndpointsInMinutes
-	if source.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes != nil {
-		trafficRestorationTimeToHealedOrNewEndpointsInMinute := *source.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes
-		group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = &trafficRestorationTimeToHealedOrNewEndpointsInMinute
-	} else {
-		group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = nil
-	}
+	group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = genruntime.ClonePointerToInt(source.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes)
 
 	// No error
 	return nil
@@ -3382,12 +3317,7 @@ func (group *DeepCreatedOriginGroup) AssignProperties_To_DeepCreatedOriginGroup(
 	}
 
 	// TrafficRestorationTimeToHealedOrNewEndpointsInMinutes
-	if group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes != nil {
-		trafficRestorationTimeToHealedOrNewEndpointsInMinute := *group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes
-		destination.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = &trafficRestorationTimeToHealedOrNewEndpointsInMinute
-	} else {
-		destination.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = nil
-	}
+	destination.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = genruntime.ClonePointerToInt(group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -3449,12 +3379,7 @@ func (group *DeepCreatedOriginGroup) Initialize_From_DeepCreatedOriginGroup_STAT
 	}
 
 	// TrafficRestorationTimeToHealedOrNewEndpointsInMinutes
-	if source.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes != nil {
-		trafficRestorationTimeToHealedOrNewEndpointsInMinute := *source.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes
-		group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = &trafficRestorationTimeToHealedOrNewEndpointsInMinute
-	} else {
-		group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = nil
-	}
+	group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = genruntime.ClonePointerToInt(source.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes)
 
 	// No error
 	return nil
@@ -5542,12 +5467,7 @@ func (parameters *HealthProbeParameters) PopulateFromARM(owner genruntime.Arbitr
 func (parameters *HealthProbeParameters) AssignProperties_From_HealthProbeParameters(source *storage.HealthProbeParameters) error {
 
 	// ProbeIntervalInSeconds
-	if source.ProbeIntervalInSeconds != nil {
-		probeIntervalInSecond := *source.ProbeIntervalInSeconds
-		parameters.ProbeIntervalInSeconds = &probeIntervalInSecond
-	} else {
-		parameters.ProbeIntervalInSeconds = nil
-	}
+	parameters.ProbeIntervalInSeconds = genruntime.ClonePointerToInt(source.ProbeIntervalInSeconds)
 
 	// ProbePath
 	parameters.ProbePath = genruntime.ClonePointerToString(source.ProbePath)
@@ -5580,12 +5500,7 @@ func (parameters *HealthProbeParameters) AssignProperties_To_HealthProbeParamete
 	propertyBag := genruntime.NewPropertyBag()
 
 	// ProbeIntervalInSeconds
-	if parameters.ProbeIntervalInSeconds != nil {
-		probeIntervalInSecond := *parameters.ProbeIntervalInSeconds
-		destination.ProbeIntervalInSeconds = &probeIntervalInSecond
-	} else {
-		destination.ProbeIntervalInSeconds = nil
-	}
+	destination.ProbeIntervalInSeconds = genruntime.ClonePointerToInt(parameters.ProbeIntervalInSeconds)
 
 	// ProbePath
 	destination.ProbePath = genruntime.ClonePointerToString(parameters.ProbePath)
@@ -5621,12 +5536,7 @@ func (parameters *HealthProbeParameters) AssignProperties_To_HealthProbeParamete
 func (parameters *HealthProbeParameters) Initialize_From_HealthProbeParameters_STATUS(source *HealthProbeParameters_STATUS) error {
 
 	// ProbeIntervalInSeconds
-	if source.ProbeIntervalInSeconds != nil {
-		probeIntervalInSecond := *source.ProbeIntervalInSeconds
-		parameters.ProbeIntervalInSeconds = &probeIntervalInSecond
-	} else {
-		parameters.ProbeIntervalInSeconds = nil
-	}
+	parameters.ProbeIntervalInSeconds = genruntime.ClonePointerToInt(source.ProbeIntervalInSeconds)
 
 	// ProbePath
 	parameters.ProbePath = genruntime.ClonePointerToString(source.ProbePath)
@@ -6295,12 +6205,7 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters) AssignProperties_
 	}
 
 	// ResponseBasedFailoverThresholdPercentage
-	if source.ResponseBasedFailoverThresholdPercentage != nil {
-		responseBasedFailoverThresholdPercentage := *source.ResponseBasedFailoverThresholdPercentage
-		parameters.ResponseBasedFailoverThresholdPercentage = &responseBasedFailoverThresholdPercentage
-	} else {
-		parameters.ResponseBasedFailoverThresholdPercentage = nil
-	}
+	parameters.ResponseBasedFailoverThresholdPercentage = genruntime.ClonePointerToInt(source.ResponseBasedFailoverThresholdPercentage)
 
 	// No error
 	return nil
@@ -6338,12 +6243,7 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters) AssignProperties_
 	}
 
 	// ResponseBasedFailoverThresholdPercentage
-	if parameters.ResponseBasedFailoverThresholdPercentage != nil {
-		responseBasedFailoverThresholdPercentage := *parameters.ResponseBasedFailoverThresholdPercentage
-		destination.ResponseBasedFailoverThresholdPercentage = &responseBasedFailoverThresholdPercentage
-	} else {
-		destination.ResponseBasedFailoverThresholdPercentage = nil
-	}
+	destination.ResponseBasedFailoverThresholdPercentage = genruntime.ClonePointerToInt(parameters.ResponseBasedFailoverThresholdPercentage)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -6386,12 +6286,7 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters) Initialize_From_R
 	}
 
 	// ResponseBasedFailoverThresholdPercentage
-	if source.ResponseBasedFailoverThresholdPercentage != nil {
-		responseBasedFailoverThresholdPercentage := *source.ResponseBasedFailoverThresholdPercentage
-		parameters.ResponseBasedFailoverThresholdPercentage = &responseBasedFailoverThresholdPercentage
-	} else {
-		parameters.ResponseBasedFailoverThresholdPercentage = nil
-	}
+	parameters.ResponseBasedFailoverThresholdPercentage = genruntime.ClonePointerToInt(source.ResponseBasedFailoverThresholdPercentage)
 
 	// No error
 	return nil
@@ -9616,20 +9511,10 @@ func (parameters *HttpErrorRangeParameters) PopulateFromARM(owner genruntime.Arb
 func (parameters *HttpErrorRangeParameters) AssignProperties_From_HttpErrorRangeParameters(source *storage.HttpErrorRangeParameters) error {
 
 	// Begin
-	if source.Begin != nil {
-		begin := *source.Begin
-		parameters.Begin = &begin
-	} else {
-		parameters.Begin = nil
-	}
+	parameters.Begin = genruntime.ClonePointerToInt(source.Begin)
 
 	// End
-	if source.End != nil {
-		end := *source.End
-		parameters.End = &end
-	} else {
-		parameters.End = nil
-	}
+	parameters.End = genruntime.ClonePointerToInt(source.End)
 
 	// No error
 	return nil
@@ -9641,20 +9526,10 @@ func (parameters *HttpErrorRangeParameters) AssignProperties_To_HttpErrorRangePa
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Begin
-	if parameters.Begin != nil {
-		begin := *parameters.Begin
-		destination.Begin = &begin
-	} else {
-		destination.Begin = nil
-	}
+	destination.Begin = genruntime.ClonePointerToInt(parameters.Begin)
 
 	// End
-	if parameters.End != nil {
-		end := *parameters.End
-		destination.End = &end
-	} else {
-		destination.End = nil
-	}
+	destination.End = genruntime.ClonePointerToInt(parameters.End)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -9671,20 +9546,10 @@ func (parameters *HttpErrorRangeParameters) AssignProperties_To_HttpErrorRangePa
 func (parameters *HttpErrorRangeParameters) Initialize_From_HttpErrorRangeParameters_STATUS(source *HttpErrorRangeParameters_STATUS) error {
 
 	// Begin
-	if source.Begin != nil {
-		begin := *source.Begin
-		parameters.Begin = &begin
-	} else {
-		parameters.Begin = nil
-	}
+	parameters.Begin = genruntime.ClonePointerToInt(source.Begin)
 
 	// End
-	if source.End != nil {
-		end := *source.End
-		parameters.End = &end
-	} else {
-		parameters.End = nil
-	}
+	parameters.End = genruntime.ClonePointerToInt(source.End)
 
 	// No error
 	return nil

--- a/v2/api/cdn/v1api20230501/afd_origin_group_types_gen.go
+++ b/v2/api/cdn/v1api20230501/afd_origin_group_types_gen.go
@@ -510,12 +510,7 @@ func (group *AfdOriginGroup_Spec) AssignProperties_From_AfdOriginGroup_Spec(sour
 	}
 
 	// TrafficRestorationTimeToHealedOrNewEndpointsInMinutes
-	if source.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes != nil {
-		trafficRestorationTimeToHealedOrNewEndpointsInMinute := *source.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes
-		group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = &trafficRestorationTimeToHealedOrNewEndpointsInMinute
-	} else {
-		group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = nil
-	}
+	group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = genruntime.ClonePointerToInt(source.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes)
 
 	// No error
 	return nil
@@ -585,12 +580,7 @@ func (group *AfdOriginGroup_Spec) AssignProperties_To_AfdOriginGroup_Spec(destin
 	}
 
 	// TrafficRestorationTimeToHealedOrNewEndpointsInMinutes
-	if group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes != nil {
-		trafficRestorationTimeToHealedOrNewEndpointsInMinute := *group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes
-		destination.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = &trafficRestorationTimeToHealedOrNewEndpointsInMinute
-	} else {
-		destination.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = nil
-	}
+	destination.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = genruntime.ClonePointerToInt(group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -639,12 +629,7 @@ func (group *AfdOriginGroup_Spec) Initialize_From_AfdOriginGroup_STATUS(source *
 	}
 
 	// TrafficRestorationTimeToHealedOrNewEndpointsInMinutes
-	if source.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes != nil {
-		trafficRestorationTimeToHealedOrNewEndpointsInMinute := *source.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes
-		group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = &trafficRestorationTimeToHealedOrNewEndpointsInMinute
-	} else {
-		group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = nil
-	}
+	group.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = genruntime.ClonePointerToInt(source.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes)
 
 	// No error
 	return nil
@@ -1327,12 +1312,7 @@ func (parameters *HealthProbeParameters) PopulateFromARM(owner genruntime.Arbitr
 func (parameters *HealthProbeParameters) AssignProperties_From_HealthProbeParameters(source *storage.HealthProbeParameters) error {
 
 	// ProbeIntervalInSeconds
-	if source.ProbeIntervalInSeconds != nil {
-		probeIntervalInSecond := *source.ProbeIntervalInSeconds
-		parameters.ProbeIntervalInSeconds = &probeIntervalInSecond
-	} else {
-		parameters.ProbeIntervalInSeconds = nil
-	}
+	parameters.ProbeIntervalInSeconds = genruntime.ClonePointerToInt(source.ProbeIntervalInSeconds)
 
 	// ProbePath
 	parameters.ProbePath = genruntime.ClonePointerToString(source.ProbePath)
@@ -1365,12 +1345,7 @@ func (parameters *HealthProbeParameters) AssignProperties_To_HealthProbeParamete
 	propertyBag := genruntime.NewPropertyBag()
 
 	// ProbeIntervalInSeconds
-	if parameters.ProbeIntervalInSeconds != nil {
-		probeIntervalInSecond := *parameters.ProbeIntervalInSeconds
-		destination.ProbeIntervalInSeconds = &probeIntervalInSecond
-	} else {
-		destination.ProbeIntervalInSeconds = nil
-	}
+	destination.ProbeIntervalInSeconds = genruntime.ClonePointerToInt(parameters.ProbeIntervalInSeconds)
 
 	// ProbePath
 	destination.ProbePath = genruntime.ClonePointerToString(parameters.ProbePath)
@@ -1406,12 +1381,7 @@ func (parameters *HealthProbeParameters) AssignProperties_To_HealthProbeParamete
 func (parameters *HealthProbeParameters) Initialize_From_HealthProbeParameters_STATUS(source *HealthProbeParameters_STATUS) error {
 
 	// ProbeIntervalInSeconds
-	if source.ProbeIntervalInSeconds != nil {
-		probeIntervalInSecond := *source.ProbeIntervalInSeconds
-		parameters.ProbeIntervalInSeconds = &probeIntervalInSecond
-	} else {
-		parameters.ProbeIntervalInSeconds = nil
-	}
+	parameters.ProbeIntervalInSeconds = genruntime.ClonePointerToInt(source.ProbeIntervalInSeconds)
 
 	// ProbePath
 	parameters.ProbePath = genruntime.ClonePointerToString(source.ProbePath)

--- a/v2/api/cdn/v1api20230501/afd_origin_types_gen.go
+++ b/v2/api/cdn/v1api20230501/afd_origin_types_gen.go
@@ -623,20 +623,10 @@ func (origin *AfdOrigin_Spec) AssignProperties_From_AfdOrigin_Spec(source *stora
 	}
 
 	// HttpPort
-	if source.HttpPort != nil {
-		httpPort := *source.HttpPort
-		origin.HttpPort = &httpPort
-	} else {
-		origin.HttpPort = nil
-	}
+	origin.HttpPort = genruntime.ClonePointerToInt(source.HttpPort)
 
 	// HttpsPort
-	if source.HttpsPort != nil {
-		httpsPort := *source.HttpsPort
-		origin.HttpsPort = &httpsPort
-	} else {
-		origin.HttpsPort = nil
-	}
+	origin.HttpsPort = genruntime.ClonePointerToInt(source.HttpsPort)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -662,12 +652,7 @@ func (origin *AfdOrigin_Spec) AssignProperties_From_AfdOrigin_Spec(source *stora
 	}
 
 	// Priority
-	if source.Priority != nil {
-		priority := *source.Priority
-		origin.Priority = &priority
-	} else {
-		origin.Priority = nil
-	}
+	origin.Priority = genruntime.ClonePointerToInt(source.Priority)
 
 	// SharedPrivateLinkResource
 	if source.SharedPrivateLinkResource != nil {
@@ -682,12 +667,7 @@ func (origin *AfdOrigin_Spec) AssignProperties_From_AfdOrigin_Spec(source *stora
 	}
 
 	// Weight
-	if source.Weight != nil {
-		weight := *source.Weight
-		origin.Weight = &weight
-	} else {
-		origin.Weight = nil
-	}
+	origin.Weight = genruntime.ClonePointerToInt(source.Weight)
 
 	// No error
 	return nil
@@ -741,20 +721,10 @@ func (origin *AfdOrigin_Spec) AssignProperties_To_AfdOrigin_Spec(destination *st
 	}
 
 	// HttpPort
-	if origin.HttpPort != nil {
-		httpPort := *origin.HttpPort
-		destination.HttpPort = &httpPort
-	} else {
-		destination.HttpPort = nil
-	}
+	destination.HttpPort = genruntime.ClonePointerToInt(origin.HttpPort)
 
 	// HttpsPort
-	if origin.HttpsPort != nil {
-		httpsPort := *origin.HttpsPort
-		destination.HttpsPort = &httpsPort
-	} else {
-		destination.HttpsPort = nil
-	}
+	destination.HttpsPort = genruntime.ClonePointerToInt(origin.HttpsPort)
 
 	// OperatorSpec
 	if origin.OperatorSpec != nil {
@@ -783,12 +753,7 @@ func (origin *AfdOrigin_Spec) AssignProperties_To_AfdOrigin_Spec(destination *st
 	}
 
 	// Priority
-	if origin.Priority != nil {
-		priority := *origin.Priority
-		destination.Priority = &priority
-	} else {
-		destination.Priority = nil
-	}
+	destination.Priority = genruntime.ClonePointerToInt(origin.Priority)
 
 	// SharedPrivateLinkResource
 	if origin.SharedPrivateLinkResource != nil {
@@ -803,12 +768,7 @@ func (origin *AfdOrigin_Spec) AssignProperties_To_AfdOrigin_Spec(destination *st
 	}
 
 	// Weight
-	if origin.Weight != nil {
-		weight := *origin.Weight
-		destination.Weight = &weight
-	} else {
-		destination.Weight = nil
-	}
+	destination.Weight = genruntime.ClonePointerToInt(origin.Weight)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -856,31 +816,16 @@ func (origin *AfdOrigin_Spec) Initialize_From_AfdOrigin_STATUS(source *AfdOrigin
 	origin.HostName = genruntime.ClonePointerToString(source.HostName)
 
 	// HttpPort
-	if source.HttpPort != nil {
-		httpPort := *source.HttpPort
-		origin.HttpPort = &httpPort
-	} else {
-		origin.HttpPort = nil
-	}
+	origin.HttpPort = genruntime.ClonePointerToInt(source.HttpPort)
 
 	// HttpsPort
-	if source.HttpsPort != nil {
-		httpsPort := *source.HttpsPort
-		origin.HttpsPort = &httpsPort
-	} else {
-		origin.HttpsPort = nil
-	}
+	origin.HttpsPort = genruntime.ClonePointerToInt(source.HttpsPort)
 
 	// OriginHostHeader
 	origin.OriginHostHeader = genruntime.ClonePointerToString(source.OriginHostHeader)
 
 	// Priority
-	if source.Priority != nil {
-		priority := *source.Priority
-		origin.Priority = &priority
-	} else {
-		origin.Priority = nil
-	}
+	origin.Priority = genruntime.ClonePointerToInt(source.Priority)
 
 	// SharedPrivateLinkResource
 	if source.SharedPrivateLinkResource != nil {
@@ -895,12 +840,7 @@ func (origin *AfdOrigin_Spec) Initialize_From_AfdOrigin_STATUS(source *AfdOrigin
 	}
 
 	// Weight
-	if source.Weight != nil {
-		weight := *source.Weight
-		origin.Weight = &weight
-	} else {
-		origin.Weight = nil
-	}
+	origin.Weight = genruntime.ClonePointerToInt(source.Weight)
 
 	// No error
 	return nil

--- a/v2/api/cdn/v1api20230501/profile_types_gen.go
+++ b/v2/api/cdn/v1api20230501/profile_types_gen.go
@@ -494,12 +494,7 @@ func (profile *Profile_Spec) AssignProperties_From_Profile_Spec(source *storage.
 	}
 
 	// OriginResponseTimeoutSeconds
-	if source.OriginResponseTimeoutSeconds != nil {
-		originResponseTimeoutSecond := *source.OriginResponseTimeoutSeconds
-		profile.OriginResponseTimeoutSeconds = &originResponseTimeoutSecond
-	} else {
-		profile.OriginResponseTimeoutSeconds = nil
-	}
+	profile.OriginResponseTimeoutSeconds = genruntime.ClonePointerToInt(source.OriginResponseTimeoutSeconds)
 
 	// Owner
 	if source.Owner != nil {
@@ -564,12 +559,7 @@ func (profile *Profile_Spec) AssignProperties_To_Profile_Spec(destination *stora
 	}
 
 	// OriginResponseTimeoutSeconds
-	if profile.OriginResponseTimeoutSeconds != nil {
-		originResponseTimeoutSecond := *profile.OriginResponseTimeoutSeconds
-		destination.OriginResponseTimeoutSeconds = &originResponseTimeoutSecond
-	} else {
-		destination.OriginResponseTimeoutSeconds = nil
-	}
+	destination.OriginResponseTimeoutSeconds = genruntime.ClonePointerToInt(profile.OriginResponseTimeoutSeconds)
 
 	// OriginalVersion
 	destination.OriginalVersion = profile.OriginalVersion()
@@ -627,12 +617,7 @@ func (profile *Profile_Spec) Initialize_From_Profile_STATUS(source *Profile_STAT
 	profile.Location = genruntime.ClonePointerToString(source.Location)
 
 	// OriginResponseTimeoutSeconds
-	if source.OriginResponseTimeoutSeconds != nil {
-		originResponseTimeoutSecond := *source.OriginResponseTimeoutSeconds
-		profile.OriginResponseTimeoutSeconds = &originResponseTimeoutSecond
-	} else {
-		profile.OriginResponseTimeoutSeconds = nil
-	}
+	profile.OriginResponseTimeoutSeconds = genruntime.ClonePointerToInt(source.OriginResponseTimeoutSeconds)
 
 	// Sku
 	if source.Sku != nil {

--- a/v2/api/compute/v1api20201201/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/compute/v1api20201201/virtual_machine_scale_set_types_gen.go
@@ -4833,28 +4833,13 @@ func (policy *RollingUpgradePolicy) AssignProperties_From_RollingUpgradePolicy(s
 	}
 
 	// MaxBatchInstancePercent
-	if source.MaxBatchInstancePercent != nil {
-		maxBatchInstancePercent := *source.MaxBatchInstancePercent
-		policy.MaxBatchInstancePercent = &maxBatchInstancePercent
-	} else {
-		policy.MaxBatchInstancePercent = nil
-	}
+	policy.MaxBatchInstancePercent = genruntime.ClonePointerToInt(source.MaxBatchInstancePercent)
 
 	// MaxUnhealthyInstancePercent
-	if source.MaxUnhealthyInstancePercent != nil {
-		maxUnhealthyInstancePercent := *source.MaxUnhealthyInstancePercent
-		policy.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
-	} else {
-		policy.MaxUnhealthyInstancePercent = nil
-	}
+	policy.MaxUnhealthyInstancePercent = genruntime.ClonePointerToInt(source.MaxUnhealthyInstancePercent)
 
 	// MaxUnhealthyUpgradedInstancePercent
-	if source.MaxUnhealthyUpgradedInstancePercent != nil {
-		maxUnhealthyUpgradedInstancePercent := *source.MaxUnhealthyUpgradedInstancePercent
-		policy.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
-	} else {
-		policy.MaxUnhealthyUpgradedInstancePercent = nil
-	}
+	policy.MaxUnhealthyUpgradedInstancePercent = genruntime.ClonePointerToInt(source.MaxUnhealthyUpgradedInstancePercent)
 
 	// PauseTimeBetweenBatches
 	policy.PauseTimeBetweenBatches = genruntime.ClonePointerToString(source.PauseTimeBetweenBatches)
@@ -4885,28 +4870,13 @@ func (policy *RollingUpgradePolicy) AssignProperties_To_RollingUpgradePolicy(des
 	}
 
 	// MaxBatchInstancePercent
-	if policy.MaxBatchInstancePercent != nil {
-		maxBatchInstancePercent := *policy.MaxBatchInstancePercent
-		destination.MaxBatchInstancePercent = &maxBatchInstancePercent
-	} else {
-		destination.MaxBatchInstancePercent = nil
-	}
+	destination.MaxBatchInstancePercent = genruntime.ClonePointerToInt(policy.MaxBatchInstancePercent)
 
 	// MaxUnhealthyInstancePercent
-	if policy.MaxUnhealthyInstancePercent != nil {
-		maxUnhealthyInstancePercent := *policy.MaxUnhealthyInstancePercent
-		destination.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
-	} else {
-		destination.MaxUnhealthyInstancePercent = nil
-	}
+	destination.MaxUnhealthyInstancePercent = genruntime.ClonePointerToInt(policy.MaxUnhealthyInstancePercent)
 
 	// MaxUnhealthyUpgradedInstancePercent
-	if policy.MaxUnhealthyUpgradedInstancePercent != nil {
-		maxUnhealthyUpgradedInstancePercent := *policy.MaxUnhealthyUpgradedInstancePercent
-		destination.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
-	} else {
-		destination.MaxUnhealthyUpgradedInstancePercent = nil
-	}
+	destination.MaxUnhealthyUpgradedInstancePercent = genruntime.ClonePointerToInt(policy.MaxUnhealthyUpgradedInstancePercent)
 
 	// PauseTimeBetweenBatches
 	destination.PauseTimeBetweenBatches = genruntime.ClonePointerToString(policy.PauseTimeBetweenBatches)

--- a/v2/api/compute/v1api20220301/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/compute/v1api20220301/virtual_machine_scale_set_types_gen.go
@@ -6206,28 +6206,13 @@ func (policy *RollingUpgradePolicy) AssignProperties_From_RollingUpgradePolicy(s
 	}
 
 	// MaxBatchInstancePercent
-	if source.MaxBatchInstancePercent != nil {
-		maxBatchInstancePercent := *source.MaxBatchInstancePercent
-		policy.MaxBatchInstancePercent = &maxBatchInstancePercent
-	} else {
-		policy.MaxBatchInstancePercent = nil
-	}
+	policy.MaxBatchInstancePercent = genruntime.ClonePointerToInt(source.MaxBatchInstancePercent)
 
 	// MaxUnhealthyInstancePercent
-	if source.MaxUnhealthyInstancePercent != nil {
-		maxUnhealthyInstancePercent := *source.MaxUnhealthyInstancePercent
-		policy.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
-	} else {
-		policy.MaxUnhealthyInstancePercent = nil
-	}
+	policy.MaxUnhealthyInstancePercent = genruntime.ClonePointerToInt(source.MaxUnhealthyInstancePercent)
 
 	// MaxUnhealthyUpgradedInstancePercent
-	if source.MaxUnhealthyUpgradedInstancePercent != nil {
-		maxUnhealthyUpgradedInstancePercent := *source.MaxUnhealthyUpgradedInstancePercent
-		policy.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
-	} else {
-		policy.MaxUnhealthyUpgradedInstancePercent = nil
-	}
+	policy.MaxUnhealthyUpgradedInstancePercent = genruntime.ClonePointerToInt(source.MaxUnhealthyUpgradedInstancePercent)
 
 	// PauseTimeBetweenBatches
 	policy.PauseTimeBetweenBatches = genruntime.ClonePointerToString(source.PauseTimeBetweenBatches)
@@ -6258,28 +6243,13 @@ func (policy *RollingUpgradePolicy) AssignProperties_To_RollingUpgradePolicy(des
 	}
 
 	// MaxBatchInstancePercent
-	if policy.MaxBatchInstancePercent != nil {
-		maxBatchInstancePercent := *policy.MaxBatchInstancePercent
-		destination.MaxBatchInstancePercent = &maxBatchInstancePercent
-	} else {
-		destination.MaxBatchInstancePercent = nil
-	}
+	destination.MaxBatchInstancePercent = genruntime.ClonePointerToInt(policy.MaxBatchInstancePercent)
 
 	// MaxUnhealthyInstancePercent
-	if policy.MaxUnhealthyInstancePercent != nil {
-		maxUnhealthyInstancePercent := *policy.MaxUnhealthyInstancePercent
-		destination.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
-	} else {
-		destination.MaxUnhealthyInstancePercent = nil
-	}
+	destination.MaxUnhealthyInstancePercent = genruntime.ClonePointerToInt(policy.MaxUnhealthyInstancePercent)
 
 	// MaxUnhealthyUpgradedInstancePercent
-	if policy.MaxUnhealthyUpgradedInstancePercent != nil {
-		maxUnhealthyUpgradedInstancePercent := *policy.MaxUnhealthyUpgradedInstancePercent
-		destination.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
-	} else {
-		destination.MaxUnhealthyUpgradedInstancePercent = nil
-	}
+	destination.MaxUnhealthyUpgradedInstancePercent = genruntime.ClonePointerToInt(policy.MaxUnhealthyUpgradedInstancePercent)
 
 	// PauseTimeBetweenBatches
 	destination.PauseTimeBetweenBatches = genruntime.ClonePointerToString(policy.PauseTimeBetweenBatches)
@@ -6315,28 +6285,13 @@ func (policy *RollingUpgradePolicy) Initialize_From_RollingUpgradePolicy_STATUS(
 	}
 
 	// MaxBatchInstancePercent
-	if source.MaxBatchInstancePercent != nil {
-		maxBatchInstancePercent := *source.MaxBatchInstancePercent
-		policy.MaxBatchInstancePercent = &maxBatchInstancePercent
-	} else {
-		policy.MaxBatchInstancePercent = nil
-	}
+	policy.MaxBatchInstancePercent = genruntime.ClonePointerToInt(source.MaxBatchInstancePercent)
 
 	// MaxUnhealthyInstancePercent
-	if source.MaxUnhealthyInstancePercent != nil {
-		maxUnhealthyInstancePercent := *source.MaxUnhealthyInstancePercent
-		policy.MaxUnhealthyInstancePercent = &maxUnhealthyInstancePercent
-	} else {
-		policy.MaxUnhealthyInstancePercent = nil
-	}
+	policy.MaxUnhealthyInstancePercent = genruntime.ClonePointerToInt(source.MaxUnhealthyInstancePercent)
 
 	// MaxUnhealthyUpgradedInstancePercent
-	if source.MaxUnhealthyUpgradedInstancePercent != nil {
-		maxUnhealthyUpgradedInstancePercent := *source.MaxUnhealthyUpgradedInstancePercent
-		policy.MaxUnhealthyUpgradedInstancePercent = &maxUnhealthyUpgradedInstancePercent
-	} else {
-		policy.MaxUnhealthyUpgradedInstancePercent = nil
-	}
+	policy.MaxUnhealthyUpgradedInstancePercent = genruntime.ClonePointerToInt(source.MaxUnhealthyUpgradedInstancePercent)
 
 	// PauseTimeBetweenBatches
 	policy.PauseTimeBetweenBatches = genruntime.ClonePointerToString(source.PauseTimeBetweenBatches)

--- a/v2/api/containerservice/v1api20210501/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20210501/managed_cluster_types_gen.go
@@ -2785,12 +2785,7 @@ func (profile *ContainerServiceLinuxProfile) PopulateFromARM(owner genruntime.Ar
 func (profile *ContainerServiceLinuxProfile) AssignProperties_From_ContainerServiceLinuxProfile(source *storage.ContainerServiceLinuxProfile) error {
 
 	// AdminUsername
-	if source.AdminUsername != nil {
-		adminUsername := *source.AdminUsername
-		profile.AdminUsername = &adminUsername
-	} else {
-		profile.AdminUsername = nil
-	}
+	profile.AdminUsername = genruntime.ClonePointerToString(source.AdminUsername)
 
 	// Ssh
 	if source.Ssh != nil {
@@ -2814,12 +2809,7 @@ func (profile *ContainerServiceLinuxProfile) AssignProperties_To_ContainerServic
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AdminUsername
-	if profile.AdminUsername != nil {
-		adminUsername := *profile.AdminUsername
-		destination.AdminUsername = &adminUsername
-	} else {
-		destination.AdminUsername = nil
-	}
+	destination.AdminUsername = genruntime.ClonePointerToString(profile.AdminUsername)
 
 	// Ssh
 	if profile.Ssh != nil {
@@ -3137,20 +3127,10 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 func (profile *ContainerServiceNetworkProfile) AssignProperties_From_ContainerServiceNetworkProfile(source *storage.ContainerServiceNetworkProfile) error {
 
 	// DnsServiceIP
-	if source.DnsServiceIP != nil {
-		dnsServiceIP := *source.DnsServiceIP
-		profile.DnsServiceIP = &dnsServiceIP
-	} else {
-		profile.DnsServiceIP = nil
-	}
+	profile.DnsServiceIP = genruntime.ClonePointerToString(source.DnsServiceIP)
 
 	// DockerBridgeCidr
-	if source.DockerBridgeCidr != nil {
-		dockerBridgeCidr := *source.DockerBridgeCidr
-		profile.DockerBridgeCidr = &dockerBridgeCidr
-	} else {
-		profile.DockerBridgeCidr = nil
-	}
+	profile.DockerBridgeCidr = genruntime.ClonePointerToString(source.DockerBridgeCidr)
 
 	// LoadBalancerProfile
 	if source.LoadBalancerProfile != nil {
@@ -3210,20 +3190,10 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_From_ContainerSe
 	}
 
 	// PodCidr
-	if source.PodCidr != nil {
-		podCidr := *source.PodCidr
-		profile.PodCidr = &podCidr
-	} else {
-		profile.PodCidr = nil
-	}
+	profile.PodCidr = genruntime.ClonePointerToString(source.PodCidr)
 
 	// ServiceCidr
-	if source.ServiceCidr != nil {
-		serviceCidr := *source.ServiceCidr
-		profile.ServiceCidr = &serviceCidr
-	} else {
-		profile.ServiceCidr = nil
-	}
+	profile.ServiceCidr = genruntime.ClonePointerToString(source.ServiceCidr)
 
 	// No error
 	return nil
@@ -3235,20 +3205,10 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_To_ContainerServ
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DnsServiceIP
-	if profile.DnsServiceIP != nil {
-		dnsServiceIP := *profile.DnsServiceIP
-		destination.DnsServiceIP = &dnsServiceIP
-	} else {
-		destination.DnsServiceIP = nil
-	}
+	destination.DnsServiceIP = genruntime.ClonePointerToString(profile.DnsServiceIP)
 
 	// DockerBridgeCidr
-	if profile.DockerBridgeCidr != nil {
-		dockerBridgeCidr := *profile.DockerBridgeCidr
-		destination.DockerBridgeCidr = &dockerBridgeCidr
-	} else {
-		destination.DockerBridgeCidr = nil
-	}
+	destination.DockerBridgeCidr = genruntime.ClonePointerToString(profile.DockerBridgeCidr)
 
 	// LoadBalancerProfile
 	if profile.LoadBalancerProfile != nil {
@@ -3303,20 +3263,10 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_To_ContainerServ
 	}
 
 	// PodCidr
-	if profile.PodCidr != nil {
-		podCidr := *profile.PodCidr
-		destination.PodCidr = &podCidr
-	} else {
-		destination.PodCidr = nil
-	}
+	destination.PodCidr = genruntime.ClonePointerToString(profile.PodCidr)
 
 	// ServiceCidr
-	if profile.ServiceCidr != nil {
-		serviceCidr := *profile.ServiceCidr
-		destination.ServiceCidr = &serviceCidr
-	} else {
-		destination.ServiceCidr = nil
-	}
+	destination.ServiceCidr = genruntime.ClonePointerToString(profile.ServiceCidr)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -5034,12 +4984,7 @@ func (profile *ManagedClusterAgentPoolProfile) AssignProperties_From_ManagedClus
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		profile.Name = &name
-	} else {
-		profile.Name = nil
-	}
+	profile.Name = genruntime.ClonePointerToString(source.Name)
 
 	// NodeLabels
 	profile.NodeLabels = genruntime.CloneMapOfStringToString(source.NodeLabels)
@@ -5278,12 +5223,7 @@ func (profile *ManagedClusterAgentPoolProfile) AssignProperties_To_ManagedCluste
 	}
 
 	// Name
-	if profile.Name != nil {
-		name := *profile.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(profile.Name)
 
 	// NodeLabels
 	destination.NodeLabels = genruntime.CloneMapOfStringToString(profile.NodeLabels)
@@ -10185,12 +10125,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_From_ManagedClusterLoadBalancerProfile(source *storage.ManagedClusterLoadBalancerProfile) error {
 
 	// AllocatedOutboundPorts
-	if source.AllocatedOutboundPorts != nil {
-		allocatedOutboundPort := *source.AllocatedOutboundPorts
-		profile.AllocatedOutboundPorts = &allocatedOutboundPort
-	} else {
-		profile.AllocatedOutboundPorts = nil
-	}
+	profile.AllocatedOutboundPorts = genruntime.ClonePointerToInt(source.AllocatedOutboundPorts)
 
 	// EffectiveOutboundIPs
 	if source.EffectiveOutboundIPs != nil {
@@ -10211,12 +10146,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_From_ManagedC
 	}
 
 	// IdleTimeoutInMinutes
-	if source.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *source.IdleTimeoutInMinutes
-		profile.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		profile.IdleTimeoutInMinutes = nil
-	}
+	profile.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(source.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPs
 	if source.ManagedOutboundIPs != nil {
@@ -10264,12 +10194,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_To_ManagedClu
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AllocatedOutboundPorts
-	if profile.AllocatedOutboundPorts != nil {
-		allocatedOutboundPort := *profile.AllocatedOutboundPorts
-		destination.AllocatedOutboundPorts = &allocatedOutboundPort
-	} else {
-		destination.AllocatedOutboundPorts = nil
-	}
+	destination.AllocatedOutboundPorts = genruntime.ClonePointerToInt(profile.AllocatedOutboundPorts)
 
 	// EffectiveOutboundIPs
 	if profile.EffectiveOutboundIPs != nil {
@@ -10290,12 +10215,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_To_ManagedClu
 	}
 
 	// IdleTimeoutInMinutes
-	if profile.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *profile.IdleTimeoutInMinutes
-		destination.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		destination.IdleTimeoutInMinutes = nil
-	}
+	destination.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(profile.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPs
 	if profile.ManagedOutboundIPs != nil {
@@ -11514,12 +11434,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) PopulateFromARM
 func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) AssignProperties_From_ManagedClusterLoadBalancerProfile_ManagedOutboundIPs(source *storage.ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		iPs.Count = &count
-	} else {
-		iPs.Count = nil
-	}
+	iPs.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// No error
 	return nil
@@ -11531,12 +11446,7 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) AssignPropertie
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Count
-	if iPs.Count != nil {
-		count := *iPs.Count
-		destination.Count = &count
-	} else {
-		destination.Count = nil
-	}
+	destination.Count = genruntime.ClonePointerToInt(iPs.Count)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/containerservice/v1api20210501/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20210501/managed_clusters_agent_pool_types_gen.go
@@ -3043,12 +3043,7 @@ func (config *KubeletConfig) AssignProperties_From_KubeletConfig(source *storage
 	config.AllowedUnsafeSysctls = genruntime.CloneSliceOfString(source.AllowedUnsafeSysctls)
 
 	// ContainerLogMaxFiles
-	if source.ContainerLogMaxFiles != nil {
-		containerLogMaxFile := *source.ContainerLogMaxFiles
-		config.ContainerLogMaxFiles = &containerLogMaxFile
-	} else {
-		config.ContainerLogMaxFiles = nil
-	}
+	config.ContainerLogMaxFiles = genruntime.ClonePointerToInt(source.ContainerLogMaxFiles)
 
 	// ContainerLogMaxSizeMB
 	config.ContainerLogMaxSizeMB = genruntime.ClonePointerToInt(source.ContainerLogMaxSizeMB)
@@ -3100,12 +3095,7 @@ func (config *KubeletConfig) AssignProperties_To_KubeletConfig(destination *stor
 	destination.AllowedUnsafeSysctls = genruntime.CloneSliceOfString(config.AllowedUnsafeSysctls)
 
 	// ContainerLogMaxFiles
-	if config.ContainerLogMaxFiles != nil {
-		containerLogMaxFile := *config.ContainerLogMaxFiles
-		destination.ContainerLogMaxFiles = &containerLogMaxFile
-	} else {
-		destination.ContainerLogMaxFiles = nil
-	}
+	destination.ContainerLogMaxFiles = genruntime.ClonePointerToInt(config.ContainerLogMaxFiles)
 
 	// ContainerLogMaxSizeMB
 	destination.ContainerLogMaxSizeMB = genruntime.ClonePointerToInt(config.ContainerLogMaxSizeMB)

--- a/v2/api/containerservice/v1api20230201/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20230201/managed_cluster_types_gen.go
@@ -3367,12 +3367,7 @@ func (profile *ContainerServiceLinuxProfile) PopulateFromARM(owner genruntime.Ar
 func (profile *ContainerServiceLinuxProfile) AssignProperties_From_ContainerServiceLinuxProfile(source *storage.ContainerServiceLinuxProfile) error {
 
 	// AdminUsername
-	if source.AdminUsername != nil {
-		adminUsername := *source.AdminUsername
-		profile.AdminUsername = &adminUsername
-	} else {
-		profile.AdminUsername = nil
-	}
+	profile.AdminUsername = genruntime.ClonePointerToString(source.AdminUsername)
 
 	// Ssh
 	if source.Ssh != nil {
@@ -3396,12 +3391,7 @@ func (profile *ContainerServiceLinuxProfile) AssignProperties_To_ContainerServic
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AdminUsername
-	if profile.AdminUsername != nil {
-		adminUsername := *profile.AdminUsername
-		destination.AdminUsername = &adminUsername
-	} else {
-		destination.AdminUsername = nil
-	}
+	destination.AdminUsername = genruntime.ClonePointerToString(profile.AdminUsername)
 
 	// Ssh
 	if profile.Ssh != nil {
@@ -3812,20 +3802,10 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 func (profile *ContainerServiceNetworkProfile) AssignProperties_From_ContainerServiceNetworkProfile(source *storage.ContainerServiceNetworkProfile) error {
 
 	// DnsServiceIP
-	if source.DnsServiceIP != nil {
-		dnsServiceIP := *source.DnsServiceIP
-		profile.DnsServiceIP = &dnsServiceIP
-	} else {
-		profile.DnsServiceIP = nil
-	}
+	profile.DnsServiceIP = genruntime.ClonePointerToString(source.DnsServiceIP)
 
 	// DockerBridgeCidr
-	if source.DockerBridgeCidr != nil {
-		dockerBridgeCidr := *source.DockerBridgeCidr
-		profile.DockerBridgeCidr = &dockerBridgeCidr
-	} else {
-		profile.DockerBridgeCidr = nil
-	}
+	profile.DockerBridgeCidr = genruntime.ClonePointerToString(source.DockerBridgeCidr)
 
 	// IpFamilies
 	if source.IpFamilies != nil {
@@ -3928,23 +3908,13 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_From_ContainerSe
 	}
 
 	// PodCidr
-	if source.PodCidr != nil {
-		podCidr := *source.PodCidr
-		profile.PodCidr = &podCidr
-	} else {
-		profile.PodCidr = nil
-	}
+	profile.PodCidr = genruntime.ClonePointerToString(source.PodCidr)
 
 	// PodCidrs
 	profile.PodCidrs = genruntime.CloneSliceOfString(source.PodCidrs)
 
 	// ServiceCidr
-	if source.ServiceCidr != nil {
-		serviceCidr := *source.ServiceCidr
-		profile.ServiceCidr = &serviceCidr
-	} else {
-		profile.ServiceCidr = nil
-	}
+	profile.ServiceCidr = genruntime.ClonePointerToString(source.ServiceCidr)
 
 	// ServiceCidrs
 	profile.ServiceCidrs = genruntime.CloneSliceOfString(source.ServiceCidrs)
@@ -3959,20 +3929,10 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_To_ContainerServ
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DnsServiceIP
-	if profile.DnsServiceIP != nil {
-		dnsServiceIP := *profile.DnsServiceIP
-		destination.DnsServiceIP = &dnsServiceIP
-	} else {
-		destination.DnsServiceIP = nil
-	}
+	destination.DnsServiceIP = genruntime.ClonePointerToString(profile.DnsServiceIP)
 
 	// DockerBridgeCidr
-	if profile.DockerBridgeCidr != nil {
-		dockerBridgeCidr := *profile.DockerBridgeCidr
-		destination.DockerBridgeCidr = &dockerBridgeCidr
-	} else {
-		destination.DockerBridgeCidr = nil
-	}
+	destination.DockerBridgeCidr = genruntime.ClonePointerToString(profile.DockerBridgeCidr)
 
 	// IpFamilies
 	if profile.IpFamilies != nil {
@@ -4068,23 +4028,13 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_To_ContainerServ
 	}
 
 	// PodCidr
-	if profile.PodCidr != nil {
-		podCidr := *profile.PodCidr
-		destination.PodCidr = &podCidr
-	} else {
-		destination.PodCidr = nil
-	}
+	destination.PodCidr = genruntime.ClonePointerToString(profile.PodCidr)
 
 	// PodCidrs
 	destination.PodCidrs = genruntime.CloneSliceOfString(profile.PodCidrs)
 
 	// ServiceCidr
-	if profile.ServiceCidr != nil {
-		serviceCidr := *profile.ServiceCidr
-		destination.ServiceCidr = &serviceCidr
-	} else {
-		destination.ServiceCidr = nil
-	}
+	destination.ServiceCidr = genruntime.ClonePointerToString(profile.ServiceCidr)
 
 	// ServiceCidrs
 	destination.ServiceCidrs = genruntime.CloneSliceOfString(profile.ServiceCidrs)
@@ -6063,12 +6013,7 @@ func (profile *ManagedClusterAgentPoolProfile) AssignProperties_From_ManagedClus
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		profile.Name = &name
-	} else {
-		profile.Name = nil
-	}
+	profile.Name = genruntime.ClonePointerToString(source.Name)
 
 	// NodeLabels
 	profile.NodeLabels = genruntime.CloneMapOfStringToString(source.NodeLabels)
@@ -6362,12 +6307,7 @@ func (profile *ManagedClusterAgentPoolProfile) AssignProperties_To_ManagedCluste
 	}
 
 	// Name
-	if profile.Name != nil {
-		name := *profile.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(profile.Name)
 
 	// NodeLabels
 	destination.NodeLabels = genruntime.CloneMapOfStringToString(profile.NodeLabels)
@@ -13739,12 +13679,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_From_ManagedClusterLoadBalancerProfile(source *storage.ManagedClusterLoadBalancerProfile) error {
 
 	// AllocatedOutboundPorts
-	if source.AllocatedOutboundPorts != nil {
-		allocatedOutboundPort := *source.AllocatedOutboundPorts
-		profile.AllocatedOutboundPorts = &allocatedOutboundPort
-	} else {
-		profile.AllocatedOutboundPorts = nil
-	}
+	profile.AllocatedOutboundPorts = genruntime.ClonePointerToInt(source.AllocatedOutboundPorts)
 
 	// EffectiveOutboundIPs
 	if source.EffectiveOutboundIPs != nil {
@@ -13773,12 +13708,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_From_ManagedC
 	}
 
 	// IdleTimeoutInMinutes
-	if source.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *source.IdleTimeoutInMinutes
-		profile.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		profile.IdleTimeoutInMinutes = nil
-	}
+	profile.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(source.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPs
 	if source.ManagedOutboundIPs != nil {
@@ -13826,12 +13756,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_To_ManagedClu
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AllocatedOutboundPorts
-	if profile.AllocatedOutboundPorts != nil {
-		allocatedOutboundPort := *profile.AllocatedOutboundPorts
-		destination.AllocatedOutboundPorts = &allocatedOutboundPort
-	} else {
-		destination.AllocatedOutboundPorts = nil
-	}
+	destination.AllocatedOutboundPorts = genruntime.ClonePointerToInt(profile.AllocatedOutboundPorts)
 
 	// EffectiveOutboundIPs
 	if profile.EffectiveOutboundIPs != nil {
@@ -13860,12 +13785,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_To_ManagedClu
 	}
 
 	// IdleTimeoutInMinutes
-	if profile.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *profile.IdleTimeoutInMinutes
-		destination.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		destination.IdleTimeoutInMinutes = nil
-	}
+	destination.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(profile.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPs
 	if profile.ManagedOutboundIPs != nil {
@@ -14272,12 +14192,7 @@ func (profile *ManagedClusterNATGatewayProfile) AssignProperties_From_ManagedClu
 	}
 
 	// IdleTimeoutInMinutes
-	if source.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *source.IdleTimeoutInMinutes
-		profile.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		profile.IdleTimeoutInMinutes = nil
-	}
+	profile.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(source.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPProfile
 	if source.ManagedOutboundIPProfile != nil {
@@ -14319,12 +14234,7 @@ func (profile *ManagedClusterNATGatewayProfile) AssignProperties_To_ManagedClust
 	}
 
 	// IdleTimeoutInMinutes
-	if profile.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *profile.IdleTimeoutInMinutes
-		destination.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		destination.IdleTimeoutInMinutes = nil
-	}
+	destination.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(profile.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPProfile
 	if profile.ManagedOutboundIPProfile != nil {
@@ -17246,20 +17156,10 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) PopulateFromARM
 func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) AssignProperties_From_ManagedClusterLoadBalancerProfile_ManagedOutboundIPs(source *storage.ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		iPs.Count = &count
-	} else {
-		iPs.Count = nil
-	}
+	iPs.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// CountIPv6
-	if source.CountIPv6 != nil {
-		countIPv6 := *source.CountIPv6
-		iPs.CountIPv6 = &countIPv6
-	} else {
-		iPs.CountIPv6 = nil
-	}
+	iPs.CountIPv6 = genruntime.ClonePointerToInt(source.CountIPv6)
 
 	// No error
 	return nil
@@ -17271,20 +17171,10 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) AssignPropertie
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Count
-	if iPs.Count != nil {
-		count := *iPs.Count
-		destination.Count = &count
-	} else {
-		destination.Count = nil
-	}
+	destination.Count = genruntime.ClonePointerToInt(iPs.Count)
 
 	// CountIPv6
-	if iPs.CountIPv6 != nil {
-		countIPv6 := *iPs.CountIPv6
-		destination.CountIPv6 = &countIPv6
-	} else {
-		destination.CountIPv6 = nil
-	}
+	destination.CountIPv6 = genruntime.ClonePointerToInt(iPs.CountIPv6)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -17816,12 +17706,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) PopulateFromARM(owner gen
 func (profile *ManagedClusterManagedOutboundIPProfile) AssignProperties_From_ManagedClusterManagedOutboundIPProfile(source *storage.ManagedClusterManagedOutboundIPProfile) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		profile.Count = &count
-	} else {
-		profile.Count = nil
-	}
+	profile.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// No error
 	return nil
@@ -17833,12 +17718,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) AssignProperties_To_Manag
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Count
-	if profile.Count != nil {
-		count := *profile.Count
-		destination.Count = &count
-	} else {
-		destination.Count = nil
-	}
+	destination.Count = genruntime.ClonePointerToInt(profile.Count)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/containerservice/v1api20230201/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20230201/managed_clusters_agent_pool_types_gen.go
@@ -3554,12 +3554,7 @@ func (config *KubeletConfig) AssignProperties_From_KubeletConfig(source *storage
 	config.AllowedUnsafeSysctls = genruntime.CloneSliceOfString(source.AllowedUnsafeSysctls)
 
 	// ContainerLogMaxFiles
-	if source.ContainerLogMaxFiles != nil {
-		containerLogMaxFile := *source.ContainerLogMaxFiles
-		config.ContainerLogMaxFiles = &containerLogMaxFile
-	} else {
-		config.ContainerLogMaxFiles = nil
-	}
+	config.ContainerLogMaxFiles = genruntime.ClonePointerToInt(source.ContainerLogMaxFiles)
 
 	// ContainerLogMaxSizeMB
 	config.ContainerLogMaxSizeMB = genruntime.ClonePointerToInt(source.ContainerLogMaxSizeMB)
@@ -3611,12 +3606,7 @@ func (config *KubeletConfig) AssignProperties_To_KubeletConfig(destination *stor
 	destination.AllowedUnsafeSysctls = genruntime.CloneSliceOfString(config.AllowedUnsafeSysctls)
 
 	// ContainerLogMaxFiles
-	if config.ContainerLogMaxFiles != nil {
-		containerLogMaxFile := *config.ContainerLogMaxFiles
-		destination.ContainerLogMaxFiles = &containerLogMaxFile
-	} else {
-		destination.ContainerLogMaxFiles = nil
-	}
+	destination.ContainerLogMaxFiles = genruntime.ClonePointerToInt(config.ContainerLogMaxFiles)
 
 	// ContainerLogMaxSizeMB
 	destination.ContainerLogMaxSizeMB = genruntime.ClonePointerToInt(config.ContainerLogMaxSizeMB)

--- a/v2/api/containerservice/v1api20230315preview/fleet_types_gen.go
+++ b/v2/api/containerservice/v1api20230315preview/fleet_types_gen.go
@@ -929,12 +929,7 @@ func (profile *FleetHubProfile) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 func (profile *FleetHubProfile) AssignProperties_From_FleetHubProfile(source *storage.FleetHubProfile) error {
 
 	// DnsPrefix
-	if source.DnsPrefix != nil {
-		dnsPrefix := *source.DnsPrefix
-		profile.DnsPrefix = &dnsPrefix
-	} else {
-		profile.DnsPrefix = nil
-	}
+	profile.DnsPrefix = genruntime.ClonePointerToString(source.DnsPrefix)
 
 	// No error
 	return nil
@@ -946,12 +941,7 @@ func (profile *FleetHubProfile) AssignProperties_To_FleetHubProfile(destination 
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DnsPrefix
-	if profile.DnsPrefix != nil {
-		dnsPrefix := *profile.DnsPrefix
-		destination.DnsPrefix = &dnsPrefix
-	} else {
-		destination.DnsPrefix = nil
-	}
+	destination.DnsPrefix = genruntime.ClonePointerToString(profile.DnsPrefix)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -968,12 +958,7 @@ func (profile *FleetHubProfile) AssignProperties_To_FleetHubProfile(destination 
 func (profile *FleetHubProfile) Initialize_From_FleetHubProfile_STATUS(source *FleetHubProfile_STATUS) error {
 
 	// DnsPrefix
-	if source.DnsPrefix != nil {
-		dnsPrefix := *source.DnsPrefix
-		profile.DnsPrefix = &dnsPrefix
-	} else {
-		profile.DnsPrefix = nil
-	}
+	profile.DnsPrefix = genruntime.ClonePointerToString(source.DnsPrefix)
 
 	// No error
 	return nil

--- a/v2/api/containerservice/v1api20230315preview/fleets_member_types_gen.go
+++ b/v2/api/containerservice/v1api20230315preview/fleets_member_types_gen.go
@@ -410,12 +410,7 @@ func (member *FleetsMember_Spec) AssignProperties_From_FleetsMember_Spec(source 
 	}
 
 	// Group
-	if source.Group != nil {
-		group := *source.Group
-		member.Group = &group
-	} else {
-		member.Group = nil
-	}
+	member.Group = genruntime.ClonePointerToString(source.Group)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -458,12 +453,7 @@ func (member *FleetsMember_Spec) AssignProperties_To_FleetsMember_Spec(destinati
 	}
 
 	// Group
-	if member.Group != nil {
-		group := *member.Group
-		destination.Group = &group
-	} else {
-		destination.Group = nil
-	}
+	destination.Group = genruntime.ClonePointerToString(member.Group)
 
 	// OperatorSpec
 	if member.OperatorSpec != nil {
@@ -511,12 +501,7 @@ func (member *FleetsMember_Spec) Initialize_From_FleetsMember_STATUS(source *Fle
 	}
 
 	// Group
-	if source.Group != nil {
-		group := *source.Group
-		member.Group = &group
-	} else {
-		member.Group = nil
-	}
+	member.Group = genruntime.ClonePointerToString(source.Group)
 
 	// No error
 	return nil

--- a/v2/api/containerservice/v1api20230315preview/fleets_update_run_types_gen.go
+++ b/v2/api/containerservice/v1api20230315preview/fleets_update_run_types_gen.go
@@ -1966,12 +1966,7 @@ func (stage *UpdateStage) AssignProperties_From_UpdateStage(source *storage.Upda
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		stage.Name = &name
-	} else {
-		stage.Name = nil
-	}
+	stage.Name = genruntime.ClonePointerToString(source.Name)
 
 	// No error
 	return nil
@@ -2004,12 +1999,7 @@ func (stage *UpdateStage) AssignProperties_To_UpdateStage(destination *storage.U
 	}
 
 	// Name
-	if stage.Name != nil {
-		name := *stage.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(stage.Name)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -2047,12 +2037,7 @@ func (stage *UpdateStage) Initialize_From_UpdateStage_STATUS(source *UpdateStage
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		stage.Name = &name
-	} else {
-		stage.Name = nil
-	}
+	stage.Name = genruntime.ClonePointerToString(source.Name)
 
 	// No error
 	return nil
@@ -2777,12 +2762,7 @@ func (group *UpdateGroup) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 func (group *UpdateGroup) AssignProperties_From_UpdateGroup(source *storage.UpdateGroup) error {
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		group.Name = &name
-	} else {
-		group.Name = nil
-	}
+	group.Name = genruntime.ClonePointerToString(source.Name)
 
 	// No error
 	return nil
@@ -2794,12 +2774,7 @@ func (group *UpdateGroup) AssignProperties_To_UpdateGroup(destination *storage.U
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	if group.Name != nil {
-		name := *group.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(group.Name)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -2816,12 +2791,7 @@ func (group *UpdateGroup) AssignProperties_To_UpdateGroup(destination *storage.U
 func (group *UpdateGroup) Initialize_From_UpdateGroup_STATUS(source *UpdateGroup_STATUS) error {
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		group.Name = &name
-	} else {
-		group.Name = nil
-	}
+	group.Name = genruntime.ClonePointerToString(source.Name)
 
 	// No error
 	return nil

--- a/v2/api/containerservice/v1api20231001/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20231001/managed_cluster_types_gen.go
@@ -4012,12 +4012,7 @@ func (profile *ContainerServiceLinuxProfile) PopulateFromARM(owner genruntime.Ar
 func (profile *ContainerServiceLinuxProfile) AssignProperties_From_ContainerServiceLinuxProfile(source *storage.ContainerServiceLinuxProfile) error {
 
 	// AdminUsername
-	if source.AdminUsername != nil {
-		adminUsername := *source.AdminUsername
-		profile.AdminUsername = &adminUsername
-	} else {
-		profile.AdminUsername = nil
-	}
+	profile.AdminUsername = genruntime.ClonePointerToString(source.AdminUsername)
 
 	// Ssh
 	if source.Ssh != nil {
@@ -4041,12 +4036,7 @@ func (profile *ContainerServiceLinuxProfile) AssignProperties_To_ContainerServic
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AdminUsername
-	if profile.AdminUsername != nil {
-		adminUsername := *profile.AdminUsername
-		destination.AdminUsername = &adminUsername
-	} else {
-		destination.AdminUsername = nil
-	}
+	destination.AdminUsername = genruntime.ClonePointerToString(profile.AdminUsername)
 
 	// Ssh
 	if profile.Ssh != nil {
@@ -4482,12 +4472,7 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 func (profile *ContainerServiceNetworkProfile) AssignProperties_From_ContainerServiceNetworkProfile(source *storage.ContainerServiceNetworkProfile) error {
 
 	// DnsServiceIP
-	if source.DnsServiceIP != nil {
-		dnsServiceIP := *source.DnsServiceIP
-		profile.DnsServiceIP = &dnsServiceIP
-	} else {
-		profile.DnsServiceIP = nil
-	}
+	profile.DnsServiceIP = genruntime.ClonePointerToString(source.DnsServiceIP)
 
 	// IpFamilies
 	if source.IpFamilies != nil {
@@ -4590,23 +4575,13 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_From_ContainerSe
 	}
 
 	// PodCidr
-	if source.PodCidr != nil {
-		podCidr := *source.PodCidr
-		profile.PodCidr = &podCidr
-	} else {
-		profile.PodCidr = nil
-	}
+	profile.PodCidr = genruntime.ClonePointerToString(source.PodCidr)
 
 	// PodCidrs
 	profile.PodCidrs = genruntime.CloneSliceOfString(source.PodCidrs)
 
 	// ServiceCidr
-	if source.ServiceCidr != nil {
-		serviceCidr := *source.ServiceCidr
-		profile.ServiceCidr = &serviceCidr
-	} else {
-		profile.ServiceCidr = nil
-	}
+	profile.ServiceCidr = genruntime.ClonePointerToString(source.ServiceCidr)
 
 	// ServiceCidrs
 	profile.ServiceCidrs = genruntime.CloneSliceOfString(source.ServiceCidrs)
@@ -4621,12 +4596,7 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_To_ContainerServ
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DnsServiceIP
-	if profile.DnsServiceIP != nil {
-		dnsServiceIP := *profile.DnsServiceIP
-		destination.DnsServiceIP = &dnsServiceIP
-	} else {
-		destination.DnsServiceIP = nil
-	}
+	destination.DnsServiceIP = genruntime.ClonePointerToString(profile.DnsServiceIP)
 
 	// IpFamilies
 	if profile.IpFamilies != nil {
@@ -4722,23 +4692,13 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_To_ContainerServ
 	}
 
 	// PodCidr
-	if profile.PodCidr != nil {
-		podCidr := *profile.PodCidr
-		destination.PodCidr = &podCidr
-	} else {
-		destination.PodCidr = nil
-	}
+	destination.PodCidr = genruntime.ClonePointerToString(profile.PodCidr)
 
 	// PodCidrs
 	destination.PodCidrs = genruntime.CloneSliceOfString(profile.PodCidrs)
 
 	// ServiceCidr
-	if profile.ServiceCidr != nil {
-		serviceCidr := *profile.ServiceCidr
-		destination.ServiceCidr = &serviceCidr
-	} else {
-		destination.ServiceCidr = nil
-	}
+	destination.ServiceCidr = genruntime.ClonePointerToString(profile.ServiceCidr)
 
 	// ServiceCidrs
 	destination.ServiceCidrs = genruntime.CloneSliceOfString(profile.ServiceCidrs)
@@ -6976,12 +6936,7 @@ func (profile *ManagedClusterAgentPoolProfile) AssignProperties_From_ManagedClus
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		profile.Name = &name
-	} else {
-		profile.Name = nil
-	}
+	profile.Name = genruntime.ClonePointerToString(source.Name)
 
 	// NetworkProfile
 	if source.NetworkProfile != nil {
@@ -7295,12 +7250,7 @@ func (profile *ManagedClusterAgentPoolProfile) AssignProperties_To_ManagedCluste
 	}
 
 	// Name
-	if profile.Name != nil {
-		name := *profile.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(profile.Name)
 
 	// NetworkProfile
 	if profile.NetworkProfile != nil {
@@ -15281,12 +15231,7 @@ func (resource *DelegatedResource) AssignProperties_From_DelegatedResource(sourc
 	}
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		resource.TenantId = &tenantId
-	} else {
-		resource.TenantId = nil
-	}
+	resource.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// No error
 	return nil
@@ -15312,12 +15257,7 @@ func (resource *DelegatedResource) AssignProperties_To_DelegatedResource(destina
 	}
 
 	// TenantId
-	if resource.TenantId != nil {
-		tenantId := *resource.TenantId
-		destination.TenantId = &tenantId
-	} else {
-		destination.TenantId = nil
-	}
+	destination.TenantId = genruntime.ClonePointerToString(resource.TenantId)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -15578,17 +15518,7 @@ func (mesh *IstioServiceMesh) AssignProperties_From_IstioServiceMesh(source *sto
 	}
 
 	// Revisions
-	if source.Revisions != nil {
-		revisionList := make([]string, len(source.Revisions))
-		for revisionIndex, revisionItem := range source.Revisions {
-			// Shadow the loop variable to avoid aliasing
-			revisionItem := revisionItem
-			revisionList[revisionIndex] = revisionItem
-		}
-		mesh.Revisions = revisionList
-	} else {
-		mesh.Revisions = nil
-	}
+	mesh.Revisions = genruntime.CloneSliceOfString(source.Revisions)
 
 	// No error
 	return nil
@@ -15624,17 +15554,7 @@ func (mesh *IstioServiceMesh) AssignProperties_To_IstioServiceMesh(destination *
 	}
 
 	// Revisions
-	if mesh.Revisions != nil {
-		revisionList := make([]string, len(mesh.Revisions))
-		for revisionIndex, revisionItem := range mesh.Revisions {
-			// Shadow the loop variable to avoid aliasing
-			revisionItem := revisionItem
-			revisionList[revisionIndex] = revisionItem
-		}
-		destination.Revisions = revisionList
-	} else {
-		destination.Revisions = nil
-	}
+	destination.Revisions = genruntime.CloneSliceOfString(mesh.Revisions)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -16406,12 +16326,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_From_ManagedClusterLoadBalancerProfile(source *storage.ManagedClusterLoadBalancerProfile) error {
 
 	// AllocatedOutboundPorts
-	if source.AllocatedOutboundPorts != nil {
-		allocatedOutboundPort := *source.AllocatedOutboundPorts
-		profile.AllocatedOutboundPorts = &allocatedOutboundPort
-	} else {
-		profile.AllocatedOutboundPorts = nil
-	}
+	profile.AllocatedOutboundPorts = genruntime.ClonePointerToInt(source.AllocatedOutboundPorts)
 
 	// BackendPoolType
 	if source.BackendPoolType != nil {
@@ -16449,12 +16364,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_From_ManagedC
 	}
 
 	// IdleTimeoutInMinutes
-	if source.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *source.IdleTimeoutInMinutes
-		profile.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		profile.IdleTimeoutInMinutes = nil
-	}
+	profile.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(source.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPs
 	if source.ManagedOutboundIPs != nil {
@@ -16502,12 +16412,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_To_ManagedClu
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AllocatedOutboundPorts
-	if profile.AllocatedOutboundPorts != nil {
-		allocatedOutboundPort := *profile.AllocatedOutboundPorts
-		destination.AllocatedOutboundPorts = &allocatedOutboundPort
-	} else {
-		destination.AllocatedOutboundPorts = nil
-	}
+	destination.AllocatedOutboundPorts = genruntime.ClonePointerToInt(profile.AllocatedOutboundPorts)
 
 	// BackendPoolType
 	if profile.BackendPoolType != nil {
@@ -16544,12 +16449,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_To_ManagedClu
 	}
 
 	// IdleTimeoutInMinutes
-	if profile.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *profile.IdleTimeoutInMinutes
-		destination.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		destination.IdleTimeoutInMinutes = nil
-	}
+	destination.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(profile.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPs
 	if profile.ManagedOutboundIPs != nil {
@@ -17006,12 +16906,7 @@ func (profile *ManagedClusterNATGatewayProfile) AssignProperties_From_ManagedClu
 	}
 
 	// IdleTimeoutInMinutes
-	if source.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *source.IdleTimeoutInMinutes
-		profile.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		profile.IdleTimeoutInMinutes = nil
-	}
+	profile.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(source.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPProfile
 	if source.ManagedOutboundIPProfile != nil {
@@ -17053,12 +16948,7 @@ func (profile *ManagedClusterNATGatewayProfile) AssignProperties_To_ManagedClust
 	}
 
 	// IdleTimeoutInMinutes
-	if profile.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *profile.IdleTimeoutInMinutes
-		destination.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		destination.IdleTimeoutInMinutes = nil
-	}
+	destination.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(profile.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPProfile
 	if profile.ManagedOutboundIPProfile != nil {
@@ -21026,20 +20916,10 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) PopulateFromARM
 func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) AssignProperties_From_ManagedClusterLoadBalancerProfile_ManagedOutboundIPs(source *storage.ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		iPs.Count = &count
-	} else {
-		iPs.Count = nil
-	}
+	iPs.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// CountIPv6
-	if source.CountIPv6 != nil {
-		countIPv6 := *source.CountIPv6
-		iPs.CountIPv6 = &countIPv6
-	} else {
-		iPs.CountIPv6 = nil
-	}
+	iPs.CountIPv6 = genruntime.ClonePointerToInt(source.CountIPv6)
 
 	// No error
 	return nil
@@ -21051,20 +20931,10 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) AssignPropertie
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Count
-	if iPs.Count != nil {
-		count := *iPs.Count
-		destination.Count = &count
-	} else {
-		destination.Count = nil
-	}
+	destination.Count = genruntime.ClonePointerToInt(iPs.Count)
 
 	// CountIPv6
-	if iPs.CountIPv6 != nil {
-		countIPv6 := *iPs.CountIPv6
-		destination.CountIPv6 = &countIPv6
-	} else {
-		destination.CountIPv6 = nil
-	}
+	destination.CountIPv6 = genruntime.ClonePointerToInt(iPs.CountIPv6)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -21608,12 +21478,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) PopulateFromARM(owner gen
 func (profile *ManagedClusterManagedOutboundIPProfile) AssignProperties_From_ManagedClusterManagedOutboundIPProfile(source *storage.ManagedClusterManagedOutboundIPProfile) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		profile.Count = &count
-	} else {
-		profile.Count = nil
-	}
+	profile.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// No error
 	return nil
@@ -21625,12 +21490,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) AssignProperties_To_Manag
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Count
-	if profile.Count != nil {
-		count := *profile.Count
-		destination.Count = &count
-	} else {
-		destination.Count = nil
-	}
+	destination.Count = genruntime.ClonePointerToInt(profile.Count)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/containerservice/v1api20231001/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20231001/managed_clusters_agent_pool_types_gen.go
@@ -3648,12 +3648,7 @@ func (settings *AgentPoolUpgradeSettings) PopulateFromARM(owner genruntime.Arbit
 func (settings *AgentPoolUpgradeSettings) AssignProperties_From_AgentPoolUpgradeSettings(source *storage.AgentPoolUpgradeSettings) error {
 
 	// DrainTimeoutInMinutes
-	if source.DrainTimeoutInMinutes != nil {
-		drainTimeoutInMinute := *source.DrainTimeoutInMinutes
-		settings.DrainTimeoutInMinutes = &drainTimeoutInMinute
-	} else {
-		settings.DrainTimeoutInMinutes = nil
-	}
+	settings.DrainTimeoutInMinutes = genruntime.ClonePointerToInt(source.DrainTimeoutInMinutes)
 
 	// MaxSurge
 	settings.MaxSurge = genruntime.ClonePointerToString(source.MaxSurge)
@@ -3668,12 +3663,7 @@ func (settings *AgentPoolUpgradeSettings) AssignProperties_To_AgentPoolUpgradeSe
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DrainTimeoutInMinutes
-	if settings.DrainTimeoutInMinutes != nil {
-		drainTimeoutInMinute := *settings.DrainTimeoutInMinutes
-		destination.DrainTimeoutInMinutes = &drainTimeoutInMinute
-	} else {
-		destination.DrainTimeoutInMinutes = nil
-	}
+	destination.DrainTimeoutInMinutes = genruntime.ClonePointerToInt(settings.DrainTimeoutInMinutes)
 
 	// MaxSurge
 	destination.MaxSurge = genruntime.ClonePointerToString(settings.MaxSurge)
@@ -4163,12 +4153,7 @@ func (config *KubeletConfig) AssignProperties_From_KubeletConfig(source *storage
 	config.AllowedUnsafeSysctls = genruntime.CloneSliceOfString(source.AllowedUnsafeSysctls)
 
 	// ContainerLogMaxFiles
-	if source.ContainerLogMaxFiles != nil {
-		containerLogMaxFile := *source.ContainerLogMaxFiles
-		config.ContainerLogMaxFiles = &containerLogMaxFile
-	} else {
-		config.ContainerLogMaxFiles = nil
-	}
+	config.ContainerLogMaxFiles = genruntime.ClonePointerToInt(source.ContainerLogMaxFiles)
 
 	// ContainerLogMaxSizeMB
 	config.ContainerLogMaxSizeMB = genruntime.ClonePointerToInt(source.ContainerLogMaxSizeMB)
@@ -4220,12 +4205,7 @@ func (config *KubeletConfig) AssignProperties_To_KubeletConfig(destination *stor
 	destination.AllowedUnsafeSysctls = genruntime.CloneSliceOfString(config.AllowedUnsafeSysctls)
 
 	// ContainerLogMaxFiles
-	if config.ContainerLogMaxFiles != nil {
-		containerLogMaxFile := *config.ContainerLogMaxFiles
-		destination.ContainerLogMaxFiles = &containerLogMaxFile
-	} else {
-		destination.ContainerLogMaxFiles = nil
-	}
+	destination.ContainerLogMaxFiles = genruntime.ClonePointerToInt(config.ContainerLogMaxFiles)
 
 	// ContainerLogMaxSizeMB
 	destination.ContainerLogMaxSizeMB = genruntime.ClonePointerToInt(config.ContainerLogMaxSizeMB)
@@ -5513,20 +5493,10 @@ func (portRange *PortRange) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 func (portRange *PortRange) AssignProperties_From_PortRange(source *storage.PortRange) error {
 
 	// PortEnd
-	if source.PortEnd != nil {
-		portEnd := *source.PortEnd
-		portRange.PortEnd = &portEnd
-	} else {
-		portRange.PortEnd = nil
-	}
+	portRange.PortEnd = genruntime.ClonePointerToInt(source.PortEnd)
 
 	// PortStart
-	if source.PortStart != nil {
-		portStart := *source.PortStart
-		portRange.PortStart = &portStart
-	} else {
-		portRange.PortStart = nil
-	}
+	portRange.PortStart = genruntime.ClonePointerToInt(source.PortStart)
 
 	// Protocol
 	if source.Protocol != nil {
@@ -5547,20 +5517,10 @@ func (portRange *PortRange) AssignProperties_To_PortRange(destination *storage.P
 	propertyBag := genruntime.NewPropertyBag()
 
 	// PortEnd
-	if portRange.PortEnd != nil {
-		portEnd := *portRange.PortEnd
-		destination.PortEnd = &portEnd
-	} else {
-		destination.PortEnd = nil
-	}
+	destination.PortEnd = genruntime.ClonePointerToInt(portRange.PortEnd)
 
 	// PortStart
-	if portRange.PortStart != nil {
-		portStart := *portRange.PortStart
-		destination.PortStart = &portStart
-	} else {
-		destination.PortStart = nil
-	}
+	destination.PortStart = genruntime.ClonePointerToInt(portRange.PortStart)
 
 	// Protocol
 	if portRange.Protocol != nil {
@@ -6230,28 +6190,13 @@ func (config *SysctlConfig) AssignProperties_From_SysctlConfig(source *storage.S
 	}
 
 	// NetIpv4TcpkeepaliveIntvl
-	if source.NetIpv4TcpkeepaliveIntvl != nil {
-		netIpv4TcpkeepaliveIntvl := *source.NetIpv4TcpkeepaliveIntvl
-		config.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
-	} else {
-		config.NetIpv4TcpkeepaliveIntvl = nil
-	}
+	config.NetIpv4TcpkeepaliveIntvl = genruntime.ClonePointerToInt(source.NetIpv4TcpkeepaliveIntvl)
 
 	// NetNetfilterNfConntrackBuckets
-	if source.NetNetfilterNfConntrackBuckets != nil {
-		netNetfilterNfConntrackBucket := *source.NetNetfilterNfConntrackBuckets
-		config.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBucket
-	} else {
-		config.NetNetfilterNfConntrackBuckets = nil
-	}
+	config.NetNetfilterNfConntrackBuckets = genruntime.ClonePointerToInt(source.NetNetfilterNfConntrackBuckets)
 
 	// NetNetfilterNfConntrackMax
-	if source.NetNetfilterNfConntrackMax != nil {
-		netNetfilterNfConntrackMax := *source.NetNetfilterNfConntrackMax
-		config.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
-	} else {
-		config.NetNetfilterNfConntrackMax = nil
-	}
+	config.NetNetfilterNfConntrackMax = genruntime.ClonePointerToInt(source.NetNetfilterNfConntrackMax)
 
 	// VmMaxMapCount
 	config.VmMaxMapCount = genruntime.ClonePointerToInt(source.VmMaxMapCount)
@@ -6343,28 +6288,13 @@ func (config *SysctlConfig) AssignProperties_To_SysctlConfig(destination *storag
 	}
 
 	// NetIpv4TcpkeepaliveIntvl
-	if config.NetIpv4TcpkeepaliveIntvl != nil {
-		netIpv4TcpkeepaliveIntvl := *config.NetIpv4TcpkeepaliveIntvl
-		destination.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
-	} else {
-		destination.NetIpv4TcpkeepaliveIntvl = nil
-	}
+	destination.NetIpv4TcpkeepaliveIntvl = genruntime.ClonePointerToInt(config.NetIpv4TcpkeepaliveIntvl)
 
 	// NetNetfilterNfConntrackBuckets
-	if config.NetNetfilterNfConntrackBuckets != nil {
-		netNetfilterNfConntrackBucket := *config.NetNetfilterNfConntrackBuckets
-		destination.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBucket
-	} else {
-		destination.NetNetfilterNfConntrackBuckets = nil
-	}
+	destination.NetNetfilterNfConntrackBuckets = genruntime.ClonePointerToInt(config.NetNetfilterNfConntrackBuckets)
 
 	// NetNetfilterNfConntrackMax
-	if config.NetNetfilterNfConntrackMax != nil {
-		netNetfilterNfConntrackMax := *config.NetNetfilterNfConntrackMax
-		destination.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
-	} else {
-		destination.NetNetfilterNfConntrackMax = nil
-	}
+	destination.NetNetfilterNfConntrackMax = genruntime.ClonePointerToInt(config.NetNetfilterNfConntrackMax)
 
 	// VmMaxMapCount
 	destination.VmMaxMapCount = genruntime.ClonePointerToInt(config.VmMaxMapCount)

--- a/v2/api/containerservice/v1api20231102preview/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20231102preview/managed_cluster_types_gen.go
@@ -4460,12 +4460,7 @@ func (profile *ContainerServiceLinuxProfile) PopulateFromARM(owner genruntime.Ar
 func (profile *ContainerServiceLinuxProfile) AssignProperties_From_ContainerServiceLinuxProfile(source *storage.ContainerServiceLinuxProfile) error {
 
 	// AdminUsername
-	if source.AdminUsername != nil {
-		adminUsername := *source.AdminUsername
-		profile.AdminUsername = &adminUsername
-	} else {
-		profile.AdminUsername = nil
-	}
+	profile.AdminUsername = genruntime.ClonePointerToString(source.AdminUsername)
 
 	// Ssh
 	if source.Ssh != nil {
@@ -4489,12 +4484,7 @@ func (profile *ContainerServiceLinuxProfile) AssignProperties_To_ContainerServic
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AdminUsername
-	if profile.AdminUsername != nil {
-		adminUsername := *profile.AdminUsername
-		destination.AdminUsername = &adminUsername
-	} else {
-		destination.AdminUsername = nil
-	}
+	destination.AdminUsername = genruntime.ClonePointerToString(profile.AdminUsername)
 
 	// Ssh
 	if profile.Ssh != nil {
@@ -4934,12 +4924,7 @@ func (profile *ContainerServiceNetworkProfile) PopulateFromARM(owner genruntime.
 func (profile *ContainerServiceNetworkProfile) AssignProperties_From_ContainerServiceNetworkProfile(source *storage.ContainerServiceNetworkProfile) error {
 
 	// DnsServiceIP
-	if source.DnsServiceIP != nil {
-		dnsServiceIP := *source.DnsServiceIP
-		profile.DnsServiceIP = &dnsServiceIP
-	} else {
-		profile.DnsServiceIP = nil
-	}
+	profile.DnsServiceIP = genruntime.ClonePointerToString(source.DnsServiceIP)
 
 	// IpFamilies
 	if source.IpFamilies != nil {
@@ -5066,23 +5051,13 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_From_ContainerSe
 	}
 
 	// PodCidr
-	if source.PodCidr != nil {
-		podCidr := *source.PodCidr
-		profile.PodCidr = &podCidr
-	} else {
-		profile.PodCidr = nil
-	}
+	profile.PodCidr = genruntime.ClonePointerToString(source.PodCidr)
 
 	// PodCidrs
 	profile.PodCidrs = genruntime.CloneSliceOfString(source.PodCidrs)
 
 	// ServiceCidr
-	if source.ServiceCidr != nil {
-		serviceCidr := *source.ServiceCidr
-		profile.ServiceCidr = &serviceCidr
-	} else {
-		profile.ServiceCidr = nil
-	}
+	profile.ServiceCidr = genruntime.ClonePointerToString(source.ServiceCidr)
 
 	// ServiceCidrs
 	profile.ServiceCidrs = genruntime.CloneSliceOfString(source.ServiceCidrs)
@@ -5097,12 +5072,7 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_To_ContainerServ
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DnsServiceIP
-	if profile.DnsServiceIP != nil {
-		dnsServiceIP := *profile.DnsServiceIP
-		destination.DnsServiceIP = &dnsServiceIP
-	} else {
-		destination.DnsServiceIP = nil
-	}
+	destination.DnsServiceIP = genruntime.ClonePointerToString(profile.DnsServiceIP)
 
 	// IpFamilies
 	if profile.IpFamilies != nil {
@@ -5222,23 +5192,13 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_To_ContainerServ
 	}
 
 	// PodCidr
-	if profile.PodCidr != nil {
-		podCidr := *profile.PodCidr
-		destination.PodCidr = &podCidr
-	} else {
-		destination.PodCidr = nil
-	}
+	destination.PodCidr = genruntime.ClonePointerToString(profile.PodCidr)
 
 	// PodCidrs
 	destination.PodCidrs = genruntime.CloneSliceOfString(profile.PodCidrs)
 
 	// ServiceCidr
-	if profile.ServiceCidr != nil {
-		serviceCidr := *profile.ServiceCidr
-		destination.ServiceCidr = &serviceCidr
-	} else {
-		destination.ServiceCidr = nil
-	}
+	destination.ServiceCidr = genruntime.ClonePointerToString(profile.ServiceCidr)
 
 	// ServiceCidrs
 	destination.ServiceCidrs = genruntime.CloneSliceOfString(profile.ServiceCidrs)
@@ -7687,12 +7647,7 @@ func (profile *ManagedClusterAgentPoolProfile) AssignProperties_From_ManagedClus
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		profile.Name = &name
-	} else {
-		profile.Name = nil
-	}
+	profile.Name = genruntime.ClonePointerToString(source.Name)
 
 	// NetworkProfile
 	if source.NetworkProfile != nil {
@@ -8098,12 +8053,7 @@ func (profile *ManagedClusterAgentPoolProfile) AssignProperties_To_ManagedCluste
 	}
 
 	// Name
-	if profile.Name != nil {
-		name := *profile.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(profile.Name)
 
 	// NetworkProfile
 	if profile.NetworkProfile != nil {
@@ -17600,12 +17550,7 @@ func (resource *DelegatedResource) AssignProperties_From_DelegatedResource(sourc
 	}
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		resource.TenantId = &tenantId
-	} else {
-		resource.TenantId = nil
-	}
+	resource.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// No error
 	return nil
@@ -17631,12 +17576,7 @@ func (resource *DelegatedResource) AssignProperties_To_DelegatedResource(destina
 	}
 
 	// TenantId
-	if resource.TenantId != nil {
-		tenantId := *resource.TenantId
-		destination.TenantId = &tenantId
-	} else {
-		destination.TenantId = nil
-	}
+	destination.TenantId = genruntime.ClonePointerToString(resource.TenantId)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -17941,17 +17881,7 @@ func (mesh *IstioServiceMesh) AssignProperties_From_IstioServiceMesh(source *sto
 	}
 
 	// Revisions
-	if source.Revisions != nil {
-		revisionList := make([]string, len(source.Revisions))
-		for revisionIndex, revisionItem := range source.Revisions {
-			// Shadow the loop variable to avoid aliasing
-			revisionItem := revisionItem
-			revisionList[revisionIndex] = revisionItem
-		}
-		mesh.Revisions = revisionList
-	} else {
-		mesh.Revisions = nil
-	}
+	mesh.Revisions = genruntime.CloneSliceOfString(source.Revisions)
 
 	// No error
 	return nil
@@ -17987,17 +17917,7 @@ func (mesh *IstioServiceMesh) AssignProperties_To_IstioServiceMesh(destination *
 	}
 
 	// Revisions
-	if mesh.Revisions != nil {
-		revisionList := make([]string, len(mesh.Revisions))
-		for revisionIndex, revisionItem := range mesh.Revisions {
-			// Shadow the loop variable to avoid aliasing
-			revisionItem := revisionItem
-			revisionList[revisionIndex] = revisionItem
-		}
-		destination.Revisions = revisionList
-	} else {
-		destination.Revisions = nil
-	}
+	destination.Revisions = genruntime.CloneSliceOfString(mesh.Revisions)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -19481,12 +19401,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_From_ManagedClusterLoadBalancerProfile(source *storage.ManagedClusterLoadBalancerProfile) error {
 
 	// AllocatedOutboundPorts
-	if source.AllocatedOutboundPorts != nil {
-		allocatedOutboundPort := *source.AllocatedOutboundPorts
-		profile.AllocatedOutboundPorts = &allocatedOutboundPort
-	} else {
-		profile.AllocatedOutboundPorts = nil
-	}
+	profile.AllocatedOutboundPorts = genruntime.ClonePointerToInt(source.AllocatedOutboundPorts)
 
 	// BackendPoolType
 	if source.BackendPoolType != nil {
@@ -19524,12 +19439,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_From_ManagedC
 	}
 
 	// IdleTimeoutInMinutes
-	if source.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *source.IdleTimeoutInMinutes
-		profile.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		profile.IdleTimeoutInMinutes = nil
-	}
+	profile.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(source.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPs
 	if source.ManagedOutboundIPs != nil {
@@ -19577,12 +19487,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_To_ManagedClu
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AllocatedOutboundPorts
-	if profile.AllocatedOutboundPorts != nil {
-		allocatedOutboundPort := *profile.AllocatedOutboundPorts
-		destination.AllocatedOutboundPorts = &allocatedOutboundPort
-	} else {
-		destination.AllocatedOutboundPorts = nil
-	}
+	destination.AllocatedOutboundPorts = genruntime.ClonePointerToInt(profile.AllocatedOutboundPorts)
 
 	// BackendPoolType
 	if profile.BackendPoolType != nil {
@@ -19619,12 +19524,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_To_ManagedClu
 	}
 
 	// IdleTimeoutInMinutes
-	if profile.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *profile.IdleTimeoutInMinutes
-		destination.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		destination.IdleTimeoutInMinutes = nil
-	}
+	destination.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(profile.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPs
 	if profile.ManagedOutboundIPs != nil {
@@ -20057,12 +19957,7 @@ func (profile *ManagedClusterNATGatewayProfile) AssignProperties_From_ManagedClu
 	}
 
 	// IdleTimeoutInMinutes
-	if source.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *source.IdleTimeoutInMinutes
-		profile.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		profile.IdleTimeoutInMinutes = nil
-	}
+	profile.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(source.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPProfile
 	if source.ManagedOutboundIPProfile != nil {
@@ -20104,12 +19999,7 @@ func (profile *ManagedClusterNATGatewayProfile) AssignProperties_To_ManagedClust
 	}
 
 	// IdleTimeoutInMinutes
-	if profile.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *profile.IdleTimeoutInMinutes
-		destination.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		destination.IdleTimeoutInMinutes = nil
-	}
+	destination.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(profile.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPProfile
 	if profile.ManagedOutboundIPProfile != nil {
@@ -25467,20 +25357,10 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) PopulateFromARM
 func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) AssignProperties_From_ManagedClusterLoadBalancerProfile_ManagedOutboundIPs(source *storage.ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		iPs.Count = &count
-	} else {
-		iPs.Count = nil
-	}
+	iPs.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// CountIPv6
-	if source.CountIPv6 != nil {
-		countIPv6 := *source.CountIPv6
-		iPs.CountIPv6 = &countIPv6
-	} else {
-		iPs.CountIPv6 = nil
-	}
+	iPs.CountIPv6 = genruntime.ClonePointerToInt(source.CountIPv6)
 
 	// No error
 	return nil
@@ -25492,20 +25372,10 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) AssignPropertie
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Count
-	if iPs.Count != nil {
-		count := *iPs.Count
-		destination.Count = &count
-	} else {
-		destination.Count = nil
-	}
+	destination.Count = genruntime.ClonePointerToInt(iPs.Count)
 
 	// CountIPv6
-	if iPs.CountIPv6 != nil {
-		countIPv6 := *iPs.CountIPv6
-		destination.CountIPv6 = &countIPv6
-	} else {
-		destination.CountIPv6 = nil
-	}
+	destination.CountIPv6 = genruntime.ClonePointerToInt(iPs.CountIPv6)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -26037,12 +25907,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) PopulateFromARM(owner gen
 func (profile *ManagedClusterManagedOutboundIPProfile) AssignProperties_From_ManagedClusterManagedOutboundIPProfile(source *storage.ManagedClusterManagedOutboundIPProfile) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		profile.Count = &count
-	} else {
-		profile.Count = nil
-	}
+	profile.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// No error
 	return nil
@@ -26054,12 +25919,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) AssignProperties_To_Manag
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Count
-	if profile.Count != nil {
-		count := *profile.Count
-		destination.Count = &count
-	} else {
-		destination.Count = nil
-	}
+	destination.Count = genruntime.ClonePointerToInt(profile.Count)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/containerservice/v1api20231102preview/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20231102preview/managed_clusters_agent_pool_types_gen.go
@@ -4918,23 +4918,13 @@ func (settings *AgentPoolUpgradeSettings) PopulateFromARM(owner genruntime.Arbit
 func (settings *AgentPoolUpgradeSettings) AssignProperties_From_AgentPoolUpgradeSettings(source *storage.AgentPoolUpgradeSettings) error {
 
 	// DrainTimeoutInMinutes
-	if source.DrainTimeoutInMinutes != nil {
-		drainTimeoutInMinute := *source.DrainTimeoutInMinutes
-		settings.DrainTimeoutInMinutes = &drainTimeoutInMinute
-	} else {
-		settings.DrainTimeoutInMinutes = nil
-	}
+	settings.DrainTimeoutInMinutes = genruntime.ClonePointerToInt(source.DrainTimeoutInMinutes)
 
 	// MaxSurge
 	settings.MaxSurge = genruntime.ClonePointerToString(source.MaxSurge)
 
 	// NodeSoakDurationInMinutes
-	if source.NodeSoakDurationInMinutes != nil {
-		nodeSoakDurationInMinute := *source.NodeSoakDurationInMinutes
-		settings.NodeSoakDurationInMinutes = &nodeSoakDurationInMinute
-	} else {
-		settings.NodeSoakDurationInMinutes = nil
-	}
+	settings.NodeSoakDurationInMinutes = genruntime.ClonePointerToInt(source.NodeSoakDurationInMinutes)
 
 	// No error
 	return nil
@@ -4946,23 +4936,13 @@ func (settings *AgentPoolUpgradeSettings) AssignProperties_To_AgentPoolUpgradeSe
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DrainTimeoutInMinutes
-	if settings.DrainTimeoutInMinutes != nil {
-		drainTimeoutInMinute := *settings.DrainTimeoutInMinutes
-		destination.DrainTimeoutInMinutes = &drainTimeoutInMinute
-	} else {
-		destination.DrainTimeoutInMinutes = nil
-	}
+	destination.DrainTimeoutInMinutes = genruntime.ClonePointerToInt(settings.DrainTimeoutInMinutes)
 
 	// MaxSurge
 	destination.MaxSurge = genruntime.ClonePointerToString(settings.MaxSurge)
 
 	// NodeSoakDurationInMinutes
-	if settings.NodeSoakDurationInMinutes != nil {
-		nodeSoakDurationInMinute := *settings.NodeSoakDurationInMinutes
-		destination.NodeSoakDurationInMinutes = &nodeSoakDurationInMinute
-	} else {
-		destination.NodeSoakDurationInMinutes = nil
-	}
+	destination.NodeSoakDurationInMinutes = genruntime.ClonePointerToInt(settings.NodeSoakDurationInMinutes)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -5430,12 +5410,7 @@ func (config *KubeletConfig) AssignProperties_From_KubeletConfig(source *storage
 	config.AllowedUnsafeSysctls = genruntime.CloneSliceOfString(source.AllowedUnsafeSysctls)
 
 	// ContainerLogMaxFiles
-	if source.ContainerLogMaxFiles != nil {
-		containerLogMaxFile := *source.ContainerLogMaxFiles
-		config.ContainerLogMaxFiles = &containerLogMaxFile
-	} else {
-		config.ContainerLogMaxFiles = nil
-	}
+	config.ContainerLogMaxFiles = genruntime.ClonePointerToInt(source.ContainerLogMaxFiles)
 
 	// ContainerLogMaxSizeMB
 	config.ContainerLogMaxSizeMB = genruntime.ClonePointerToInt(source.ContainerLogMaxSizeMB)
@@ -5487,12 +5462,7 @@ func (config *KubeletConfig) AssignProperties_To_KubeletConfig(destination *stor
 	destination.AllowedUnsafeSysctls = genruntime.CloneSliceOfString(config.AllowedUnsafeSysctls)
 
 	// ContainerLogMaxFiles
-	if config.ContainerLogMaxFiles != nil {
-		containerLogMaxFile := *config.ContainerLogMaxFiles
-		destination.ContainerLogMaxFiles = &containerLogMaxFile
-	} else {
-		destination.ContainerLogMaxFiles = nil
-	}
+	destination.ContainerLogMaxFiles = genruntime.ClonePointerToInt(config.ContainerLogMaxFiles)
 
 	// ContainerLogMaxSizeMB
 	destination.ContainerLogMaxSizeMB = genruntime.ClonePointerToInt(config.ContainerLogMaxSizeMB)
@@ -7064,20 +7034,10 @@ func (portRange *PortRange) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 func (portRange *PortRange) AssignProperties_From_PortRange(source *storage.PortRange) error {
 
 	// PortEnd
-	if source.PortEnd != nil {
-		portEnd := *source.PortEnd
-		portRange.PortEnd = &portEnd
-	} else {
-		portRange.PortEnd = nil
-	}
+	portRange.PortEnd = genruntime.ClonePointerToInt(source.PortEnd)
 
 	// PortStart
-	if source.PortStart != nil {
-		portStart := *source.PortStart
-		portRange.PortStart = &portStart
-	} else {
-		portRange.PortStart = nil
-	}
+	portRange.PortStart = genruntime.ClonePointerToInt(source.PortStart)
 
 	// Protocol
 	if source.Protocol != nil {
@@ -7098,20 +7058,10 @@ func (portRange *PortRange) AssignProperties_To_PortRange(destination *storage.P
 	propertyBag := genruntime.NewPropertyBag()
 
 	// PortEnd
-	if portRange.PortEnd != nil {
-		portEnd := *portRange.PortEnd
-		destination.PortEnd = &portEnd
-	} else {
-		destination.PortEnd = nil
-	}
+	destination.PortEnd = genruntime.ClonePointerToInt(portRange.PortEnd)
 
 	// PortStart
-	if portRange.PortStart != nil {
-		portStart := *portRange.PortStart
-		destination.PortStart = &portStart
-	} else {
-		destination.PortStart = nil
-	}
+	destination.PortStart = genruntime.ClonePointerToInt(portRange.PortStart)
 
 	// Protocol
 	if portRange.Protocol != nil {
@@ -7920,28 +7870,13 @@ func (config *SysctlConfig) AssignProperties_From_SysctlConfig(source *storage.S
 	}
 
 	// NetIpv4TcpkeepaliveIntvl
-	if source.NetIpv4TcpkeepaliveIntvl != nil {
-		netIpv4TcpkeepaliveIntvl := *source.NetIpv4TcpkeepaliveIntvl
-		config.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
-	} else {
-		config.NetIpv4TcpkeepaliveIntvl = nil
-	}
+	config.NetIpv4TcpkeepaliveIntvl = genruntime.ClonePointerToInt(source.NetIpv4TcpkeepaliveIntvl)
 
 	// NetNetfilterNfConntrackBuckets
-	if source.NetNetfilterNfConntrackBuckets != nil {
-		netNetfilterNfConntrackBucket := *source.NetNetfilterNfConntrackBuckets
-		config.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBucket
-	} else {
-		config.NetNetfilterNfConntrackBuckets = nil
-	}
+	config.NetNetfilterNfConntrackBuckets = genruntime.ClonePointerToInt(source.NetNetfilterNfConntrackBuckets)
 
 	// NetNetfilterNfConntrackMax
-	if source.NetNetfilterNfConntrackMax != nil {
-		netNetfilterNfConntrackMax := *source.NetNetfilterNfConntrackMax
-		config.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
-	} else {
-		config.NetNetfilterNfConntrackMax = nil
-	}
+	config.NetNetfilterNfConntrackMax = genruntime.ClonePointerToInt(source.NetNetfilterNfConntrackMax)
 
 	// VmMaxMapCount
 	config.VmMaxMapCount = genruntime.ClonePointerToInt(source.VmMaxMapCount)
@@ -8033,28 +7968,13 @@ func (config *SysctlConfig) AssignProperties_To_SysctlConfig(destination *storag
 	}
 
 	// NetIpv4TcpkeepaliveIntvl
-	if config.NetIpv4TcpkeepaliveIntvl != nil {
-		netIpv4TcpkeepaliveIntvl := *config.NetIpv4TcpkeepaliveIntvl
-		destination.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
-	} else {
-		destination.NetIpv4TcpkeepaliveIntvl = nil
-	}
+	destination.NetIpv4TcpkeepaliveIntvl = genruntime.ClonePointerToInt(config.NetIpv4TcpkeepaliveIntvl)
 
 	// NetNetfilterNfConntrackBuckets
-	if config.NetNetfilterNfConntrackBuckets != nil {
-		netNetfilterNfConntrackBucket := *config.NetNetfilterNfConntrackBuckets
-		destination.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBucket
-	} else {
-		destination.NetNetfilterNfConntrackBuckets = nil
-	}
+	destination.NetNetfilterNfConntrackBuckets = genruntime.ClonePointerToInt(config.NetNetfilterNfConntrackBuckets)
 
 	// NetNetfilterNfConntrackMax
-	if config.NetNetfilterNfConntrackMax != nil {
-		netNetfilterNfConntrackMax := *config.NetNetfilterNfConntrackMax
-		destination.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
-	} else {
-		destination.NetNetfilterNfConntrackMax = nil
-	}
+	destination.NetNetfilterNfConntrackMax = genruntime.ClonePointerToInt(config.NetNetfilterNfConntrackMax)
 
 	// VmMaxMapCount
 	destination.VmMaxMapCount = genruntime.ClonePointerToInt(config.VmMaxMapCount)
@@ -8554,12 +8474,7 @@ func (profile *ManualScaleProfile) PopulateFromARM(owner genruntime.ArbitraryOwn
 func (profile *ManualScaleProfile) AssignProperties_From_ManualScaleProfile(source *storage.ManualScaleProfile) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		profile.Count = &count
-	} else {
-		profile.Count = nil
-	}
+	profile.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// Sizes
 	profile.Sizes = genruntime.CloneSliceOfString(source.Sizes)
@@ -8574,12 +8489,7 @@ func (profile *ManualScaleProfile) AssignProperties_To_ManualScaleProfile(destin
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Count
-	if profile.Count != nil {
-		count := *profile.Count
-		destination.Count = &count
-	} else {
-		destination.Count = nil
-	}
+	destination.Count = genruntime.ClonePointerToInt(profile.Count)
 
 	// Sizes
 	destination.Sizes = genruntime.CloneSliceOfString(profile.Sizes)

--- a/v2/api/containerservice/v1api20240402preview/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20240402preview/managed_cluster_types_gen.go
@@ -4845,12 +4845,7 @@ func (profile *ContainerServiceLinuxProfile) PopulateFromARM(owner genruntime.Ar
 func (profile *ContainerServiceLinuxProfile) AssignProperties_From_ContainerServiceLinuxProfile(source *storage.ContainerServiceLinuxProfile) error {
 
 	// AdminUsername
-	if source.AdminUsername != nil {
-		adminUsername := *source.AdminUsername
-		profile.AdminUsername = &adminUsername
-	} else {
-		profile.AdminUsername = nil
-	}
+	profile.AdminUsername = genruntime.ClonePointerToString(source.AdminUsername)
 
 	// Ssh
 	if source.Ssh != nil {
@@ -4874,12 +4869,7 @@ func (profile *ContainerServiceLinuxProfile) AssignProperties_To_ContainerServic
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AdminUsername
-	if profile.AdminUsername != nil {
-		adminUsername := *profile.AdminUsername
-		destination.AdminUsername = &adminUsername
-	} else {
-		destination.AdminUsername = nil
-	}
+	destination.AdminUsername = genruntime.ClonePointerToString(profile.AdminUsername)
 
 	// Ssh
 	if profile.Ssh != nil {
@@ -5423,12 +5413,7 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_From_ContainerSe
 	}
 
 	// DnsServiceIP
-	if source.DnsServiceIP != nil {
-		dnsServiceIP := *source.DnsServiceIP
-		profile.DnsServiceIP = &dnsServiceIP
-	} else {
-		profile.DnsServiceIP = nil
-	}
+	profile.DnsServiceIP = genruntime.ClonePointerToString(source.DnsServiceIP)
 
 	// IpFamilies
 	if source.IpFamilies != nil {
@@ -5543,12 +5528,7 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_From_ContainerSe
 	}
 
 	// PodCidr
-	if source.PodCidr != nil {
-		podCidr := *source.PodCidr
-		profile.PodCidr = &podCidr
-	} else {
-		profile.PodCidr = nil
-	}
+	profile.PodCidr = genruntime.ClonePointerToString(source.PodCidr)
 
 	// PodCidrs
 	profile.PodCidrs = genruntime.CloneSliceOfString(source.PodCidrs)
@@ -5563,12 +5543,7 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_From_ContainerSe
 	}
 
 	// ServiceCidr
-	if source.ServiceCidr != nil {
-		serviceCidr := *source.ServiceCidr
-		profile.ServiceCidr = &serviceCidr
-	} else {
-		profile.ServiceCidr = nil
-	}
+	profile.ServiceCidr = genruntime.ClonePointerToString(source.ServiceCidr)
 
 	// ServiceCidrs
 	profile.ServiceCidrs = genruntime.CloneSliceOfString(source.ServiceCidrs)
@@ -5607,12 +5582,7 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_To_ContainerServ
 	}
 
 	// DnsServiceIP
-	if profile.DnsServiceIP != nil {
-		dnsServiceIP := *profile.DnsServiceIP
-		destination.DnsServiceIP = &dnsServiceIP
-	} else {
-		destination.DnsServiceIP = nil
-	}
+	destination.DnsServiceIP = genruntime.ClonePointerToString(profile.DnsServiceIP)
 
 	// IpFamilies
 	if profile.IpFamilies != nil {
@@ -5720,12 +5690,7 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_To_ContainerServ
 	}
 
 	// PodCidr
-	if profile.PodCidr != nil {
-		podCidr := *profile.PodCidr
-		destination.PodCidr = &podCidr
-	} else {
-		destination.PodCidr = nil
-	}
+	destination.PodCidr = genruntime.ClonePointerToString(profile.PodCidr)
 
 	// PodCidrs
 	destination.PodCidrs = genruntime.CloneSliceOfString(profile.PodCidrs)
@@ -5739,12 +5704,7 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_To_ContainerServ
 	}
 
 	// ServiceCidr
-	if profile.ServiceCidr != nil {
-		serviceCidr := *profile.ServiceCidr
-		destination.ServiceCidr = &serviceCidr
-	} else {
-		destination.ServiceCidr = nil
-	}
+	destination.ServiceCidr = genruntime.ClonePointerToString(profile.ServiceCidr)
 
 	// ServiceCidrs
 	destination.ServiceCidrs = genruntime.CloneSliceOfString(profile.ServiceCidrs)
@@ -8567,12 +8527,7 @@ func (profile *ManagedClusterAgentPoolProfile) AssignProperties_From_ManagedClus
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		profile.Name = &name
-	} else {
-		profile.Name = nil
-	}
+	profile.Name = genruntime.ClonePointerToString(source.Name)
 
 	// NetworkProfile
 	if source.NetworkProfile != nil {
@@ -8999,12 +8954,7 @@ func (profile *ManagedClusterAgentPoolProfile) AssignProperties_To_ManagedCluste
 	}
 
 	// Name
-	if profile.Name != nil {
-		name := *profile.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(profile.Name)
 
 	// NetworkProfile
 	if profile.NetworkProfile != nil {
@@ -19730,12 +19680,7 @@ func (resource *DelegatedResource) AssignProperties_From_DelegatedResource(sourc
 	}
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		resource.TenantId = &tenantId
-	} else {
-		resource.TenantId = nil
-	}
+	resource.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// No error
 	return nil
@@ -19761,12 +19706,7 @@ func (resource *DelegatedResource) AssignProperties_To_DelegatedResource(destina
 	}
 
 	// TenantId
-	if resource.TenantId != nil {
-		tenantId := *resource.TenantId
-		destination.TenantId = &tenantId
-	} else {
-		destination.TenantId = nil
-	}
+	destination.TenantId = genruntime.ClonePointerToString(resource.TenantId)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -20097,17 +20037,7 @@ func (mesh *IstioServiceMesh) AssignProperties_From_IstioServiceMesh(source *sto
 	}
 
 	// Revisions
-	if source.Revisions != nil {
-		revisionList := make([]string, len(source.Revisions))
-		for revisionIndex, revisionItem := range source.Revisions {
-			// Shadow the loop variable to avoid aliasing
-			revisionItem := revisionItem
-			revisionList[revisionIndex] = revisionItem
-		}
-		mesh.Revisions = revisionList
-	} else {
-		mesh.Revisions = nil
-	}
+	mesh.Revisions = genruntime.CloneSliceOfString(source.Revisions)
 
 	// No error
 	return nil
@@ -20143,17 +20073,7 @@ func (mesh *IstioServiceMesh) AssignProperties_To_IstioServiceMesh(destination *
 	}
 
 	// Revisions
-	if mesh.Revisions != nil {
-		revisionList := make([]string, len(mesh.Revisions))
-		for revisionIndex, revisionItem := range mesh.Revisions {
-			// Shadow the loop variable to avoid aliasing
-			revisionItem := revisionItem
-			revisionList[revisionIndex] = revisionItem
-		}
-		destination.Revisions = revisionList
-	} else {
-		destination.Revisions = nil
-	}
+	destination.Revisions = genruntime.CloneSliceOfString(mesh.Revisions)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -22135,12 +22055,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_From_ManagedClusterLoadBalancerProfile(source *storage.ManagedClusterLoadBalancerProfile) error {
 
 	// AllocatedOutboundPorts
-	if source.AllocatedOutboundPorts != nil {
-		allocatedOutboundPort := *source.AllocatedOutboundPorts
-		profile.AllocatedOutboundPorts = &allocatedOutboundPort
-	} else {
-		profile.AllocatedOutboundPorts = nil
-	}
+	profile.AllocatedOutboundPorts = genruntime.ClonePointerToInt(source.AllocatedOutboundPorts)
 
 	// BackendPoolType
 	if source.BackendPoolType != nil {
@@ -22187,12 +22102,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_From_ManagedC
 	}
 
 	// IdleTimeoutInMinutes
-	if source.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *source.IdleTimeoutInMinutes
-		profile.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		profile.IdleTimeoutInMinutes = nil
-	}
+	profile.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(source.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPs
 	if source.ManagedOutboundIPs != nil {
@@ -22240,12 +22150,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_To_ManagedClu
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AllocatedOutboundPorts
-	if profile.AllocatedOutboundPorts != nil {
-		allocatedOutboundPort := *profile.AllocatedOutboundPorts
-		destination.AllocatedOutboundPorts = &allocatedOutboundPort
-	} else {
-		destination.AllocatedOutboundPorts = nil
-	}
+	destination.AllocatedOutboundPorts = genruntime.ClonePointerToInt(profile.AllocatedOutboundPorts)
 
 	// BackendPoolType
 	if profile.BackendPoolType != nil {
@@ -22290,12 +22195,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_To_ManagedClu
 	}
 
 	// IdleTimeoutInMinutes
-	if profile.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *profile.IdleTimeoutInMinutes
-		destination.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		destination.IdleTimeoutInMinutes = nil
-	}
+	destination.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(profile.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPs
 	if profile.ManagedOutboundIPs != nil {
@@ -22780,12 +22680,7 @@ func (profile *ManagedClusterNATGatewayProfile) AssignProperties_From_ManagedClu
 	}
 
 	// IdleTimeoutInMinutes
-	if source.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *source.IdleTimeoutInMinutes
-		profile.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		profile.IdleTimeoutInMinutes = nil
-	}
+	profile.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(source.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPProfile
 	if source.ManagedOutboundIPProfile != nil {
@@ -22827,12 +22722,7 @@ func (profile *ManagedClusterNATGatewayProfile) AssignProperties_To_ManagedClust
 	}
 
 	// IdleTimeoutInMinutes
-	if profile.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *profile.IdleTimeoutInMinutes
-		destination.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		destination.IdleTimeoutInMinutes = nil
-	}
+	destination.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(profile.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPProfile
 	if profile.ManagedOutboundIPProfile != nil {
@@ -28575,20 +28465,10 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) PopulateFromARM
 func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) AssignProperties_From_ManagedClusterLoadBalancerProfile_ManagedOutboundIPs(source *storage.ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		iPs.Count = &count
-	} else {
-		iPs.Count = nil
-	}
+	iPs.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// CountIPv6
-	if source.CountIPv6 != nil {
-		countIPv6 := *source.CountIPv6
-		iPs.CountIPv6 = &countIPv6
-	} else {
-		iPs.CountIPv6 = nil
-	}
+	iPs.CountIPv6 = genruntime.ClonePointerToInt(source.CountIPv6)
 
 	// No error
 	return nil
@@ -28600,20 +28480,10 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) AssignPropertie
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Count
-	if iPs.Count != nil {
-		count := *iPs.Count
-		destination.Count = &count
-	} else {
-		destination.Count = nil
-	}
+	destination.Count = genruntime.ClonePointerToInt(iPs.Count)
 
 	// CountIPv6
-	if iPs.CountIPv6 != nil {
-		countIPv6 := *iPs.CountIPv6
-		destination.CountIPv6 = &countIPv6
-	} else {
-		destination.CountIPv6 = nil
-	}
+	destination.CountIPv6 = genruntime.ClonePointerToInt(iPs.CountIPv6)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -29157,12 +29027,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) PopulateFromARM(owner gen
 func (profile *ManagedClusterManagedOutboundIPProfile) AssignProperties_From_ManagedClusterManagedOutboundIPProfile(source *storage.ManagedClusterManagedOutboundIPProfile) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		profile.Count = &count
-	} else {
-		profile.Count = nil
-	}
+	profile.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// No error
 	return nil
@@ -29174,12 +29039,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) AssignProperties_To_Manag
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Count
-	if profile.Count != nil {
-		count := *profile.Count
-		destination.Count = &count
-	} else {
-		destination.Count = nil
-	}
+	destination.Count = genruntime.ClonePointerToInt(profile.Count)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/containerservice/v1api20240402preview/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20240402preview/managed_clusters_agent_pool_types_gen.go
@@ -4262,12 +4262,7 @@ func (profile *AgentPoolGatewayProfile) PopulateFromARM(owner genruntime.Arbitra
 func (profile *AgentPoolGatewayProfile) AssignProperties_From_AgentPoolGatewayProfile(source *storage.AgentPoolGatewayProfile) error {
 
 	// PublicIPPrefixSize
-	if source.PublicIPPrefixSize != nil {
-		publicIPPrefixSize := *source.PublicIPPrefixSize
-		profile.PublicIPPrefixSize = &publicIPPrefixSize
-	} else {
-		profile.PublicIPPrefixSize = nil
-	}
+	profile.PublicIPPrefixSize = genruntime.ClonePointerToInt(source.PublicIPPrefixSize)
 
 	// No error
 	return nil
@@ -4279,12 +4274,7 @@ func (profile *AgentPoolGatewayProfile) AssignProperties_To_AgentPoolGatewayProf
 	propertyBag := genruntime.NewPropertyBag()
 
 	// PublicIPPrefixSize
-	if profile.PublicIPPrefixSize != nil {
-		publicIPPrefixSize := *profile.PublicIPPrefixSize
-		destination.PublicIPPrefixSize = &publicIPPrefixSize
-	} else {
-		destination.PublicIPPrefixSize = nil
-	}
+	destination.PublicIPPrefixSize = genruntime.ClonePointerToInt(profile.PublicIPPrefixSize)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -5338,23 +5328,13 @@ func (settings *AgentPoolUpgradeSettings) PopulateFromARM(owner genruntime.Arbit
 func (settings *AgentPoolUpgradeSettings) AssignProperties_From_AgentPoolUpgradeSettings(source *storage.AgentPoolUpgradeSettings) error {
 
 	// DrainTimeoutInMinutes
-	if source.DrainTimeoutInMinutes != nil {
-		drainTimeoutInMinute := *source.DrainTimeoutInMinutes
-		settings.DrainTimeoutInMinutes = &drainTimeoutInMinute
-	} else {
-		settings.DrainTimeoutInMinutes = nil
-	}
+	settings.DrainTimeoutInMinutes = genruntime.ClonePointerToInt(source.DrainTimeoutInMinutes)
 
 	// MaxSurge
 	settings.MaxSurge = genruntime.ClonePointerToString(source.MaxSurge)
 
 	// NodeSoakDurationInMinutes
-	if source.NodeSoakDurationInMinutes != nil {
-		nodeSoakDurationInMinute := *source.NodeSoakDurationInMinutes
-		settings.NodeSoakDurationInMinutes = &nodeSoakDurationInMinute
-	} else {
-		settings.NodeSoakDurationInMinutes = nil
-	}
+	settings.NodeSoakDurationInMinutes = genruntime.ClonePointerToInt(source.NodeSoakDurationInMinutes)
 
 	// UndrainableNodeBehavior
 	if source.UndrainableNodeBehavior != nil {
@@ -5375,23 +5355,13 @@ func (settings *AgentPoolUpgradeSettings) AssignProperties_To_AgentPoolUpgradeSe
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DrainTimeoutInMinutes
-	if settings.DrainTimeoutInMinutes != nil {
-		drainTimeoutInMinute := *settings.DrainTimeoutInMinutes
-		destination.DrainTimeoutInMinutes = &drainTimeoutInMinute
-	} else {
-		destination.DrainTimeoutInMinutes = nil
-	}
+	destination.DrainTimeoutInMinutes = genruntime.ClonePointerToInt(settings.DrainTimeoutInMinutes)
 
 	// MaxSurge
 	destination.MaxSurge = genruntime.ClonePointerToString(settings.MaxSurge)
 
 	// NodeSoakDurationInMinutes
-	if settings.NodeSoakDurationInMinutes != nil {
-		nodeSoakDurationInMinute := *settings.NodeSoakDurationInMinutes
-		destination.NodeSoakDurationInMinutes = &nodeSoakDurationInMinute
-	} else {
-		destination.NodeSoakDurationInMinutes = nil
-	}
+	destination.NodeSoakDurationInMinutes = genruntime.ClonePointerToInt(settings.NodeSoakDurationInMinutes)
 
 	// UndrainableNodeBehavior
 	if settings.UndrainableNodeBehavior != nil {
@@ -5944,12 +5914,7 @@ func (config *KubeletConfig) AssignProperties_From_KubeletConfig(source *storage
 	config.AllowedUnsafeSysctls = genruntime.CloneSliceOfString(source.AllowedUnsafeSysctls)
 
 	// ContainerLogMaxFiles
-	if source.ContainerLogMaxFiles != nil {
-		containerLogMaxFile := *source.ContainerLogMaxFiles
-		config.ContainerLogMaxFiles = &containerLogMaxFile
-	} else {
-		config.ContainerLogMaxFiles = nil
-	}
+	config.ContainerLogMaxFiles = genruntime.ClonePointerToInt(source.ContainerLogMaxFiles)
 
 	// ContainerLogMaxSizeMB
 	config.ContainerLogMaxSizeMB = genruntime.ClonePointerToInt(source.ContainerLogMaxSizeMB)
@@ -6001,12 +5966,7 @@ func (config *KubeletConfig) AssignProperties_To_KubeletConfig(destination *stor
 	destination.AllowedUnsafeSysctls = genruntime.CloneSliceOfString(config.AllowedUnsafeSysctls)
 
 	// ContainerLogMaxFiles
-	if config.ContainerLogMaxFiles != nil {
-		containerLogMaxFile := *config.ContainerLogMaxFiles
-		destination.ContainerLogMaxFiles = &containerLogMaxFile
-	} else {
-		destination.ContainerLogMaxFiles = nil
-	}
+	destination.ContainerLogMaxFiles = genruntime.ClonePointerToInt(config.ContainerLogMaxFiles)
 
 	// ContainerLogMaxSizeMB
 	destination.ContainerLogMaxSizeMB = genruntime.ClonePointerToInt(config.ContainerLogMaxSizeMB)
@@ -7743,20 +7703,10 @@ func (portRange *PortRange) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 func (portRange *PortRange) AssignProperties_From_PortRange(source *storage.PortRange) error {
 
 	// PortEnd
-	if source.PortEnd != nil {
-		portEnd := *source.PortEnd
-		portRange.PortEnd = &portEnd
-	} else {
-		portRange.PortEnd = nil
-	}
+	portRange.PortEnd = genruntime.ClonePointerToInt(source.PortEnd)
 
 	// PortStart
-	if source.PortStart != nil {
-		portStart := *source.PortStart
-		portRange.PortStart = &portStart
-	} else {
-		portRange.PortStart = nil
-	}
+	portRange.PortStart = genruntime.ClonePointerToInt(source.PortStart)
 
 	// Protocol
 	if source.Protocol != nil {
@@ -7777,20 +7727,10 @@ func (portRange *PortRange) AssignProperties_To_PortRange(destination *storage.P
 	propertyBag := genruntime.NewPropertyBag()
 
 	// PortEnd
-	if portRange.PortEnd != nil {
-		portEnd := *portRange.PortEnd
-		destination.PortEnd = &portEnd
-	} else {
-		destination.PortEnd = nil
-	}
+	destination.PortEnd = genruntime.ClonePointerToInt(portRange.PortEnd)
 
 	// PortStart
-	if portRange.PortStart != nil {
-		portStart := *portRange.PortStart
-		destination.PortStart = &portStart
-	} else {
-		destination.PortStart = nil
-	}
+	destination.PortStart = genruntime.ClonePointerToInt(portRange.PortStart)
 
 	// Protocol
 	if portRange.Protocol != nil {
@@ -8773,28 +8713,13 @@ func (config *SysctlConfig) AssignProperties_From_SysctlConfig(source *storage.S
 	}
 
 	// NetIpv4TcpkeepaliveIntvl
-	if source.NetIpv4TcpkeepaliveIntvl != nil {
-		netIpv4TcpkeepaliveIntvl := *source.NetIpv4TcpkeepaliveIntvl
-		config.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
-	} else {
-		config.NetIpv4TcpkeepaliveIntvl = nil
-	}
+	config.NetIpv4TcpkeepaliveIntvl = genruntime.ClonePointerToInt(source.NetIpv4TcpkeepaliveIntvl)
 
 	// NetNetfilterNfConntrackBuckets
-	if source.NetNetfilterNfConntrackBuckets != nil {
-		netNetfilterNfConntrackBucket := *source.NetNetfilterNfConntrackBuckets
-		config.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBucket
-	} else {
-		config.NetNetfilterNfConntrackBuckets = nil
-	}
+	config.NetNetfilterNfConntrackBuckets = genruntime.ClonePointerToInt(source.NetNetfilterNfConntrackBuckets)
 
 	// NetNetfilterNfConntrackMax
-	if source.NetNetfilterNfConntrackMax != nil {
-		netNetfilterNfConntrackMax := *source.NetNetfilterNfConntrackMax
-		config.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
-	} else {
-		config.NetNetfilterNfConntrackMax = nil
-	}
+	config.NetNetfilterNfConntrackMax = genruntime.ClonePointerToInt(source.NetNetfilterNfConntrackMax)
 
 	// VmMaxMapCount
 	config.VmMaxMapCount = genruntime.ClonePointerToInt(source.VmMaxMapCount)
@@ -8886,28 +8811,13 @@ func (config *SysctlConfig) AssignProperties_To_SysctlConfig(destination *storag
 	}
 
 	// NetIpv4TcpkeepaliveIntvl
-	if config.NetIpv4TcpkeepaliveIntvl != nil {
-		netIpv4TcpkeepaliveIntvl := *config.NetIpv4TcpkeepaliveIntvl
-		destination.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
-	} else {
-		destination.NetIpv4TcpkeepaliveIntvl = nil
-	}
+	destination.NetIpv4TcpkeepaliveIntvl = genruntime.ClonePointerToInt(config.NetIpv4TcpkeepaliveIntvl)
 
 	// NetNetfilterNfConntrackBuckets
-	if config.NetNetfilterNfConntrackBuckets != nil {
-		netNetfilterNfConntrackBucket := *config.NetNetfilterNfConntrackBuckets
-		destination.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBucket
-	} else {
-		destination.NetNetfilterNfConntrackBuckets = nil
-	}
+	destination.NetNetfilterNfConntrackBuckets = genruntime.ClonePointerToInt(config.NetNetfilterNfConntrackBuckets)
 
 	// NetNetfilterNfConntrackMax
-	if config.NetNetfilterNfConntrackMax != nil {
-		netNetfilterNfConntrackMax := *config.NetNetfilterNfConntrackMax
-		destination.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
-	} else {
-		destination.NetNetfilterNfConntrackMax = nil
-	}
+	destination.NetNetfilterNfConntrackMax = genruntime.ClonePointerToInt(config.NetNetfilterNfConntrackMax)
 
 	// VmMaxMapCount
 	destination.VmMaxMapCount = genruntime.ClonePointerToInt(config.VmMaxMapCount)

--- a/v2/api/containerservice/v1api20240901/maintenance_configuration_types_gen.go
+++ b/v2/api/containerservice/v1api20240901/maintenance_configuration_types_gen.go
@@ -1258,12 +1258,7 @@ func (window *MaintenanceWindow) PopulateFromARM(owner genruntime.ArbitraryOwner
 func (window *MaintenanceWindow) AssignProperties_From_MaintenanceWindow(source *storage.MaintenanceWindow) error {
 
 	// DurationHours
-	if source.DurationHours != nil {
-		durationHour := *source.DurationHours
-		window.DurationHours = &durationHour
-	} else {
-		window.DurationHours = nil
-	}
+	window.DurationHours = genruntime.ClonePointerToInt(source.DurationHours)
 
 	// NotAllowedDates
 	if source.NotAllowedDates != nil {
@@ -1299,20 +1294,10 @@ func (window *MaintenanceWindow) AssignProperties_From_MaintenanceWindow(source 
 	window.StartDate = genruntime.ClonePointerToString(source.StartDate)
 
 	// StartTime
-	if source.StartTime != nil {
-		startTime := *source.StartTime
-		window.StartTime = &startTime
-	} else {
-		window.StartTime = nil
-	}
+	window.StartTime = genruntime.ClonePointerToString(source.StartTime)
 
 	// UtcOffset
-	if source.UtcOffset != nil {
-		utcOffset := *source.UtcOffset
-		window.UtcOffset = &utcOffset
-	} else {
-		window.UtcOffset = nil
-	}
+	window.UtcOffset = genruntime.ClonePointerToString(source.UtcOffset)
 
 	// No error
 	return nil
@@ -1324,12 +1309,7 @@ func (window *MaintenanceWindow) AssignProperties_To_MaintenanceWindow(destinati
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DurationHours
-	if window.DurationHours != nil {
-		durationHour := *window.DurationHours
-		destination.DurationHours = &durationHour
-	} else {
-		destination.DurationHours = nil
-	}
+	destination.DurationHours = genruntime.ClonePointerToInt(window.DurationHours)
 
 	// NotAllowedDates
 	if window.NotAllowedDates != nil {
@@ -1365,20 +1345,10 @@ func (window *MaintenanceWindow) AssignProperties_To_MaintenanceWindow(destinati
 	destination.StartDate = genruntime.ClonePointerToString(window.StartDate)
 
 	// StartTime
-	if window.StartTime != nil {
-		startTime := *window.StartTime
-		destination.StartTime = &startTime
-	} else {
-		destination.StartTime = nil
-	}
+	destination.StartTime = genruntime.ClonePointerToString(window.StartTime)
 
 	// UtcOffset
-	if window.UtcOffset != nil {
-		utcOffset := *window.UtcOffset
-		destination.UtcOffset = &utcOffset
-	} else {
-		destination.UtcOffset = nil
-	}
+	destination.UtcOffset = genruntime.ClonePointerToString(window.UtcOffset)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -1395,12 +1365,7 @@ func (window *MaintenanceWindow) AssignProperties_To_MaintenanceWindow(destinati
 func (window *MaintenanceWindow) Initialize_From_MaintenanceWindow_STATUS(source *MaintenanceWindow_STATUS) error {
 
 	// DurationHours
-	if source.DurationHours != nil {
-		durationHour := *source.DurationHours
-		window.DurationHours = &durationHour
-	} else {
-		window.DurationHours = nil
-	}
+	window.DurationHours = genruntime.ClonePointerToInt(source.DurationHours)
 
 	// NotAllowedDates
 	if source.NotAllowedDates != nil {
@@ -1436,20 +1401,10 @@ func (window *MaintenanceWindow) Initialize_From_MaintenanceWindow_STATUS(source
 	window.StartDate = genruntime.ClonePointerToString(source.StartDate)
 
 	// StartTime
-	if source.StartTime != nil {
-		startTime := *source.StartTime
-		window.StartTime = &startTime
-	} else {
-		window.StartTime = nil
-	}
+	window.StartTime = genruntime.ClonePointerToString(source.StartTime)
 
 	// UtcOffset
-	if source.UtcOffset != nil {
-		utcOffset := *source.UtcOffset
-		window.UtcOffset = &utcOffset
-	} else {
-		window.UtcOffset = nil
-	}
+	window.UtcOffset = genruntime.ClonePointerToString(source.UtcOffset)
 
 	// No error
 	return nil
@@ -3098,20 +3053,10 @@ func (schedule *AbsoluteMonthlySchedule) PopulateFromARM(owner genruntime.Arbitr
 func (schedule *AbsoluteMonthlySchedule) AssignProperties_From_AbsoluteMonthlySchedule(source *storage.AbsoluteMonthlySchedule) error {
 
 	// DayOfMonth
-	if source.DayOfMonth != nil {
-		dayOfMonth := *source.DayOfMonth
-		schedule.DayOfMonth = &dayOfMonth
-	} else {
-		schedule.DayOfMonth = nil
-	}
+	schedule.DayOfMonth = genruntime.ClonePointerToInt(source.DayOfMonth)
 
 	// IntervalMonths
-	if source.IntervalMonths != nil {
-		intervalMonth := *source.IntervalMonths
-		schedule.IntervalMonths = &intervalMonth
-	} else {
-		schedule.IntervalMonths = nil
-	}
+	schedule.IntervalMonths = genruntime.ClonePointerToInt(source.IntervalMonths)
 
 	// No error
 	return nil
@@ -3123,20 +3068,10 @@ func (schedule *AbsoluteMonthlySchedule) AssignProperties_To_AbsoluteMonthlySche
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DayOfMonth
-	if schedule.DayOfMonth != nil {
-		dayOfMonth := *schedule.DayOfMonth
-		destination.DayOfMonth = &dayOfMonth
-	} else {
-		destination.DayOfMonth = nil
-	}
+	destination.DayOfMonth = genruntime.ClonePointerToInt(schedule.DayOfMonth)
 
 	// IntervalMonths
-	if schedule.IntervalMonths != nil {
-		intervalMonth := *schedule.IntervalMonths
-		destination.IntervalMonths = &intervalMonth
-	} else {
-		destination.IntervalMonths = nil
-	}
+	destination.IntervalMonths = genruntime.ClonePointerToInt(schedule.IntervalMonths)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -3153,20 +3088,10 @@ func (schedule *AbsoluteMonthlySchedule) AssignProperties_To_AbsoluteMonthlySche
 func (schedule *AbsoluteMonthlySchedule) Initialize_From_AbsoluteMonthlySchedule_STATUS(source *AbsoluteMonthlySchedule_STATUS) error {
 
 	// DayOfMonth
-	if source.DayOfMonth != nil {
-		dayOfMonth := *source.DayOfMonth
-		schedule.DayOfMonth = &dayOfMonth
-	} else {
-		schedule.DayOfMonth = nil
-	}
+	schedule.DayOfMonth = genruntime.ClonePointerToInt(source.DayOfMonth)
 
 	// IntervalMonths
-	if source.IntervalMonths != nil {
-		intervalMonth := *source.IntervalMonths
-		schedule.IntervalMonths = &intervalMonth
-	} else {
-		schedule.IntervalMonths = nil
-	}
+	schedule.IntervalMonths = genruntime.ClonePointerToInt(source.IntervalMonths)
 
 	// No error
 	return nil
@@ -3298,12 +3223,7 @@ func (schedule *DailySchedule) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 func (schedule *DailySchedule) AssignProperties_From_DailySchedule(source *storage.DailySchedule) error {
 
 	// IntervalDays
-	if source.IntervalDays != nil {
-		intervalDay := *source.IntervalDays
-		schedule.IntervalDays = &intervalDay
-	} else {
-		schedule.IntervalDays = nil
-	}
+	schedule.IntervalDays = genruntime.ClonePointerToInt(source.IntervalDays)
 
 	// No error
 	return nil
@@ -3315,12 +3235,7 @@ func (schedule *DailySchedule) AssignProperties_To_DailySchedule(destination *st
 	propertyBag := genruntime.NewPropertyBag()
 
 	// IntervalDays
-	if schedule.IntervalDays != nil {
-		intervalDay := *schedule.IntervalDays
-		destination.IntervalDays = &intervalDay
-	} else {
-		destination.IntervalDays = nil
-	}
+	destination.IntervalDays = genruntime.ClonePointerToInt(schedule.IntervalDays)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -3337,12 +3252,7 @@ func (schedule *DailySchedule) AssignProperties_To_DailySchedule(destination *st
 func (schedule *DailySchedule) Initialize_From_DailySchedule_STATUS(source *DailySchedule_STATUS) error {
 
 	// IntervalDays
-	if source.IntervalDays != nil {
-		intervalDay := *source.IntervalDays
-		schedule.IntervalDays = &intervalDay
-	} else {
-		schedule.IntervalDays = nil
-	}
+	schedule.IntervalDays = genruntime.ClonePointerToInt(source.IntervalDays)
 
 	// No error
 	return nil
@@ -3508,12 +3418,7 @@ func (schedule *RelativeMonthlySchedule) AssignProperties_From_RelativeMonthlySc
 	}
 
 	// IntervalMonths
-	if source.IntervalMonths != nil {
-		intervalMonth := *source.IntervalMonths
-		schedule.IntervalMonths = &intervalMonth
-	} else {
-		schedule.IntervalMonths = nil
-	}
+	schedule.IntervalMonths = genruntime.ClonePointerToInt(source.IntervalMonths)
 
 	// WeekIndex
 	if source.WeekIndex != nil {
@@ -3542,12 +3447,7 @@ func (schedule *RelativeMonthlySchedule) AssignProperties_To_RelativeMonthlySche
 	}
 
 	// IntervalMonths
-	if schedule.IntervalMonths != nil {
-		intervalMonth := *schedule.IntervalMonths
-		destination.IntervalMonths = &intervalMonth
-	} else {
-		destination.IntervalMonths = nil
-	}
+	destination.IntervalMonths = genruntime.ClonePointerToInt(schedule.IntervalMonths)
 
 	// WeekIndex
 	if schedule.WeekIndex != nil {
@@ -3580,12 +3480,7 @@ func (schedule *RelativeMonthlySchedule) Initialize_From_RelativeMonthlySchedule
 	}
 
 	// IntervalMonths
-	if source.IntervalMonths != nil {
-		intervalMonth := *source.IntervalMonths
-		schedule.IntervalMonths = &intervalMonth
-	} else {
-		schedule.IntervalMonths = nil
-	}
+	schedule.IntervalMonths = genruntime.ClonePointerToInt(source.IntervalMonths)
 
 	// WeekIndex
 	if source.WeekIndex != nil {
@@ -3795,12 +3690,7 @@ func (schedule *WeeklySchedule) AssignProperties_From_WeeklySchedule(source *sto
 	}
 
 	// IntervalWeeks
-	if source.IntervalWeeks != nil {
-		intervalWeek := *source.IntervalWeeks
-		schedule.IntervalWeeks = &intervalWeek
-	} else {
-		schedule.IntervalWeeks = nil
-	}
+	schedule.IntervalWeeks = genruntime.ClonePointerToInt(source.IntervalWeeks)
 
 	// No error
 	return nil
@@ -3820,12 +3710,7 @@ func (schedule *WeeklySchedule) AssignProperties_To_WeeklySchedule(destination *
 	}
 
 	// IntervalWeeks
-	if schedule.IntervalWeeks != nil {
-		intervalWeek := *schedule.IntervalWeeks
-		destination.IntervalWeeks = &intervalWeek
-	} else {
-		destination.IntervalWeeks = nil
-	}
+	destination.IntervalWeeks = genruntime.ClonePointerToInt(schedule.IntervalWeeks)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -3850,12 +3735,7 @@ func (schedule *WeeklySchedule) Initialize_From_WeeklySchedule_STATUS(source *We
 	}
 
 	// IntervalWeeks
-	if source.IntervalWeeks != nil {
-		intervalWeek := *source.IntervalWeeks
-		schedule.IntervalWeeks = &intervalWeek
-	} else {
-		schedule.IntervalWeeks = nil
-	}
+	schedule.IntervalWeeks = genruntime.ClonePointerToInt(source.IntervalWeeks)
 
 	// No error
 	return nil

--- a/v2/api/containerservice/v1api20240901/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1api20240901/managed_cluster_types_gen.go
@@ -4723,12 +4723,7 @@ func (profile *ContainerServiceLinuxProfile) PopulateFromARM(owner genruntime.Ar
 func (profile *ContainerServiceLinuxProfile) AssignProperties_From_ContainerServiceLinuxProfile(source *storage.ContainerServiceLinuxProfile) error {
 
 	// AdminUsername
-	if source.AdminUsername != nil {
-		adminUsername := *source.AdminUsername
-		profile.AdminUsername = &adminUsername
-	} else {
-		profile.AdminUsername = nil
-	}
+	profile.AdminUsername = genruntime.ClonePointerToString(source.AdminUsername)
 
 	// Ssh
 	if source.Ssh != nil {
@@ -4752,12 +4747,7 @@ func (profile *ContainerServiceLinuxProfile) AssignProperties_To_ContainerServic
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AdminUsername
-	if profile.AdminUsername != nil {
-		adminUsername := *profile.AdminUsername
-		destination.AdminUsername = &adminUsername
-	} else {
-		destination.AdminUsername = nil
-	}
+	destination.AdminUsername = genruntime.ClonePointerToString(profile.AdminUsername)
 
 	// Ssh
 	if profile.Ssh != nil {
@@ -4786,12 +4776,7 @@ func (profile *ContainerServiceLinuxProfile) AssignProperties_To_ContainerServic
 func (profile *ContainerServiceLinuxProfile) Initialize_From_ContainerServiceLinuxProfile_STATUS(source *ContainerServiceLinuxProfile_STATUS) error {
 
 	// AdminUsername
-	if source.AdminUsername != nil {
-		adminUsername := *source.AdminUsername
-		profile.AdminUsername = &adminUsername
-	} else {
-		profile.AdminUsername = nil
-	}
+	profile.AdminUsername = genruntime.ClonePointerToString(source.AdminUsername)
 
 	// Ssh
 	if source.Ssh != nil {
@@ -5257,12 +5242,7 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_From_ContainerSe
 	}
 
 	// DnsServiceIP
-	if source.DnsServiceIP != nil {
-		dnsServiceIP := *source.DnsServiceIP
-		profile.DnsServiceIP = &dnsServiceIP
-	} else {
-		profile.DnsServiceIP = nil
-	}
+	profile.DnsServiceIP = genruntime.ClonePointerToString(source.DnsServiceIP)
 
 	// IpFamilies
 	if source.IpFamilies != nil {
@@ -5365,23 +5345,13 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_From_ContainerSe
 	}
 
 	// PodCidr
-	if source.PodCidr != nil {
-		podCidr := *source.PodCidr
-		profile.PodCidr = &podCidr
-	} else {
-		profile.PodCidr = nil
-	}
+	profile.PodCidr = genruntime.ClonePointerToString(source.PodCidr)
 
 	// PodCidrs
 	profile.PodCidrs = genruntime.CloneSliceOfString(source.PodCidrs)
 
 	// ServiceCidr
-	if source.ServiceCidr != nil {
-		serviceCidr := *source.ServiceCidr
-		profile.ServiceCidr = &serviceCidr
-	} else {
-		profile.ServiceCidr = nil
-	}
+	profile.ServiceCidr = genruntime.ClonePointerToString(source.ServiceCidr)
 
 	// ServiceCidrs
 	profile.ServiceCidrs = genruntime.CloneSliceOfString(source.ServiceCidrs)
@@ -5408,12 +5378,7 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_To_ContainerServ
 	}
 
 	// DnsServiceIP
-	if profile.DnsServiceIP != nil {
-		dnsServiceIP := *profile.DnsServiceIP
-		destination.DnsServiceIP = &dnsServiceIP
-	} else {
-		destination.DnsServiceIP = nil
-	}
+	destination.DnsServiceIP = genruntime.ClonePointerToString(profile.DnsServiceIP)
 
 	// IpFamilies
 	if profile.IpFamilies != nil {
@@ -5509,23 +5474,13 @@ func (profile *ContainerServiceNetworkProfile) AssignProperties_To_ContainerServ
 	}
 
 	// PodCidr
-	if profile.PodCidr != nil {
-		podCidr := *profile.PodCidr
-		destination.PodCidr = &podCidr
-	} else {
-		destination.PodCidr = nil
-	}
+	destination.PodCidr = genruntime.ClonePointerToString(profile.PodCidr)
 
 	// PodCidrs
 	destination.PodCidrs = genruntime.CloneSliceOfString(profile.PodCidrs)
 
 	// ServiceCidr
-	if profile.ServiceCidr != nil {
-		serviceCidr := *profile.ServiceCidr
-		destination.ServiceCidr = &serviceCidr
-	} else {
-		destination.ServiceCidr = nil
-	}
+	destination.ServiceCidr = genruntime.ClonePointerToString(profile.ServiceCidr)
 
 	// ServiceCidrs
 	destination.ServiceCidrs = genruntime.CloneSliceOfString(profile.ServiceCidrs)
@@ -5557,12 +5512,7 @@ func (profile *ContainerServiceNetworkProfile) Initialize_From_ContainerServiceN
 	}
 
 	// DnsServiceIP
-	if source.DnsServiceIP != nil {
-		dnsServiceIP := *source.DnsServiceIP
-		profile.DnsServiceIP = &dnsServiceIP
-	} else {
-		profile.DnsServiceIP = nil
-	}
+	profile.DnsServiceIP = genruntime.ClonePointerToString(source.DnsServiceIP)
 
 	// IpFamilies
 	if source.IpFamilies != nil {
@@ -5659,23 +5609,13 @@ func (profile *ContainerServiceNetworkProfile) Initialize_From_ContainerServiceN
 	}
 
 	// PodCidr
-	if source.PodCidr != nil {
-		podCidr := *source.PodCidr
-		profile.PodCidr = &podCidr
-	} else {
-		profile.PodCidr = nil
-	}
+	profile.PodCidr = genruntime.ClonePointerToString(source.PodCidr)
 
 	// PodCidrs
 	profile.PodCidrs = genruntime.CloneSliceOfString(source.PodCidrs)
 
 	// ServiceCidr
-	if source.ServiceCidr != nil {
-		serviceCidr := *source.ServiceCidr
-		profile.ServiceCidr = &serviceCidr
-	} else {
-		profile.ServiceCidr = nil
-	}
+	profile.ServiceCidr = genruntime.ClonePointerToString(source.ServiceCidr)
 
 	// ServiceCidrs
 	profile.ServiceCidrs = genruntime.CloneSliceOfString(source.ServiceCidrs)
@@ -8067,12 +8007,7 @@ func (profile *ManagedClusterAgentPoolProfile) AssignProperties_From_ManagedClus
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		profile.Name = &name
-	} else {
-		profile.Name = nil
-	}
+	profile.Name = genruntime.ClonePointerToString(source.Name)
 
 	// NetworkProfile
 	if source.NetworkProfile != nil {
@@ -8410,12 +8345,7 @@ func (profile *ManagedClusterAgentPoolProfile) AssignProperties_To_ManagedCluste
 	}
 
 	// Name
-	if profile.Name != nil {
-		name := *profile.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(profile.Name)
 
 	// NetworkProfile
 	if profile.NetworkProfile != nil {
@@ -8734,12 +8664,7 @@ func (profile *ManagedClusterAgentPoolProfile) Initialize_From_ManagedClusterAge
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		profile.Name = &name
-	} else {
-		profile.Name = nil
-	}
+	profile.Name = genruntime.ClonePointerToString(source.Name)
 
 	// NetworkProfile
 	if source.NetworkProfile != nil {
@@ -18440,12 +18365,7 @@ func (resource *DelegatedResource) AssignProperties_From_DelegatedResource(sourc
 	}
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		resource.TenantId = &tenantId
-	} else {
-		resource.TenantId = nil
-	}
+	resource.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// No error
 	return nil
@@ -18471,12 +18391,7 @@ func (resource *DelegatedResource) AssignProperties_To_DelegatedResource(destina
 	}
 
 	// TenantId
-	if resource.TenantId != nil {
-		tenantId := *resource.TenantId
-		destination.TenantId = &tenantId
-	} else {
-		destination.TenantId = nil
-	}
+	destination.TenantId = genruntime.ClonePointerToString(resource.TenantId)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -18507,12 +18422,7 @@ func (resource *DelegatedResource) Initialize_From_DelegatedResource_STATUS(sour
 	}
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		resource.TenantId = &tenantId
-	} else {
-		resource.TenantId = nil
-	}
+	resource.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// No error
 	return nil
@@ -18766,17 +18676,7 @@ func (mesh *IstioServiceMesh) AssignProperties_From_IstioServiceMesh(source *sto
 	}
 
 	// Revisions
-	if source.Revisions != nil {
-		revisionList := make([]string, len(source.Revisions))
-		for revisionIndex, revisionItem := range source.Revisions {
-			// Shadow the loop variable to avoid aliasing
-			revisionItem := revisionItem
-			revisionList[revisionIndex] = revisionItem
-		}
-		mesh.Revisions = revisionList
-	} else {
-		mesh.Revisions = nil
-	}
+	mesh.Revisions = genruntime.CloneSliceOfString(source.Revisions)
 
 	// No error
 	return nil
@@ -18812,17 +18712,7 @@ func (mesh *IstioServiceMesh) AssignProperties_To_IstioServiceMesh(destination *
 	}
 
 	// Revisions
-	if mesh.Revisions != nil {
-		revisionList := make([]string, len(mesh.Revisions))
-		for revisionIndex, revisionItem := range mesh.Revisions {
-			// Shadow the loop variable to avoid aliasing
-			revisionItem := revisionItem
-			revisionList[revisionIndex] = revisionItem
-		}
-		destination.Revisions = revisionList
-	} else {
-		destination.Revisions = nil
-	}
+	destination.Revisions = genruntime.CloneSliceOfString(mesh.Revisions)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -18863,17 +18753,7 @@ func (mesh *IstioServiceMesh) Initialize_From_IstioServiceMesh_STATUS(source *Is
 	}
 
 	// Revisions
-	if source.Revisions != nil {
-		revisionList := make([]string, len(source.Revisions))
-		for revisionIndex, revisionItem := range source.Revisions {
-			// Shadow the loop variable to avoid aliasing
-			revisionItem := revisionItem
-			revisionList[revisionIndex] = revisionItem
-		}
-		mesh.Revisions = revisionList
-	} else {
-		mesh.Revisions = nil
-	}
+	mesh.Revisions = genruntime.CloneSliceOfString(source.Revisions)
 
 	// No error
 	return nil
@@ -20107,12 +19987,7 @@ func (profile *ManagedClusterLoadBalancerProfile) PopulateFromARM(owner genrunti
 func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_From_ManagedClusterLoadBalancerProfile(source *storage.ManagedClusterLoadBalancerProfile) error {
 
 	// AllocatedOutboundPorts
-	if source.AllocatedOutboundPorts != nil {
-		allocatedOutboundPort := *source.AllocatedOutboundPorts
-		profile.AllocatedOutboundPorts = &allocatedOutboundPort
-	} else {
-		profile.AllocatedOutboundPorts = nil
-	}
+	profile.AllocatedOutboundPorts = genruntime.ClonePointerToInt(source.AllocatedOutboundPorts)
 
 	// BackendPoolType
 	if source.BackendPoolType != nil {
@@ -20150,12 +20025,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_From_ManagedC
 	}
 
 	// IdleTimeoutInMinutes
-	if source.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *source.IdleTimeoutInMinutes
-		profile.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		profile.IdleTimeoutInMinutes = nil
-	}
+	profile.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(source.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPs
 	if source.ManagedOutboundIPs != nil {
@@ -20203,12 +20073,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_To_ManagedClu
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AllocatedOutboundPorts
-	if profile.AllocatedOutboundPorts != nil {
-		allocatedOutboundPort := *profile.AllocatedOutboundPorts
-		destination.AllocatedOutboundPorts = &allocatedOutboundPort
-	} else {
-		destination.AllocatedOutboundPorts = nil
-	}
+	destination.AllocatedOutboundPorts = genruntime.ClonePointerToInt(profile.AllocatedOutboundPorts)
 
 	// BackendPoolType
 	if profile.BackendPoolType != nil {
@@ -20245,12 +20110,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_To_ManagedClu
 	}
 
 	// IdleTimeoutInMinutes
-	if profile.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *profile.IdleTimeoutInMinutes
-		destination.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		destination.IdleTimeoutInMinutes = nil
-	}
+	destination.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(profile.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPs
 	if profile.ManagedOutboundIPs != nil {
@@ -20303,12 +20163,7 @@ func (profile *ManagedClusterLoadBalancerProfile) AssignProperties_To_ManagedClu
 func (profile *ManagedClusterLoadBalancerProfile) Initialize_From_ManagedClusterLoadBalancerProfile_STATUS(source *ManagedClusterLoadBalancerProfile_STATUS) error {
 
 	// AllocatedOutboundPorts
-	if source.AllocatedOutboundPorts != nil {
-		allocatedOutboundPort := *source.AllocatedOutboundPorts
-		profile.AllocatedOutboundPorts = &allocatedOutboundPort
-	} else {
-		profile.AllocatedOutboundPorts = nil
-	}
+	profile.AllocatedOutboundPorts = genruntime.ClonePointerToInt(source.AllocatedOutboundPorts)
 
 	// BackendPoolType
 	if source.BackendPoolType != nil {
@@ -20345,12 +20200,7 @@ func (profile *ManagedClusterLoadBalancerProfile) Initialize_From_ManagedCluster
 	}
 
 	// IdleTimeoutInMinutes
-	if source.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *source.IdleTimeoutInMinutes
-		profile.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		profile.IdleTimeoutInMinutes = nil
-	}
+	profile.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(source.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPs
 	if source.ManagedOutboundIPs != nil {
@@ -20800,12 +20650,7 @@ func (profile *ManagedClusterNATGatewayProfile) AssignProperties_From_ManagedClu
 	}
 
 	// IdleTimeoutInMinutes
-	if source.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *source.IdleTimeoutInMinutes
-		profile.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		profile.IdleTimeoutInMinutes = nil
-	}
+	profile.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(source.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPProfile
 	if source.ManagedOutboundIPProfile != nil {
@@ -20847,12 +20692,7 @@ func (profile *ManagedClusterNATGatewayProfile) AssignProperties_To_ManagedClust
 	}
 
 	// IdleTimeoutInMinutes
-	if profile.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *profile.IdleTimeoutInMinutes
-		destination.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		destination.IdleTimeoutInMinutes = nil
-	}
+	destination.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(profile.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPProfile
 	if profile.ManagedOutboundIPProfile != nil {
@@ -20899,12 +20739,7 @@ func (profile *ManagedClusterNATGatewayProfile) Initialize_From_ManagedClusterNA
 	}
 
 	// IdleTimeoutInMinutes
-	if source.IdleTimeoutInMinutes != nil {
-		idleTimeoutInMinute := *source.IdleTimeoutInMinutes
-		profile.IdleTimeoutInMinutes = &idleTimeoutInMinute
-	} else {
-		profile.IdleTimeoutInMinutes = nil
-	}
+	profile.IdleTimeoutInMinutes = genruntime.ClonePointerToInt(source.IdleTimeoutInMinutes)
 
 	// ManagedOutboundIPProfile
 	if source.ManagedOutboundIPProfile != nil {
@@ -25479,20 +25314,10 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) PopulateFromARM
 func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) AssignProperties_From_ManagedClusterLoadBalancerProfile_ManagedOutboundIPs(source *storage.ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		iPs.Count = &count
-	} else {
-		iPs.Count = nil
-	}
+	iPs.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// CountIPv6
-	if source.CountIPv6 != nil {
-		countIPv6 := *source.CountIPv6
-		iPs.CountIPv6 = &countIPv6
-	} else {
-		iPs.CountIPv6 = nil
-	}
+	iPs.CountIPv6 = genruntime.ClonePointerToInt(source.CountIPv6)
 
 	// No error
 	return nil
@@ -25504,20 +25329,10 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) AssignPropertie
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Count
-	if iPs.Count != nil {
-		count := *iPs.Count
-		destination.Count = &count
-	} else {
-		destination.Count = nil
-	}
+	destination.Count = genruntime.ClonePointerToInt(iPs.Count)
 
 	// CountIPv6
-	if iPs.CountIPv6 != nil {
-		countIPv6 := *iPs.CountIPv6
-		destination.CountIPv6 = &countIPv6
-	} else {
-		destination.CountIPv6 = nil
-	}
+	destination.CountIPv6 = genruntime.ClonePointerToInt(iPs.CountIPv6)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -25534,20 +25349,10 @@ func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) AssignPropertie
 func (iPs *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs) Initialize_From_ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS(source *ManagedClusterLoadBalancerProfile_ManagedOutboundIPs_STATUS) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		iPs.Count = &count
-	} else {
-		iPs.Count = nil
-	}
+	iPs.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// CountIPv6
-	if source.CountIPv6 != nil {
-		countIPv6 := *source.CountIPv6
-		iPs.CountIPv6 = &countIPv6
-	} else {
-		iPs.CountIPv6 = nil
-	}
+	iPs.CountIPv6 = genruntime.ClonePointerToInt(source.CountIPv6)
 
 	// No error
 	return nil
@@ -26134,12 +25939,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) PopulateFromARM(owner gen
 func (profile *ManagedClusterManagedOutboundIPProfile) AssignProperties_From_ManagedClusterManagedOutboundIPProfile(source *storage.ManagedClusterManagedOutboundIPProfile) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		profile.Count = &count
-	} else {
-		profile.Count = nil
-	}
+	profile.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// No error
 	return nil
@@ -26151,12 +25951,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) AssignProperties_To_Manag
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Count
-	if profile.Count != nil {
-		count := *profile.Count
-		destination.Count = &count
-	} else {
-		destination.Count = nil
-	}
+	destination.Count = genruntime.ClonePointerToInt(profile.Count)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -26173,12 +25968,7 @@ func (profile *ManagedClusterManagedOutboundIPProfile) AssignProperties_To_Manag
 func (profile *ManagedClusterManagedOutboundIPProfile) Initialize_From_ManagedClusterManagedOutboundIPProfile_STATUS(source *ManagedClusterManagedOutboundIPProfile_STATUS) error {
 
 	// Count
-	if source.Count != nil {
-		count := *source.Count
-		profile.Count = &count
-	} else {
-		profile.Count = nil
-	}
+	profile.Count = genruntime.ClonePointerToInt(source.Count)
 
 	// No error
 	return nil

--- a/v2/api/containerservice/v1api20240901/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1api20240901/managed_clusters_agent_pool_types_gen.go
@@ -4421,23 +4421,13 @@ func (settings *AgentPoolUpgradeSettings) PopulateFromARM(owner genruntime.Arbit
 func (settings *AgentPoolUpgradeSettings) AssignProperties_From_AgentPoolUpgradeSettings(source *storage.AgentPoolUpgradeSettings) error {
 
 	// DrainTimeoutInMinutes
-	if source.DrainTimeoutInMinutes != nil {
-		drainTimeoutInMinute := *source.DrainTimeoutInMinutes
-		settings.DrainTimeoutInMinutes = &drainTimeoutInMinute
-	} else {
-		settings.DrainTimeoutInMinutes = nil
-	}
+	settings.DrainTimeoutInMinutes = genruntime.ClonePointerToInt(source.DrainTimeoutInMinutes)
 
 	// MaxSurge
 	settings.MaxSurge = genruntime.ClonePointerToString(source.MaxSurge)
 
 	// NodeSoakDurationInMinutes
-	if source.NodeSoakDurationInMinutes != nil {
-		nodeSoakDurationInMinute := *source.NodeSoakDurationInMinutes
-		settings.NodeSoakDurationInMinutes = &nodeSoakDurationInMinute
-	} else {
-		settings.NodeSoakDurationInMinutes = nil
-	}
+	settings.NodeSoakDurationInMinutes = genruntime.ClonePointerToInt(source.NodeSoakDurationInMinutes)
 
 	// No error
 	return nil
@@ -4449,23 +4439,13 @@ func (settings *AgentPoolUpgradeSettings) AssignProperties_To_AgentPoolUpgradeSe
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DrainTimeoutInMinutes
-	if settings.DrainTimeoutInMinutes != nil {
-		drainTimeoutInMinute := *settings.DrainTimeoutInMinutes
-		destination.DrainTimeoutInMinutes = &drainTimeoutInMinute
-	} else {
-		destination.DrainTimeoutInMinutes = nil
-	}
+	destination.DrainTimeoutInMinutes = genruntime.ClonePointerToInt(settings.DrainTimeoutInMinutes)
 
 	// MaxSurge
 	destination.MaxSurge = genruntime.ClonePointerToString(settings.MaxSurge)
 
 	// NodeSoakDurationInMinutes
-	if settings.NodeSoakDurationInMinutes != nil {
-		nodeSoakDurationInMinute := *settings.NodeSoakDurationInMinutes
-		destination.NodeSoakDurationInMinutes = &nodeSoakDurationInMinute
-	} else {
-		destination.NodeSoakDurationInMinutes = nil
-	}
+	destination.NodeSoakDurationInMinutes = genruntime.ClonePointerToInt(settings.NodeSoakDurationInMinutes)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4482,23 +4462,13 @@ func (settings *AgentPoolUpgradeSettings) AssignProperties_To_AgentPoolUpgradeSe
 func (settings *AgentPoolUpgradeSettings) Initialize_From_AgentPoolUpgradeSettings_STATUS(source *AgentPoolUpgradeSettings_STATUS) error {
 
 	// DrainTimeoutInMinutes
-	if source.DrainTimeoutInMinutes != nil {
-		drainTimeoutInMinute := *source.DrainTimeoutInMinutes
-		settings.DrainTimeoutInMinutes = &drainTimeoutInMinute
-	} else {
-		settings.DrainTimeoutInMinutes = nil
-	}
+	settings.DrainTimeoutInMinutes = genruntime.ClonePointerToInt(source.DrainTimeoutInMinutes)
 
 	// MaxSurge
 	settings.MaxSurge = genruntime.ClonePointerToString(source.MaxSurge)
 
 	// NodeSoakDurationInMinutes
-	if source.NodeSoakDurationInMinutes != nil {
-		nodeSoakDurationInMinute := *source.NodeSoakDurationInMinutes
-		settings.NodeSoakDurationInMinutes = &nodeSoakDurationInMinute
-	} else {
-		settings.NodeSoakDurationInMinutes = nil
-	}
+	settings.NodeSoakDurationInMinutes = genruntime.ClonePointerToInt(source.NodeSoakDurationInMinutes)
 
 	// No error
 	return nil
@@ -5179,12 +5149,7 @@ func (config *KubeletConfig) AssignProperties_From_KubeletConfig(source *storage
 	config.AllowedUnsafeSysctls = genruntime.CloneSliceOfString(source.AllowedUnsafeSysctls)
 
 	// ContainerLogMaxFiles
-	if source.ContainerLogMaxFiles != nil {
-		containerLogMaxFile := *source.ContainerLogMaxFiles
-		config.ContainerLogMaxFiles = &containerLogMaxFile
-	} else {
-		config.ContainerLogMaxFiles = nil
-	}
+	config.ContainerLogMaxFiles = genruntime.ClonePointerToInt(source.ContainerLogMaxFiles)
 
 	// ContainerLogMaxSizeMB
 	config.ContainerLogMaxSizeMB = genruntime.ClonePointerToInt(source.ContainerLogMaxSizeMB)
@@ -5236,12 +5201,7 @@ func (config *KubeletConfig) AssignProperties_To_KubeletConfig(destination *stor
 	destination.AllowedUnsafeSysctls = genruntime.CloneSliceOfString(config.AllowedUnsafeSysctls)
 
 	// ContainerLogMaxFiles
-	if config.ContainerLogMaxFiles != nil {
-		containerLogMaxFile := *config.ContainerLogMaxFiles
-		destination.ContainerLogMaxFiles = &containerLogMaxFile
-	} else {
-		destination.ContainerLogMaxFiles = nil
-	}
+	destination.ContainerLogMaxFiles = genruntime.ClonePointerToInt(config.ContainerLogMaxFiles)
 
 	// ContainerLogMaxSizeMB
 	destination.ContainerLogMaxSizeMB = genruntime.ClonePointerToInt(config.ContainerLogMaxSizeMB)
@@ -5298,12 +5258,7 @@ func (config *KubeletConfig) Initialize_From_KubeletConfig_STATUS(source *Kubele
 	config.AllowedUnsafeSysctls = genruntime.CloneSliceOfString(source.AllowedUnsafeSysctls)
 
 	// ContainerLogMaxFiles
-	if source.ContainerLogMaxFiles != nil {
-		containerLogMaxFile := *source.ContainerLogMaxFiles
-		config.ContainerLogMaxFiles = &containerLogMaxFile
-	} else {
-		config.ContainerLogMaxFiles = nil
-	}
+	config.ContainerLogMaxFiles = genruntime.ClonePointerToInt(source.ContainerLogMaxFiles)
 
 	// ContainerLogMaxSizeMB
 	config.ContainerLogMaxSizeMB = genruntime.ClonePointerToInt(source.ContainerLogMaxSizeMB)
@@ -6640,20 +6595,10 @@ func (portRange *PortRange) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 func (portRange *PortRange) AssignProperties_From_PortRange(source *storage.PortRange) error {
 
 	// PortEnd
-	if source.PortEnd != nil {
-		portEnd := *source.PortEnd
-		portRange.PortEnd = &portEnd
-	} else {
-		portRange.PortEnd = nil
-	}
+	portRange.PortEnd = genruntime.ClonePointerToInt(source.PortEnd)
 
 	// PortStart
-	if source.PortStart != nil {
-		portStart := *source.PortStart
-		portRange.PortStart = &portStart
-	} else {
-		portRange.PortStart = nil
-	}
+	portRange.PortStart = genruntime.ClonePointerToInt(source.PortStart)
 
 	// Protocol
 	if source.Protocol != nil {
@@ -6674,20 +6619,10 @@ func (portRange *PortRange) AssignProperties_To_PortRange(destination *storage.P
 	propertyBag := genruntime.NewPropertyBag()
 
 	// PortEnd
-	if portRange.PortEnd != nil {
-		portEnd := *portRange.PortEnd
-		destination.PortEnd = &portEnd
-	} else {
-		destination.PortEnd = nil
-	}
+	destination.PortEnd = genruntime.ClonePointerToInt(portRange.PortEnd)
 
 	// PortStart
-	if portRange.PortStart != nil {
-		portStart := *portRange.PortStart
-		destination.PortStart = &portStart
-	} else {
-		destination.PortStart = nil
-	}
+	destination.PortStart = genruntime.ClonePointerToInt(portRange.PortStart)
 
 	// Protocol
 	if portRange.Protocol != nil {
@@ -6712,20 +6647,10 @@ func (portRange *PortRange) AssignProperties_To_PortRange(destination *storage.P
 func (portRange *PortRange) Initialize_From_PortRange_STATUS(source *PortRange_STATUS) error {
 
 	// PortEnd
-	if source.PortEnd != nil {
-		portEnd := *source.PortEnd
-		portRange.PortEnd = &portEnd
-	} else {
-		portRange.PortEnd = nil
-	}
+	portRange.PortEnd = genruntime.ClonePointerToInt(source.PortEnd)
 
 	// PortStart
-	if source.PortStart != nil {
-		portStart := *source.PortStart
-		portRange.PortStart = &portStart
-	} else {
-		portRange.PortStart = nil
-	}
+	portRange.PortStart = genruntime.ClonePointerToInt(source.PortStart)
 
 	// Protocol
 	if source.Protocol != nil {
@@ -7388,28 +7313,13 @@ func (config *SysctlConfig) AssignProperties_From_SysctlConfig(source *storage.S
 	}
 
 	// NetIpv4TcpkeepaliveIntvl
-	if source.NetIpv4TcpkeepaliveIntvl != nil {
-		netIpv4TcpkeepaliveIntvl := *source.NetIpv4TcpkeepaliveIntvl
-		config.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
-	} else {
-		config.NetIpv4TcpkeepaliveIntvl = nil
-	}
+	config.NetIpv4TcpkeepaliveIntvl = genruntime.ClonePointerToInt(source.NetIpv4TcpkeepaliveIntvl)
 
 	// NetNetfilterNfConntrackBuckets
-	if source.NetNetfilterNfConntrackBuckets != nil {
-		netNetfilterNfConntrackBucket := *source.NetNetfilterNfConntrackBuckets
-		config.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBucket
-	} else {
-		config.NetNetfilterNfConntrackBuckets = nil
-	}
+	config.NetNetfilterNfConntrackBuckets = genruntime.ClonePointerToInt(source.NetNetfilterNfConntrackBuckets)
 
 	// NetNetfilterNfConntrackMax
-	if source.NetNetfilterNfConntrackMax != nil {
-		netNetfilterNfConntrackMax := *source.NetNetfilterNfConntrackMax
-		config.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
-	} else {
-		config.NetNetfilterNfConntrackMax = nil
-	}
+	config.NetNetfilterNfConntrackMax = genruntime.ClonePointerToInt(source.NetNetfilterNfConntrackMax)
 
 	// VmMaxMapCount
 	config.VmMaxMapCount = genruntime.ClonePointerToInt(source.VmMaxMapCount)
@@ -7501,28 +7411,13 @@ func (config *SysctlConfig) AssignProperties_To_SysctlConfig(destination *storag
 	}
 
 	// NetIpv4TcpkeepaliveIntvl
-	if config.NetIpv4TcpkeepaliveIntvl != nil {
-		netIpv4TcpkeepaliveIntvl := *config.NetIpv4TcpkeepaliveIntvl
-		destination.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
-	} else {
-		destination.NetIpv4TcpkeepaliveIntvl = nil
-	}
+	destination.NetIpv4TcpkeepaliveIntvl = genruntime.ClonePointerToInt(config.NetIpv4TcpkeepaliveIntvl)
 
 	// NetNetfilterNfConntrackBuckets
-	if config.NetNetfilterNfConntrackBuckets != nil {
-		netNetfilterNfConntrackBucket := *config.NetNetfilterNfConntrackBuckets
-		destination.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBucket
-	} else {
-		destination.NetNetfilterNfConntrackBuckets = nil
-	}
+	destination.NetNetfilterNfConntrackBuckets = genruntime.ClonePointerToInt(config.NetNetfilterNfConntrackBuckets)
 
 	// NetNetfilterNfConntrackMax
-	if config.NetNetfilterNfConntrackMax != nil {
-		netNetfilterNfConntrackMax := *config.NetNetfilterNfConntrackMax
-		destination.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
-	} else {
-		destination.NetNetfilterNfConntrackMax = nil
-	}
+	destination.NetNetfilterNfConntrackMax = genruntime.ClonePointerToInt(config.NetNetfilterNfConntrackMax)
 
 	// VmMaxMapCount
 	destination.VmMaxMapCount = genruntime.ClonePointerToInt(config.VmMaxMapCount)
@@ -7619,28 +7514,13 @@ func (config *SysctlConfig) Initialize_From_SysctlConfig_STATUS(source *SysctlCo
 	}
 
 	// NetIpv4TcpkeepaliveIntvl
-	if source.NetIpv4TcpkeepaliveIntvl != nil {
-		netIpv4TcpkeepaliveIntvl := *source.NetIpv4TcpkeepaliveIntvl
-		config.NetIpv4TcpkeepaliveIntvl = &netIpv4TcpkeepaliveIntvl
-	} else {
-		config.NetIpv4TcpkeepaliveIntvl = nil
-	}
+	config.NetIpv4TcpkeepaliveIntvl = genruntime.ClonePointerToInt(source.NetIpv4TcpkeepaliveIntvl)
 
 	// NetNetfilterNfConntrackBuckets
-	if source.NetNetfilterNfConntrackBuckets != nil {
-		netNetfilterNfConntrackBucket := *source.NetNetfilterNfConntrackBuckets
-		config.NetNetfilterNfConntrackBuckets = &netNetfilterNfConntrackBucket
-	} else {
-		config.NetNetfilterNfConntrackBuckets = nil
-	}
+	config.NetNetfilterNfConntrackBuckets = genruntime.ClonePointerToInt(source.NetNetfilterNfConntrackBuckets)
 
 	// NetNetfilterNfConntrackMax
-	if source.NetNetfilterNfConntrackMax != nil {
-		netNetfilterNfConntrackMax := *source.NetNetfilterNfConntrackMax
-		config.NetNetfilterNfConntrackMax = &netNetfilterNfConntrackMax
-	} else {
-		config.NetNetfilterNfConntrackMax = nil
-	}
+	config.NetNetfilterNfConntrackMax = genruntime.ClonePointerToInt(source.NetNetfilterNfConntrackMax)
 
 	// VmMaxMapCount
 	config.VmMaxMapCount = genruntime.ClonePointerToInt(source.VmMaxMapCount)

--- a/v2/api/dbformariadb/v1api20180601/server_types_gen.go
+++ b/v2/api/dbformariadb/v1api20180601/server_types_gen.go
@@ -1829,12 +1829,7 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 func (sku *Sku) AssignProperties_From_Sku(source *storage.Sku) error {
 
 	// Capacity
-	if source.Capacity != nil {
-		capacity := *source.Capacity
-		sku.Capacity = &capacity
-	} else {
-		sku.Capacity = nil
-	}
+	sku.Capacity = genruntime.ClonePointerToInt(source.Capacity)
 
 	// Family
 	sku.Family = genruntime.ClonePointerToString(source.Family)
@@ -1864,12 +1859,7 @@ func (sku *Sku) AssignProperties_To_Sku(destination *storage.Sku) error {
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Capacity
-	if sku.Capacity != nil {
-		capacity := *sku.Capacity
-		destination.Capacity = &capacity
-	} else {
-		destination.Capacity = nil
-	}
+	destination.Capacity = genruntime.ClonePointerToInt(sku.Capacity)
 
 	// Family
 	destination.Family = genruntime.ClonePointerToString(sku.Family)
@@ -1903,12 +1893,7 @@ func (sku *Sku) AssignProperties_To_Sku(destination *storage.Sku) error {
 func (sku *Sku) Initialize_From_Sku_STATUS(source *Sku_STATUS) error {
 
 	// Capacity
-	if source.Capacity != nil {
-		capacity := *source.Capacity
-		sku.Capacity = &capacity
-	} else {
-		sku.Capacity = nil
-	}
+	sku.Capacity = genruntime.ClonePointerToInt(source.Capacity)
 
 	// Family
 	sku.Family = genruntime.ClonePointerToString(source.Family)

--- a/v2/api/dbformysql/v1api20210501/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbformysql/v1api20210501/flexible_servers_firewall_rule_types_gen.go
@@ -403,12 +403,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	rule.AzureName = source.AzureName
 
 	// EndIpAddress
-	if source.EndIpAddress != nil {
-		endIpAddress := *source.EndIpAddress
-		rule.EndIpAddress = &endIpAddress
-	} else {
-		rule.EndIpAddress = nil
-	}
+	rule.EndIpAddress = genruntime.ClonePointerToString(source.EndIpAddress)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -431,12 +426,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	}
 
 	// StartIpAddress
-	if source.StartIpAddress != nil {
-		startIpAddress := *source.StartIpAddress
-		rule.StartIpAddress = &startIpAddress
-	} else {
-		rule.StartIpAddress = nil
-	}
+	rule.StartIpAddress = genruntime.ClonePointerToString(source.StartIpAddress)
 
 	// No error
 	return nil
@@ -451,12 +441,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	destination.AzureName = rule.AzureName
 
 	// EndIpAddress
-	if rule.EndIpAddress != nil {
-		endIpAddress := *rule.EndIpAddress
-		destination.EndIpAddress = &endIpAddress
-	} else {
-		destination.EndIpAddress = nil
-	}
+	destination.EndIpAddress = genruntime.ClonePointerToString(rule.EndIpAddress)
 
 	// OperatorSpec
 	if rule.OperatorSpec != nil {
@@ -482,12 +467,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	}
 
 	// StartIpAddress
-	if rule.StartIpAddress != nil {
-		startIpAddress := *rule.StartIpAddress
-		destination.StartIpAddress = &startIpAddress
-	} else {
-		destination.StartIpAddress = nil
-	}
+	destination.StartIpAddress = genruntime.ClonePointerToString(rule.StartIpAddress)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/dbformysql/v1api20230630/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbformysql/v1api20230630/flexible_servers_firewall_rule_types_gen.go
@@ -403,12 +403,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	rule.AzureName = source.AzureName
 
 	// EndIpAddress
-	if source.EndIpAddress != nil {
-		endIpAddress := *source.EndIpAddress
-		rule.EndIpAddress = &endIpAddress
-	} else {
-		rule.EndIpAddress = nil
-	}
+	rule.EndIpAddress = genruntime.ClonePointerToString(source.EndIpAddress)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -431,12 +426,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	}
 
 	// StartIpAddress
-	if source.StartIpAddress != nil {
-		startIpAddress := *source.StartIpAddress
-		rule.StartIpAddress = &startIpAddress
-	} else {
-		rule.StartIpAddress = nil
-	}
+	rule.StartIpAddress = genruntime.ClonePointerToString(source.StartIpAddress)
 
 	// No error
 	return nil
@@ -451,12 +441,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	destination.AzureName = rule.AzureName
 
 	// EndIpAddress
-	if rule.EndIpAddress != nil {
-		endIpAddress := *rule.EndIpAddress
-		destination.EndIpAddress = &endIpAddress
-	} else {
-		destination.EndIpAddress = nil
-	}
+	destination.EndIpAddress = genruntime.ClonePointerToString(rule.EndIpAddress)
 
 	// OperatorSpec
 	if rule.OperatorSpec != nil {
@@ -482,12 +467,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	}
 
 	// StartIpAddress
-	if rule.StartIpAddress != nil {
-		startIpAddress := *rule.StartIpAddress
-		destination.StartIpAddress = &startIpAddress
-	} else {
-		destination.StartIpAddress = nil
-	}
+	destination.StartIpAddress = genruntime.ClonePointerToString(rule.StartIpAddress)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/dbformysql/v1api20231230/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbformysql/v1api20231230/flexible_servers_firewall_rule_types_gen.go
@@ -400,12 +400,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	rule.AzureName = source.AzureName
 
 	// EndIpAddress
-	if source.EndIpAddress != nil {
-		endIpAddress := *source.EndIpAddress
-		rule.EndIpAddress = &endIpAddress
-	} else {
-		rule.EndIpAddress = nil
-	}
+	rule.EndIpAddress = genruntime.ClonePointerToString(source.EndIpAddress)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -428,12 +423,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	}
 
 	// StartIpAddress
-	if source.StartIpAddress != nil {
-		startIpAddress := *source.StartIpAddress
-		rule.StartIpAddress = &startIpAddress
-	} else {
-		rule.StartIpAddress = nil
-	}
+	rule.StartIpAddress = genruntime.ClonePointerToString(source.StartIpAddress)
 
 	// No error
 	return nil
@@ -448,12 +438,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	destination.AzureName = rule.AzureName
 
 	// EndIpAddress
-	if rule.EndIpAddress != nil {
-		endIpAddress := *rule.EndIpAddress
-		destination.EndIpAddress = &endIpAddress
-	} else {
-		destination.EndIpAddress = nil
-	}
+	destination.EndIpAddress = genruntime.ClonePointerToString(rule.EndIpAddress)
 
 	// OperatorSpec
 	if rule.OperatorSpec != nil {
@@ -479,12 +464,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	}
 
 	// StartIpAddress
-	if rule.StartIpAddress != nil {
-		startIpAddress := *rule.StartIpAddress
-		destination.StartIpAddress = &startIpAddress
-	} else {
-		destination.StartIpAddress = nil
-	}
+	destination.StartIpAddress = genruntime.ClonePointerToString(rule.StartIpAddress)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -501,20 +481,10 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 func (rule *FlexibleServersFirewallRule_Spec) Initialize_From_FlexibleServersFirewallRule_STATUS(source *FlexibleServersFirewallRule_STATUS) error {
 
 	// EndIpAddress
-	if source.EndIpAddress != nil {
-		endIpAddress := *source.EndIpAddress
-		rule.EndIpAddress = &endIpAddress
-	} else {
-		rule.EndIpAddress = nil
-	}
+	rule.EndIpAddress = genruntime.ClonePointerToString(source.EndIpAddress)
 
 	// StartIpAddress
-	if source.StartIpAddress != nil {
-		startIpAddress := *source.StartIpAddress
-		rule.StartIpAddress = &startIpAddress
-	} else {
-		rule.StartIpAddress = nil
-	}
+	rule.StartIpAddress = genruntime.ClonePointerToString(source.StartIpAddress)
 
 	// No error
 	return nil

--- a/v2/api/dbforpostgresql/v1api20210601/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20210601/flexible_servers_firewall_rule_types_gen.go
@@ -403,12 +403,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	rule.AzureName = source.AzureName
 
 	// EndIpAddress
-	if source.EndIpAddress != nil {
-		endIpAddress := *source.EndIpAddress
-		rule.EndIpAddress = &endIpAddress
-	} else {
-		rule.EndIpAddress = nil
-	}
+	rule.EndIpAddress = genruntime.ClonePointerToString(source.EndIpAddress)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -431,12 +426,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	}
 
 	// StartIpAddress
-	if source.StartIpAddress != nil {
-		startIpAddress := *source.StartIpAddress
-		rule.StartIpAddress = &startIpAddress
-	} else {
-		rule.StartIpAddress = nil
-	}
+	rule.StartIpAddress = genruntime.ClonePointerToString(source.StartIpAddress)
 
 	// No error
 	return nil
@@ -451,12 +441,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	destination.AzureName = rule.AzureName
 
 	// EndIpAddress
-	if rule.EndIpAddress != nil {
-		endIpAddress := *rule.EndIpAddress
-		destination.EndIpAddress = &endIpAddress
-	} else {
-		destination.EndIpAddress = nil
-	}
+	destination.EndIpAddress = genruntime.ClonePointerToString(rule.EndIpAddress)
 
 	// OperatorSpec
 	if rule.OperatorSpec != nil {
@@ -482,12 +467,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	}
 
 	// StartIpAddress
-	if rule.StartIpAddress != nil {
-		startIpAddress := *rule.StartIpAddress
-		destination.StartIpAddress = &startIpAddress
-	} else {
-		destination.StartIpAddress = nil
-	}
+	destination.StartIpAddress = genruntime.ClonePointerToString(rule.StartIpAddress)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/dbforpostgresql/v1api20220120preview/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20220120preview/flexible_servers_firewall_rule_types_gen.go
@@ -403,12 +403,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	rule.AzureName = source.AzureName
 
 	// EndIpAddress
-	if source.EndIpAddress != nil {
-		endIpAddress := *source.EndIpAddress
-		rule.EndIpAddress = &endIpAddress
-	} else {
-		rule.EndIpAddress = nil
-	}
+	rule.EndIpAddress = genruntime.ClonePointerToString(source.EndIpAddress)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -431,12 +426,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	}
 
 	// StartIpAddress
-	if source.StartIpAddress != nil {
-		startIpAddress := *source.StartIpAddress
-		rule.StartIpAddress = &startIpAddress
-	} else {
-		rule.StartIpAddress = nil
-	}
+	rule.StartIpAddress = genruntime.ClonePointerToString(source.StartIpAddress)
 
 	// No error
 	return nil
@@ -451,12 +441,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	destination.AzureName = rule.AzureName
 
 	// EndIpAddress
-	if rule.EndIpAddress != nil {
-		endIpAddress := *rule.EndIpAddress
-		destination.EndIpAddress = &endIpAddress
-	} else {
-		destination.EndIpAddress = nil
-	}
+	destination.EndIpAddress = genruntime.ClonePointerToString(rule.EndIpAddress)
 
 	// OperatorSpec
 	if rule.OperatorSpec != nil {
@@ -482,12 +467,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	}
 
 	// StartIpAddress
-	if rule.StartIpAddress != nil {
-		startIpAddress := *rule.StartIpAddress
-		destination.StartIpAddress = &startIpAddress
-	} else {
-		destination.StartIpAddress = nil
-	}
+	destination.StartIpAddress = genruntime.ClonePointerToString(rule.StartIpAddress)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/dbforpostgresql/v1api20221201/flexible_servers_database_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20221201/flexible_servers_database_types_gen.go
@@ -400,20 +400,10 @@ func (database *FlexibleServersDatabase_Spec) AssignProperties_From_FlexibleServ
 	database.AzureName = source.AzureName
 
 	// Charset
-	if source.Charset != nil {
-		charset := *source.Charset
-		database.Charset = &charset
-	} else {
-		database.Charset = nil
-	}
+	database.Charset = genruntime.ClonePointerToString(source.Charset)
 
 	// Collation
-	if source.Collation != nil {
-		collation := *source.Collation
-		database.Collation = &collation
-	} else {
-		database.Collation = nil
-	}
+	database.Collation = genruntime.ClonePointerToString(source.Collation)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -448,20 +438,10 @@ func (database *FlexibleServersDatabase_Spec) AssignProperties_To_FlexibleServer
 	destination.AzureName = database.AzureName
 
 	// Charset
-	if database.Charset != nil {
-		charset := *database.Charset
-		destination.Charset = &charset
-	} else {
-		destination.Charset = nil
-	}
+	destination.Charset = genruntime.ClonePointerToString(database.Charset)
 
 	// Collation
-	if database.Collation != nil {
-		collation := *database.Collation
-		destination.Collation = &collation
-	} else {
-		destination.Collation = nil
-	}
+	destination.Collation = genruntime.ClonePointerToString(database.Collation)
 
 	// OperatorSpec
 	if database.OperatorSpec != nil {
@@ -501,20 +481,10 @@ func (database *FlexibleServersDatabase_Spec) AssignProperties_To_FlexibleServer
 func (database *FlexibleServersDatabase_Spec) Initialize_From_FlexibleServersDatabase_STATUS(source *FlexibleServersDatabase_STATUS) error {
 
 	// Charset
-	if source.Charset != nil {
-		charset := *source.Charset
-		database.Charset = &charset
-	} else {
-		database.Charset = nil
-	}
+	database.Charset = genruntime.ClonePointerToString(source.Charset)
 
 	// Collation
-	if source.Collation != nil {
-		collation := *source.Collation
-		database.Collation = &collation
-	} else {
-		database.Collation = nil
-	}
+	database.Collation = genruntime.ClonePointerToString(source.Collation)
 
 	// No error
 	return nil

--- a/v2/api/dbforpostgresql/v1api20221201/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20221201/flexible_servers_firewall_rule_types_gen.go
@@ -402,12 +402,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	rule.AzureName = source.AzureName
 
 	// EndIpAddress
-	if source.EndIpAddress != nil {
-		endIpAddress := *source.EndIpAddress
-		rule.EndIpAddress = &endIpAddress
-	} else {
-		rule.EndIpAddress = nil
-	}
+	rule.EndIpAddress = genruntime.ClonePointerToString(source.EndIpAddress)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -430,12 +425,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	}
 
 	// StartIpAddress
-	if source.StartIpAddress != nil {
-		startIpAddress := *source.StartIpAddress
-		rule.StartIpAddress = &startIpAddress
-	} else {
-		rule.StartIpAddress = nil
-	}
+	rule.StartIpAddress = genruntime.ClonePointerToString(source.StartIpAddress)
 
 	// No error
 	return nil
@@ -450,12 +440,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	destination.AzureName = rule.AzureName
 
 	// EndIpAddress
-	if rule.EndIpAddress != nil {
-		endIpAddress := *rule.EndIpAddress
-		destination.EndIpAddress = &endIpAddress
-	} else {
-		destination.EndIpAddress = nil
-	}
+	destination.EndIpAddress = genruntime.ClonePointerToString(rule.EndIpAddress)
 
 	// OperatorSpec
 	if rule.OperatorSpec != nil {
@@ -481,12 +466,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	}
 
 	// StartIpAddress
-	if rule.StartIpAddress != nil {
-		startIpAddress := *rule.StartIpAddress
-		destination.StartIpAddress = &startIpAddress
-	} else {
-		destination.StartIpAddress = nil
-	}
+	destination.StartIpAddress = genruntime.ClonePointerToString(rule.StartIpAddress)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -503,20 +483,10 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 func (rule *FlexibleServersFirewallRule_Spec) Initialize_From_FlexibleServersFirewallRule_STATUS(source *FlexibleServersFirewallRule_STATUS) error {
 
 	// EndIpAddress
-	if source.EndIpAddress != nil {
-		endIpAddress := *source.EndIpAddress
-		rule.EndIpAddress = &endIpAddress
-	} else {
-		rule.EndIpAddress = nil
-	}
+	rule.EndIpAddress = genruntime.ClonePointerToString(source.EndIpAddress)
 
 	// StartIpAddress
-	if source.StartIpAddress != nil {
-		startIpAddress := *source.StartIpAddress
-		rule.StartIpAddress = &startIpAddress
-	} else {
-		rule.StartIpAddress = nil
-	}
+	rule.StartIpAddress = genruntime.ClonePointerToString(source.StartIpAddress)
 
 	// No error
 	return nil

--- a/v2/api/dbforpostgresql/v1api20230601preview/flexible_servers_database_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20230601preview/flexible_servers_database_types_gen.go
@@ -403,20 +403,10 @@ func (database *FlexibleServersDatabase_Spec) AssignProperties_From_FlexibleServ
 	database.AzureName = source.AzureName
 
 	// Charset
-	if source.Charset != nil {
-		charset := *source.Charset
-		database.Charset = &charset
-	} else {
-		database.Charset = nil
-	}
+	database.Charset = genruntime.ClonePointerToString(source.Charset)
 
 	// Collation
-	if source.Collation != nil {
-		collation := *source.Collation
-		database.Collation = &collation
-	} else {
-		database.Collation = nil
-	}
+	database.Collation = genruntime.ClonePointerToString(source.Collation)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -451,20 +441,10 @@ func (database *FlexibleServersDatabase_Spec) AssignProperties_To_FlexibleServer
 	destination.AzureName = database.AzureName
 
 	// Charset
-	if database.Charset != nil {
-		charset := *database.Charset
-		destination.Charset = &charset
-	} else {
-		destination.Charset = nil
-	}
+	destination.Charset = genruntime.ClonePointerToString(database.Charset)
 
 	// Collation
-	if database.Collation != nil {
-		collation := *database.Collation
-		destination.Collation = &collation
-	} else {
-		destination.Collation = nil
-	}
+	destination.Collation = genruntime.ClonePointerToString(database.Collation)
 
 	// OperatorSpec
 	if database.OperatorSpec != nil {

--- a/v2/api/dbforpostgresql/v1api20230601preview/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbforpostgresql/v1api20230601preview/flexible_servers_firewall_rule_types_gen.go
@@ -405,12 +405,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	rule.AzureName = source.AzureName
 
 	// EndIpAddress
-	if source.EndIpAddress != nil {
-		endIpAddress := *source.EndIpAddress
-		rule.EndIpAddress = &endIpAddress
-	} else {
-		rule.EndIpAddress = nil
-	}
+	rule.EndIpAddress = genruntime.ClonePointerToString(source.EndIpAddress)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -433,12 +428,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_From_FlexibleServ
 	}
 
 	// StartIpAddress
-	if source.StartIpAddress != nil {
-		startIpAddress := *source.StartIpAddress
-		rule.StartIpAddress = &startIpAddress
-	} else {
-		rule.StartIpAddress = nil
-	}
+	rule.StartIpAddress = genruntime.ClonePointerToString(source.StartIpAddress)
 
 	// No error
 	return nil
@@ -453,12 +443,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	destination.AzureName = rule.AzureName
 
 	// EndIpAddress
-	if rule.EndIpAddress != nil {
-		endIpAddress := *rule.EndIpAddress
-		destination.EndIpAddress = &endIpAddress
-	} else {
-		destination.EndIpAddress = nil
-	}
+	destination.EndIpAddress = genruntime.ClonePointerToString(rule.EndIpAddress)
 
 	// OperatorSpec
 	if rule.OperatorSpec != nil {
@@ -484,12 +469,7 @@ func (rule *FlexibleServersFirewallRule_Spec) AssignProperties_To_FlexibleServer
 	}
 
 	// StartIpAddress
-	if rule.StartIpAddress != nil {
-		startIpAddress := *rule.StartIpAddress
-		destination.StartIpAddress = &startIpAddress
-	} else {
-		destination.StartIpAddress = nil
-	}
+	destination.StartIpAddress = genruntime.ClonePointerToString(rule.StartIpAddress)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/devices/v1api20210702/iot_hub_types_gen.go
+++ b/v2/api/devices/v1api20210702/iot_hub_types_gen.go
@@ -3945,12 +3945,7 @@ func (properties *CloudToDeviceProperties) AssignProperties_From_CloudToDevicePr
 	}
 
 	// MaxDeliveryCount
-	if source.MaxDeliveryCount != nil {
-		maxDeliveryCount := *source.MaxDeliveryCount
-		properties.MaxDeliveryCount = &maxDeliveryCount
-	} else {
-		properties.MaxDeliveryCount = nil
-	}
+	properties.MaxDeliveryCount = genruntime.ClonePointerToInt(source.MaxDeliveryCount)
 
 	// No error
 	return nil
@@ -3977,12 +3972,7 @@ func (properties *CloudToDeviceProperties) AssignProperties_To_CloudToDeviceProp
 	}
 
 	// MaxDeliveryCount
-	if properties.MaxDeliveryCount != nil {
-		maxDeliveryCount := *properties.MaxDeliveryCount
-		destination.MaxDeliveryCount = &maxDeliveryCount
-	} else {
-		destination.MaxDeliveryCount = nil
-	}
+	destination.MaxDeliveryCount = genruntime.ClonePointerToInt(properties.MaxDeliveryCount)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4014,12 +4004,7 @@ func (properties *CloudToDeviceProperties) Initialize_From_CloudToDeviceProperti
 	}
 
 	// MaxDeliveryCount
-	if source.MaxDeliveryCount != nil {
-		maxDeliveryCount := *source.MaxDeliveryCount
-		properties.MaxDeliveryCount = &maxDeliveryCount
-	} else {
-		properties.MaxDeliveryCount = nil
-	}
+	properties.MaxDeliveryCount = genruntime.ClonePointerToInt(source.MaxDeliveryCount)
 
 	// No error
 	return nil
@@ -5142,12 +5127,7 @@ func (properties *MessagingEndpointProperties) AssignProperties_From_MessagingEn
 	properties.LockDurationAsIso8601 = genruntime.ClonePointerToString(source.LockDurationAsIso8601)
 
 	// MaxDeliveryCount
-	if source.MaxDeliveryCount != nil {
-		maxDeliveryCount := *source.MaxDeliveryCount
-		properties.MaxDeliveryCount = &maxDeliveryCount
-	} else {
-		properties.MaxDeliveryCount = nil
-	}
+	properties.MaxDeliveryCount = genruntime.ClonePointerToInt(source.MaxDeliveryCount)
 
 	// TtlAsIso8601
 	properties.TtlAsIso8601 = genruntime.ClonePointerToString(source.TtlAsIso8601)
@@ -5165,12 +5145,7 @@ func (properties *MessagingEndpointProperties) AssignProperties_To_MessagingEndp
 	destination.LockDurationAsIso8601 = genruntime.ClonePointerToString(properties.LockDurationAsIso8601)
 
 	// MaxDeliveryCount
-	if properties.MaxDeliveryCount != nil {
-		maxDeliveryCount := *properties.MaxDeliveryCount
-		destination.MaxDeliveryCount = &maxDeliveryCount
-	} else {
-		destination.MaxDeliveryCount = nil
-	}
+	destination.MaxDeliveryCount = genruntime.ClonePointerToInt(properties.MaxDeliveryCount)
 
 	// TtlAsIso8601
 	destination.TtlAsIso8601 = genruntime.ClonePointerToString(properties.TtlAsIso8601)
@@ -5193,12 +5168,7 @@ func (properties *MessagingEndpointProperties) Initialize_From_MessagingEndpoint
 	properties.LockDurationAsIso8601 = genruntime.ClonePointerToString(source.LockDurationAsIso8601)
 
 	// MaxDeliveryCount
-	if source.MaxDeliveryCount != nil {
-		maxDeliveryCount := *source.MaxDeliveryCount
-		properties.MaxDeliveryCount = &maxDeliveryCount
-	} else {
-		properties.MaxDeliveryCount = nil
-	}
+	properties.MaxDeliveryCount = genruntime.ClonePointerToInt(source.MaxDeliveryCount)
 
 	// TtlAsIso8601
 	properties.TtlAsIso8601 = genruntime.ClonePointerToString(source.TtlAsIso8601)
@@ -7043,17 +7013,7 @@ func (properties *EnrichmentProperties) PopulateFromARM(owner genruntime.Arbitra
 func (properties *EnrichmentProperties) AssignProperties_From_EnrichmentProperties(source *storage.EnrichmentProperties) error {
 
 	// EndpointNames
-	if source.EndpointNames != nil {
-		endpointNameList := make([]string, len(source.EndpointNames))
-		for endpointNameIndex, endpointNameItem := range source.EndpointNames {
-			// Shadow the loop variable to avoid aliasing
-			endpointNameItem := endpointNameItem
-			endpointNameList[endpointNameIndex] = endpointNameItem
-		}
-		properties.EndpointNames = endpointNameList
-	} else {
-		properties.EndpointNames = nil
-	}
+	properties.EndpointNames = genruntime.CloneSliceOfString(source.EndpointNames)
 
 	// Key
 	properties.Key = genruntime.ClonePointerToString(source.Key)
@@ -7071,17 +7031,7 @@ func (properties *EnrichmentProperties) AssignProperties_To_EnrichmentProperties
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointNames
-	if properties.EndpointNames != nil {
-		endpointNameList := make([]string, len(properties.EndpointNames))
-		for endpointNameIndex, endpointNameItem := range properties.EndpointNames {
-			// Shadow the loop variable to avoid aliasing
-			endpointNameItem := endpointNameItem
-			endpointNameList[endpointNameIndex] = endpointNameItem
-		}
-		destination.EndpointNames = endpointNameList
-	} else {
-		destination.EndpointNames = nil
-	}
+	destination.EndpointNames = genruntime.CloneSliceOfString(properties.EndpointNames)
 
 	// Key
 	destination.Key = genruntime.ClonePointerToString(properties.Key)
@@ -7104,17 +7054,7 @@ func (properties *EnrichmentProperties) AssignProperties_To_EnrichmentProperties
 func (properties *EnrichmentProperties) Initialize_From_EnrichmentProperties_STATUS(source *EnrichmentProperties_STATUS) error {
 
 	// EndpointNames
-	if source.EndpointNames != nil {
-		endpointNameList := make([]string, len(source.EndpointNames))
-		for endpointNameIndex, endpointNameItem := range source.EndpointNames {
-			// Shadow the loop variable to avoid aliasing
-			endpointNameItem := endpointNameItem
-			endpointNameList[endpointNameIndex] = endpointNameItem
-		}
-		properties.EndpointNames = endpointNameList
-	} else {
-		properties.EndpointNames = nil
-	}
+	properties.EndpointNames = genruntime.CloneSliceOfString(source.EndpointNames)
 
 	// Key
 	properties.Key = genruntime.ClonePointerToString(source.Key)
@@ -7337,17 +7277,7 @@ func (properties *FallbackRouteProperties) AssignProperties_From_FallbackRoutePr
 	properties.Condition = genruntime.ClonePointerToString(source.Condition)
 
 	// EndpointNames
-	if source.EndpointNames != nil {
-		endpointNameList := make([]string, len(source.EndpointNames))
-		for endpointNameIndex, endpointNameItem := range source.EndpointNames {
-			// Shadow the loop variable to avoid aliasing
-			endpointNameItem := endpointNameItem
-			endpointNameList[endpointNameIndex] = endpointNameItem
-		}
-		properties.EndpointNames = endpointNameList
-	} else {
-		properties.EndpointNames = nil
-	}
+	properties.EndpointNames = genruntime.CloneSliceOfString(source.EndpointNames)
 
 	// IsEnabled
 	if source.IsEnabled != nil {
@@ -7382,17 +7312,7 @@ func (properties *FallbackRouteProperties) AssignProperties_To_FallbackRouteProp
 	destination.Condition = genruntime.ClonePointerToString(properties.Condition)
 
 	// EndpointNames
-	if properties.EndpointNames != nil {
-		endpointNameList := make([]string, len(properties.EndpointNames))
-		for endpointNameIndex, endpointNameItem := range properties.EndpointNames {
-			// Shadow the loop variable to avoid aliasing
-			endpointNameItem := endpointNameItem
-			endpointNameList[endpointNameIndex] = endpointNameItem
-		}
-		destination.EndpointNames = endpointNameList
-	} else {
-		destination.EndpointNames = nil
-	}
+	destination.EndpointNames = genruntime.CloneSliceOfString(properties.EndpointNames)
 
 	// IsEnabled
 	if properties.IsEnabled != nil {
@@ -7431,17 +7351,7 @@ func (properties *FallbackRouteProperties) Initialize_From_FallbackRouteProperti
 	properties.Condition = genruntime.ClonePointerToString(source.Condition)
 
 	// EndpointNames
-	if source.EndpointNames != nil {
-		endpointNameList := make([]string, len(source.EndpointNames))
-		for endpointNameIndex, endpointNameItem := range source.EndpointNames {
-			// Shadow the loop variable to avoid aliasing
-			endpointNameItem := endpointNameItem
-			endpointNameList[endpointNameIndex] = endpointNameItem
-		}
-		properties.EndpointNames = endpointNameList
-	} else {
-		properties.EndpointNames = nil
-	}
+	properties.EndpointNames = genruntime.CloneSliceOfString(source.EndpointNames)
 
 	// IsEnabled
 	if source.IsEnabled != nil {
@@ -7698,12 +7608,7 @@ func (properties *FeedbackProperties) AssignProperties_From_FeedbackProperties(s
 	properties.LockDurationAsIso8601 = genruntime.ClonePointerToString(source.LockDurationAsIso8601)
 
 	// MaxDeliveryCount
-	if source.MaxDeliveryCount != nil {
-		maxDeliveryCount := *source.MaxDeliveryCount
-		properties.MaxDeliveryCount = &maxDeliveryCount
-	} else {
-		properties.MaxDeliveryCount = nil
-	}
+	properties.MaxDeliveryCount = genruntime.ClonePointerToInt(source.MaxDeliveryCount)
 
 	// TtlAsIso8601
 	properties.TtlAsIso8601 = genruntime.ClonePointerToString(source.TtlAsIso8601)
@@ -7721,12 +7626,7 @@ func (properties *FeedbackProperties) AssignProperties_To_FeedbackProperties(des
 	destination.LockDurationAsIso8601 = genruntime.ClonePointerToString(properties.LockDurationAsIso8601)
 
 	// MaxDeliveryCount
-	if properties.MaxDeliveryCount != nil {
-		maxDeliveryCount := *properties.MaxDeliveryCount
-		destination.MaxDeliveryCount = &maxDeliveryCount
-	} else {
-		destination.MaxDeliveryCount = nil
-	}
+	destination.MaxDeliveryCount = genruntime.ClonePointerToInt(properties.MaxDeliveryCount)
 
 	// TtlAsIso8601
 	destination.TtlAsIso8601 = genruntime.ClonePointerToString(properties.TtlAsIso8601)
@@ -7749,12 +7649,7 @@ func (properties *FeedbackProperties) Initialize_From_FeedbackProperties_STATUS(
 	properties.LockDurationAsIso8601 = genruntime.ClonePointerToString(source.LockDurationAsIso8601)
 
 	// MaxDeliveryCount
-	if source.MaxDeliveryCount != nil {
-		maxDeliveryCount := *source.MaxDeliveryCount
-		properties.MaxDeliveryCount = &maxDeliveryCount
-	} else {
-		properties.MaxDeliveryCount = nil
-	}
+	properties.MaxDeliveryCount = genruntime.ClonePointerToInt(source.MaxDeliveryCount)
 
 	// TtlAsIso8601
 	properties.TtlAsIso8601 = genruntime.ClonePointerToString(source.TtlAsIso8601)
@@ -8445,17 +8340,7 @@ func (properties *RouteProperties) AssignProperties_From_RouteProperties(source 
 	properties.Condition = genruntime.ClonePointerToString(source.Condition)
 
 	// EndpointNames
-	if source.EndpointNames != nil {
-		endpointNameList := make([]string, len(source.EndpointNames))
-		for endpointNameIndex, endpointNameItem := range source.EndpointNames {
-			// Shadow the loop variable to avoid aliasing
-			endpointNameItem := endpointNameItem
-			endpointNameList[endpointNameIndex] = endpointNameItem
-		}
-		properties.EndpointNames = endpointNameList
-	} else {
-		properties.EndpointNames = nil
-	}
+	properties.EndpointNames = genruntime.CloneSliceOfString(source.EndpointNames)
 
 	// IsEnabled
 	if source.IsEnabled != nil {
@@ -8466,12 +8351,7 @@ func (properties *RouteProperties) AssignProperties_From_RouteProperties(source 
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		properties.Name = &name
-	} else {
-		properties.Name = nil
-	}
+	properties.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Source
 	if source.Source != nil {
@@ -8495,17 +8375,7 @@ func (properties *RouteProperties) AssignProperties_To_RouteProperties(destinati
 	destination.Condition = genruntime.ClonePointerToString(properties.Condition)
 
 	// EndpointNames
-	if properties.EndpointNames != nil {
-		endpointNameList := make([]string, len(properties.EndpointNames))
-		for endpointNameIndex, endpointNameItem := range properties.EndpointNames {
-			// Shadow the loop variable to avoid aliasing
-			endpointNameItem := endpointNameItem
-			endpointNameList[endpointNameIndex] = endpointNameItem
-		}
-		destination.EndpointNames = endpointNameList
-	} else {
-		destination.EndpointNames = nil
-	}
+	destination.EndpointNames = genruntime.CloneSliceOfString(properties.EndpointNames)
 
 	// IsEnabled
 	if properties.IsEnabled != nil {
@@ -8516,12 +8386,7 @@ func (properties *RouteProperties) AssignProperties_To_RouteProperties(destinati
 	}
 
 	// Name
-	if properties.Name != nil {
-		name := *properties.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(properties.Name)
 
 	// Source
 	if properties.Source != nil {
@@ -8549,17 +8414,7 @@ func (properties *RouteProperties) Initialize_From_RouteProperties_STATUS(source
 	properties.Condition = genruntime.ClonePointerToString(source.Condition)
 
 	// EndpointNames
-	if source.EndpointNames != nil {
-		endpointNameList := make([]string, len(source.EndpointNames))
-		for endpointNameIndex, endpointNameItem := range source.EndpointNames {
-			// Shadow the loop variable to avoid aliasing
-			endpointNameItem := endpointNameItem
-			endpointNameList[endpointNameIndex] = endpointNameItem
-		}
-		properties.EndpointNames = endpointNameList
-	} else {
-		properties.EndpointNames = nil
-	}
+	properties.EndpointNames = genruntime.CloneSliceOfString(source.EndpointNames)
 
 	// IsEnabled
 	if source.IsEnabled != nil {
@@ -8570,12 +8425,7 @@ func (properties *RouteProperties) Initialize_From_RouteProperties_STATUS(source
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		properties.Name = &name
-	} else {
-		properties.Name = nil
-	}
+	properties.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Source
 	if source.Source != nil {
@@ -9755,12 +9605,7 @@ func (properties *RoutingEventHubProperties) AssignProperties_From_RoutingEventH
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		properties.Name = &name
-	} else {
-		properties.Name = nil
-	}
+	properties.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Reference
 	if source.Reference != nil {
@@ -9820,12 +9665,7 @@ func (properties *RoutingEventHubProperties) AssignProperties_To_RoutingEventHub
 	}
 
 	// Name
-	if properties.Name != nil {
-		name := *properties.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(properties.Name)
 
 	// Reference
 	if properties.Reference != nil {
@@ -9882,12 +9722,7 @@ func (properties *RoutingEventHubProperties) Initialize_From_RoutingEventHubProp
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		properties.Name = &name
-	} else {
-		properties.Name = nil
-	}
+	properties.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Reference
 	if source.Id != nil {
@@ -10330,12 +10165,7 @@ func (properties *RoutingServiceBusQueueEndpointProperties) AssignProperties_Fro
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		properties.Name = &name
-	} else {
-		properties.Name = nil
-	}
+	properties.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Reference
 	if source.Reference != nil {
@@ -10395,12 +10225,7 @@ func (properties *RoutingServiceBusQueueEndpointProperties) AssignProperties_To_
 	}
 
 	// Name
-	if properties.Name != nil {
-		name := *properties.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(properties.Name)
 
 	// Reference
 	if properties.Reference != nil {
@@ -10457,12 +10282,7 @@ func (properties *RoutingServiceBusQueueEndpointProperties) Initialize_From_Rout
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		properties.Name = &name
-	} else {
-		properties.Name = nil
-	}
+	properties.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Reference
 	if source.Id != nil {
@@ -10905,12 +10725,7 @@ func (properties *RoutingServiceBusTopicEndpointProperties) AssignProperties_Fro
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		properties.Name = &name
-	} else {
-		properties.Name = nil
-	}
+	properties.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Reference
 	if source.Reference != nil {
@@ -10970,12 +10785,7 @@ func (properties *RoutingServiceBusTopicEndpointProperties) AssignProperties_To_
 	}
 
 	// Name
-	if properties.Name != nil {
-		name := *properties.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(properties.Name)
 
 	// Reference
 	if properties.Reference != nil {
@@ -11032,12 +10842,7 @@ func (properties *RoutingServiceBusTopicEndpointProperties) Initialize_From_Rout
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		properties.Name = &name
-	} else {
-		properties.Name = nil
-	}
+	properties.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Reference
 	if source.Id != nil {
@@ -11527,12 +11332,7 @@ func (properties *RoutingStorageContainerProperties) AssignProperties_From_Routi
 	}
 
 	// BatchFrequencyInSeconds
-	if source.BatchFrequencyInSeconds != nil {
-		batchFrequencyInSecond := *source.BatchFrequencyInSeconds
-		properties.BatchFrequencyInSeconds = &batchFrequencyInSecond
-	} else {
-		properties.BatchFrequencyInSeconds = nil
-	}
+	properties.BatchFrequencyInSeconds = genruntime.ClonePointerToInt(source.BatchFrequencyInSeconds)
 
 	// ConnectionString
 	if source.ConnectionString != nil {
@@ -11573,20 +11373,10 @@ func (properties *RoutingStorageContainerProperties) AssignProperties_From_Routi
 	}
 
 	// MaxChunkSizeInBytes
-	if source.MaxChunkSizeInBytes != nil {
-		maxChunkSizeInByte := *source.MaxChunkSizeInBytes
-		properties.MaxChunkSizeInBytes = &maxChunkSizeInByte
-	} else {
-		properties.MaxChunkSizeInBytes = nil
-	}
+	properties.MaxChunkSizeInBytes = genruntime.ClonePointerToInt(source.MaxChunkSizeInBytes)
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		properties.Name = &name
-	} else {
-		properties.Name = nil
-	}
+	properties.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Reference
 	if source.Reference != nil {
@@ -11620,12 +11410,7 @@ func (properties *RoutingStorageContainerProperties) AssignProperties_To_Routing
 	}
 
 	// BatchFrequencyInSeconds
-	if properties.BatchFrequencyInSeconds != nil {
-		batchFrequencyInSecond := *properties.BatchFrequencyInSeconds
-		destination.BatchFrequencyInSeconds = &batchFrequencyInSecond
-	} else {
-		destination.BatchFrequencyInSeconds = nil
-	}
+	destination.BatchFrequencyInSeconds = genruntime.ClonePointerToInt(properties.BatchFrequencyInSeconds)
 
 	// ConnectionString
 	if properties.ConnectionString != nil {
@@ -11665,20 +11450,10 @@ func (properties *RoutingStorageContainerProperties) AssignProperties_To_Routing
 	}
 
 	// MaxChunkSizeInBytes
-	if properties.MaxChunkSizeInBytes != nil {
-		maxChunkSizeInByte := *properties.MaxChunkSizeInBytes
-		destination.MaxChunkSizeInBytes = &maxChunkSizeInByte
-	} else {
-		destination.MaxChunkSizeInBytes = nil
-	}
+	destination.MaxChunkSizeInBytes = genruntime.ClonePointerToInt(properties.MaxChunkSizeInBytes)
 
 	// Name
-	if properties.Name != nil {
-		name := *properties.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(properties.Name)
 
 	// Reference
 	if properties.Reference != nil {
@@ -11717,12 +11492,7 @@ func (properties *RoutingStorageContainerProperties) Initialize_From_RoutingStor
 	}
 
 	// BatchFrequencyInSeconds
-	if source.BatchFrequencyInSeconds != nil {
-		batchFrequencyInSecond := *source.BatchFrequencyInSeconds
-		properties.BatchFrequencyInSeconds = &batchFrequencyInSecond
-	} else {
-		properties.BatchFrequencyInSeconds = nil
-	}
+	properties.BatchFrequencyInSeconds = genruntime.ClonePointerToInt(source.BatchFrequencyInSeconds)
 
 	// ContainerName
 	properties.ContainerName = genruntime.ClonePointerToString(source.ContainerName)
@@ -11754,20 +11524,10 @@ func (properties *RoutingStorageContainerProperties) Initialize_From_RoutingStor
 	}
 
 	// MaxChunkSizeInBytes
-	if source.MaxChunkSizeInBytes != nil {
-		maxChunkSizeInByte := *source.MaxChunkSizeInBytes
-		properties.MaxChunkSizeInBytes = &maxChunkSizeInByte
-	} else {
-		properties.MaxChunkSizeInBytes = nil
-	}
+	properties.MaxChunkSizeInBytes = genruntime.ClonePointerToInt(source.MaxChunkSizeInBytes)
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		properties.Name = &name
-	} else {
-		properties.Name = nil
-	}
+	properties.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Reference
 	if source.Id != nil {

--- a/v2/api/documentdb/v1api20210515/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/database_account_types_gen.go
@@ -3663,20 +3663,10 @@ func (policy *ConsistencyPolicy) AssignProperties_From_ConsistencyPolicy(source 
 	}
 
 	// MaxIntervalInSeconds
-	if source.MaxIntervalInSeconds != nil {
-		maxIntervalInSecond := *source.MaxIntervalInSeconds
-		policy.MaxIntervalInSeconds = &maxIntervalInSecond
-	} else {
-		policy.MaxIntervalInSeconds = nil
-	}
+	policy.MaxIntervalInSeconds = genruntime.ClonePointerToInt(source.MaxIntervalInSeconds)
 
 	// MaxStalenessPrefix
-	if source.MaxStalenessPrefix != nil {
-		maxStalenessPrefix := *source.MaxStalenessPrefix
-		policy.MaxStalenessPrefix = &maxStalenessPrefix
-	} else {
-		policy.MaxStalenessPrefix = nil
-	}
+	policy.MaxStalenessPrefix = genruntime.ClonePointerToInt(source.MaxStalenessPrefix)
 
 	// No error
 	return nil
@@ -3696,20 +3686,10 @@ func (policy *ConsistencyPolicy) AssignProperties_To_ConsistencyPolicy(destinati
 	}
 
 	// MaxIntervalInSeconds
-	if policy.MaxIntervalInSeconds != nil {
-		maxIntervalInSecond := *policy.MaxIntervalInSeconds
-		destination.MaxIntervalInSeconds = &maxIntervalInSecond
-	} else {
-		destination.MaxIntervalInSeconds = nil
-	}
+	destination.MaxIntervalInSeconds = genruntime.ClonePointerToInt(policy.MaxIntervalInSeconds)
 
 	// MaxStalenessPrefix
-	if policy.MaxStalenessPrefix != nil {
-		maxStalenessPrefix := *policy.MaxStalenessPrefix
-		destination.MaxStalenessPrefix = &maxStalenessPrefix
-	} else {
-		destination.MaxStalenessPrefix = nil
-	}
+	destination.MaxStalenessPrefix = genruntime.ClonePointerToInt(policy.MaxStalenessPrefix)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -3953,12 +3933,7 @@ func (policy *CorsPolicy) AssignProperties_From_CorsPolicy(source *storage.CorsP
 	policy.ExposedHeaders = genruntime.ClonePointerToString(source.ExposedHeaders)
 
 	// MaxAgeInSeconds
-	if source.MaxAgeInSeconds != nil {
-		maxAgeInSecond := *source.MaxAgeInSeconds
-		policy.MaxAgeInSeconds = &maxAgeInSecond
-	} else {
-		policy.MaxAgeInSeconds = nil
-	}
+	policy.MaxAgeInSeconds = genruntime.ClonePointerToInt(source.MaxAgeInSeconds)
 
 	// No error
 	return nil
@@ -3982,12 +3957,7 @@ func (policy *CorsPolicy) AssignProperties_To_CorsPolicy(destination *storage.Co
 	destination.ExposedHeaders = genruntime.ClonePointerToString(policy.ExposedHeaders)
 
 	// MaxAgeInSeconds
-	if policy.MaxAgeInSeconds != nil {
-		maxAgeInSecond := *policy.MaxAgeInSeconds
-		destination.MaxAgeInSeconds = &maxAgeInSecond
-	} else {
-		destination.MaxAgeInSeconds = nil
-	}
+	destination.MaxAgeInSeconds = genruntime.ClonePointerToInt(policy.MaxAgeInSeconds)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4616,12 +4586,7 @@ func (location *Location) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 func (location *Location) AssignProperties_From_Location(source *storage.Location) error {
 
 	// FailoverPriority
-	if source.FailoverPriority != nil {
-		failoverPriority := *source.FailoverPriority
-		location.FailoverPriority = &failoverPriority
-	} else {
-		location.FailoverPriority = nil
-	}
+	location.FailoverPriority = genruntime.ClonePointerToInt(source.FailoverPriority)
 
 	// IsZoneRedundant
 	if source.IsZoneRedundant != nil {
@@ -4644,12 +4609,7 @@ func (location *Location) AssignProperties_To_Location(destination *storage.Loca
 	propertyBag := genruntime.NewPropertyBag()
 
 	// FailoverPriority
-	if location.FailoverPriority != nil {
-		failoverPriority := *location.FailoverPriority
-		destination.FailoverPriority = &failoverPriority
-	} else {
-		destination.FailoverPriority = nil
-	}
+	destination.FailoverPriority = genruntime.ClonePointerToInt(location.FailoverPriority)
 
 	// IsZoneRedundant
 	if location.IsZoneRedundant != nil {
@@ -6309,20 +6269,10 @@ func (properties *PeriodicModeProperties) PopulateFromARM(owner genruntime.Arbit
 func (properties *PeriodicModeProperties) AssignProperties_From_PeriodicModeProperties(source *storage.PeriodicModeProperties) error {
 
 	// BackupIntervalInMinutes
-	if source.BackupIntervalInMinutes != nil {
-		backupIntervalInMinute := *source.BackupIntervalInMinutes
-		properties.BackupIntervalInMinutes = &backupIntervalInMinute
-	} else {
-		properties.BackupIntervalInMinutes = nil
-	}
+	properties.BackupIntervalInMinutes = genruntime.ClonePointerToInt(source.BackupIntervalInMinutes)
 
 	// BackupRetentionIntervalInHours
-	if source.BackupRetentionIntervalInHours != nil {
-		backupRetentionIntervalInHour := *source.BackupRetentionIntervalInHours
-		properties.BackupRetentionIntervalInHours = &backupRetentionIntervalInHour
-	} else {
-		properties.BackupRetentionIntervalInHours = nil
-	}
+	properties.BackupRetentionIntervalInHours = genruntime.ClonePointerToInt(source.BackupRetentionIntervalInHours)
 
 	// No error
 	return nil
@@ -6334,20 +6284,10 @@ func (properties *PeriodicModeProperties) AssignProperties_To_PeriodicModeProper
 	propertyBag := genruntime.NewPropertyBag()
 
 	// BackupIntervalInMinutes
-	if properties.BackupIntervalInMinutes != nil {
-		backupIntervalInMinute := *properties.BackupIntervalInMinutes
-		destination.BackupIntervalInMinutes = &backupIntervalInMinute
-	} else {
-		destination.BackupIntervalInMinutes = nil
-	}
+	destination.BackupIntervalInMinutes = genruntime.ClonePointerToInt(properties.BackupIntervalInMinutes)
 
 	// BackupRetentionIntervalInHours
-	if properties.BackupRetentionIntervalInHours != nil {
-		backupRetentionIntervalInHour := *properties.BackupRetentionIntervalInHours
-		destination.BackupRetentionIntervalInHours = &backupRetentionIntervalInHour
-	} else {
-		destination.BackupRetentionIntervalInHours = nil
-	}
+	destination.BackupRetentionIntervalInHours = genruntime.ClonePointerToInt(properties.BackupRetentionIntervalInHours)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/documentdb/v1api20210515/sql_database_container_types_gen.go
+++ b/v2/api/documentdb/v1api20210515/sql_database_container_types_gen.go
@@ -1886,12 +1886,7 @@ func (partitionKey *ContainerPartitionKey) AssignProperties_From_ContainerPartit
 	partitionKey.Paths = genruntime.CloneSliceOfString(source.Paths)
 
 	// Version
-	if source.Version != nil {
-		version := *source.Version
-		partitionKey.Version = &version
-	} else {
-		partitionKey.Version = nil
-	}
+	partitionKey.Version = genruntime.ClonePointerToInt(source.Version)
 
 	// No error
 	return nil
@@ -1914,12 +1909,7 @@ func (partitionKey *ContainerPartitionKey) AssignProperties_To_ContainerPartitio
 	destination.Paths = genruntime.CloneSliceOfString(partitionKey.Paths)
 
 	// Version
-	if partitionKey.Version != nil {
-		version := *partitionKey.Version
-		destination.Version = &version
-	} else {
-		destination.Version = nil
-	}
+	destination.Version = genruntime.ClonePointerToInt(partitionKey.Version)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/documentdb/v1api20231115/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/database_account_types_gen.go
@@ -4257,12 +4257,7 @@ func (capacity *Capacity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 func (capacity *Capacity) AssignProperties_From_Capacity(source *storage.Capacity) error {
 
 	// TotalThroughputLimit
-	if source.TotalThroughputLimit != nil {
-		totalThroughputLimit := *source.TotalThroughputLimit
-		capacity.TotalThroughputLimit = &totalThroughputLimit
-	} else {
-		capacity.TotalThroughputLimit = nil
-	}
+	capacity.TotalThroughputLimit = genruntime.ClonePointerToInt(source.TotalThroughputLimit)
 
 	// No error
 	return nil
@@ -4274,12 +4269,7 @@ func (capacity *Capacity) AssignProperties_To_Capacity(destination *storage.Capa
 	propertyBag := genruntime.NewPropertyBag()
 
 	// TotalThroughputLimit
-	if capacity.TotalThroughputLimit != nil {
-		totalThroughputLimit := *capacity.TotalThroughputLimit
-		destination.TotalThroughputLimit = &totalThroughputLimit
-	} else {
-		destination.TotalThroughputLimit = nil
-	}
+	destination.TotalThroughputLimit = genruntime.ClonePointerToInt(capacity.TotalThroughputLimit)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4475,20 +4465,10 @@ func (policy *ConsistencyPolicy) AssignProperties_From_ConsistencyPolicy(source 
 	}
 
 	// MaxIntervalInSeconds
-	if source.MaxIntervalInSeconds != nil {
-		maxIntervalInSecond := *source.MaxIntervalInSeconds
-		policy.MaxIntervalInSeconds = &maxIntervalInSecond
-	} else {
-		policy.MaxIntervalInSeconds = nil
-	}
+	policy.MaxIntervalInSeconds = genruntime.ClonePointerToInt(source.MaxIntervalInSeconds)
 
 	// MaxStalenessPrefix
-	if source.MaxStalenessPrefix != nil {
-		maxStalenessPrefix := *source.MaxStalenessPrefix
-		policy.MaxStalenessPrefix = &maxStalenessPrefix
-	} else {
-		policy.MaxStalenessPrefix = nil
-	}
+	policy.MaxStalenessPrefix = genruntime.ClonePointerToInt(source.MaxStalenessPrefix)
 
 	// No error
 	return nil
@@ -4508,20 +4488,10 @@ func (policy *ConsistencyPolicy) AssignProperties_To_ConsistencyPolicy(destinati
 	}
 
 	// MaxIntervalInSeconds
-	if policy.MaxIntervalInSeconds != nil {
-		maxIntervalInSecond := *policy.MaxIntervalInSeconds
-		destination.MaxIntervalInSeconds = &maxIntervalInSecond
-	} else {
-		destination.MaxIntervalInSeconds = nil
-	}
+	destination.MaxIntervalInSeconds = genruntime.ClonePointerToInt(policy.MaxIntervalInSeconds)
 
 	// MaxStalenessPrefix
-	if policy.MaxStalenessPrefix != nil {
-		maxStalenessPrefix := *policy.MaxStalenessPrefix
-		destination.MaxStalenessPrefix = &maxStalenessPrefix
-	} else {
-		destination.MaxStalenessPrefix = nil
-	}
+	destination.MaxStalenessPrefix = genruntime.ClonePointerToInt(policy.MaxStalenessPrefix)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4765,12 +4735,7 @@ func (policy *CorsPolicy) AssignProperties_From_CorsPolicy(source *storage.CorsP
 	policy.ExposedHeaders = genruntime.ClonePointerToString(source.ExposedHeaders)
 
 	// MaxAgeInSeconds
-	if source.MaxAgeInSeconds != nil {
-		maxAgeInSecond := *source.MaxAgeInSeconds
-		policy.MaxAgeInSeconds = &maxAgeInSecond
-	} else {
-		policy.MaxAgeInSeconds = nil
-	}
+	policy.MaxAgeInSeconds = genruntime.ClonePointerToInt(source.MaxAgeInSeconds)
 
 	// No error
 	return nil
@@ -4794,12 +4759,7 @@ func (policy *CorsPolicy) AssignProperties_To_CorsPolicy(destination *storage.Co
 	destination.ExposedHeaders = genruntime.ClonePointerToString(policy.ExposedHeaders)
 
 	// MaxAgeInSeconds
-	if policy.MaxAgeInSeconds != nil {
-		maxAgeInSecond := *policy.MaxAgeInSeconds
-		destination.MaxAgeInSeconds = &maxAgeInSecond
-	} else {
-		destination.MaxAgeInSeconds = nil
-	}
+	destination.MaxAgeInSeconds = genruntime.ClonePointerToInt(policy.MaxAgeInSeconds)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -5653,12 +5613,7 @@ func (location *Location) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 func (location *Location) AssignProperties_From_Location(source *storage.Location) error {
 
 	// FailoverPriority
-	if source.FailoverPriority != nil {
-		failoverPriority := *source.FailoverPriority
-		location.FailoverPriority = &failoverPriority
-	} else {
-		location.FailoverPriority = nil
-	}
+	location.FailoverPriority = genruntime.ClonePointerToInt(source.FailoverPriority)
 
 	// IsZoneRedundant
 	if source.IsZoneRedundant != nil {
@@ -5681,12 +5636,7 @@ func (location *Location) AssignProperties_To_Location(destination *storage.Loca
 	propertyBag := genruntime.NewPropertyBag()
 
 	// FailoverPriority
-	if location.FailoverPriority != nil {
-		failoverPriority := *location.FailoverPriority
-		destination.FailoverPriority = &failoverPriority
-	} else {
-		destination.FailoverPriority = nil
-	}
+	destination.FailoverPriority = genruntime.ClonePointerToInt(location.FailoverPriority)
 
 	// IsZoneRedundant
 	if location.IsZoneRedundant != nil {
@@ -9178,20 +9128,10 @@ func (properties *PeriodicModeProperties) PopulateFromARM(owner genruntime.Arbit
 func (properties *PeriodicModeProperties) AssignProperties_From_PeriodicModeProperties(source *storage.PeriodicModeProperties) error {
 
 	// BackupIntervalInMinutes
-	if source.BackupIntervalInMinutes != nil {
-		backupIntervalInMinute := *source.BackupIntervalInMinutes
-		properties.BackupIntervalInMinutes = &backupIntervalInMinute
-	} else {
-		properties.BackupIntervalInMinutes = nil
-	}
+	properties.BackupIntervalInMinutes = genruntime.ClonePointerToInt(source.BackupIntervalInMinutes)
 
 	// BackupRetentionIntervalInHours
-	if source.BackupRetentionIntervalInHours != nil {
-		backupRetentionIntervalInHour := *source.BackupRetentionIntervalInHours
-		properties.BackupRetentionIntervalInHours = &backupRetentionIntervalInHour
-	} else {
-		properties.BackupRetentionIntervalInHours = nil
-	}
+	properties.BackupRetentionIntervalInHours = genruntime.ClonePointerToInt(source.BackupRetentionIntervalInHours)
 
 	// BackupStorageRedundancy
 	if source.BackupStorageRedundancy != nil {
@@ -9212,20 +9152,10 @@ func (properties *PeriodicModeProperties) AssignProperties_To_PeriodicModeProper
 	propertyBag := genruntime.NewPropertyBag()
 
 	// BackupIntervalInMinutes
-	if properties.BackupIntervalInMinutes != nil {
-		backupIntervalInMinute := *properties.BackupIntervalInMinutes
-		destination.BackupIntervalInMinutes = &backupIntervalInMinute
-	} else {
-		destination.BackupIntervalInMinutes = nil
-	}
+	destination.BackupIntervalInMinutes = genruntime.ClonePointerToInt(properties.BackupIntervalInMinutes)
 
 	// BackupRetentionIntervalInHours
-	if properties.BackupRetentionIntervalInHours != nil {
-		backupRetentionIntervalInHour := *properties.BackupRetentionIntervalInHours
-		destination.BackupRetentionIntervalInHours = &backupRetentionIntervalInHour
-	} else {
-		destination.BackupRetentionIntervalInHours = nil
-	}
+	destination.BackupRetentionIntervalInHours = genruntime.ClonePointerToInt(properties.BackupRetentionIntervalInHours)
 
 	// BackupStorageRedundancy
 	if properties.BackupStorageRedundancy != nil {

--- a/v2/api/documentdb/v1api20231115/sql_database_container_types_gen.go
+++ b/v2/api/documentdb/v1api20231115/sql_database_container_types_gen.go
@@ -1994,12 +1994,7 @@ func (policy *ClientEncryptionPolicy) AssignProperties_From_ClientEncryptionPoli
 	}
 
 	// PolicyFormatVersion
-	if source.PolicyFormatVersion != nil {
-		policyFormatVersion := *source.PolicyFormatVersion
-		policy.PolicyFormatVersion = &policyFormatVersion
-	} else {
-		policy.PolicyFormatVersion = nil
-	}
+	policy.PolicyFormatVersion = genruntime.ClonePointerToInt(source.PolicyFormatVersion)
 
 	// No error
 	return nil
@@ -2029,12 +2024,7 @@ func (policy *ClientEncryptionPolicy) AssignProperties_To_ClientEncryptionPolicy
 	}
 
 	// PolicyFormatVersion
-	if policy.PolicyFormatVersion != nil {
-		policyFormatVersion := *policy.PolicyFormatVersion
-		destination.PolicyFormatVersion = &policyFormatVersion
-	} else {
-		destination.PolicyFormatVersion = nil
-	}
+	destination.PolicyFormatVersion = genruntime.ClonePointerToInt(policy.PolicyFormatVersion)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -2654,12 +2644,7 @@ func (partitionKey *ContainerPartitionKey) AssignProperties_From_ContainerPartit
 	partitionKey.Paths = genruntime.CloneSliceOfString(source.Paths)
 
 	// Version
-	if source.Version != nil {
-		version := *source.Version
-		partitionKey.Version = &version
-	} else {
-		partitionKey.Version = nil
-	}
+	partitionKey.Version = genruntime.ClonePointerToInt(source.Version)
 
 	// No error
 	return nil
@@ -2682,12 +2667,7 @@ func (partitionKey *ContainerPartitionKey) AssignProperties_To_ContainerPartitio
 	destination.Paths = genruntime.CloneSliceOfString(partitionKey.Paths)
 
 	// Version
-	if partitionKey.Version != nil {
-		version := *partitionKey.Version
-		destination.Version = &version
-	} else {
-		destination.Version = nil
-	}
+	destination.Version = genruntime.ClonePointerToInt(partitionKey.Version)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/documentdb/v1api20240815/database_account_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/database_account_types_gen.go
@@ -4657,12 +4657,7 @@ func (capacity *Capacity) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 func (capacity *Capacity) AssignProperties_From_Capacity(source *storage.Capacity) error {
 
 	// TotalThroughputLimit
-	if source.TotalThroughputLimit != nil {
-		totalThroughputLimit := *source.TotalThroughputLimit
-		capacity.TotalThroughputLimit = &totalThroughputLimit
-	} else {
-		capacity.TotalThroughputLimit = nil
-	}
+	capacity.TotalThroughputLimit = genruntime.ClonePointerToInt(source.TotalThroughputLimit)
 
 	// No error
 	return nil
@@ -4674,12 +4669,7 @@ func (capacity *Capacity) AssignProperties_To_Capacity(destination *storage.Capa
 	propertyBag := genruntime.NewPropertyBag()
 
 	// TotalThroughputLimit
-	if capacity.TotalThroughputLimit != nil {
-		totalThroughputLimit := *capacity.TotalThroughputLimit
-		destination.TotalThroughputLimit = &totalThroughputLimit
-	} else {
-		destination.TotalThroughputLimit = nil
-	}
+	destination.TotalThroughputLimit = genruntime.ClonePointerToInt(capacity.TotalThroughputLimit)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4696,12 +4686,7 @@ func (capacity *Capacity) AssignProperties_To_Capacity(destination *storage.Capa
 func (capacity *Capacity) Initialize_From_Capacity_STATUS(source *Capacity_STATUS) error {
 
 	// TotalThroughputLimit
-	if source.TotalThroughputLimit != nil {
-		totalThroughputLimit := *source.TotalThroughputLimit
-		capacity.TotalThroughputLimit = &totalThroughputLimit
-	} else {
-		capacity.TotalThroughputLimit = nil
-	}
+	capacity.TotalThroughputLimit = genruntime.ClonePointerToInt(source.TotalThroughputLimit)
 
 	// No error
 	return nil
@@ -4890,20 +4875,10 @@ func (policy *ConsistencyPolicy) AssignProperties_From_ConsistencyPolicy(source 
 	}
 
 	// MaxIntervalInSeconds
-	if source.MaxIntervalInSeconds != nil {
-		maxIntervalInSecond := *source.MaxIntervalInSeconds
-		policy.MaxIntervalInSeconds = &maxIntervalInSecond
-	} else {
-		policy.MaxIntervalInSeconds = nil
-	}
+	policy.MaxIntervalInSeconds = genruntime.ClonePointerToInt(source.MaxIntervalInSeconds)
 
 	// MaxStalenessPrefix
-	if source.MaxStalenessPrefix != nil {
-		maxStalenessPrefix := *source.MaxStalenessPrefix
-		policy.MaxStalenessPrefix = &maxStalenessPrefix
-	} else {
-		policy.MaxStalenessPrefix = nil
-	}
+	policy.MaxStalenessPrefix = genruntime.ClonePointerToInt(source.MaxStalenessPrefix)
 
 	// No error
 	return nil
@@ -4923,20 +4898,10 @@ func (policy *ConsistencyPolicy) AssignProperties_To_ConsistencyPolicy(destinati
 	}
 
 	// MaxIntervalInSeconds
-	if policy.MaxIntervalInSeconds != nil {
-		maxIntervalInSecond := *policy.MaxIntervalInSeconds
-		destination.MaxIntervalInSeconds = &maxIntervalInSecond
-	} else {
-		destination.MaxIntervalInSeconds = nil
-	}
+	destination.MaxIntervalInSeconds = genruntime.ClonePointerToInt(policy.MaxIntervalInSeconds)
 
 	// MaxStalenessPrefix
-	if policy.MaxStalenessPrefix != nil {
-		maxStalenessPrefix := *policy.MaxStalenessPrefix
-		destination.MaxStalenessPrefix = &maxStalenessPrefix
-	} else {
-		destination.MaxStalenessPrefix = nil
-	}
+	destination.MaxStalenessPrefix = genruntime.ClonePointerToInt(policy.MaxStalenessPrefix)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4961,20 +4926,10 @@ func (policy *ConsistencyPolicy) Initialize_From_ConsistencyPolicy_STATUS(source
 	}
 
 	// MaxIntervalInSeconds
-	if source.MaxIntervalInSeconds != nil {
-		maxIntervalInSecond := *source.MaxIntervalInSeconds
-		policy.MaxIntervalInSeconds = &maxIntervalInSecond
-	} else {
-		policy.MaxIntervalInSeconds = nil
-	}
+	policy.MaxIntervalInSeconds = genruntime.ClonePointerToInt(source.MaxIntervalInSeconds)
 
 	// MaxStalenessPrefix
-	if source.MaxStalenessPrefix != nil {
-		maxStalenessPrefix := *source.MaxStalenessPrefix
-		policy.MaxStalenessPrefix = &maxStalenessPrefix
-	} else {
-		policy.MaxStalenessPrefix = nil
-	}
+	policy.MaxStalenessPrefix = genruntime.ClonePointerToInt(source.MaxStalenessPrefix)
 
 	// No error
 	return nil
@@ -5211,12 +5166,7 @@ func (policy *CorsPolicy) AssignProperties_From_CorsPolicy(source *storage.CorsP
 	policy.ExposedHeaders = genruntime.ClonePointerToString(source.ExposedHeaders)
 
 	// MaxAgeInSeconds
-	if source.MaxAgeInSeconds != nil {
-		maxAgeInSecond := *source.MaxAgeInSeconds
-		policy.MaxAgeInSeconds = &maxAgeInSecond
-	} else {
-		policy.MaxAgeInSeconds = nil
-	}
+	policy.MaxAgeInSeconds = genruntime.ClonePointerToInt(source.MaxAgeInSeconds)
 
 	// No error
 	return nil
@@ -5240,12 +5190,7 @@ func (policy *CorsPolicy) AssignProperties_To_CorsPolicy(destination *storage.Co
 	destination.ExposedHeaders = genruntime.ClonePointerToString(policy.ExposedHeaders)
 
 	// MaxAgeInSeconds
-	if policy.MaxAgeInSeconds != nil {
-		maxAgeInSecond := *policy.MaxAgeInSeconds
-		destination.MaxAgeInSeconds = &maxAgeInSecond
-	} else {
-		destination.MaxAgeInSeconds = nil
-	}
+	destination.MaxAgeInSeconds = genruntime.ClonePointerToInt(policy.MaxAgeInSeconds)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -5274,12 +5219,7 @@ func (policy *CorsPolicy) Initialize_From_CorsPolicy_STATUS(source *CorsPolicy_S
 	policy.ExposedHeaders = genruntime.ClonePointerToString(source.ExposedHeaders)
 
 	// MaxAgeInSeconds
-	if source.MaxAgeInSeconds != nil {
-		maxAgeInSecond := *source.MaxAgeInSeconds
-		policy.MaxAgeInSeconds = &maxAgeInSecond
-	} else {
-		policy.MaxAgeInSeconds = nil
-	}
+	policy.MaxAgeInSeconds = genruntime.ClonePointerToInt(source.MaxAgeInSeconds)
 
 	// No error
 	return nil
@@ -6136,12 +6076,7 @@ func (location *Location) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 func (location *Location) AssignProperties_From_Location(source *storage.Location) error {
 
 	// FailoverPriority
-	if source.FailoverPriority != nil {
-		failoverPriority := *source.FailoverPriority
-		location.FailoverPriority = &failoverPriority
-	} else {
-		location.FailoverPriority = nil
-	}
+	location.FailoverPriority = genruntime.ClonePointerToInt(source.FailoverPriority)
 
 	// IsZoneRedundant
 	if source.IsZoneRedundant != nil {
@@ -6164,12 +6099,7 @@ func (location *Location) AssignProperties_To_Location(destination *storage.Loca
 	propertyBag := genruntime.NewPropertyBag()
 
 	// FailoverPriority
-	if location.FailoverPriority != nil {
-		failoverPriority := *location.FailoverPriority
-		destination.FailoverPriority = &failoverPriority
-	} else {
-		destination.FailoverPriority = nil
-	}
+	destination.FailoverPriority = genruntime.ClonePointerToInt(location.FailoverPriority)
 
 	// IsZoneRedundant
 	if location.IsZoneRedundant != nil {
@@ -6197,12 +6127,7 @@ func (location *Location) AssignProperties_To_Location(destination *storage.Loca
 func (location *Location) Initialize_From_Location_STATUS(source *Location_STATUS) error {
 
 	// FailoverPriority
-	if source.FailoverPriority != nil {
-		failoverPriority := *source.FailoverPriority
-		location.FailoverPriority = &failoverPriority
-	} else {
-		location.FailoverPriority = nil
-	}
+	location.FailoverPriority = genruntime.ClonePointerToInt(source.FailoverPriority)
 
 	// IsZoneRedundant
 	if source.IsZoneRedundant != nil {
@@ -10020,20 +9945,10 @@ func (properties *PeriodicModeProperties) PopulateFromARM(owner genruntime.Arbit
 func (properties *PeriodicModeProperties) AssignProperties_From_PeriodicModeProperties(source *storage.PeriodicModeProperties) error {
 
 	// BackupIntervalInMinutes
-	if source.BackupIntervalInMinutes != nil {
-		backupIntervalInMinute := *source.BackupIntervalInMinutes
-		properties.BackupIntervalInMinutes = &backupIntervalInMinute
-	} else {
-		properties.BackupIntervalInMinutes = nil
-	}
+	properties.BackupIntervalInMinutes = genruntime.ClonePointerToInt(source.BackupIntervalInMinutes)
 
 	// BackupRetentionIntervalInHours
-	if source.BackupRetentionIntervalInHours != nil {
-		backupRetentionIntervalInHour := *source.BackupRetentionIntervalInHours
-		properties.BackupRetentionIntervalInHours = &backupRetentionIntervalInHour
-	} else {
-		properties.BackupRetentionIntervalInHours = nil
-	}
+	properties.BackupRetentionIntervalInHours = genruntime.ClonePointerToInt(source.BackupRetentionIntervalInHours)
 
 	// BackupStorageRedundancy
 	if source.BackupStorageRedundancy != nil {
@@ -10054,20 +9969,10 @@ func (properties *PeriodicModeProperties) AssignProperties_To_PeriodicModeProper
 	propertyBag := genruntime.NewPropertyBag()
 
 	// BackupIntervalInMinutes
-	if properties.BackupIntervalInMinutes != nil {
-		backupIntervalInMinute := *properties.BackupIntervalInMinutes
-		destination.BackupIntervalInMinutes = &backupIntervalInMinute
-	} else {
-		destination.BackupIntervalInMinutes = nil
-	}
+	destination.BackupIntervalInMinutes = genruntime.ClonePointerToInt(properties.BackupIntervalInMinutes)
 
 	// BackupRetentionIntervalInHours
-	if properties.BackupRetentionIntervalInHours != nil {
-		backupRetentionIntervalInHour := *properties.BackupRetentionIntervalInHours
-		destination.BackupRetentionIntervalInHours = &backupRetentionIntervalInHour
-	} else {
-		destination.BackupRetentionIntervalInHours = nil
-	}
+	destination.BackupRetentionIntervalInHours = genruntime.ClonePointerToInt(properties.BackupRetentionIntervalInHours)
 
 	// BackupStorageRedundancy
 	if properties.BackupStorageRedundancy != nil {
@@ -10092,20 +9997,10 @@ func (properties *PeriodicModeProperties) AssignProperties_To_PeriodicModeProper
 func (properties *PeriodicModeProperties) Initialize_From_PeriodicModeProperties_STATUS(source *PeriodicModeProperties_STATUS) error {
 
 	// BackupIntervalInMinutes
-	if source.BackupIntervalInMinutes != nil {
-		backupIntervalInMinute := *source.BackupIntervalInMinutes
-		properties.BackupIntervalInMinutes = &backupIntervalInMinute
-	} else {
-		properties.BackupIntervalInMinutes = nil
-	}
+	properties.BackupIntervalInMinutes = genruntime.ClonePointerToInt(source.BackupIntervalInMinutes)
 
 	// BackupRetentionIntervalInHours
-	if source.BackupRetentionIntervalInHours != nil {
-		backupRetentionIntervalInHour := *source.BackupRetentionIntervalInHours
-		properties.BackupRetentionIntervalInHours = &backupRetentionIntervalInHour
-	} else {
-		properties.BackupRetentionIntervalInHours = nil
-	}
+	properties.BackupRetentionIntervalInHours = genruntime.ClonePointerToInt(source.BackupRetentionIntervalInHours)
 
 	// BackupStorageRedundancy
 	if source.BackupStorageRedundancy != nil {

--- a/v2/api/documentdb/v1api20240815/sql_database_container_types_gen.go
+++ b/v2/api/documentdb/v1api20240815/sql_database_container_types_gen.go
@@ -2142,12 +2142,7 @@ func (policy *ClientEncryptionPolicy) AssignProperties_From_ClientEncryptionPoli
 	}
 
 	// PolicyFormatVersion
-	if source.PolicyFormatVersion != nil {
-		policyFormatVersion := *source.PolicyFormatVersion
-		policy.PolicyFormatVersion = &policyFormatVersion
-	} else {
-		policy.PolicyFormatVersion = nil
-	}
+	policy.PolicyFormatVersion = genruntime.ClonePointerToInt(source.PolicyFormatVersion)
 
 	// No error
 	return nil
@@ -2177,12 +2172,7 @@ func (policy *ClientEncryptionPolicy) AssignProperties_To_ClientEncryptionPolicy
 	}
 
 	// PolicyFormatVersion
-	if policy.PolicyFormatVersion != nil {
-		policyFormatVersion := *policy.PolicyFormatVersion
-		destination.PolicyFormatVersion = &policyFormatVersion
-	} else {
-		destination.PolicyFormatVersion = nil
-	}
+	destination.PolicyFormatVersion = genruntime.ClonePointerToInt(policy.PolicyFormatVersion)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -2217,12 +2207,7 @@ func (policy *ClientEncryptionPolicy) Initialize_From_ClientEncryptionPolicy_STA
 	}
 
 	// PolicyFormatVersion
-	if source.PolicyFormatVersion != nil {
-		policyFormatVersion := *source.PolicyFormatVersion
-		policy.PolicyFormatVersion = &policyFormatVersion
-	} else {
-		policy.PolicyFormatVersion = nil
-	}
+	policy.PolicyFormatVersion = genruntime.ClonePointerToInt(source.PolicyFormatVersion)
 
 	// No error
 	return nil
@@ -2869,12 +2854,7 @@ func (partitionKey *ContainerPartitionKey) AssignProperties_From_ContainerPartit
 	partitionKey.Paths = genruntime.CloneSliceOfString(source.Paths)
 
 	// Version
-	if source.Version != nil {
-		version := *source.Version
-		partitionKey.Version = &version
-	} else {
-		partitionKey.Version = nil
-	}
+	partitionKey.Version = genruntime.ClonePointerToInt(source.Version)
 
 	// No error
 	return nil
@@ -2897,12 +2877,7 @@ func (partitionKey *ContainerPartitionKey) AssignProperties_To_ContainerPartitio
 	destination.Paths = genruntime.CloneSliceOfString(partitionKey.Paths)
 
 	// Version
-	if partitionKey.Version != nil {
-		version := *partitionKey.Version
-		destination.Version = &version
-	} else {
-		destination.Version = nil
-	}
+	destination.Version = genruntime.ClonePointerToInt(partitionKey.Version)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -2930,12 +2905,7 @@ func (partitionKey *ContainerPartitionKey) Initialize_From_ContainerPartitionKey
 	partitionKey.Paths = genruntime.CloneSliceOfString(source.Paths)
 
 	// Version
-	if source.Version != nil {
-		version := *source.Version
-		partitionKey.Version = &version
-	} else {
-		partitionKey.Version = nil
-	}
+	partitionKey.Version = genruntime.ClonePointerToInt(source.Version)
 
 	// No error
 	return nil

--- a/v2/api/eventhub/v1api20211101/namespace_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/namespace_types_gen.go
@@ -2412,12 +2412,7 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 func (sku *Sku) AssignProperties_From_Sku(source *storage.Sku) error {
 
 	// Capacity
-	if source.Capacity != nil {
-		capacity := *source.Capacity
-		sku.Capacity = &capacity
-	} else {
-		sku.Capacity = nil
-	}
+	sku.Capacity = genruntime.ClonePointerToInt(source.Capacity)
 
 	// Name
 	if source.Name != nil {
@@ -2447,12 +2442,7 @@ func (sku *Sku) AssignProperties_To_Sku(destination *storage.Sku) error {
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Capacity
-	if sku.Capacity != nil {
-		capacity := *sku.Capacity
-		destination.Capacity = &capacity
-	} else {
-		destination.Capacity = nil
-	}
+	destination.Capacity = genruntime.ClonePointerToInt(sku.Capacity)
 
 	// Name
 	if sku.Name != nil {

--- a/v2/api/eventhub/v1api20211101/namespaces_eventhub_types_gen.go
+++ b/v2/api/eventhub/v1api20211101/namespaces_eventhub_types_gen.go
@@ -442,12 +442,7 @@ func (eventhub *NamespacesEventhub_Spec) AssignProperties_From_NamespacesEventhu
 	}
 
 	// MessageRetentionInDays
-	if source.MessageRetentionInDays != nil {
-		messageRetentionInDay := *source.MessageRetentionInDays
-		eventhub.MessageRetentionInDays = &messageRetentionInDay
-	} else {
-		eventhub.MessageRetentionInDays = nil
-	}
+	eventhub.MessageRetentionInDays = genruntime.ClonePointerToInt(source.MessageRetentionInDays)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -470,12 +465,7 @@ func (eventhub *NamespacesEventhub_Spec) AssignProperties_From_NamespacesEventhu
 	}
 
 	// PartitionCount
-	if source.PartitionCount != nil {
-		partitionCount := *source.PartitionCount
-		eventhub.PartitionCount = &partitionCount
-	} else {
-		eventhub.PartitionCount = nil
-	}
+	eventhub.PartitionCount = genruntime.ClonePointerToInt(source.PartitionCount)
 
 	// No error
 	return nil
@@ -502,12 +492,7 @@ func (eventhub *NamespacesEventhub_Spec) AssignProperties_To_NamespacesEventhub_
 	}
 
 	// MessageRetentionInDays
-	if eventhub.MessageRetentionInDays != nil {
-		messageRetentionInDay := *eventhub.MessageRetentionInDays
-		destination.MessageRetentionInDays = &messageRetentionInDay
-	} else {
-		destination.MessageRetentionInDays = nil
-	}
+	destination.MessageRetentionInDays = genruntime.ClonePointerToInt(eventhub.MessageRetentionInDays)
 
 	// OperatorSpec
 	if eventhub.OperatorSpec != nil {
@@ -533,12 +518,7 @@ func (eventhub *NamespacesEventhub_Spec) AssignProperties_To_NamespacesEventhub_
 	}
 
 	// PartitionCount
-	if eventhub.PartitionCount != nil {
-		partitionCount := *eventhub.PartitionCount
-		destination.PartitionCount = &partitionCount
-	} else {
-		destination.PartitionCount = nil
-	}
+	destination.PartitionCount = genruntime.ClonePointerToInt(eventhub.PartitionCount)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -1687,12 +1667,7 @@ func (destination *Destination) AssignProperties_From_Destination(source *storag
 	destination.DataLakeFolderPath = genruntime.ClonePointerToString(source.DataLakeFolderPath)
 
 	// DataLakeSubscriptionId
-	if source.DataLakeSubscriptionId != nil {
-		dataLakeSubscriptionId := *source.DataLakeSubscriptionId
-		destination.DataLakeSubscriptionId = &dataLakeSubscriptionId
-	} else {
-		destination.DataLakeSubscriptionId = nil
-	}
+	destination.DataLakeSubscriptionId = genruntime.ClonePointerToString(source.DataLakeSubscriptionId)
 
 	// Name
 	destination.Name = genruntime.ClonePointerToString(source.Name)
@@ -1727,12 +1702,7 @@ func (destination *Destination) AssignProperties_To_Destination(target *storage.
 	target.DataLakeFolderPath = genruntime.ClonePointerToString(destination.DataLakeFolderPath)
 
 	// DataLakeSubscriptionId
-	if destination.DataLakeSubscriptionId != nil {
-		dataLakeSubscriptionId := *destination.DataLakeSubscriptionId
-		target.DataLakeSubscriptionId = &dataLakeSubscriptionId
-	} else {
-		target.DataLakeSubscriptionId = nil
-	}
+	target.DataLakeSubscriptionId = genruntime.ClonePointerToString(destination.DataLakeSubscriptionId)
 
 	// Name
 	target.Name = genruntime.ClonePointerToString(destination.Name)

--- a/v2/api/eventhub/v1api20240101/namespace_types_gen.go
+++ b/v2/api/eventhub/v1api20240101/namespace_types_gen.go
@@ -701,12 +701,7 @@ func (namespace *Namespace_Spec) AssignProperties_From_Namespace_Spec(source *st
 	namespace.Location = genruntime.ClonePointerToString(source.Location)
 
 	// MaximumThroughputUnits
-	if source.MaximumThroughputUnits != nil {
-		maximumThroughputUnit := *source.MaximumThroughputUnits
-		namespace.MaximumThroughputUnits = &maximumThroughputUnit
-	} else {
-		namespace.MaximumThroughputUnits = nil
-	}
+	namespace.MaximumThroughputUnits = genruntime.ClonePointerToInt(source.MaximumThroughputUnits)
 
 	// MinimumTlsVersion
 	if source.MinimumTlsVersion != nil {
@@ -844,12 +839,7 @@ func (namespace *Namespace_Spec) AssignProperties_To_Namespace_Spec(destination 
 	destination.Location = genruntime.ClonePointerToString(namespace.Location)
 
 	// MaximumThroughputUnits
-	if namespace.MaximumThroughputUnits != nil {
-		maximumThroughputUnit := *namespace.MaximumThroughputUnits
-		destination.MaximumThroughputUnits = &maximumThroughputUnit
-	} else {
-		destination.MaximumThroughputUnits = nil
-	}
+	destination.MaximumThroughputUnits = genruntime.ClonePointerToInt(namespace.MaximumThroughputUnits)
 
 	// MinimumTlsVersion
 	if namespace.MinimumTlsVersion != nil {
@@ -990,12 +980,7 @@ func (namespace *Namespace_Spec) Initialize_From_Namespace_STATUS(source *Namesp
 	namespace.Location = genruntime.ClonePointerToString(source.Location)
 
 	// MaximumThroughputUnits
-	if source.MaximumThroughputUnits != nil {
-		maximumThroughputUnit := *source.MaximumThroughputUnits
-		namespace.MaximumThroughputUnits = &maximumThroughputUnit
-	} else {
-		namespace.MaximumThroughputUnits = nil
-	}
+	namespace.MaximumThroughputUnits = genruntime.ClonePointerToInt(source.MaximumThroughputUnits)
 
 	// MinimumTlsVersion
 	if source.MinimumTlsVersion != nil {
@@ -2804,12 +2789,7 @@ func (sku *Sku) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 func (sku *Sku) AssignProperties_From_Sku(source *storage.Sku) error {
 
 	// Capacity
-	if source.Capacity != nil {
-		capacity := *source.Capacity
-		sku.Capacity = &capacity
-	} else {
-		sku.Capacity = nil
-	}
+	sku.Capacity = genruntime.ClonePointerToInt(source.Capacity)
 
 	// Name
 	if source.Name != nil {
@@ -2839,12 +2819,7 @@ func (sku *Sku) AssignProperties_To_Sku(destination *storage.Sku) error {
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Capacity
-	if sku.Capacity != nil {
-		capacity := *sku.Capacity
-		destination.Capacity = &capacity
-	} else {
-		destination.Capacity = nil
-	}
+	destination.Capacity = genruntime.ClonePointerToInt(sku.Capacity)
 
 	// Name
 	if sku.Name != nil {
@@ -2877,12 +2852,7 @@ func (sku *Sku) AssignProperties_To_Sku(destination *storage.Sku) error {
 func (sku *Sku) Initialize_From_Sku_STATUS(source *Sku_STATUS) error {
 
 	// Capacity
-	if source.Capacity != nil {
-		capacity := *source.Capacity
-		sku.Capacity = &capacity
-	} else {
-		sku.Capacity = nil
-	}
+	sku.Capacity = genruntime.ClonePointerToInt(source.Capacity)
 
 	// Name
 	if source.Name != nil {

--- a/v2/api/eventhub/v1api20240101/namespaces_eventhub_types_gen.go
+++ b/v2/api/eventhub/v1api20240101/namespaces_eventhub_types_gen.go
@@ -482,12 +482,7 @@ func (eventhub *NamespacesEventhub_Spec) AssignProperties_From_NamespacesEventhu
 	}
 
 	// MessageRetentionInDays
-	if source.MessageRetentionInDays != nil {
-		messageRetentionInDay := *source.MessageRetentionInDays
-		eventhub.MessageRetentionInDays = &messageRetentionInDay
-	} else {
-		eventhub.MessageRetentionInDays = nil
-	}
+	eventhub.MessageRetentionInDays = genruntime.ClonePointerToInt(source.MessageRetentionInDays)
 
 	// OperatorSpec
 	if source.OperatorSpec != nil {
@@ -510,12 +505,7 @@ func (eventhub *NamespacesEventhub_Spec) AssignProperties_From_NamespacesEventhu
 	}
 
 	// PartitionCount
-	if source.PartitionCount != nil {
-		partitionCount := *source.PartitionCount
-		eventhub.PartitionCount = &partitionCount
-	} else {
-		eventhub.PartitionCount = nil
-	}
+	eventhub.PartitionCount = genruntime.ClonePointerToInt(source.PartitionCount)
 
 	// RetentionDescription
 	if source.RetentionDescription != nil {
@@ -557,12 +547,7 @@ func (eventhub *NamespacesEventhub_Spec) AssignProperties_To_NamespacesEventhub_
 	}
 
 	// MessageRetentionInDays
-	if eventhub.MessageRetentionInDays != nil {
-		messageRetentionInDay := *eventhub.MessageRetentionInDays
-		destination.MessageRetentionInDays = &messageRetentionInDay
-	} else {
-		destination.MessageRetentionInDays = nil
-	}
+	destination.MessageRetentionInDays = genruntime.ClonePointerToInt(eventhub.MessageRetentionInDays)
 
 	// OperatorSpec
 	if eventhub.OperatorSpec != nil {
@@ -588,12 +573,7 @@ func (eventhub *NamespacesEventhub_Spec) AssignProperties_To_NamespacesEventhub_
 	}
 
 	// PartitionCount
-	if eventhub.PartitionCount != nil {
-		partitionCount := *eventhub.PartitionCount
-		destination.PartitionCount = &partitionCount
-	} else {
-		destination.PartitionCount = nil
-	}
+	destination.PartitionCount = genruntime.ClonePointerToInt(eventhub.PartitionCount)
 
 	// RetentionDescription
 	if eventhub.RetentionDescription != nil {
@@ -637,20 +617,10 @@ func (eventhub *NamespacesEventhub_Spec) Initialize_From_NamespacesEventhub_STAT
 	}
 
 	// MessageRetentionInDays
-	if source.MessageRetentionInDays != nil {
-		messageRetentionInDay := *source.MessageRetentionInDays
-		eventhub.MessageRetentionInDays = &messageRetentionInDay
-	} else {
-		eventhub.MessageRetentionInDays = nil
-	}
+	eventhub.MessageRetentionInDays = genruntime.ClonePointerToInt(source.MessageRetentionInDays)
 
 	// PartitionCount
-	if source.PartitionCount != nil {
-		partitionCount := *source.PartitionCount
-		eventhub.PartitionCount = &partitionCount
-	} else {
-		eventhub.PartitionCount = nil
-	}
+	eventhub.PartitionCount = genruntime.ClonePointerToInt(source.PartitionCount)
 
 	// RetentionDescription
 	if source.RetentionDescription != nil {
@@ -2201,12 +2171,7 @@ func (destination *Destination) AssignProperties_From_Destination(source *storag
 	destination.DataLakeFolderPath = genruntime.ClonePointerToString(source.DataLakeFolderPath)
 
 	// DataLakeSubscriptionId
-	if source.DataLakeSubscriptionId != nil {
-		dataLakeSubscriptionId := *source.DataLakeSubscriptionId
-		destination.DataLakeSubscriptionId = &dataLakeSubscriptionId
-	} else {
-		destination.DataLakeSubscriptionId = nil
-	}
+	destination.DataLakeSubscriptionId = genruntime.ClonePointerToString(source.DataLakeSubscriptionId)
 
 	// Identity
 	if source.Identity != nil {
@@ -2253,12 +2218,7 @@ func (destination *Destination) AssignProperties_To_Destination(target *storage.
 	target.DataLakeFolderPath = genruntime.ClonePointerToString(destination.DataLakeFolderPath)
 
 	// DataLakeSubscriptionId
-	if destination.DataLakeSubscriptionId != nil {
-		dataLakeSubscriptionId := *destination.DataLakeSubscriptionId
-		target.DataLakeSubscriptionId = &dataLakeSubscriptionId
-	} else {
-		target.DataLakeSubscriptionId = nil
-	}
+	target.DataLakeSubscriptionId = genruntime.ClonePointerToString(destination.DataLakeSubscriptionId)
 
 	// Identity
 	if destination.Identity != nil {
@@ -2310,12 +2270,7 @@ func (destination *Destination) Initialize_From_Destination_STATUS(source *Desti
 	destination.DataLakeFolderPath = genruntime.ClonePointerToString(source.DataLakeFolderPath)
 
 	// DataLakeSubscriptionId
-	if source.DataLakeSubscriptionId != nil {
-		dataLakeSubscriptionId := *source.DataLakeSubscriptionId
-		destination.DataLakeSubscriptionId = &dataLakeSubscriptionId
-	} else {
-		destination.DataLakeSubscriptionId = nil
-	}
+	destination.DataLakeSubscriptionId = genruntime.ClonePointerToString(source.DataLakeSubscriptionId)
 
 	// Identity
 	if source.Identity != nil {

--- a/v2/api/insights/v1api20210501preview/diagnostic_setting_types_gen.go
+++ b/v2/api/insights/v1api20210501preview/diagnostic_setting_types_gen.go
@@ -2285,12 +2285,7 @@ func (policy *RetentionPolicy) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 func (policy *RetentionPolicy) AssignProperties_From_RetentionPolicy(source *storage.RetentionPolicy) error {
 
 	// Days
-	if source.Days != nil {
-		day := *source.Days
-		policy.Days = &day
-	} else {
-		policy.Days = nil
-	}
+	policy.Days = genruntime.ClonePointerToInt(source.Days)
 
 	// Enabled
 	if source.Enabled != nil {
@@ -2310,12 +2305,7 @@ func (policy *RetentionPolicy) AssignProperties_To_RetentionPolicy(destination *
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Days
-	if policy.Days != nil {
-		day := *policy.Days
-		destination.Days = &day
-	} else {
-		destination.Days = nil
-	}
+	destination.Days = genruntime.ClonePointerToInt(policy.Days)
 
 	// Enabled
 	if policy.Enabled != nil {
@@ -2340,12 +2330,7 @@ func (policy *RetentionPolicy) AssignProperties_To_RetentionPolicy(destination *
 func (policy *RetentionPolicy) Initialize_From_RetentionPolicy_STATUS(source *RetentionPolicy_STATUS) error {
 
 	// Days
-	if source.Days != nil {
-		day := *source.Days
-		policy.Days = &day
-	} else {
-		policy.Days = nil
-	}
+	policy.Days = genruntime.ClonePointerToInt(source.Days)
 
 	// Enabled
 	if source.Enabled != nil {

--- a/v2/api/insights/v1api20230101/action_group_types_gen.go
+++ b/v2/api/insights/v1api20230101/action_group_types_gen.go
@@ -817,12 +817,7 @@ func (group *ActionGroup_Spec) AssignProperties_From_ActionGroup_Spec(source *st
 	}
 
 	// GroupShortName
-	if source.GroupShortName != nil {
-		groupShortName := *source.GroupShortName
-		group.GroupShortName = &groupShortName
-	} else {
-		group.GroupShortName = nil
-	}
+	group.GroupShortName = genruntime.ClonePointerToString(source.GroupShortName)
 
 	// ItsmReceivers
 	if source.ItsmReceivers != nil {
@@ -1069,12 +1064,7 @@ func (group *ActionGroup_Spec) AssignProperties_To_ActionGroup_Spec(destination 
 	}
 
 	// GroupShortName
-	if group.GroupShortName != nil {
-		groupShortName := *group.GroupShortName
-		destination.GroupShortName = &groupShortName
-	} else {
-		destination.GroupShortName = nil
-	}
+	destination.GroupShortName = genruntime.ClonePointerToString(group.GroupShortName)
 
 	// ItsmReceivers
 	if group.ItsmReceivers != nil {
@@ -1326,12 +1316,7 @@ func (group *ActionGroup_Spec) Initialize_From_ActionGroupResource_STATUS(source
 	}
 
 	// GroupShortName
-	if source.GroupShortName != nil {
-		groupShortName := *source.GroupShortName
-		group.GroupShortName = &groupShortName
-	} else {
-		group.GroupShortName = nil
-	}
+	group.GroupShortName = genruntime.ClonePointerToString(source.GroupShortName)
 
 	// ItsmReceivers
 	if source.ItsmReceivers != nil {

--- a/v2/api/keyvault/v1api20210401preview/vault_types_gen.go
+++ b/v2/api/keyvault/v1api20210401preview/vault_types_gen.go
@@ -1477,12 +1477,7 @@ func (properties *VaultProperties) AssignProperties_From_VaultProperties(source 
 	properties.SoftDeleteRetentionInDays = genruntime.ClonePointerToInt(source.SoftDeleteRetentionInDays)
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		properties.TenantId = &tenantId
-	} else {
-		properties.TenantId = nil
-	}
+	properties.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// TenantIdFromConfig
 	if source.TenantIdFromConfig != nil {
@@ -1614,12 +1609,7 @@ func (properties *VaultProperties) AssignProperties_To_VaultProperties(destinati
 	destination.SoftDeleteRetentionInDays = genruntime.ClonePointerToInt(properties.SoftDeleteRetentionInDays)
 
 	// TenantId
-	if properties.TenantId != nil {
-		tenantId := *properties.TenantId
-		destination.TenantId = &tenantId
-	} else {
-		destination.TenantId = nil
-	}
+	destination.TenantId = genruntime.ClonePointerToString(properties.TenantId)
 
 	// TenantIdFromConfig
 	if properties.TenantIdFromConfig != nil {
@@ -2290,12 +2280,7 @@ func (entry *AccessPolicyEntry) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 func (entry *AccessPolicyEntry) AssignProperties_From_AccessPolicyEntry(source *storage.AccessPolicyEntry) error {
 
 	// ApplicationId
-	if source.ApplicationId != nil {
-		applicationId := *source.ApplicationId
-		entry.ApplicationId = &applicationId
-	} else {
-		entry.ApplicationId = nil
-	}
+	entry.ApplicationId = genruntime.ClonePointerToString(source.ApplicationId)
 
 	// ApplicationIdFromConfig
 	if source.ApplicationIdFromConfig != nil {
@@ -2329,12 +2314,7 @@ func (entry *AccessPolicyEntry) AssignProperties_From_AccessPolicyEntry(source *
 	}
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		entry.TenantId = &tenantId
-	} else {
-		entry.TenantId = nil
-	}
+	entry.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// TenantIdFromConfig
 	if source.TenantIdFromConfig != nil {
@@ -2354,12 +2334,7 @@ func (entry *AccessPolicyEntry) AssignProperties_To_AccessPolicyEntry(destinatio
 	propertyBag := genruntime.NewPropertyBag()
 
 	// ApplicationId
-	if entry.ApplicationId != nil {
-		applicationId := *entry.ApplicationId
-		destination.ApplicationId = &applicationId
-	} else {
-		destination.ApplicationId = nil
-	}
+	destination.ApplicationId = genruntime.ClonePointerToString(entry.ApplicationId)
 
 	// ApplicationIdFromConfig
 	if entry.ApplicationIdFromConfig != nil {
@@ -2393,12 +2368,7 @@ func (entry *AccessPolicyEntry) AssignProperties_To_AccessPolicyEntry(destinatio
 	}
 
 	// TenantId
-	if entry.TenantId != nil {
-		tenantId := *entry.TenantId
-		destination.TenantId = &tenantId
-	} else {
-		destination.TenantId = nil
-	}
+	destination.TenantId = genruntime.ClonePointerToString(entry.TenantId)
 
 	// TenantIdFromConfig
 	if entry.TenantIdFromConfig != nil {

--- a/v2/api/keyvault/v1api20230701/vault_types_gen.go
+++ b/v2/api/keyvault/v1api20230701/vault_types_gen.go
@@ -1520,12 +1520,7 @@ func (properties *VaultProperties) AssignProperties_From_VaultProperties(source 
 	properties.SoftDeleteRetentionInDays = genruntime.ClonePointerToInt(source.SoftDeleteRetentionInDays)
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		properties.TenantId = &tenantId
-	} else {
-		properties.TenantId = nil
-	}
+	properties.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// TenantIdFromConfig
 	if source.TenantIdFromConfig != nil {
@@ -1660,12 +1655,7 @@ func (properties *VaultProperties) AssignProperties_To_VaultProperties(destinati
 	destination.SoftDeleteRetentionInDays = genruntime.ClonePointerToInt(properties.SoftDeleteRetentionInDays)
 
 	// TenantId
-	if properties.TenantId != nil {
-		tenantId := *properties.TenantId
-		destination.TenantId = &tenantId
-	} else {
-		destination.TenantId = nil
-	}
+	destination.TenantId = genruntime.ClonePointerToString(properties.TenantId)
 
 	// TenantIdFromConfig
 	if properties.TenantIdFromConfig != nil {
@@ -1805,12 +1795,7 @@ func (properties *VaultProperties) Initialize_From_VaultProperties_STATUS(source
 	properties.SoftDeleteRetentionInDays = genruntime.ClonePointerToInt(source.SoftDeleteRetentionInDays)
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		properties.TenantId = &tenantId
-	} else {
-		properties.TenantId = nil
-	}
+	properties.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// VaultUri
 	properties.VaultUri = genruntime.ClonePointerToString(source.VaultUri)
@@ -2484,12 +2469,7 @@ func (entry *AccessPolicyEntry) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 func (entry *AccessPolicyEntry) AssignProperties_From_AccessPolicyEntry(source *storage.AccessPolicyEntry) error {
 
 	// ApplicationId
-	if source.ApplicationId != nil {
-		applicationId := *source.ApplicationId
-		entry.ApplicationId = &applicationId
-	} else {
-		entry.ApplicationId = nil
-	}
+	entry.ApplicationId = genruntime.ClonePointerToString(source.ApplicationId)
 
 	// ApplicationIdFromConfig
 	if source.ApplicationIdFromConfig != nil {
@@ -2523,12 +2503,7 @@ func (entry *AccessPolicyEntry) AssignProperties_From_AccessPolicyEntry(source *
 	}
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		entry.TenantId = &tenantId
-	} else {
-		entry.TenantId = nil
-	}
+	entry.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// TenantIdFromConfig
 	if source.TenantIdFromConfig != nil {
@@ -2548,12 +2523,7 @@ func (entry *AccessPolicyEntry) AssignProperties_To_AccessPolicyEntry(destinatio
 	propertyBag := genruntime.NewPropertyBag()
 
 	// ApplicationId
-	if entry.ApplicationId != nil {
-		applicationId := *entry.ApplicationId
-		destination.ApplicationId = &applicationId
-	} else {
-		destination.ApplicationId = nil
-	}
+	destination.ApplicationId = genruntime.ClonePointerToString(entry.ApplicationId)
 
 	// ApplicationIdFromConfig
 	if entry.ApplicationIdFromConfig != nil {
@@ -2587,12 +2557,7 @@ func (entry *AccessPolicyEntry) AssignProperties_To_AccessPolicyEntry(destinatio
 	}
 
 	// TenantId
-	if entry.TenantId != nil {
-		tenantId := *entry.TenantId
-		destination.TenantId = &tenantId
-	} else {
-		destination.TenantId = nil
-	}
+	destination.TenantId = genruntime.ClonePointerToString(entry.TenantId)
 
 	// TenantIdFromConfig
 	if entry.TenantIdFromConfig != nil {
@@ -2617,12 +2582,7 @@ func (entry *AccessPolicyEntry) AssignProperties_To_AccessPolicyEntry(destinatio
 func (entry *AccessPolicyEntry) Initialize_From_AccessPolicyEntry_STATUS(source *AccessPolicyEntry_STATUS) error {
 
 	// ApplicationId
-	if source.ApplicationId != nil {
-		applicationId := *source.ApplicationId
-		entry.ApplicationId = &applicationId
-	} else {
-		entry.ApplicationId = nil
-	}
+	entry.ApplicationId = genruntime.ClonePointerToString(source.ApplicationId)
 
 	// ObjectId
 	entry.ObjectId = genruntime.ClonePointerToString(source.ObjectId)
@@ -2640,12 +2600,7 @@ func (entry *AccessPolicyEntry) Initialize_From_AccessPolicyEntry_STATUS(source 
 	}
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		entry.TenantId = &tenantId
-	} else {
-		entry.TenantId = nil
-	}
+	entry.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// No error
 	return nil

--- a/v2/api/machinelearningservices/v1api20210701/workspaces_compute_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20210701/workspaces_compute_types_gen.go
@@ -7718,12 +7718,7 @@ func (properties *AKS_Properties) PopulateFromARM(owner genruntime.ArbitraryOwne
 func (properties *AKS_Properties) AssignProperties_From_AKS_Properties(source *storage.AKS_Properties) error {
 
 	// AgentCount
-	if source.AgentCount != nil {
-		agentCount := *source.AgentCount
-		properties.AgentCount = &agentCount
-	} else {
-		properties.AgentCount = nil
-	}
+	properties.AgentCount = genruntime.ClonePointerToInt(source.AgentCount)
 
 	// AgentVmSize
 	properties.AgentVmSize = genruntime.ClonePointerToString(source.AgentVmSize)
@@ -7786,12 +7781,7 @@ func (properties *AKS_Properties) AssignProperties_To_AKS_Properties(destination
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AgentCount
-	if properties.AgentCount != nil {
-		agentCount := *properties.AgentCount
-		destination.AgentCount = &agentCount
-	} else {
-		destination.AgentCount = nil
-	}
+	destination.AgentCount = genruntime.ClonePointerToInt(properties.AgentCount)
 
 	// AgentVmSize
 	destination.AgentVmSize = genruntime.ClonePointerToString(properties.AgentVmSize)
@@ -12491,28 +12481,13 @@ func (configuration *AksNetworkingConfiguration) PopulateFromARM(owner genruntim
 func (configuration *AksNetworkingConfiguration) AssignProperties_From_AksNetworkingConfiguration(source *storage.AksNetworkingConfiguration) error {
 
 	// DnsServiceIP
-	if source.DnsServiceIP != nil {
-		dnsServiceIP := *source.DnsServiceIP
-		configuration.DnsServiceIP = &dnsServiceIP
-	} else {
-		configuration.DnsServiceIP = nil
-	}
+	configuration.DnsServiceIP = genruntime.ClonePointerToString(source.DnsServiceIP)
 
 	// DockerBridgeCidr
-	if source.DockerBridgeCidr != nil {
-		dockerBridgeCidr := *source.DockerBridgeCidr
-		configuration.DockerBridgeCidr = &dockerBridgeCidr
-	} else {
-		configuration.DockerBridgeCidr = nil
-	}
+	configuration.DockerBridgeCidr = genruntime.ClonePointerToString(source.DockerBridgeCidr)
 
 	// ServiceCidr
-	if source.ServiceCidr != nil {
-		serviceCidr := *source.ServiceCidr
-		configuration.ServiceCidr = &serviceCidr
-	} else {
-		configuration.ServiceCidr = nil
-	}
+	configuration.ServiceCidr = genruntime.ClonePointerToString(source.ServiceCidr)
 
 	// SubnetReference
 	if source.SubnetReference != nil {
@@ -12532,28 +12507,13 @@ func (configuration *AksNetworkingConfiguration) AssignProperties_To_AksNetworki
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DnsServiceIP
-	if configuration.DnsServiceIP != nil {
-		dnsServiceIP := *configuration.DnsServiceIP
-		destination.DnsServiceIP = &dnsServiceIP
-	} else {
-		destination.DnsServiceIP = nil
-	}
+	destination.DnsServiceIP = genruntime.ClonePointerToString(configuration.DnsServiceIP)
 
 	// DockerBridgeCidr
-	if configuration.DockerBridgeCidr != nil {
-		dockerBridgeCidr := *configuration.DockerBridgeCidr
-		destination.DockerBridgeCidr = &dockerBridgeCidr
-	} else {
-		destination.DockerBridgeCidr = nil
-	}
+	destination.DockerBridgeCidr = genruntime.ClonePointerToString(configuration.DockerBridgeCidr)
 
 	// ServiceCidr
-	if configuration.ServiceCidr != nil {
-		serviceCidr := *configuration.ServiceCidr
-		destination.ServiceCidr = &serviceCidr
-	} else {
-		destination.ServiceCidr = nil
-	}
+	destination.ServiceCidr = genruntime.ClonePointerToString(configuration.ServiceCidr)
 
 	// SubnetReference
 	if configuration.SubnetReference != nil {

--- a/v2/api/machinelearningservices/v1api20240401/workspaces_compute_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20240401/workspaces_compute_types_gen.go
@@ -8321,12 +8321,7 @@ func (properties *AKS_Properties) PopulateFromARM(owner genruntime.ArbitraryOwne
 func (properties *AKS_Properties) AssignProperties_From_AKS_Properties(source *storage.AKS_Properties) error {
 
 	// AgentCount
-	if source.AgentCount != nil {
-		agentCount := *source.AgentCount
-		properties.AgentCount = &agentCount
-	} else {
-		properties.AgentCount = nil
-	}
+	properties.AgentCount = genruntime.ClonePointerToInt(source.AgentCount)
 
 	// AgentVmSize
 	properties.AgentVmSize = genruntime.ClonePointerToString(source.AgentVmSize)
@@ -8394,12 +8389,7 @@ func (properties *AKS_Properties) AssignProperties_To_AKS_Properties(destination
 	propertyBag := genruntime.NewPropertyBag()
 
 	// AgentCount
-	if properties.AgentCount != nil {
-		agentCount := *properties.AgentCount
-		destination.AgentCount = &agentCount
-	} else {
-		destination.AgentCount = nil
-	}
+	destination.AgentCount = genruntime.ClonePointerToInt(properties.AgentCount)
 
 	// AgentVmSize
 	destination.AgentVmSize = genruntime.ClonePointerToString(properties.AgentVmSize)
@@ -8470,12 +8460,7 @@ func (properties *AKS_Properties) AssignProperties_To_AKS_Properties(destination
 func (properties *AKS_Properties) Initialize_From_AKS_Properties_STATUS(source *AKS_Properties_STATUS) error {
 
 	// AgentCount
-	if source.AgentCount != nil {
-		agentCount := *source.AgentCount
-		properties.AgentCount = &agentCount
-	} else {
-		properties.AgentCount = nil
-	}
+	properties.AgentCount = genruntime.ClonePointerToInt(source.AgentCount)
 
 	// AgentVmSize
 	properties.AgentVmSize = genruntime.ClonePointerToString(source.AgentVmSize)
@@ -14190,28 +14175,13 @@ func (configuration *AksNetworkingConfiguration) PopulateFromARM(owner genruntim
 func (configuration *AksNetworkingConfiguration) AssignProperties_From_AksNetworkingConfiguration(source *storage.AksNetworkingConfiguration) error {
 
 	// DnsServiceIP
-	if source.DnsServiceIP != nil {
-		dnsServiceIP := *source.DnsServiceIP
-		configuration.DnsServiceIP = &dnsServiceIP
-	} else {
-		configuration.DnsServiceIP = nil
-	}
+	configuration.DnsServiceIP = genruntime.ClonePointerToString(source.DnsServiceIP)
 
 	// DockerBridgeCidr
-	if source.DockerBridgeCidr != nil {
-		dockerBridgeCidr := *source.DockerBridgeCidr
-		configuration.DockerBridgeCidr = &dockerBridgeCidr
-	} else {
-		configuration.DockerBridgeCidr = nil
-	}
+	configuration.DockerBridgeCidr = genruntime.ClonePointerToString(source.DockerBridgeCidr)
 
 	// ServiceCidr
-	if source.ServiceCidr != nil {
-		serviceCidr := *source.ServiceCidr
-		configuration.ServiceCidr = &serviceCidr
-	} else {
-		configuration.ServiceCidr = nil
-	}
+	configuration.ServiceCidr = genruntime.ClonePointerToString(source.ServiceCidr)
 
 	// SubnetReference
 	if source.SubnetReference != nil {
@@ -14231,28 +14201,13 @@ func (configuration *AksNetworkingConfiguration) AssignProperties_To_AksNetworki
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DnsServiceIP
-	if configuration.DnsServiceIP != nil {
-		dnsServiceIP := *configuration.DnsServiceIP
-		destination.DnsServiceIP = &dnsServiceIP
-	} else {
-		destination.DnsServiceIP = nil
-	}
+	destination.DnsServiceIP = genruntime.ClonePointerToString(configuration.DnsServiceIP)
 
 	// DockerBridgeCidr
-	if configuration.DockerBridgeCidr != nil {
-		dockerBridgeCidr := *configuration.DockerBridgeCidr
-		destination.DockerBridgeCidr = &dockerBridgeCidr
-	} else {
-		destination.DockerBridgeCidr = nil
-	}
+	destination.DockerBridgeCidr = genruntime.ClonePointerToString(configuration.DockerBridgeCidr)
 
 	// ServiceCidr
-	if configuration.ServiceCidr != nil {
-		serviceCidr := *configuration.ServiceCidr
-		destination.ServiceCidr = &serviceCidr
-	} else {
-		destination.ServiceCidr = nil
-	}
+	destination.ServiceCidr = genruntime.ClonePointerToString(configuration.ServiceCidr)
 
 	// SubnetReference
 	if configuration.SubnetReference != nil {
@@ -14277,28 +14232,13 @@ func (configuration *AksNetworkingConfiguration) AssignProperties_To_AksNetworki
 func (configuration *AksNetworkingConfiguration) Initialize_From_AksNetworkingConfiguration_STATUS(source *AksNetworkingConfiguration_STATUS) error {
 
 	// DnsServiceIP
-	if source.DnsServiceIP != nil {
-		dnsServiceIP := *source.DnsServiceIP
-		configuration.DnsServiceIP = &dnsServiceIP
-	} else {
-		configuration.DnsServiceIP = nil
-	}
+	configuration.DnsServiceIP = genruntime.ClonePointerToString(source.DnsServiceIP)
 
 	// DockerBridgeCidr
-	if source.DockerBridgeCidr != nil {
-		dockerBridgeCidr := *source.DockerBridgeCidr
-		configuration.DockerBridgeCidr = &dockerBridgeCidr
-	} else {
-		configuration.DockerBridgeCidr = nil
-	}
+	configuration.DockerBridgeCidr = genruntime.ClonePointerToString(source.DockerBridgeCidr)
 
 	// ServiceCidr
-	if source.ServiceCidr != nil {
-		serviceCidr := *source.ServiceCidr
-		configuration.ServiceCidr = &serviceCidr
-	} else {
-		configuration.ServiceCidr = nil
-	}
+	configuration.ServiceCidr = genruntime.ClonePointerToString(source.ServiceCidr)
 
 	// SubnetReference
 	if source.SubnetId != nil {

--- a/v2/api/machinelearningservices/v1api20240401/workspaces_connection_types_gen.go
+++ b/v2/api/machinelearningservices/v1api20240401/workspaces_connection_types_gen.go
@@ -12218,12 +12218,7 @@ func (auth2 *WorkspaceConnectionOAuth2) AssignProperties_From_WorkspaceConnectio
 	auth2.AuthUrl = genruntime.ClonePointerToString(source.AuthUrl)
 
 	// ClientId
-	if source.ClientId != nil {
-		clientId := *source.ClientId
-		auth2.ClientId = &clientId
-	} else {
-		auth2.ClientId = nil
-	}
+	auth2.ClientId = genruntime.ClonePointerToString(source.ClientId)
 
 	// ClientIdFromConfig
 	if source.ClientIdFromConfig != nil {
@@ -12292,12 +12287,7 @@ func (auth2 *WorkspaceConnectionOAuth2) AssignProperties_To_WorkspaceConnectionO
 	destination.AuthUrl = genruntime.ClonePointerToString(auth2.AuthUrl)
 
 	// ClientId
-	if auth2.ClientId != nil {
-		clientId := *auth2.ClientId
-		destination.ClientId = &clientId
-	} else {
-		destination.ClientId = nil
-	}
+	destination.ClientId = genruntime.ClonePointerToString(auth2.ClientId)
 
 	// ClientIdFromConfig
 	if auth2.ClientIdFromConfig != nil {
@@ -12371,12 +12361,7 @@ func (auth2 *WorkspaceConnectionOAuth2) Initialize_From_WorkspaceConnectionOAuth
 	auth2.AuthUrl = genruntime.ClonePointerToString(source.AuthUrl)
 
 	// ClientId
-	if source.ClientId != nil {
-		clientId := *source.ClientId
-		auth2.ClientId = &clientId
-	} else {
-		auth2.ClientId = nil
-	}
+	auth2.ClientId = genruntime.ClonePointerToString(source.ClientId)
 
 	// TenantId
 	auth2.TenantId = genruntime.ClonePointerToString(source.TenantId)

--- a/v2/api/network.frontdoor/v1api20220501/web_application_firewall_policy_types_gen.go
+++ b/v2/api/network.frontdoor/v1api20220501/web_application_firewall_policy_types_gen.go
@@ -1988,12 +1988,7 @@ func (settings *PolicySettings) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 func (settings *PolicySettings) AssignProperties_From_PolicySettings(source *storage.PolicySettings) error {
 
 	// CustomBlockResponseBody
-	if source.CustomBlockResponseBody != nil {
-		customBlockResponseBody := *source.CustomBlockResponseBody
-		settings.CustomBlockResponseBody = &customBlockResponseBody
-	} else {
-		settings.CustomBlockResponseBody = nil
-	}
+	settings.CustomBlockResponseBody = genruntime.ClonePointerToString(source.CustomBlockResponseBody)
 
 	// CustomBlockResponseStatusCode
 	settings.CustomBlockResponseStatusCode = genruntime.ClonePointerToInt(source.CustomBlockResponseStatusCode)
@@ -2038,12 +2033,7 @@ func (settings *PolicySettings) AssignProperties_To_PolicySettings(destination *
 	propertyBag := genruntime.NewPropertyBag()
 
 	// CustomBlockResponseBody
-	if settings.CustomBlockResponseBody != nil {
-		customBlockResponseBody := *settings.CustomBlockResponseBody
-		destination.CustomBlockResponseBody = &customBlockResponseBody
-	} else {
-		destination.CustomBlockResponseBody = nil
-	}
+	destination.CustomBlockResponseBody = genruntime.ClonePointerToString(settings.CustomBlockResponseBody)
 
 	// CustomBlockResponseStatusCode
 	destination.CustomBlockResponseStatusCode = genruntime.ClonePointerToInt(settings.CustomBlockResponseStatusCode)
@@ -2090,12 +2080,7 @@ func (settings *PolicySettings) AssignProperties_To_PolicySettings(destination *
 func (settings *PolicySettings) Initialize_From_PolicySettings_STATUS(source *PolicySettings_STATUS) error {
 
 	// CustomBlockResponseBody
-	if source.CustomBlockResponseBody != nil {
-		customBlockResponseBody := *source.CustomBlockResponseBody
-		settings.CustomBlockResponseBody = &customBlockResponseBody
-	} else {
-		settings.CustomBlockResponseBody = nil
-	}
+	settings.CustomBlockResponseBody = genruntime.ClonePointerToString(source.CustomBlockResponseBody)
 
 	// CustomBlockResponseStatusCode
 	settings.CustomBlockResponseStatusCode = genruntime.ClonePointerToInt(source.CustomBlockResponseStatusCode)
@@ -2941,31 +2926,16 @@ func (rule *CustomRule) AssignProperties_From_CustomRule(source *storage.CustomR
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		rule.Name = &name
-	} else {
-		rule.Name = nil
-	}
+	rule.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Priority
 	rule.Priority = genruntime.ClonePointerToInt(source.Priority)
 
 	// RateLimitDurationInMinutes
-	if source.RateLimitDurationInMinutes != nil {
-		rateLimitDurationInMinute := *source.RateLimitDurationInMinutes
-		rule.RateLimitDurationInMinutes = &rateLimitDurationInMinute
-	} else {
-		rule.RateLimitDurationInMinutes = nil
-	}
+	rule.RateLimitDurationInMinutes = genruntime.ClonePointerToInt(source.RateLimitDurationInMinutes)
 
 	// RateLimitThreshold
-	if source.RateLimitThreshold != nil {
-		rateLimitThreshold := *source.RateLimitThreshold
-		rule.RateLimitThreshold = &rateLimitThreshold
-	} else {
-		rule.RateLimitThreshold = nil
-	}
+	rule.RateLimitThreshold = genruntime.ClonePointerToInt(source.RateLimitThreshold)
 
 	// RuleType
 	if source.RuleType != nil {
@@ -3020,31 +2990,16 @@ func (rule *CustomRule) AssignProperties_To_CustomRule(destination *storage.Cust
 	}
 
 	// Name
-	if rule.Name != nil {
-		name := *rule.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(rule.Name)
 
 	// Priority
 	destination.Priority = genruntime.ClonePointerToInt(rule.Priority)
 
 	// RateLimitDurationInMinutes
-	if rule.RateLimitDurationInMinutes != nil {
-		rateLimitDurationInMinute := *rule.RateLimitDurationInMinutes
-		destination.RateLimitDurationInMinutes = &rateLimitDurationInMinute
-	} else {
-		destination.RateLimitDurationInMinutes = nil
-	}
+	destination.RateLimitDurationInMinutes = genruntime.ClonePointerToInt(rule.RateLimitDurationInMinutes)
 
 	// RateLimitThreshold
-	if rule.RateLimitThreshold != nil {
-		rateLimitThreshold := *rule.RateLimitThreshold
-		destination.RateLimitThreshold = &rateLimitThreshold
-	} else {
-		destination.RateLimitThreshold = nil
-	}
+	destination.RateLimitThreshold = genruntime.ClonePointerToInt(rule.RateLimitThreshold)
 
 	// RuleType
 	if rule.RuleType != nil {
@@ -3103,31 +3058,16 @@ func (rule *CustomRule) Initialize_From_CustomRule_STATUS(source *CustomRule_STA
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		rule.Name = &name
-	} else {
-		rule.Name = nil
-	}
+	rule.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Priority
 	rule.Priority = genruntime.ClonePointerToInt(source.Priority)
 
 	// RateLimitDurationInMinutes
-	if source.RateLimitDurationInMinutes != nil {
-		rateLimitDurationInMinute := *source.RateLimitDurationInMinutes
-		rule.RateLimitDurationInMinutes = &rateLimitDurationInMinute
-	} else {
-		rule.RateLimitDurationInMinutes = nil
-	}
+	rule.RateLimitDurationInMinutes = genruntime.ClonePointerToInt(source.RateLimitDurationInMinutes)
 
 	// RateLimitThreshold
-	if source.RateLimitThreshold != nil {
-		rateLimitThreshold := *source.RateLimitThreshold
-		rule.RateLimitThreshold = &rateLimitThreshold
-	} else {
-		rule.RateLimitThreshold = nil
-	}
+	rule.RateLimitThreshold = genruntime.ClonePointerToInt(source.RateLimitThreshold)
 
 	// RuleType
 	if source.RuleType != nil {

--- a/v2/api/network/v1api20220701/application_gateway_types_gen.go
+++ b/v2/api/network/v1api20220701/application_gateway_types_gen.go
@@ -4933,20 +4933,10 @@ func (configuration *ApplicationGatewayAutoscaleConfiguration) PopulateFromARM(o
 func (configuration *ApplicationGatewayAutoscaleConfiguration) AssignProperties_From_ApplicationGatewayAutoscaleConfiguration(source *storage.ApplicationGatewayAutoscaleConfiguration) error {
 
 	// MaxCapacity
-	if source.MaxCapacity != nil {
-		maxCapacity := *source.MaxCapacity
-		configuration.MaxCapacity = &maxCapacity
-	} else {
-		configuration.MaxCapacity = nil
-	}
+	configuration.MaxCapacity = genruntime.ClonePointerToInt(source.MaxCapacity)
 
 	// MinCapacity
-	if source.MinCapacity != nil {
-		minCapacity := *source.MinCapacity
-		configuration.MinCapacity = &minCapacity
-	} else {
-		configuration.MinCapacity = nil
-	}
+	configuration.MinCapacity = genruntime.ClonePointerToInt(source.MinCapacity)
 
 	// No error
 	return nil
@@ -4958,20 +4948,10 @@ func (configuration *ApplicationGatewayAutoscaleConfiguration) AssignProperties_
 	propertyBag := genruntime.NewPropertyBag()
 
 	// MaxCapacity
-	if configuration.MaxCapacity != nil {
-		maxCapacity := *configuration.MaxCapacity
-		destination.MaxCapacity = &maxCapacity
-	} else {
-		destination.MaxCapacity = nil
-	}
+	destination.MaxCapacity = genruntime.ClonePointerToInt(configuration.MaxCapacity)
 
 	// MinCapacity
-	if configuration.MinCapacity != nil {
-		minCapacity := *configuration.MinCapacity
-		destination.MinCapacity = &minCapacity
-	} else {
-		destination.MinCapacity = nil
-	}
+	destination.MinCapacity = genruntime.ClonePointerToInt(configuration.MinCapacity)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4988,20 +4968,10 @@ func (configuration *ApplicationGatewayAutoscaleConfiguration) AssignProperties_
 func (configuration *ApplicationGatewayAutoscaleConfiguration) Initialize_From_ApplicationGatewayAutoscaleConfiguration_STATUS(source *ApplicationGatewayAutoscaleConfiguration_STATUS) error {
 
 	// MaxCapacity
-	if source.MaxCapacity != nil {
-		maxCapacity := *source.MaxCapacity
-		configuration.MaxCapacity = &maxCapacity
-	} else {
-		configuration.MaxCapacity = nil
-	}
+	configuration.MaxCapacity = genruntime.ClonePointerToInt(source.MaxCapacity)
 
 	// MinCapacity
-	if source.MinCapacity != nil {
-		minCapacity := *source.MinCapacity
-		configuration.MinCapacity = &minCapacity
-	} else {
-		configuration.MinCapacity = nil
-	}
+	configuration.MinCapacity = genruntime.ClonePointerToInt(source.MinCapacity)
 
 	// No error
 	return nil
@@ -9331,12 +9301,7 @@ func (probe *ApplicationGatewayProbe) AssignProperties_From_ApplicationGatewayPr
 	}
 
 	// Port
-	if source.Port != nil {
-		port := *source.Port
-		probe.Port = &port
-	} else {
-		probe.Port = nil
-	}
+	probe.Port = genruntime.ClonePointerToInt(source.Port)
 
 	// Protocol
 	if source.Protocol != nil {
@@ -9406,12 +9371,7 @@ func (probe *ApplicationGatewayProbe) AssignProperties_To_ApplicationGatewayProb
 	}
 
 	// Port
-	if probe.Port != nil {
-		port := *probe.Port
-		destination.Port = &port
-	} else {
-		destination.Port = nil
-	}
+	destination.Port = genruntime.ClonePointerToInt(probe.Port)
 
 	// Protocol
 	if probe.Protocol != nil {
@@ -10366,12 +10326,7 @@ func (rule *ApplicationGatewayRequestRoutingRule) AssignProperties_From_Applicat
 	rule.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Priority
-	if source.Priority != nil {
-		priority := *source.Priority
-		rule.Priority = &priority
-	} else {
-		rule.Priority = nil
-	}
+	rule.Priority = genruntime.ClonePointerToInt(source.Priority)
 
 	// RedirectConfiguration
 	if source.RedirectConfiguration != nil {
@@ -10479,12 +10434,7 @@ func (rule *ApplicationGatewayRequestRoutingRule) AssignProperties_To_Applicatio
 	destination.Name = genruntime.ClonePointerToString(rule.Name)
 
 	// Priority
-	if rule.Priority != nil {
-		priority := *rule.Priority
-		destination.Priority = &priority
-	} else {
-		destination.Priority = nil
-	}
+	destination.Priority = genruntime.ClonePointerToInt(rule.Priority)
 
 	// RedirectConfiguration
 	if rule.RedirectConfiguration != nil {
@@ -11022,12 +10972,7 @@ func (rule *ApplicationGatewayRoutingRule) AssignProperties_From_ApplicationGate
 	rule.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Priority
-	if source.Priority != nil {
-		priority := *source.Priority
-		rule.Priority = &priority
-	} else {
-		rule.Priority = nil
-	}
+	rule.Priority = genruntime.ClonePointerToInt(source.Priority)
 
 	// RuleType
 	if source.RuleType != nil {
@@ -11087,12 +11032,7 @@ func (rule *ApplicationGatewayRoutingRule) AssignProperties_To_ApplicationGatewa
 	destination.Name = genruntime.ClonePointerToString(rule.Name)
 
 	// Priority
-	if rule.Priority != nil {
-		priority := *rule.Priority
-		destination.Priority = &priority
-	} else {
-		destination.Priority = nil
-	}
+	destination.Priority = genruntime.ClonePointerToInt(rule.Priority)
 
 	// RuleType
 	if rule.RuleType != nil {
@@ -13582,12 +13522,7 @@ func (configuration *ApplicationGatewayWebApplicationFirewallConfiguration) Assi
 	}
 
 	// FileUploadLimitInMb
-	if source.FileUploadLimitInMb != nil {
-		fileUploadLimitInMb := *source.FileUploadLimitInMb
-		configuration.FileUploadLimitInMb = &fileUploadLimitInMb
-	} else {
-		configuration.FileUploadLimitInMb = nil
-	}
+	configuration.FileUploadLimitInMb = genruntime.ClonePointerToInt(source.FileUploadLimitInMb)
 
 	// FirewallMode
 	if source.FirewallMode != nil {
@@ -13599,20 +13534,10 @@ func (configuration *ApplicationGatewayWebApplicationFirewallConfiguration) Assi
 	}
 
 	// MaxRequestBodySize
-	if source.MaxRequestBodySize != nil {
-		maxRequestBodySize := *source.MaxRequestBodySize
-		configuration.MaxRequestBodySize = &maxRequestBodySize
-	} else {
-		configuration.MaxRequestBodySize = nil
-	}
+	configuration.MaxRequestBodySize = genruntime.ClonePointerToInt(source.MaxRequestBodySize)
 
 	// MaxRequestBodySizeInKb
-	if source.MaxRequestBodySizeInKb != nil {
-		maxRequestBodySizeInKb := *source.MaxRequestBodySizeInKb
-		configuration.MaxRequestBodySizeInKb = &maxRequestBodySizeInKb
-	} else {
-		configuration.MaxRequestBodySizeInKb = nil
-	}
+	configuration.MaxRequestBodySizeInKb = genruntime.ClonePointerToInt(source.MaxRequestBodySizeInKb)
 
 	// RequestBodyCheck
 	if source.RequestBodyCheck != nil {
@@ -13682,12 +13607,7 @@ func (configuration *ApplicationGatewayWebApplicationFirewallConfiguration) Assi
 	}
 
 	// FileUploadLimitInMb
-	if configuration.FileUploadLimitInMb != nil {
-		fileUploadLimitInMb := *configuration.FileUploadLimitInMb
-		destination.FileUploadLimitInMb = &fileUploadLimitInMb
-	} else {
-		destination.FileUploadLimitInMb = nil
-	}
+	destination.FileUploadLimitInMb = genruntime.ClonePointerToInt(configuration.FileUploadLimitInMb)
 
 	// FirewallMode
 	if configuration.FirewallMode != nil {
@@ -13698,20 +13618,10 @@ func (configuration *ApplicationGatewayWebApplicationFirewallConfiguration) Assi
 	}
 
 	// MaxRequestBodySize
-	if configuration.MaxRequestBodySize != nil {
-		maxRequestBodySize := *configuration.MaxRequestBodySize
-		destination.MaxRequestBodySize = &maxRequestBodySize
-	} else {
-		destination.MaxRequestBodySize = nil
-	}
+	destination.MaxRequestBodySize = genruntime.ClonePointerToInt(configuration.MaxRequestBodySize)
 
 	// MaxRequestBodySizeInKb
-	if configuration.MaxRequestBodySizeInKb != nil {
-		maxRequestBodySizeInKb := *configuration.MaxRequestBodySizeInKb
-		destination.MaxRequestBodySizeInKb = &maxRequestBodySizeInKb
-	} else {
-		destination.MaxRequestBodySizeInKb = nil
-	}
+	destination.MaxRequestBodySizeInKb = genruntime.ClonePointerToInt(configuration.MaxRequestBodySizeInKb)
 
 	// RequestBodyCheck
 	if configuration.RequestBodyCheck != nil {
@@ -13786,12 +13696,7 @@ func (configuration *ApplicationGatewayWebApplicationFirewallConfiguration) Init
 	}
 
 	// FileUploadLimitInMb
-	if source.FileUploadLimitInMb != nil {
-		fileUploadLimitInMb := *source.FileUploadLimitInMb
-		configuration.FileUploadLimitInMb = &fileUploadLimitInMb
-	} else {
-		configuration.FileUploadLimitInMb = nil
-	}
+	configuration.FileUploadLimitInMb = genruntime.ClonePointerToInt(source.FileUploadLimitInMb)
 
 	// FirewallMode
 	if source.FirewallMode != nil {
@@ -13802,20 +13707,10 @@ func (configuration *ApplicationGatewayWebApplicationFirewallConfiguration) Init
 	}
 
 	// MaxRequestBodySize
-	if source.MaxRequestBodySize != nil {
-		maxRequestBodySize := *source.MaxRequestBodySize
-		configuration.MaxRequestBodySize = &maxRequestBodySize
-	} else {
-		configuration.MaxRequestBodySize = nil
-	}
+	configuration.MaxRequestBodySize = genruntime.ClonePointerToInt(source.MaxRequestBodySize)
 
 	// MaxRequestBodySizeInKb
-	if source.MaxRequestBodySizeInKb != nil {
-		maxRequestBodySizeInKb := *source.MaxRequestBodySizeInKb
-		configuration.MaxRequestBodySizeInKb = &maxRequestBodySizeInKb
-	} else {
-		configuration.MaxRequestBodySizeInKb = nil
-	}
+	configuration.MaxRequestBodySizeInKb = genruntime.ClonePointerToInt(source.MaxRequestBodySizeInKb)
 
 	// RequestBodyCheck
 	if source.RequestBodyCheck != nil {
@@ -14919,12 +14814,7 @@ func (draining *ApplicationGatewayConnectionDraining) PopulateFromARM(owner genr
 func (draining *ApplicationGatewayConnectionDraining) AssignProperties_From_ApplicationGatewayConnectionDraining(source *storage.ApplicationGatewayConnectionDraining) error {
 
 	// DrainTimeoutInSec
-	if source.DrainTimeoutInSec != nil {
-		drainTimeoutInSec := *source.DrainTimeoutInSec
-		draining.DrainTimeoutInSec = &drainTimeoutInSec
-	} else {
-		draining.DrainTimeoutInSec = nil
-	}
+	draining.DrainTimeoutInSec = genruntime.ClonePointerToInt(source.DrainTimeoutInSec)
 
 	// Enabled
 	if source.Enabled != nil {
@@ -14944,12 +14834,7 @@ func (draining *ApplicationGatewayConnectionDraining) AssignProperties_To_Applic
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DrainTimeoutInSec
-	if draining.DrainTimeoutInSec != nil {
-		drainTimeoutInSec := *draining.DrainTimeoutInSec
-		destination.DrainTimeoutInSec = &drainTimeoutInSec
-	} else {
-		destination.DrainTimeoutInSec = nil
-	}
+	destination.DrainTimeoutInSec = genruntime.ClonePointerToInt(draining.DrainTimeoutInSec)
 
 	// Enabled
 	if draining.Enabled != nil {

--- a/v2/api/network/v1api20220701/bastion_host_types_gen.go
+++ b/v2/api/network/v1api20220701/bastion_host_types_gen.go
@@ -653,12 +653,7 @@ func (host *BastionHost_Spec) AssignProperties_From_BastionHost_Spec(source *sto
 	}
 
 	// ScaleUnits
-	if source.ScaleUnits != nil {
-		scaleUnit := *source.ScaleUnits
-		host.ScaleUnits = &scaleUnit
-	} else {
-		host.ScaleUnits = nil
-	}
+	host.ScaleUnits = genruntime.ClonePointerToInt(source.ScaleUnits)
 
 	// Sku
 	if source.Sku != nil {
@@ -775,12 +770,7 @@ func (host *BastionHost_Spec) AssignProperties_To_BastionHost_Spec(destination *
 	}
 
 	// ScaleUnits
-	if host.ScaleUnits != nil {
-		scaleUnit := *host.ScaleUnits
-		destination.ScaleUnits = &scaleUnit
-	} else {
-		destination.ScaleUnits = nil
-	}
+	destination.ScaleUnits = genruntime.ClonePointerToInt(host.ScaleUnits)
 
 	// Sku
 	if host.Sku != nil {

--- a/v2/api/network/v1api20240101/web_application_firewall_policy_types_gen.go
+++ b/v2/api/network/v1api20240101/web_application_firewall_policy_types_gen.go
@@ -1902,20 +1902,10 @@ func (settings *PolicySettings) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 func (settings *PolicySettings) AssignProperties_From_PolicySettings(source *storage.PolicySettings) error {
 
 	// CustomBlockResponseBody
-	if source.CustomBlockResponseBody != nil {
-		customBlockResponseBody := *source.CustomBlockResponseBody
-		settings.CustomBlockResponseBody = &customBlockResponseBody
-	} else {
-		settings.CustomBlockResponseBody = nil
-	}
+	settings.CustomBlockResponseBody = genruntime.ClonePointerToString(source.CustomBlockResponseBody)
 
 	// CustomBlockResponseStatusCode
-	if source.CustomBlockResponseStatusCode != nil {
-		customBlockResponseStatusCode := *source.CustomBlockResponseStatusCode
-		settings.CustomBlockResponseStatusCode = &customBlockResponseStatusCode
-	} else {
-		settings.CustomBlockResponseStatusCode = nil
-	}
+	settings.CustomBlockResponseStatusCode = genruntime.ClonePointerToInt(source.CustomBlockResponseStatusCode)
 
 	// FileUploadEnforcement
 	if source.FileUploadEnforcement != nil {
@@ -1926,20 +1916,10 @@ func (settings *PolicySettings) AssignProperties_From_PolicySettings(source *sto
 	}
 
 	// FileUploadLimitInMb
-	if source.FileUploadLimitInMb != nil {
-		fileUploadLimitInMb := *source.FileUploadLimitInMb
-		settings.FileUploadLimitInMb = &fileUploadLimitInMb
-	} else {
-		settings.FileUploadLimitInMb = nil
-	}
+	settings.FileUploadLimitInMb = genruntime.ClonePointerToInt(source.FileUploadLimitInMb)
 
 	// JsChallengeCookieExpirationInMins
-	if source.JsChallengeCookieExpirationInMins != nil {
-		jsChallengeCookieExpirationInMin := *source.JsChallengeCookieExpirationInMins
-		settings.JsChallengeCookieExpirationInMins = &jsChallengeCookieExpirationInMin
-	} else {
-		settings.JsChallengeCookieExpirationInMins = nil
-	}
+	settings.JsChallengeCookieExpirationInMins = genruntime.ClonePointerToInt(source.JsChallengeCookieExpirationInMins)
 
 	// LogScrubbing
 	if source.LogScrubbing != nil {
@@ -1954,12 +1934,7 @@ func (settings *PolicySettings) AssignProperties_From_PolicySettings(source *sto
 	}
 
 	// MaxRequestBodySizeInKb
-	if source.MaxRequestBodySizeInKb != nil {
-		maxRequestBodySizeInKb := *source.MaxRequestBodySizeInKb
-		settings.MaxRequestBodySizeInKb = &maxRequestBodySizeInKb
-	} else {
-		settings.MaxRequestBodySizeInKb = nil
-	}
+	settings.MaxRequestBodySizeInKb = genruntime.ClonePointerToInt(source.MaxRequestBodySizeInKb)
 
 	// Mode
 	if source.Mode != nil {
@@ -2008,20 +1983,10 @@ func (settings *PolicySettings) AssignProperties_To_PolicySettings(destination *
 	propertyBag := genruntime.NewPropertyBag()
 
 	// CustomBlockResponseBody
-	if settings.CustomBlockResponseBody != nil {
-		customBlockResponseBody := *settings.CustomBlockResponseBody
-		destination.CustomBlockResponseBody = &customBlockResponseBody
-	} else {
-		destination.CustomBlockResponseBody = nil
-	}
+	destination.CustomBlockResponseBody = genruntime.ClonePointerToString(settings.CustomBlockResponseBody)
 
 	// CustomBlockResponseStatusCode
-	if settings.CustomBlockResponseStatusCode != nil {
-		customBlockResponseStatusCode := *settings.CustomBlockResponseStatusCode
-		destination.CustomBlockResponseStatusCode = &customBlockResponseStatusCode
-	} else {
-		destination.CustomBlockResponseStatusCode = nil
-	}
+	destination.CustomBlockResponseStatusCode = genruntime.ClonePointerToInt(settings.CustomBlockResponseStatusCode)
 
 	// FileUploadEnforcement
 	if settings.FileUploadEnforcement != nil {
@@ -2032,20 +1997,10 @@ func (settings *PolicySettings) AssignProperties_To_PolicySettings(destination *
 	}
 
 	// FileUploadLimitInMb
-	if settings.FileUploadLimitInMb != nil {
-		fileUploadLimitInMb := *settings.FileUploadLimitInMb
-		destination.FileUploadLimitInMb = &fileUploadLimitInMb
-	} else {
-		destination.FileUploadLimitInMb = nil
-	}
+	destination.FileUploadLimitInMb = genruntime.ClonePointerToInt(settings.FileUploadLimitInMb)
 
 	// JsChallengeCookieExpirationInMins
-	if settings.JsChallengeCookieExpirationInMins != nil {
-		jsChallengeCookieExpirationInMin := *settings.JsChallengeCookieExpirationInMins
-		destination.JsChallengeCookieExpirationInMins = &jsChallengeCookieExpirationInMin
-	} else {
-		destination.JsChallengeCookieExpirationInMins = nil
-	}
+	destination.JsChallengeCookieExpirationInMins = genruntime.ClonePointerToInt(settings.JsChallengeCookieExpirationInMins)
 
 	// LogScrubbing
 	if settings.LogScrubbing != nil {
@@ -2060,12 +2015,7 @@ func (settings *PolicySettings) AssignProperties_To_PolicySettings(destination *
 	}
 
 	// MaxRequestBodySizeInKb
-	if settings.MaxRequestBodySizeInKb != nil {
-		maxRequestBodySizeInKb := *settings.MaxRequestBodySizeInKb
-		destination.MaxRequestBodySizeInKb = &maxRequestBodySizeInKb
-	} else {
-		destination.MaxRequestBodySizeInKb = nil
-	}
+	destination.MaxRequestBodySizeInKb = genruntime.ClonePointerToInt(settings.MaxRequestBodySizeInKb)
 
 	// Mode
 	if settings.Mode != nil {
@@ -2117,20 +2067,10 @@ func (settings *PolicySettings) AssignProperties_To_PolicySettings(destination *
 func (settings *PolicySettings) Initialize_From_PolicySettings_STATUS(source *PolicySettings_STATUS) error {
 
 	// CustomBlockResponseBody
-	if source.CustomBlockResponseBody != nil {
-		customBlockResponseBody := *source.CustomBlockResponseBody
-		settings.CustomBlockResponseBody = &customBlockResponseBody
-	} else {
-		settings.CustomBlockResponseBody = nil
-	}
+	settings.CustomBlockResponseBody = genruntime.ClonePointerToString(source.CustomBlockResponseBody)
 
 	// CustomBlockResponseStatusCode
-	if source.CustomBlockResponseStatusCode != nil {
-		customBlockResponseStatusCode := *source.CustomBlockResponseStatusCode
-		settings.CustomBlockResponseStatusCode = &customBlockResponseStatusCode
-	} else {
-		settings.CustomBlockResponseStatusCode = nil
-	}
+	settings.CustomBlockResponseStatusCode = genruntime.ClonePointerToInt(source.CustomBlockResponseStatusCode)
 
 	// FileUploadEnforcement
 	if source.FileUploadEnforcement != nil {
@@ -2141,20 +2081,10 @@ func (settings *PolicySettings) Initialize_From_PolicySettings_STATUS(source *Po
 	}
 
 	// FileUploadLimitInMb
-	if source.FileUploadLimitInMb != nil {
-		fileUploadLimitInMb := *source.FileUploadLimitInMb
-		settings.FileUploadLimitInMb = &fileUploadLimitInMb
-	} else {
-		settings.FileUploadLimitInMb = nil
-	}
+	settings.FileUploadLimitInMb = genruntime.ClonePointerToInt(source.FileUploadLimitInMb)
 
 	// JsChallengeCookieExpirationInMins
-	if source.JsChallengeCookieExpirationInMins != nil {
-		jsChallengeCookieExpirationInMin := *source.JsChallengeCookieExpirationInMins
-		settings.JsChallengeCookieExpirationInMins = &jsChallengeCookieExpirationInMin
-	} else {
-		settings.JsChallengeCookieExpirationInMins = nil
-	}
+	settings.JsChallengeCookieExpirationInMins = genruntime.ClonePointerToInt(source.JsChallengeCookieExpirationInMins)
 
 	// LogScrubbing
 	if source.LogScrubbing != nil {
@@ -2169,12 +2099,7 @@ func (settings *PolicySettings) Initialize_From_PolicySettings_STATUS(source *Po
 	}
 
 	// MaxRequestBodySizeInKb
-	if source.MaxRequestBodySizeInKb != nil {
-		maxRequestBodySizeInKb := *source.MaxRequestBodySizeInKb
-		settings.MaxRequestBodySizeInKb = &maxRequestBodySizeInKb
-	} else {
-		settings.MaxRequestBodySizeInKb = nil
-	}
+	settings.MaxRequestBodySizeInKb = genruntime.ClonePointerToInt(source.MaxRequestBodySizeInKb)
 
 	// Mode
 	if source.Mode != nil {
@@ -2827,12 +2752,7 @@ func (rule *WebApplicationFirewallCustomRule) AssignProperties_From_WebApplicati
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		rule.Name = &name
-	} else {
-		rule.Name = nil
-	}
+	rule.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Priority
 	rule.Priority = genruntime.ClonePointerToInt(source.Priority)
@@ -2921,12 +2841,7 @@ func (rule *WebApplicationFirewallCustomRule) AssignProperties_To_WebApplication
 	}
 
 	// Name
-	if rule.Name != nil {
-		name := *rule.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(rule.Name)
 
 	// Priority
 	destination.Priority = genruntime.ClonePointerToInt(rule.Priority)
@@ -3017,12 +2932,7 @@ func (rule *WebApplicationFirewallCustomRule) Initialize_From_WebApplicationFire
 	}
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		rule.Name = &name
-	} else {
-		rule.Name = nil
-	}
+	rule.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Priority
 	rule.Priority = genruntime.ClonePointerToInt(source.Priority)

--- a/v2/api/network/v1api20240301/bastion_host_types_gen.go
+++ b/v2/api/network/v1api20240301/bastion_host_types_gen.go
@@ -780,12 +780,7 @@ func (host *BastionHost_Spec) AssignProperties_From_BastionHost_Spec(source *sto
 	}
 
 	// ScaleUnits
-	if source.ScaleUnits != nil {
-		scaleUnit := *source.ScaleUnits
-		host.ScaleUnits = &scaleUnit
-	} else {
-		host.ScaleUnits = nil
-	}
+	host.ScaleUnits = genruntime.ClonePointerToInt(source.ScaleUnits)
 
 	// Sku
 	if source.Sku != nil {
@@ -945,12 +940,7 @@ func (host *BastionHost_Spec) AssignProperties_To_BastionHost_Spec(destination *
 	}
 
 	// ScaleUnits
-	if host.ScaleUnits != nil {
-		scaleUnit := *host.ScaleUnits
-		destination.ScaleUnits = &scaleUnit
-	} else {
-		destination.ScaleUnits = nil
-	}
+	destination.ScaleUnits = genruntime.ClonePointerToInt(host.ScaleUnits)
 
 	// Sku
 	if host.Sku != nil {
@@ -1089,12 +1079,7 @@ func (host *BastionHost_Spec) Initialize_From_BastionHost_STATUS(source *Bastion
 	}
 
 	// ScaleUnits
-	if source.ScaleUnits != nil {
-		scaleUnit := *source.ScaleUnits
-		host.ScaleUnits = &scaleUnit
-	} else {
-		host.ScaleUnits = nil
-	}
+	host.ScaleUnits = genruntime.ClonePointerToInt(source.ScaleUnits)
 
 	// Sku
 	if source.Sku != nil {

--- a/v2/api/network/v1api20240301/network_interface_types_gen.go
+++ b/v2/api/network/v1api20240301/network_interface_types_gen.go
@@ -2737,12 +2737,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 	embedded.PrivateIPAddress = genruntime.ClonePointerToString(source.PrivateIPAddress)
 
 	// PrivateIPAddressPrefixLength
-	if source.PrivateIPAddressPrefixLength != nil {
-		privateIPAddressPrefixLength := *source.PrivateIPAddressPrefixLength
-		embedded.PrivateIPAddressPrefixLength = &privateIPAddressPrefixLength
-	} else {
-		embedded.PrivateIPAddressPrefixLength = nil
-	}
+	embedded.PrivateIPAddressPrefixLength = genruntime.ClonePointerToInt(source.PrivateIPAddressPrefixLength)
 
 	// PrivateIPAddressVersion
 	if source.PrivateIPAddressVersion != nil {
@@ -2912,12 +2907,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 	destination.PrivateIPAddress = genruntime.ClonePointerToString(embedded.PrivateIPAddress)
 
 	// PrivateIPAddressPrefixLength
-	if embedded.PrivateIPAddressPrefixLength != nil {
-		privateIPAddressPrefixLength := *embedded.PrivateIPAddressPrefixLength
-		destination.PrivateIPAddressPrefixLength = &privateIPAddressPrefixLength
-	} else {
-		destination.PrivateIPAddressPrefixLength = nil
-	}
+	destination.PrivateIPAddressPrefixLength = genruntime.ClonePointerToInt(embedded.PrivateIPAddressPrefixLength)
 
 	// PrivateIPAddressVersion
 	if embedded.PrivateIPAddressVersion != nil {
@@ -3090,12 +3080,7 @@ func (embedded *NetworkInterfaceIPConfiguration_NetworkInterface_SubResourceEmbe
 	embedded.PrivateIPAddress = genruntime.ClonePointerToString(source.PrivateIPAddress)
 
 	// PrivateIPAddressPrefixLength
-	if source.PrivateIPAddressPrefixLength != nil {
-		privateIPAddressPrefixLength := *source.PrivateIPAddressPrefixLength
-		embedded.PrivateIPAddressPrefixLength = &privateIPAddressPrefixLength
-	} else {
-		embedded.PrivateIPAddressPrefixLength = nil
-	}
+	embedded.PrivateIPAddressPrefixLength = genruntime.ClonePointerToInt(source.PrivateIPAddressPrefixLength)
 
 	// PrivateIPAddressVersion
 	if source.PrivateIPAddressVersion != nil {

--- a/v2/api/notificationhubs/v1api20230901/namespace_types_gen.go
+++ b/v2/api/notificationhubs/v1api20230901/namespace_types_gen.go
@@ -4265,12 +4265,7 @@ func (rule *IpRule) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, ar
 func (rule *IpRule) AssignProperties_From_IpRule(source *storage.IpRule) error {
 
 	// IpMask
-	if source.IpMask != nil {
-		ipMask := *source.IpMask
-		rule.IpMask = &ipMask
-	} else {
-		rule.IpMask = nil
-	}
+	rule.IpMask = genruntime.ClonePointerToString(source.IpMask)
 
 	// Rights
 	if source.Rights != nil {
@@ -4295,12 +4290,7 @@ func (rule *IpRule) AssignProperties_To_IpRule(destination *storage.IpRule) erro
 	propertyBag := genruntime.NewPropertyBag()
 
 	// IpMask
-	if rule.IpMask != nil {
-		ipMask := *rule.IpMask
-		destination.IpMask = &ipMask
-	} else {
-		destination.IpMask = nil
-	}
+	destination.IpMask = genruntime.ClonePointerToString(rule.IpMask)
 
 	// Rights
 	if rule.Rights != nil {
@@ -4330,12 +4320,7 @@ func (rule *IpRule) AssignProperties_To_IpRule(destination *storage.IpRule) erro
 func (rule *IpRule) Initialize_From_IpRule_STATUS(source *IpRule_STATUS) error {
 
 	// IpMask
-	if source.IpMask != nil {
-		ipMask := *source.IpMask
-		rule.IpMask = &ipMask
-	} else {
-		rule.IpMask = nil
-	}
+	rule.IpMask = genruntime.ClonePointerToString(source.IpMask)
 
 	// Rights
 	if source.Rights != nil {

--- a/v2/api/search/v1api20220901/search_service_types_gen.go
+++ b/v2/api/search/v1api20220901/search_service_types_gen.go
@@ -726,12 +726,7 @@ func (service *SearchService_Spec) AssignProperties_From_SearchService_Spec(sour
 	}
 
 	// PartitionCount
-	if source.PartitionCount != nil {
-		partitionCount := *source.PartitionCount
-		service.PartitionCount = &partitionCount
-	} else {
-		service.PartitionCount = nil
-	}
+	service.PartitionCount = genruntime.ClonePointerToInt(source.PartitionCount)
 
 	// PublicNetworkAccess
 	if source.PublicNetworkAccess != nil {
@@ -743,12 +738,7 @@ func (service *SearchService_Spec) AssignProperties_From_SearchService_Spec(sour
 	}
 
 	// ReplicaCount
-	if source.ReplicaCount != nil {
-		replicaCount := *source.ReplicaCount
-		service.ReplicaCount = &replicaCount
-	} else {
-		service.ReplicaCount = nil
-	}
+	service.ReplicaCount = genruntime.ClonePointerToInt(source.ReplicaCount)
 
 	// Sku
 	if source.Sku != nil {
@@ -868,12 +858,7 @@ func (service *SearchService_Spec) AssignProperties_To_SearchService_Spec(destin
 	}
 
 	// PartitionCount
-	if service.PartitionCount != nil {
-		partitionCount := *service.PartitionCount
-		destination.PartitionCount = &partitionCount
-	} else {
-		destination.PartitionCount = nil
-	}
+	destination.PartitionCount = genruntime.ClonePointerToInt(service.PartitionCount)
 
 	// PublicNetworkAccess
 	if service.PublicNetworkAccess != nil {
@@ -884,12 +869,7 @@ func (service *SearchService_Spec) AssignProperties_To_SearchService_Spec(destin
 	}
 
 	// ReplicaCount
-	if service.ReplicaCount != nil {
-		replicaCount := *service.ReplicaCount
-		destination.ReplicaCount = &replicaCount
-	} else {
-		destination.ReplicaCount = nil
-	}
+	destination.ReplicaCount = genruntime.ClonePointerToInt(service.ReplicaCount)
 
 	// Sku
 	if service.Sku != nil {
@@ -988,12 +968,7 @@ func (service *SearchService_Spec) Initialize_From_SearchService_STATUS(source *
 	}
 
 	// PartitionCount
-	if source.PartitionCount != nil {
-		partitionCount := *source.PartitionCount
-		service.PartitionCount = &partitionCount
-	} else {
-		service.PartitionCount = nil
-	}
+	service.PartitionCount = genruntime.ClonePointerToInt(source.PartitionCount)
 
 	// PublicNetworkAccess
 	if source.PublicNetworkAccess != nil {
@@ -1004,12 +979,7 @@ func (service *SearchService_Spec) Initialize_From_SearchService_STATUS(source *
 	}
 
 	// ReplicaCount
-	if source.ReplicaCount != nil {
-		replicaCount := *source.ReplicaCount
-		service.ReplicaCount = &replicaCount
-	} else {
-		service.ReplicaCount = nil
-	}
+	service.ReplicaCount = genruntime.ClonePointerToInt(source.ReplicaCount)
 
 	// Sku
 	if source.Sku != nil {

--- a/v2/api/servicebus/v1api20210101preview/namespaces_topics_subscriptions_rule_types_gen.go
+++ b/v2/api/servicebus/v1api20210101preview/namespaces_topics_subscriptions_rule_types_gen.go
@@ -1901,12 +1901,7 @@ func (filter *SqlFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 func (filter *SqlFilter) AssignProperties_From_SqlFilter(source *storage.SqlFilter) error {
 
 	// CompatibilityLevel
-	if source.CompatibilityLevel != nil {
-		compatibilityLevel := *source.CompatibilityLevel
-		filter.CompatibilityLevel = &compatibilityLevel
-	} else {
-		filter.CompatibilityLevel = nil
-	}
+	filter.CompatibilityLevel = genruntime.ClonePointerToInt(source.CompatibilityLevel)
 
 	// RequiresPreprocessing
 	if source.RequiresPreprocessing != nil {
@@ -1929,12 +1924,7 @@ func (filter *SqlFilter) AssignProperties_To_SqlFilter(destination *storage.SqlF
 	propertyBag := genruntime.NewPropertyBag()
 
 	// CompatibilityLevel
-	if filter.CompatibilityLevel != nil {
-		compatibilityLevel := *filter.CompatibilityLevel
-		destination.CompatibilityLevel = &compatibilityLevel
-	} else {
-		destination.CompatibilityLevel = nil
-	}
+	destination.CompatibilityLevel = genruntime.ClonePointerToInt(filter.CompatibilityLevel)
 
 	// RequiresPreprocessing
 	if filter.RequiresPreprocessing != nil {

--- a/v2/api/signalrservice/v1api20211001/signal_r_types_gen.go
+++ b/v2/api/signalrservice/v1api20211001/signal_r_types_gen.go
@@ -3337,12 +3337,7 @@ func (feature *SignalRFeature) AssignProperties_From_SignalRFeature(source *stor
 	feature.Properties = genruntime.CloneMapOfStringToString(source.Properties)
 
 	// Value
-	if source.Value != nil {
-		value := *source.Value
-		feature.Value = &value
-	} else {
-		feature.Value = nil
-	}
+	feature.Value = genruntime.ClonePointerToString(source.Value)
 
 	// No error
 	return nil
@@ -3365,12 +3360,7 @@ func (feature *SignalRFeature) AssignProperties_To_SignalRFeature(destination *s
 	destination.Properties = genruntime.CloneMapOfStringToString(feature.Properties)
 
 	// Value
-	if feature.Value != nil {
-		value := *feature.Value
-		destination.Value = &value
-	} else {
-		destination.Value = nil
-	}
+	destination.Value = genruntime.ClonePointerToString(feature.Value)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/signalrservice/v1api20240301/signal_r_types_gen.go
+++ b/v2/api/signalrservice/v1api20240301/signal_r_types_gen.go
@@ -3330,12 +3330,7 @@ func (settings *ServerlessSettings) PopulateFromARM(owner genruntime.ArbitraryOw
 func (settings *ServerlessSettings) AssignProperties_From_ServerlessSettings(source *storage.ServerlessSettings) error {
 
 	// ConnectionTimeoutInSeconds
-	if source.ConnectionTimeoutInSeconds != nil {
-		connectionTimeoutInSecond := *source.ConnectionTimeoutInSeconds
-		settings.ConnectionTimeoutInSeconds = &connectionTimeoutInSecond
-	} else {
-		settings.ConnectionTimeoutInSeconds = nil
-	}
+	settings.ConnectionTimeoutInSeconds = genruntime.ClonePointerToInt(source.ConnectionTimeoutInSeconds)
 
 	// No error
 	return nil
@@ -3347,12 +3342,7 @@ func (settings *ServerlessSettings) AssignProperties_To_ServerlessSettings(desti
 	propertyBag := genruntime.NewPropertyBag()
 
 	// ConnectionTimeoutInSeconds
-	if settings.ConnectionTimeoutInSeconds != nil {
-		connectionTimeoutInSecond := *settings.ConnectionTimeoutInSeconds
-		destination.ConnectionTimeoutInSeconds = &connectionTimeoutInSecond
-	} else {
-		destination.ConnectionTimeoutInSeconds = nil
-	}
+	destination.ConnectionTimeoutInSeconds = genruntime.ClonePointerToInt(settings.ConnectionTimeoutInSeconds)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -3369,12 +3359,7 @@ func (settings *ServerlessSettings) AssignProperties_To_ServerlessSettings(desti
 func (settings *ServerlessSettings) Initialize_From_ServerlessSettings_STATUS(source *ServerlessSettings_STATUS) error {
 
 	// ConnectionTimeoutInSeconds
-	if source.ConnectionTimeoutInSeconds != nil {
-		connectionTimeoutInSecond := *source.ConnectionTimeoutInSeconds
-		settings.ConnectionTimeoutInSeconds = &connectionTimeoutInSecond
-	} else {
-		settings.ConnectionTimeoutInSeconds = nil
-	}
+	settings.ConnectionTimeoutInSeconds = genruntime.ClonePointerToInt(source.ConnectionTimeoutInSeconds)
 
 	// No error
 	return nil
@@ -3990,12 +3975,7 @@ func (feature *SignalRFeature) AssignProperties_From_SignalRFeature(source *stor
 	feature.Properties = genruntime.CloneMapOfStringToString(source.Properties)
 
 	// Value
-	if source.Value != nil {
-		value := *source.Value
-		feature.Value = &value
-	} else {
-		feature.Value = nil
-	}
+	feature.Value = genruntime.ClonePointerToString(source.Value)
 
 	// No error
 	return nil
@@ -4018,12 +3998,7 @@ func (feature *SignalRFeature) AssignProperties_To_SignalRFeature(destination *s
 	destination.Properties = genruntime.CloneMapOfStringToString(feature.Properties)
 
 	// Value
-	if feature.Value != nil {
-		value := *feature.Value
-		destination.Value = &value
-	} else {
-		destination.Value = nil
-	}
+	destination.Value = genruntime.ClonePointerToString(feature.Value)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4051,12 +4026,7 @@ func (feature *SignalRFeature) Initialize_From_SignalRFeature_STATUS(source *Sig
 	feature.Properties = genruntime.CloneMapOfStringToString(source.Properties)
 
 	// Value
-	if source.Value != nil {
-		value := *source.Value
-		feature.Value = &value
-	} else {
-		feature.Value = nil
-	}
+	feature.Value = genruntime.ClonePointerToString(source.Value)
 
 	// No error
 	return nil

--- a/v2/api/sql/v1api20211101/server_types_gen.go
+++ b/v2/api/sql/v1api20211101/server_types_gen.go
@@ -655,12 +655,7 @@ func (server *Server_Spec) AssignProperties_From_Server_Spec(source *storage.Ser
 	server.AzureName = source.AzureName
 
 	// FederatedClientId
-	if source.FederatedClientId != nil {
-		federatedClientId := *source.FederatedClientId
-		server.FederatedClientId = &federatedClientId
-	} else {
-		server.FederatedClientId = nil
-	}
+	server.FederatedClientId = genruntime.ClonePointerToString(source.FederatedClientId)
 
 	// Identity
 	if source.Identity != nil {
@@ -771,12 +766,7 @@ func (server *Server_Spec) AssignProperties_To_Server_Spec(destination *storage.
 	destination.AzureName = server.AzureName
 
 	// FederatedClientId
-	if server.FederatedClientId != nil {
-		federatedClientId := *server.FederatedClientId
-		destination.FederatedClientId = &federatedClientId
-	} else {
-		destination.FederatedClientId = nil
-	}
+	destination.FederatedClientId = genruntime.ClonePointerToString(server.FederatedClientId)
 
 	// Identity
 	if server.Identity != nil {
@@ -882,12 +872,7 @@ func (server *Server_Spec) Initialize_From_Server_STATUS(source *Server_STATUS) 
 	}
 
 	// FederatedClientId
-	if source.FederatedClientId != nil {
-		federatedClientId := *source.FederatedClientId
-		server.FederatedClientId = &federatedClientId
-	} else {
-		server.FederatedClientId = nil
-	}
+	server.FederatedClientId = genruntime.ClonePointerToString(source.FederatedClientId)
 
 	// Identity
 	if source.Identity != nil {
@@ -2006,20 +1991,10 @@ func (administrator *ServerExternalAdministrator) AssignProperties_From_ServerEx
 	}
 
 	// Sid
-	if source.Sid != nil {
-		sid := *source.Sid
-		administrator.Sid = &sid
-	} else {
-		administrator.Sid = nil
-	}
+	administrator.Sid = genruntime.ClonePointerToString(source.Sid)
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		administrator.TenantId = &tenantId
-	} else {
-		administrator.TenantId = nil
-	}
+	administrator.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// No error
 	return nil
@@ -2058,20 +2033,10 @@ func (administrator *ServerExternalAdministrator) AssignProperties_To_ServerExte
 	}
 
 	// Sid
-	if administrator.Sid != nil {
-		sid := *administrator.Sid
-		destination.Sid = &sid
-	} else {
-		destination.Sid = nil
-	}
+	destination.Sid = genruntime.ClonePointerToString(administrator.Sid)
 
 	// TenantId
-	if administrator.TenantId != nil {
-		tenantId := *administrator.TenantId
-		destination.TenantId = &tenantId
-	} else {
-		destination.TenantId = nil
-	}
+	destination.TenantId = genruntime.ClonePointerToString(administrator.TenantId)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -2115,20 +2080,10 @@ func (administrator *ServerExternalAdministrator) Initialize_From_ServerExternal
 	}
 
 	// Sid
-	if source.Sid != nil {
-		sid := *source.Sid
-		administrator.Sid = &sid
-	} else {
-		administrator.Sid = nil
-	}
+	administrator.Sid = genruntime.ClonePointerToString(source.Sid)
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		administrator.TenantId = &tenantId
-	} else {
-		administrator.TenantId = nil
-	}
+	administrator.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// No error
 	return nil

--- a/v2/api/sql/v1api20211101/servers_administrator_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_administrator_types_gen.go
@@ -489,12 +489,7 @@ func (administrator *ServersAdministrator_Spec) AssignProperties_From_ServersAdm
 	}
 
 	// Sid
-	if source.Sid != nil {
-		sid := *source.Sid
-		administrator.Sid = &sid
-	} else {
-		administrator.Sid = nil
-	}
+	administrator.Sid = genruntime.ClonePointerToString(source.Sid)
 
 	// SidFromConfig
 	if source.SidFromConfig != nil {
@@ -505,12 +500,7 @@ func (administrator *ServersAdministrator_Spec) AssignProperties_From_ServersAdm
 	}
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		administrator.TenantId = &tenantId
-	} else {
-		administrator.TenantId = nil
-	}
+	administrator.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// TenantIdFromConfig
 	if source.TenantIdFromConfig != nil {
@@ -564,12 +554,7 @@ func (administrator *ServersAdministrator_Spec) AssignProperties_To_ServersAdmin
 	}
 
 	// Sid
-	if administrator.Sid != nil {
-		sid := *administrator.Sid
-		destination.Sid = &sid
-	} else {
-		destination.Sid = nil
-	}
+	destination.Sid = genruntime.ClonePointerToString(administrator.Sid)
 
 	// SidFromConfig
 	if administrator.SidFromConfig != nil {
@@ -580,12 +565,7 @@ func (administrator *ServersAdministrator_Spec) AssignProperties_To_ServersAdmin
 	}
 
 	// TenantId
-	if administrator.TenantId != nil {
-		tenantId := *administrator.TenantId
-		destination.TenantId = &tenantId
-	} else {
-		destination.TenantId = nil
-	}
+	destination.TenantId = genruntime.ClonePointerToString(administrator.TenantId)
 
 	// TenantIdFromConfig
 	if administrator.TenantIdFromConfig != nil {
@@ -621,20 +601,10 @@ func (administrator *ServersAdministrator_Spec) Initialize_From_ServersAdministr
 	administrator.Login = genruntime.ClonePointerToString(source.Login)
 
 	// Sid
-	if source.Sid != nil {
-		sid := *source.Sid
-		administrator.Sid = &sid
-	} else {
-		administrator.Sid = nil
-	}
+	administrator.Sid = genruntime.ClonePointerToString(source.Sid)
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		administrator.TenantId = &tenantId
-	} else {
-		administrator.TenantId = nil
-	}
+	administrator.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// No error
 	return nil

--- a/v2/api/sql/v1api20211101/servers_auditing_setting_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_auditing_setting_types_gen.go
@@ -704,12 +704,7 @@ func (setting *ServersAuditingSetting_Spec) AssignProperties_From_ServersAuditin
 	}
 
 	// StorageAccountSubscriptionId
-	if source.StorageAccountSubscriptionId != nil {
-		storageAccountSubscriptionId := *source.StorageAccountSubscriptionId
-		setting.StorageAccountSubscriptionId = &storageAccountSubscriptionId
-	} else {
-		setting.StorageAccountSubscriptionId = nil
-	}
+	setting.StorageAccountSubscriptionId = genruntime.ClonePointerToString(source.StorageAccountSubscriptionId)
 
 	// StorageEndpoint
 	setting.StorageEndpoint = genruntime.ClonePointerToString(source.StorageEndpoint)
@@ -804,12 +799,7 @@ func (setting *ServersAuditingSetting_Spec) AssignProperties_To_ServersAuditingS
 	}
 
 	// StorageAccountSubscriptionId
-	if setting.StorageAccountSubscriptionId != nil {
-		storageAccountSubscriptionId := *setting.StorageAccountSubscriptionId
-		destination.StorageAccountSubscriptionId = &storageAccountSubscriptionId
-	} else {
-		destination.StorageAccountSubscriptionId = nil
-	}
+	destination.StorageAccountSubscriptionId = genruntime.ClonePointerToString(setting.StorageAccountSubscriptionId)
 
 	// StorageEndpoint
 	destination.StorageEndpoint = genruntime.ClonePointerToString(setting.StorageEndpoint)
@@ -878,12 +868,7 @@ func (setting *ServersAuditingSetting_Spec) Initialize_From_ServersAuditingSetti
 	}
 
 	// StorageAccountSubscriptionId
-	if source.StorageAccountSubscriptionId != nil {
-		storageAccountSubscriptionId := *source.StorageAccountSubscriptionId
-		setting.StorageAccountSubscriptionId = &storageAccountSubscriptionId
-	} else {
-		setting.StorageAccountSubscriptionId = nil
-	}
+	setting.StorageAccountSubscriptionId = genruntime.ClonePointerToString(source.StorageAccountSubscriptionId)
 
 	// StorageEndpoint
 	setting.StorageEndpoint = genruntime.ClonePointerToString(source.StorageEndpoint)

--- a/v2/api/sql/v1api20211101/servers_database_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_database_types_gen.go
@@ -962,12 +962,7 @@ func (database *ServersDatabase_Spec) AssignProperties_From_ServersDatabase_Spec
 	}
 
 	// FederatedClientId
-	if source.FederatedClientId != nil {
-		federatedClientId := *source.FederatedClientId
-		database.FederatedClientId = &federatedClientId
-	} else {
-		database.FederatedClientId = nil
-	}
+	database.FederatedClientId = genruntime.ClonePointerToString(source.FederatedClientId)
 
 	// HighAvailabilityReplicaCount
 	database.HighAvailabilityReplicaCount = genruntime.ClonePointerToInt(source.HighAvailabilityReplicaCount)
@@ -1194,12 +1189,7 @@ func (database *ServersDatabase_Spec) AssignProperties_To_ServersDatabase_Spec(d
 	}
 
 	// FederatedClientId
-	if database.FederatedClientId != nil {
-		federatedClientId := *database.FederatedClientId
-		destination.FederatedClientId = &federatedClientId
-	} else {
-		destination.FederatedClientId = nil
-	}
+	destination.FederatedClientId = genruntime.ClonePointerToString(database.FederatedClientId)
 
 	// HighAvailabilityReplicaCount
 	destination.HighAvailabilityReplicaCount = genruntime.ClonePointerToInt(database.HighAvailabilityReplicaCount)
@@ -1426,12 +1416,7 @@ func (database *ServersDatabase_Spec) Initialize_From_ServersDatabase_STATUS(sou
 	}
 
 	// FederatedClientId
-	if source.FederatedClientId != nil {
-		federatedClientId := *source.FederatedClientId
-		database.FederatedClientId = &federatedClientId
-	} else {
-		database.FederatedClientId = nil
-	}
+	database.FederatedClientId = genruntime.ClonePointerToString(source.FederatedClientId)
 
 	// HighAvailabilityReplicaCount
 	database.HighAvailabilityReplicaCount = genruntime.ClonePointerToInt(source.HighAvailabilityReplicaCount)

--- a/v2/api/sql/v1api20211101/servers_databases_auditing_setting_types_gen.go
+++ b/v2/api/sql/v1api20211101/servers_databases_auditing_setting_types_gen.go
@@ -669,12 +669,7 @@ func (setting *ServersDatabasesAuditingSetting_Spec) AssignProperties_From_Serve
 	}
 
 	// StorageAccountSubscriptionId
-	if source.StorageAccountSubscriptionId != nil {
-		storageAccountSubscriptionId := *source.StorageAccountSubscriptionId
-		setting.StorageAccountSubscriptionId = &storageAccountSubscriptionId
-	} else {
-		setting.StorageAccountSubscriptionId = nil
-	}
+	setting.StorageAccountSubscriptionId = genruntime.ClonePointerToString(source.StorageAccountSubscriptionId)
 
 	// StorageEndpoint
 	setting.StorageEndpoint = genruntime.ClonePointerToString(source.StorageEndpoint)
@@ -761,12 +756,7 @@ func (setting *ServersDatabasesAuditingSetting_Spec) AssignProperties_To_Servers
 	}
 
 	// StorageAccountSubscriptionId
-	if setting.StorageAccountSubscriptionId != nil {
-		storageAccountSubscriptionId := *setting.StorageAccountSubscriptionId
-		destination.StorageAccountSubscriptionId = &storageAccountSubscriptionId
-	} else {
-		destination.StorageAccountSubscriptionId = nil
-	}
+	destination.StorageAccountSubscriptionId = genruntime.ClonePointerToString(setting.StorageAccountSubscriptionId)
 
 	// StorageEndpoint
 	destination.StorageEndpoint = genruntime.ClonePointerToString(setting.StorageEndpoint)
@@ -827,12 +817,7 @@ func (setting *ServersDatabasesAuditingSetting_Spec) Initialize_From_ServersData
 	}
 
 	// StorageAccountSubscriptionId
-	if source.StorageAccountSubscriptionId != nil {
-		storageAccountSubscriptionId := *source.StorageAccountSubscriptionId
-		setting.StorageAccountSubscriptionId = &storageAccountSubscriptionId
-	} else {
-		setting.StorageAccountSubscriptionId = nil
-	}
+	setting.StorageAccountSubscriptionId = genruntime.ClonePointerToString(source.StorageAccountSubscriptionId)
 
 	// StorageEndpoint
 	setting.StorageEndpoint = genruntime.ClonePointerToString(source.StorageEndpoint)

--- a/v2/api/storage/v1api20210401/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_accounts_blob_service_types_gen.go
@@ -1400,12 +1400,7 @@ func (feed *ChangeFeed) AssignProperties_From_ChangeFeed(source *storage.ChangeF
 	}
 
 	// RetentionInDays
-	if source.RetentionInDays != nil {
-		retentionInDay := *source.RetentionInDays
-		feed.RetentionInDays = &retentionInDay
-	} else {
-		feed.RetentionInDays = nil
-	}
+	feed.RetentionInDays = genruntime.ClonePointerToInt(source.RetentionInDays)
 
 	// No error
 	return nil
@@ -1425,12 +1420,7 @@ func (feed *ChangeFeed) AssignProperties_To_ChangeFeed(destination *storage.Chan
 	}
 
 	// RetentionInDays
-	if feed.RetentionInDays != nil {
-		retentionInDay := *feed.RetentionInDays
-		destination.RetentionInDays = &retentionInDay
-	} else {
-		destination.RetentionInDays = nil
-	}
+	destination.RetentionInDays = genruntime.ClonePointerToInt(feed.RetentionInDays)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -1799,12 +1789,7 @@ func (policy *DeleteRetentionPolicy) PopulateFromARM(owner genruntime.ArbitraryO
 func (policy *DeleteRetentionPolicy) AssignProperties_From_DeleteRetentionPolicy(source *storage.DeleteRetentionPolicy) error {
 
 	// Days
-	if source.Days != nil {
-		day := *source.Days
-		policy.Days = &day
-	} else {
-		policy.Days = nil
-	}
+	policy.Days = genruntime.ClonePointerToInt(source.Days)
 
 	// Enabled
 	if source.Enabled != nil {
@@ -1824,12 +1809,7 @@ func (policy *DeleteRetentionPolicy) AssignProperties_To_DeleteRetentionPolicy(d
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Days
-	if policy.Days != nil {
-		day := *policy.Days
-		destination.Days = &day
-	} else {
-		destination.Days = nil
-	}
+	destination.Days = genruntime.ClonePointerToInt(policy.Days)
 
 	// Enabled
 	if policy.Enabled != nil {
@@ -2293,12 +2273,7 @@ func (properties *RestorePolicyProperties) PopulateFromARM(owner genruntime.Arbi
 func (properties *RestorePolicyProperties) AssignProperties_From_RestorePolicyProperties(source *storage.RestorePolicyProperties) error {
 
 	// Days
-	if source.Days != nil {
-		day := *source.Days
-		properties.Days = &day
-	} else {
-		properties.Days = nil
-	}
+	properties.Days = genruntime.ClonePointerToInt(source.Days)
 
 	// Enabled
 	if source.Enabled != nil {
@@ -2318,12 +2293,7 @@ func (properties *RestorePolicyProperties) AssignProperties_To_RestorePolicyProp
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Days
-	if properties.Days != nil {
-		day := *properties.Days
-		destination.Days = &day
-	} else {
-		destination.Days = nil
-	}
+	destination.Days = genruntime.ClonePointerToInt(properties.Days)
 
 	// Enabled
 	if properties.Enabled != nil {

--- a/v2/api/storage/v1api20210401/storage_accounts_management_policy_types_gen.go
+++ b/v2/api/storage/v1api20210401/storage_accounts_management_policy_types_gen.go
@@ -3471,23 +3471,13 @@ func (filter *TagFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 func (filter *TagFilter) AssignProperties_From_TagFilter(source *storage.TagFilter) error {
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		filter.Name = &name
-	} else {
-		filter.Name = nil
-	}
+	filter.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Op
 	filter.Op = genruntime.ClonePointerToString(source.Op)
 
 	// Value
-	if source.Value != nil {
-		value := *source.Value
-		filter.Value = &value
-	} else {
-		filter.Value = nil
-	}
+	filter.Value = genruntime.ClonePointerToString(source.Value)
 
 	// No error
 	return nil
@@ -3499,23 +3489,13 @@ func (filter *TagFilter) AssignProperties_To_TagFilter(destination *storage.TagF
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	if filter.Name != nil {
-		name := *filter.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(filter.Name)
 
 	// Op
 	destination.Op = genruntime.ClonePointerToString(filter.Op)
 
 	// Value
-	if filter.Value != nil {
-		value := *filter.Value
-		destination.Value = &value
-	} else {
-		destination.Value = nil
-	}
+	destination.Value = genruntime.ClonePointerToString(filter.Value)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -3670,12 +3650,7 @@ func (creation *DateAfterCreation) PopulateFromARM(owner genruntime.ArbitraryOwn
 func (creation *DateAfterCreation) AssignProperties_From_DateAfterCreation(source *storage.DateAfterCreation) error {
 
 	// DaysAfterCreationGreaterThan
-	if source.DaysAfterCreationGreaterThan != nil {
-		daysAfterCreationGreaterThan := *source.DaysAfterCreationGreaterThan
-		creation.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
-	} else {
-		creation.DaysAfterCreationGreaterThan = nil
-	}
+	creation.DaysAfterCreationGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterCreationGreaterThan)
 
 	// No error
 	return nil
@@ -3687,12 +3662,7 @@ func (creation *DateAfterCreation) AssignProperties_To_DateAfterCreation(destina
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DaysAfterCreationGreaterThan
-	if creation.DaysAfterCreationGreaterThan != nil {
-		daysAfterCreationGreaterThan := *creation.DaysAfterCreationGreaterThan
-		destination.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
-	} else {
-		destination.DaysAfterCreationGreaterThan = nil
-	}
+	destination.DaysAfterCreationGreaterThan = genruntime.ClonePointerToInt(creation.DaysAfterCreationGreaterThan)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -3844,20 +3814,10 @@ func (modification *DateAfterModification) PopulateFromARM(owner genruntime.Arbi
 func (modification *DateAfterModification) AssignProperties_From_DateAfterModification(source *storage.DateAfterModification) error {
 
 	// DaysAfterLastAccessTimeGreaterThan
-	if source.DaysAfterLastAccessTimeGreaterThan != nil {
-		daysAfterLastAccessTimeGreaterThan := *source.DaysAfterLastAccessTimeGreaterThan
-		modification.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
-	} else {
-		modification.DaysAfterLastAccessTimeGreaterThan = nil
-	}
+	modification.DaysAfterLastAccessTimeGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterLastAccessTimeGreaterThan)
 
 	// DaysAfterModificationGreaterThan
-	if source.DaysAfterModificationGreaterThan != nil {
-		daysAfterModificationGreaterThan := *source.DaysAfterModificationGreaterThan
-		modification.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan
-	} else {
-		modification.DaysAfterModificationGreaterThan = nil
-	}
+	modification.DaysAfterModificationGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterModificationGreaterThan)
 
 	// No error
 	return nil
@@ -3869,20 +3829,10 @@ func (modification *DateAfterModification) AssignProperties_To_DateAfterModifica
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DaysAfterLastAccessTimeGreaterThan
-	if modification.DaysAfterLastAccessTimeGreaterThan != nil {
-		daysAfterLastAccessTimeGreaterThan := *modification.DaysAfterLastAccessTimeGreaterThan
-		destination.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
-	} else {
-		destination.DaysAfterLastAccessTimeGreaterThan = nil
-	}
+	destination.DaysAfterLastAccessTimeGreaterThan = genruntime.ClonePointerToInt(modification.DaysAfterLastAccessTimeGreaterThan)
 
 	// DaysAfterModificationGreaterThan
-	if modification.DaysAfterModificationGreaterThan != nil {
-		daysAfterModificationGreaterThan := *modification.DaysAfterModificationGreaterThan
-		destination.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan
-	} else {
-		destination.DaysAfterModificationGreaterThan = nil
-	}
+	destination.DaysAfterModificationGreaterThan = genruntime.ClonePointerToInt(modification.DaysAfterModificationGreaterThan)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/storage/v1api20220901/storage_account_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_account_types_gen.go
@@ -7615,12 +7615,7 @@ func (properties *AccountImmutabilityPolicyProperties) AssignProperties_From_Acc
 	}
 
 	// ImmutabilityPeriodSinceCreationInDays
-	if source.ImmutabilityPeriodSinceCreationInDays != nil {
-		immutabilityPeriodSinceCreationInDay := *source.ImmutabilityPeriodSinceCreationInDays
-		properties.ImmutabilityPeriodSinceCreationInDays = &immutabilityPeriodSinceCreationInDay
-	} else {
-		properties.ImmutabilityPeriodSinceCreationInDays = nil
-	}
+	properties.ImmutabilityPeriodSinceCreationInDays = genruntime.ClonePointerToInt(source.ImmutabilityPeriodSinceCreationInDays)
 
 	// State
 	if source.State != nil {
@@ -7649,12 +7644,7 @@ func (properties *AccountImmutabilityPolicyProperties) AssignProperties_To_Accou
 	}
 
 	// ImmutabilityPeriodSinceCreationInDays
-	if properties.ImmutabilityPeriodSinceCreationInDays != nil {
-		immutabilityPeriodSinceCreationInDay := *properties.ImmutabilityPeriodSinceCreationInDays
-		destination.ImmutabilityPeriodSinceCreationInDays = &immutabilityPeriodSinceCreationInDay
-	} else {
-		destination.ImmutabilityPeriodSinceCreationInDays = nil
-	}
+	destination.ImmutabilityPeriodSinceCreationInDays = genruntime.ClonePointerToInt(properties.ImmutabilityPeriodSinceCreationInDays)
 
 	// State
 	if properties.State != nil {

--- a/v2/api/storage/v1api20220901/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_blob_service_types_gen.go
@@ -1400,12 +1400,7 @@ func (feed *ChangeFeed) AssignProperties_From_ChangeFeed(source *storage.ChangeF
 	}
 
 	// RetentionInDays
-	if source.RetentionInDays != nil {
-		retentionInDay := *source.RetentionInDays
-		feed.RetentionInDays = &retentionInDay
-	} else {
-		feed.RetentionInDays = nil
-	}
+	feed.RetentionInDays = genruntime.ClonePointerToInt(source.RetentionInDays)
 
 	// No error
 	return nil
@@ -1425,12 +1420,7 @@ func (feed *ChangeFeed) AssignProperties_To_ChangeFeed(destination *storage.Chan
 	}
 
 	// RetentionInDays
-	if feed.RetentionInDays != nil {
-		retentionInDay := *feed.RetentionInDays
-		destination.RetentionInDays = &retentionInDay
-	} else {
-		destination.RetentionInDays = nil
-	}
+	destination.RetentionInDays = genruntime.ClonePointerToInt(feed.RetentionInDays)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -1824,12 +1814,7 @@ func (policy *DeleteRetentionPolicy) AssignProperties_From_DeleteRetentionPolicy
 	}
 
 	// Days
-	if source.Days != nil {
-		day := *source.Days
-		policy.Days = &day
-	} else {
-		policy.Days = nil
-	}
+	policy.Days = genruntime.ClonePointerToInt(source.Days)
 
 	// Enabled
 	if source.Enabled != nil {
@@ -1857,12 +1842,7 @@ func (policy *DeleteRetentionPolicy) AssignProperties_To_DeleteRetentionPolicy(d
 	}
 
 	// Days
-	if policy.Days != nil {
-		day := *policy.Days
-		destination.Days = &day
-	} else {
-		destination.Days = nil
-	}
+	destination.Days = genruntime.ClonePointerToInt(policy.Days)
 
 	// Enabled
 	if policy.Enabled != nil {
@@ -2353,12 +2333,7 @@ func (properties *RestorePolicyProperties) PopulateFromARM(owner genruntime.Arbi
 func (properties *RestorePolicyProperties) AssignProperties_From_RestorePolicyProperties(source *storage.RestorePolicyProperties) error {
 
 	// Days
-	if source.Days != nil {
-		day := *source.Days
-		properties.Days = &day
-	} else {
-		properties.Days = nil
-	}
+	properties.Days = genruntime.ClonePointerToInt(source.Days)
 
 	// Enabled
 	if source.Enabled != nil {
@@ -2378,12 +2353,7 @@ func (properties *RestorePolicyProperties) AssignProperties_To_RestorePolicyProp
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Days
-	if properties.Days != nil {
-		day := *properties.Days
-		destination.Days = &day
-	} else {
-		destination.Days = nil
-	}
+	destination.Days = genruntime.ClonePointerToInt(properties.Days)
 
 	// Enabled
 	if properties.Enabled != nil {

--- a/v2/api/storage/v1api20220901/storage_accounts_file_services_share_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_file_services_share_types_gen.go
@@ -548,12 +548,7 @@ func (share *StorageAccountsFileServicesShare_Spec) AssignProperties_From_Storag
 	}
 
 	// ShareQuota
-	if source.ShareQuota != nil {
-		shareQuota := *source.ShareQuota
-		share.ShareQuota = &shareQuota
-	} else {
-		share.ShareQuota = nil
-	}
+	share.ShareQuota = genruntime.ClonePointerToInt(source.ShareQuota)
 
 	// SignedIdentifiers
 	if source.SignedIdentifiers != nil {
@@ -636,12 +631,7 @@ func (share *StorageAccountsFileServicesShare_Spec) AssignProperties_To_StorageA
 	}
 
 	// ShareQuota
-	if share.ShareQuota != nil {
-		shareQuota := *share.ShareQuota
-		destination.ShareQuota = &shareQuota
-	} else {
-		destination.ShareQuota = nil
-	}
+	destination.ShareQuota = genruntime.ClonePointerToInt(share.ShareQuota)
 
 	// SignedIdentifiers
 	if share.SignedIdentifiers != nil {

--- a/v2/api/storage/v1api20220901/storage_accounts_management_policy_types_gen.go
+++ b/v2/api/storage/v1api20220901/storage_accounts_management_policy_types_gen.go
@@ -3993,23 +3993,13 @@ func (filter *TagFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 func (filter *TagFilter) AssignProperties_From_TagFilter(source *storage.TagFilter) error {
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		filter.Name = &name
-	} else {
-		filter.Name = nil
-	}
+	filter.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Op
 	filter.Op = genruntime.ClonePointerToString(source.Op)
 
 	// Value
-	if source.Value != nil {
-		value := *source.Value
-		filter.Value = &value
-	} else {
-		filter.Value = nil
-	}
+	filter.Value = genruntime.ClonePointerToString(source.Value)
 
 	// No error
 	return nil
@@ -4021,23 +4011,13 @@ func (filter *TagFilter) AssignProperties_To_TagFilter(destination *storage.TagF
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	if filter.Name != nil {
-		name := *filter.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(filter.Name)
 
 	// Op
 	destination.Op = genruntime.ClonePointerToString(filter.Op)
 
 	// Value
-	if filter.Value != nil {
-		value := *filter.Value
-		destination.Value = &value
-	} else {
-		destination.Value = nil
-	}
+	destination.Value = genruntime.ClonePointerToString(filter.Value)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4211,20 +4191,10 @@ func (creation *DateAfterCreation) PopulateFromARM(owner genruntime.ArbitraryOwn
 func (creation *DateAfterCreation) AssignProperties_From_DateAfterCreation(source *storage.DateAfterCreation) error {
 
 	// DaysAfterCreationGreaterThan
-	if source.DaysAfterCreationGreaterThan != nil {
-		daysAfterCreationGreaterThan := *source.DaysAfterCreationGreaterThan
-		creation.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
-	} else {
-		creation.DaysAfterCreationGreaterThan = nil
-	}
+	creation.DaysAfterCreationGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterCreationGreaterThan)
 
 	// DaysAfterLastTierChangeGreaterThan
-	if source.DaysAfterLastTierChangeGreaterThan != nil {
-		daysAfterLastTierChangeGreaterThan := *source.DaysAfterLastTierChangeGreaterThan
-		creation.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
-	} else {
-		creation.DaysAfterLastTierChangeGreaterThan = nil
-	}
+	creation.DaysAfterLastTierChangeGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterLastTierChangeGreaterThan)
 
 	// No error
 	return nil
@@ -4236,20 +4206,10 @@ func (creation *DateAfterCreation) AssignProperties_To_DateAfterCreation(destina
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DaysAfterCreationGreaterThan
-	if creation.DaysAfterCreationGreaterThan != nil {
-		daysAfterCreationGreaterThan := *creation.DaysAfterCreationGreaterThan
-		destination.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
-	} else {
-		destination.DaysAfterCreationGreaterThan = nil
-	}
+	destination.DaysAfterCreationGreaterThan = genruntime.ClonePointerToInt(creation.DaysAfterCreationGreaterThan)
 
 	// DaysAfterLastTierChangeGreaterThan
-	if creation.DaysAfterLastTierChangeGreaterThan != nil {
-		daysAfterLastTierChangeGreaterThan := *creation.DaysAfterLastTierChangeGreaterThan
-		destination.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
-	} else {
-		destination.DaysAfterLastTierChangeGreaterThan = nil
-	}
+	destination.DaysAfterLastTierChangeGreaterThan = genruntime.ClonePointerToInt(creation.DaysAfterLastTierChangeGreaterThan)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4467,36 +4427,16 @@ func (modification *DateAfterModification) PopulateFromARM(owner genruntime.Arbi
 func (modification *DateAfterModification) AssignProperties_From_DateAfterModification(source *storage.DateAfterModification) error {
 
 	// DaysAfterCreationGreaterThan
-	if source.DaysAfterCreationGreaterThan != nil {
-		daysAfterCreationGreaterThan := *source.DaysAfterCreationGreaterThan
-		modification.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
-	} else {
-		modification.DaysAfterCreationGreaterThan = nil
-	}
+	modification.DaysAfterCreationGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterCreationGreaterThan)
 
 	// DaysAfterLastAccessTimeGreaterThan
-	if source.DaysAfterLastAccessTimeGreaterThan != nil {
-		daysAfterLastAccessTimeGreaterThan := *source.DaysAfterLastAccessTimeGreaterThan
-		modification.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
-	} else {
-		modification.DaysAfterLastAccessTimeGreaterThan = nil
-	}
+	modification.DaysAfterLastAccessTimeGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterLastAccessTimeGreaterThan)
 
 	// DaysAfterLastTierChangeGreaterThan
-	if source.DaysAfterLastTierChangeGreaterThan != nil {
-		daysAfterLastTierChangeGreaterThan := *source.DaysAfterLastTierChangeGreaterThan
-		modification.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
-	} else {
-		modification.DaysAfterLastTierChangeGreaterThan = nil
-	}
+	modification.DaysAfterLastTierChangeGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterLastTierChangeGreaterThan)
 
 	// DaysAfterModificationGreaterThan
-	if source.DaysAfterModificationGreaterThan != nil {
-		daysAfterModificationGreaterThan := *source.DaysAfterModificationGreaterThan
-		modification.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan
-	} else {
-		modification.DaysAfterModificationGreaterThan = nil
-	}
+	modification.DaysAfterModificationGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterModificationGreaterThan)
 
 	// No error
 	return nil
@@ -4508,36 +4448,16 @@ func (modification *DateAfterModification) AssignProperties_To_DateAfterModifica
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DaysAfterCreationGreaterThan
-	if modification.DaysAfterCreationGreaterThan != nil {
-		daysAfterCreationGreaterThan := *modification.DaysAfterCreationGreaterThan
-		destination.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
-	} else {
-		destination.DaysAfterCreationGreaterThan = nil
-	}
+	destination.DaysAfterCreationGreaterThan = genruntime.ClonePointerToInt(modification.DaysAfterCreationGreaterThan)
 
 	// DaysAfterLastAccessTimeGreaterThan
-	if modification.DaysAfterLastAccessTimeGreaterThan != nil {
-		daysAfterLastAccessTimeGreaterThan := *modification.DaysAfterLastAccessTimeGreaterThan
-		destination.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
-	} else {
-		destination.DaysAfterLastAccessTimeGreaterThan = nil
-	}
+	destination.DaysAfterLastAccessTimeGreaterThan = genruntime.ClonePointerToInt(modification.DaysAfterLastAccessTimeGreaterThan)
 
 	// DaysAfterLastTierChangeGreaterThan
-	if modification.DaysAfterLastTierChangeGreaterThan != nil {
-		daysAfterLastTierChangeGreaterThan := *modification.DaysAfterLastTierChangeGreaterThan
-		destination.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
-	} else {
-		destination.DaysAfterLastTierChangeGreaterThan = nil
-	}
+	destination.DaysAfterLastTierChangeGreaterThan = genruntime.ClonePointerToInt(modification.DaysAfterLastTierChangeGreaterThan)
 
 	// DaysAfterModificationGreaterThan
-	if modification.DaysAfterModificationGreaterThan != nil {
-		daysAfterModificationGreaterThan := *modification.DaysAfterModificationGreaterThan
-		destination.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan
-	} else {
-		destination.DaysAfterModificationGreaterThan = nil
-	}
+	destination.DaysAfterModificationGreaterThan = genruntime.ClonePointerToInt(modification.DaysAfterModificationGreaterThan)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/storage/v1api20230101/storage_account_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_account_types_gen.go
@@ -8370,12 +8370,7 @@ func (properties *AccountImmutabilityPolicyProperties) AssignProperties_From_Acc
 	}
 
 	// ImmutabilityPeriodSinceCreationInDays
-	if source.ImmutabilityPeriodSinceCreationInDays != nil {
-		immutabilityPeriodSinceCreationInDay := *source.ImmutabilityPeriodSinceCreationInDays
-		properties.ImmutabilityPeriodSinceCreationInDays = &immutabilityPeriodSinceCreationInDay
-	} else {
-		properties.ImmutabilityPeriodSinceCreationInDays = nil
-	}
+	properties.ImmutabilityPeriodSinceCreationInDays = genruntime.ClonePointerToInt(source.ImmutabilityPeriodSinceCreationInDays)
 
 	// State
 	if source.State != nil {
@@ -8404,12 +8399,7 @@ func (properties *AccountImmutabilityPolicyProperties) AssignProperties_To_Accou
 	}
 
 	// ImmutabilityPeriodSinceCreationInDays
-	if properties.ImmutabilityPeriodSinceCreationInDays != nil {
-		immutabilityPeriodSinceCreationInDay := *properties.ImmutabilityPeriodSinceCreationInDays
-		destination.ImmutabilityPeriodSinceCreationInDays = &immutabilityPeriodSinceCreationInDay
-	} else {
-		destination.ImmutabilityPeriodSinceCreationInDays = nil
-	}
+	destination.ImmutabilityPeriodSinceCreationInDays = genruntime.ClonePointerToInt(properties.ImmutabilityPeriodSinceCreationInDays)
 
 	// State
 	if properties.State != nil {
@@ -8442,12 +8432,7 @@ func (properties *AccountImmutabilityPolicyProperties) Initialize_From_AccountIm
 	}
 
 	// ImmutabilityPeriodSinceCreationInDays
-	if source.ImmutabilityPeriodSinceCreationInDays != nil {
-		immutabilityPeriodSinceCreationInDay := *source.ImmutabilityPeriodSinceCreationInDays
-		properties.ImmutabilityPeriodSinceCreationInDays = &immutabilityPeriodSinceCreationInDay
-	} else {
-		properties.ImmutabilityPeriodSinceCreationInDays = nil
-	}
+	properties.ImmutabilityPeriodSinceCreationInDays = genruntime.ClonePointerToInt(source.ImmutabilityPeriodSinceCreationInDays)
 
 	// State
 	if source.State != nil {

--- a/v2/api/storage/v1api20230101/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_accounts_blob_service_types_gen.go
@@ -1495,12 +1495,7 @@ func (feed *ChangeFeed) AssignProperties_From_ChangeFeed(source *storage.ChangeF
 	}
 
 	// RetentionInDays
-	if source.RetentionInDays != nil {
-		retentionInDay := *source.RetentionInDays
-		feed.RetentionInDays = &retentionInDay
-	} else {
-		feed.RetentionInDays = nil
-	}
+	feed.RetentionInDays = genruntime.ClonePointerToInt(source.RetentionInDays)
 
 	// No error
 	return nil
@@ -1520,12 +1515,7 @@ func (feed *ChangeFeed) AssignProperties_To_ChangeFeed(destination *storage.Chan
 	}
 
 	// RetentionInDays
-	if feed.RetentionInDays != nil {
-		retentionInDay := *feed.RetentionInDays
-		destination.RetentionInDays = &retentionInDay
-	} else {
-		destination.RetentionInDays = nil
-	}
+	destination.RetentionInDays = genruntime.ClonePointerToInt(feed.RetentionInDays)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -1550,12 +1540,7 @@ func (feed *ChangeFeed) Initialize_From_ChangeFeed_STATUS(source *ChangeFeed_STA
 	}
 
 	// RetentionInDays
-	if source.RetentionInDays != nil {
-		retentionInDay := *source.RetentionInDays
-		feed.RetentionInDays = &retentionInDay
-	} else {
-		feed.RetentionInDays = nil
-	}
+	feed.RetentionInDays = genruntime.ClonePointerToInt(source.RetentionInDays)
 
 	// No error
 	return nil
@@ -1967,12 +1952,7 @@ func (policy *DeleteRetentionPolicy) AssignProperties_From_DeleteRetentionPolicy
 	}
 
 	// Days
-	if source.Days != nil {
-		day := *source.Days
-		policy.Days = &day
-	} else {
-		policy.Days = nil
-	}
+	policy.Days = genruntime.ClonePointerToInt(source.Days)
 
 	// Enabled
 	if source.Enabled != nil {
@@ -2000,12 +1980,7 @@ func (policy *DeleteRetentionPolicy) AssignProperties_To_DeleteRetentionPolicy(d
 	}
 
 	// Days
-	if policy.Days != nil {
-		day := *policy.Days
-		destination.Days = &day
-	} else {
-		destination.Days = nil
-	}
+	destination.Days = genruntime.ClonePointerToInt(policy.Days)
 
 	// Enabled
 	if policy.Enabled != nil {
@@ -2038,12 +2013,7 @@ func (policy *DeleteRetentionPolicy) Initialize_From_DeleteRetentionPolicy_STATU
 	}
 
 	// Days
-	if source.Days != nil {
-		day := *source.Days
-		policy.Days = &day
-	} else {
-		policy.Days = nil
-	}
+	policy.Days = genruntime.ClonePointerToInt(source.Days)
 
 	// Enabled
 	if source.Enabled != nil {
@@ -2556,12 +2526,7 @@ func (properties *RestorePolicyProperties) PopulateFromARM(owner genruntime.Arbi
 func (properties *RestorePolicyProperties) AssignProperties_From_RestorePolicyProperties(source *storage.RestorePolicyProperties) error {
 
 	// Days
-	if source.Days != nil {
-		day := *source.Days
-		properties.Days = &day
-	} else {
-		properties.Days = nil
-	}
+	properties.Days = genruntime.ClonePointerToInt(source.Days)
 
 	// Enabled
 	if source.Enabled != nil {
@@ -2581,12 +2546,7 @@ func (properties *RestorePolicyProperties) AssignProperties_To_RestorePolicyProp
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Days
-	if properties.Days != nil {
-		day := *properties.Days
-		destination.Days = &day
-	} else {
-		destination.Days = nil
-	}
+	destination.Days = genruntime.ClonePointerToInt(properties.Days)
 
 	// Enabled
 	if properties.Enabled != nil {
@@ -2611,12 +2571,7 @@ func (properties *RestorePolicyProperties) AssignProperties_To_RestorePolicyProp
 func (properties *RestorePolicyProperties) Initialize_From_RestorePolicyProperties_STATUS(source *RestorePolicyProperties_STATUS) error {
 
 	// Days
-	if source.Days != nil {
-		day := *source.Days
-		properties.Days = &day
-	} else {
-		properties.Days = nil
-	}
+	properties.Days = genruntime.ClonePointerToInt(source.Days)
 
 	// Enabled
 	if source.Enabled != nil {

--- a/v2/api/storage/v1api20230101/storage_accounts_file_services_share_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_accounts_file_services_share_types_gen.go
@@ -545,12 +545,7 @@ func (share *StorageAccountsFileServicesShare_Spec) AssignProperties_From_Storag
 	}
 
 	// ShareQuota
-	if source.ShareQuota != nil {
-		shareQuota := *source.ShareQuota
-		share.ShareQuota = &shareQuota
-	} else {
-		share.ShareQuota = nil
-	}
+	share.ShareQuota = genruntime.ClonePointerToInt(source.ShareQuota)
 
 	// SignedIdentifiers
 	if source.SignedIdentifiers != nil {
@@ -633,12 +628,7 @@ func (share *StorageAccountsFileServicesShare_Spec) AssignProperties_To_StorageA
 	}
 
 	// ShareQuota
-	if share.ShareQuota != nil {
-		shareQuota := *share.ShareQuota
-		destination.ShareQuota = &shareQuota
-	} else {
-		destination.ShareQuota = nil
-	}
+	destination.ShareQuota = genruntime.ClonePointerToInt(share.ShareQuota)
 
 	// SignedIdentifiers
 	if share.SignedIdentifiers != nil {
@@ -700,12 +690,7 @@ func (share *StorageAccountsFileServicesShare_Spec) Initialize_From_StorageAccou
 	}
 
 	// ShareQuota
-	if source.ShareQuota != nil {
-		shareQuota := *source.ShareQuota
-		share.ShareQuota = &shareQuota
-	} else {
-		share.ShareQuota = nil
-	}
+	share.ShareQuota = genruntime.ClonePointerToInt(source.ShareQuota)
 
 	// SignedIdentifiers
 	if source.SignedIdentifiers != nil {

--- a/v2/api/storage/v1api20230101/storage_accounts_management_policy_types_gen.go
+++ b/v2/api/storage/v1api20230101/storage_accounts_management_policy_types_gen.go
@@ -4386,23 +4386,13 @@ func (filter *TagFilter) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 func (filter *TagFilter) AssignProperties_From_TagFilter(source *storage.TagFilter) error {
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		filter.Name = &name
-	} else {
-		filter.Name = nil
-	}
+	filter.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Op
 	filter.Op = genruntime.ClonePointerToString(source.Op)
 
 	// Value
-	if source.Value != nil {
-		value := *source.Value
-		filter.Value = &value
-	} else {
-		filter.Value = nil
-	}
+	filter.Value = genruntime.ClonePointerToString(source.Value)
 
 	// No error
 	return nil
@@ -4414,23 +4404,13 @@ func (filter *TagFilter) AssignProperties_To_TagFilter(destination *storage.TagF
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	if filter.Name != nil {
-		name := *filter.Name
-		destination.Name = &name
-	} else {
-		destination.Name = nil
-	}
+	destination.Name = genruntime.ClonePointerToString(filter.Name)
 
 	// Op
 	destination.Op = genruntime.ClonePointerToString(filter.Op)
 
 	// Value
-	if filter.Value != nil {
-		value := *filter.Value
-		destination.Value = &value
-	} else {
-		destination.Value = nil
-	}
+	destination.Value = genruntime.ClonePointerToString(filter.Value)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4447,23 +4427,13 @@ func (filter *TagFilter) AssignProperties_To_TagFilter(destination *storage.TagF
 func (filter *TagFilter) Initialize_From_TagFilter_STATUS(source *TagFilter_STATUS) error {
 
 	// Name
-	if source.Name != nil {
-		name := *source.Name
-		filter.Name = &name
-	} else {
-		filter.Name = nil
-	}
+	filter.Name = genruntime.ClonePointerToString(source.Name)
 
 	// Op
 	filter.Op = genruntime.ClonePointerToString(source.Op)
 
 	// Value
-	if source.Value != nil {
-		value := *source.Value
-		filter.Value = &value
-	} else {
-		filter.Value = nil
-	}
+	filter.Value = genruntime.ClonePointerToString(source.Value)
 
 	// No error
 	return nil
@@ -4630,20 +4600,10 @@ func (creation *DateAfterCreation) PopulateFromARM(owner genruntime.ArbitraryOwn
 func (creation *DateAfterCreation) AssignProperties_From_DateAfterCreation(source *storage.DateAfterCreation) error {
 
 	// DaysAfterCreationGreaterThan
-	if source.DaysAfterCreationGreaterThan != nil {
-		daysAfterCreationGreaterThan := *source.DaysAfterCreationGreaterThan
-		creation.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
-	} else {
-		creation.DaysAfterCreationGreaterThan = nil
-	}
+	creation.DaysAfterCreationGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterCreationGreaterThan)
 
 	// DaysAfterLastTierChangeGreaterThan
-	if source.DaysAfterLastTierChangeGreaterThan != nil {
-		daysAfterLastTierChangeGreaterThan := *source.DaysAfterLastTierChangeGreaterThan
-		creation.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
-	} else {
-		creation.DaysAfterLastTierChangeGreaterThan = nil
-	}
+	creation.DaysAfterLastTierChangeGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterLastTierChangeGreaterThan)
 
 	// No error
 	return nil
@@ -4655,20 +4615,10 @@ func (creation *DateAfterCreation) AssignProperties_To_DateAfterCreation(destina
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DaysAfterCreationGreaterThan
-	if creation.DaysAfterCreationGreaterThan != nil {
-		daysAfterCreationGreaterThan := *creation.DaysAfterCreationGreaterThan
-		destination.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
-	} else {
-		destination.DaysAfterCreationGreaterThan = nil
-	}
+	destination.DaysAfterCreationGreaterThan = genruntime.ClonePointerToInt(creation.DaysAfterCreationGreaterThan)
 
 	// DaysAfterLastTierChangeGreaterThan
-	if creation.DaysAfterLastTierChangeGreaterThan != nil {
-		daysAfterLastTierChangeGreaterThan := *creation.DaysAfterLastTierChangeGreaterThan
-		destination.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
-	} else {
-		destination.DaysAfterLastTierChangeGreaterThan = nil
-	}
+	destination.DaysAfterLastTierChangeGreaterThan = genruntime.ClonePointerToInt(creation.DaysAfterLastTierChangeGreaterThan)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -4909,36 +4859,16 @@ func (modification *DateAfterModification) PopulateFromARM(owner genruntime.Arbi
 func (modification *DateAfterModification) AssignProperties_From_DateAfterModification(source *storage.DateAfterModification) error {
 
 	// DaysAfterCreationGreaterThan
-	if source.DaysAfterCreationGreaterThan != nil {
-		daysAfterCreationGreaterThan := *source.DaysAfterCreationGreaterThan
-		modification.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
-	} else {
-		modification.DaysAfterCreationGreaterThan = nil
-	}
+	modification.DaysAfterCreationGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterCreationGreaterThan)
 
 	// DaysAfterLastAccessTimeGreaterThan
-	if source.DaysAfterLastAccessTimeGreaterThan != nil {
-		daysAfterLastAccessTimeGreaterThan := *source.DaysAfterLastAccessTimeGreaterThan
-		modification.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
-	} else {
-		modification.DaysAfterLastAccessTimeGreaterThan = nil
-	}
+	modification.DaysAfterLastAccessTimeGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterLastAccessTimeGreaterThan)
 
 	// DaysAfterLastTierChangeGreaterThan
-	if source.DaysAfterLastTierChangeGreaterThan != nil {
-		daysAfterLastTierChangeGreaterThan := *source.DaysAfterLastTierChangeGreaterThan
-		modification.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
-	} else {
-		modification.DaysAfterLastTierChangeGreaterThan = nil
-	}
+	modification.DaysAfterLastTierChangeGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterLastTierChangeGreaterThan)
 
 	// DaysAfterModificationGreaterThan
-	if source.DaysAfterModificationGreaterThan != nil {
-		daysAfterModificationGreaterThan := *source.DaysAfterModificationGreaterThan
-		modification.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan
-	} else {
-		modification.DaysAfterModificationGreaterThan = nil
-	}
+	modification.DaysAfterModificationGreaterThan = genruntime.ClonePointerToInt(source.DaysAfterModificationGreaterThan)
 
 	// No error
 	return nil
@@ -4950,36 +4880,16 @@ func (modification *DateAfterModification) AssignProperties_To_DateAfterModifica
 	propertyBag := genruntime.NewPropertyBag()
 
 	// DaysAfterCreationGreaterThan
-	if modification.DaysAfterCreationGreaterThan != nil {
-		daysAfterCreationGreaterThan := *modification.DaysAfterCreationGreaterThan
-		destination.DaysAfterCreationGreaterThan = &daysAfterCreationGreaterThan
-	} else {
-		destination.DaysAfterCreationGreaterThan = nil
-	}
+	destination.DaysAfterCreationGreaterThan = genruntime.ClonePointerToInt(modification.DaysAfterCreationGreaterThan)
 
 	// DaysAfterLastAccessTimeGreaterThan
-	if modification.DaysAfterLastAccessTimeGreaterThan != nil {
-		daysAfterLastAccessTimeGreaterThan := *modification.DaysAfterLastAccessTimeGreaterThan
-		destination.DaysAfterLastAccessTimeGreaterThan = &daysAfterLastAccessTimeGreaterThan
-	} else {
-		destination.DaysAfterLastAccessTimeGreaterThan = nil
-	}
+	destination.DaysAfterLastAccessTimeGreaterThan = genruntime.ClonePointerToInt(modification.DaysAfterLastAccessTimeGreaterThan)
 
 	// DaysAfterLastTierChangeGreaterThan
-	if modification.DaysAfterLastTierChangeGreaterThan != nil {
-		daysAfterLastTierChangeGreaterThan := *modification.DaysAfterLastTierChangeGreaterThan
-		destination.DaysAfterLastTierChangeGreaterThan = &daysAfterLastTierChangeGreaterThan
-	} else {
-		destination.DaysAfterLastTierChangeGreaterThan = nil
-	}
+	destination.DaysAfterLastTierChangeGreaterThan = genruntime.ClonePointerToInt(modification.DaysAfterLastTierChangeGreaterThan)
 
 	// DaysAfterModificationGreaterThan
-	if modification.DaysAfterModificationGreaterThan != nil {
-		daysAfterModificationGreaterThan := *modification.DaysAfterModificationGreaterThan
-		destination.DaysAfterModificationGreaterThan = &daysAfterModificationGreaterThan
-	} else {
-		destination.DaysAfterModificationGreaterThan = nil
-	}
+	destination.DaysAfterModificationGreaterThan = genruntime.ClonePointerToInt(modification.DaysAfterModificationGreaterThan)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/synapse/v1api20210601/workspace_types_gen.go
+++ b/v2/api/synapse/v1api20210601/workspace_types_gen.go
@@ -4065,12 +4065,7 @@ func (configuration *WorkspaceRepositoryConfiguration) AssignProperties_From_Wor
 	configuration.RootFolder = genruntime.ClonePointerToString(source.RootFolder)
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		configuration.TenantId = &tenantId
-	} else {
-		configuration.TenantId = nil
-	}
+	configuration.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// Type
 	configuration.Type = genruntime.ClonePointerToString(source.Type)
@@ -4106,12 +4101,7 @@ func (configuration *WorkspaceRepositoryConfiguration) AssignProperties_To_Works
 	destination.RootFolder = genruntime.ClonePointerToString(configuration.RootFolder)
 
 	// TenantId
-	if configuration.TenantId != nil {
-		tenantId := *configuration.TenantId
-		destination.TenantId = &tenantId
-	} else {
-		destination.TenantId = nil
-	}
+	destination.TenantId = genruntime.ClonePointerToString(configuration.TenantId)
 
 	// Type
 	destination.Type = genruntime.ClonePointerToString(configuration.Type)
@@ -4152,12 +4142,7 @@ func (configuration *WorkspaceRepositoryConfiguration) Initialize_From_Workspace
 	configuration.RootFolder = genruntime.ClonePointerToString(source.RootFolder)
 
 	// TenantId
-	if source.TenantId != nil {
-		tenantId := *source.TenantId
-		configuration.TenantId = &tenantId
-	} else {
-		configuration.TenantId = nil
-	}
+	configuration.TenantId = genruntime.ClonePointerToString(source.TenantId)
 
 	// Type
 	configuration.Type = genruntime.ClonePointerToString(source.Type)

--- a/v2/api/web/v1api20220301/site_types_gen.go
+++ b/v2/api/web/v1api20220301/site_types_gen.go
@@ -3437,12 +3437,7 @@ func (info *CloningInfo) AssignProperties_From_CloningInfo(source *storage.Cloni
 	}
 
 	// CorrelationId
-	if source.CorrelationId != nil {
-		correlationId := *source.CorrelationId
-		info.CorrelationId = &correlationId
-	} else {
-		info.CorrelationId = nil
-	}
+	info.CorrelationId = genruntime.ClonePointerToString(source.CorrelationId)
 
 	// HostingEnvironment
 	info.HostingEnvironment = genruntime.ClonePointerToString(source.HostingEnvironment)
@@ -3514,12 +3509,7 @@ func (info *CloningInfo) AssignProperties_To_CloningInfo(destination *storage.Cl
 	}
 
 	// CorrelationId
-	if info.CorrelationId != nil {
-		correlationId := *info.CorrelationId
-		destination.CorrelationId = &correlationId
-	} else {
-		destination.CorrelationId = nil
-	}
+	destination.CorrelationId = genruntime.ClonePointerToString(info.CorrelationId)
 
 	// HostingEnvironment
 	destination.HostingEnvironment = genruntime.ClonePointerToString(info.HostingEnvironment)
@@ -3596,12 +3586,7 @@ func (info *CloningInfo) Initialize_From_CloningInfo_STATUS(source *CloningInfo_
 	}
 
 	// CorrelationId
-	if source.CorrelationId != nil {
-		correlationId := *source.CorrelationId
-		info.CorrelationId = &correlationId
-	} else {
-		info.CorrelationId = nil
-	}
+	info.CorrelationId = genruntime.ClonePointerToString(source.CorrelationId)
 
 	// HostingEnvironment
 	info.HostingEnvironment = genruntime.ClonePointerToString(source.HostingEnvironment)
@@ -6104,12 +6089,7 @@ func (config *SiteConfig) AssignProperties_From_SiteConfig(source *storage.SiteC
 	}
 
 	// FunctionAppScaleLimit
-	if source.FunctionAppScaleLimit != nil {
-		functionAppScaleLimit := *source.FunctionAppScaleLimit
-		config.FunctionAppScaleLimit = &functionAppScaleLimit
-	} else {
-		config.FunctionAppScaleLimit = nil
-	}
+	config.FunctionAppScaleLimit = genruntime.ClonePointerToInt(source.FunctionAppScaleLimit)
 
 	// FunctionsRuntimeScaleMonitoringEnabled
 	if source.FunctionsRuntimeScaleMonitoringEnabled != nil {
@@ -6243,12 +6223,7 @@ func (config *SiteConfig) AssignProperties_From_SiteConfig(source *storage.SiteC
 	}
 
 	// MinimumElasticInstanceCount
-	if source.MinimumElasticInstanceCount != nil {
-		minimumElasticInstanceCount := *source.MinimumElasticInstanceCount
-		config.MinimumElasticInstanceCount = &minimumElasticInstanceCount
-	} else {
-		config.MinimumElasticInstanceCount = nil
-	}
+	config.MinimumElasticInstanceCount = genruntime.ClonePointerToInt(source.MinimumElasticInstanceCount)
 
 	// NetFrameworkVersion
 	config.NetFrameworkVersion = genruntime.ClonePointerToString(source.NetFrameworkVersion)
@@ -6266,12 +6241,7 @@ func (config *SiteConfig) AssignProperties_From_SiteConfig(source *storage.SiteC
 	config.PowerShellVersion = genruntime.ClonePointerToString(source.PowerShellVersion)
 
 	// PreWarmedInstanceCount
-	if source.PreWarmedInstanceCount != nil {
-		preWarmedInstanceCount := *source.PreWarmedInstanceCount
-		config.PreWarmedInstanceCount = &preWarmedInstanceCount
-	} else {
-		config.PreWarmedInstanceCount = nil
-	}
+	config.PreWarmedInstanceCount = genruntime.ClonePointerToInt(source.PreWarmedInstanceCount)
 
 	// PublicNetworkAccess
 	config.PublicNetworkAccess = genruntime.ClonePointerToString(source.PublicNetworkAccess)
@@ -6599,12 +6569,7 @@ func (config *SiteConfig) AssignProperties_To_SiteConfig(destination *storage.Si
 	}
 
 	// FunctionAppScaleLimit
-	if config.FunctionAppScaleLimit != nil {
-		functionAppScaleLimit := *config.FunctionAppScaleLimit
-		destination.FunctionAppScaleLimit = &functionAppScaleLimit
-	} else {
-		destination.FunctionAppScaleLimit = nil
-	}
+	destination.FunctionAppScaleLimit = genruntime.ClonePointerToInt(config.FunctionAppScaleLimit)
 
 	// FunctionsRuntimeScaleMonitoringEnabled
 	if config.FunctionsRuntimeScaleMonitoringEnabled != nil {
@@ -6735,12 +6700,7 @@ func (config *SiteConfig) AssignProperties_To_SiteConfig(destination *storage.Si
 	}
 
 	// MinimumElasticInstanceCount
-	if config.MinimumElasticInstanceCount != nil {
-		minimumElasticInstanceCount := *config.MinimumElasticInstanceCount
-		destination.MinimumElasticInstanceCount = &minimumElasticInstanceCount
-	} else {
-		destination.MinimumElasticInstanceCount = nil
-	}
+	destination.MinimumElasticInstanceCount = genruntime.ClonePointerToInt(config.MinimumElasticInstanceCount)
 
 	// NetFrameworkVersion
 	destination.NetFrameworkVersion = genruntime.ClonePointerToString(config.NetFrameworkVersion)
@@ -6758,12 +6718,7 @@ func (config *SiteConfig) AssignProperties_To_SiteConfig(destination *storage.Si
 	destination.PowerShellVersion = genruntime.ClonePointerToString(config.PowerShellVersion)
 
 	// PreWarmedInstanceCount
-	if config.PreWarmedInstanceCount != nil {
-		preWarmedInstanceCount := *config.PreWarmedInstanceCount
-		destination.PreWarmedInstanceCount = &preWarmedInstanceCount
-	} else {
-		destination.PreWarmedInstanceCount = nil
-	}
+	destination.PreWarmedInstanceCount = genruntime.ClonePointerToInt(config.PreWarmedInstanceCount)
 
 	// PublicNetworkAccess
 	destination.PublicNetworkAccess = genruntime.ClonePointerToString(config.PublicNetworkAccess)
@@ -7094,12 +7049,7 @@ func (config *SiteConfig) Initialize_From_SiteConfig_STATUS(source *SiteConfig_S
 	}
 
 	// FunctionAppScaleLimit
-	if source.FunctionAppScaleLimit != nil {
-		functionAppScaleLimit := *source.FunctionAppScaleLimit
-		config.FunctionAppScaleLimit = &functionAppScaleLimit
-	} else {
-		config.FunctionAppScaleLimit = nil
-	}
+	config.FunctionAppScaleLimit = genruntime.ClonePointerToInt(source.FunctionAppScaleLimit)
 
 	// FunctionsRuntimeScaleMonitoringEnabled
 	if source.FunctionsRuntimeScaleMonitoringEnabled != nil {
@@ -7230,12 +7180,7 @@ func (config *SiteConfig) Initialize_From_SiteConfig_STATUS(source *SiteConfig_S
 	}
 
 	// MinimumElasticInstanceCount
-	if source.MinimumElasticInstanceCount != nil {
-		minimumElasticInstanceCount := *source.MinimumElasticInstanceCount
-		config.MinimumElasticInstanceCount = &minimumElasticInstanceCount
-	} else {
-		config.MinimumElasticInstanceCount = nil
-	}
+	config.MinimumElasticInstanceCount = genruntime.ClonePointerToInt(source.MinimumElasticInstanceCount)
 
 	// NetFrameworkVersion
 	config.NetFrameworkVersion = genruntime.ClonePointerToString(source.NetFrameworkVersion)
@@ -7253,12 +7198,7 @@ func (config *SiteConfig) Initialize_From_SiteConfig_STATUS(source *SiteConfig_S
 	config.PowerShellVersion = genruntime.ClonePointerToString(source.PowerShellVersion)
 
 	// PreWarmedInstanceCount
-	if source.PreWarmedInstanceCount != nil {
-		preWarmedInstanceCount := *source.PreWarmedInstanceCount
-		config.PreWarmedInstanceCount = &preWarmedInstanceCount
-	} else {
-		config.PreWarmedInstanceCount = nil
-	}
+	config.PreWarmedInstanceCount = genruntime.ClonePointerToInt(source.PreWarmedInstanceCount)
 
 	// PublicNetworkAccess
 	config.PublicNetworkAccess = genruntime.ClonePointerToString(source.PublicNetworkAccess)

--- a/v2/tools/generator/internal/astmodel/meta_type.go
+++ b/v2/tools/generator/internal/astmodel/meta_type.go
@@ -167,6 +167,20 @@ func AsResourceType(aType Type) (*ResourceType, bool) {
 	return nil, false
 }
 
+// AsValidatedType unwraps any wrappers around the provided type and returns either the underlying ValidatedType and true,
+// or a nil and false.
+func AsValidatedType(aType Type) (*ValidatedType, bool) {
+	if validated, ok := aType.(*ValidatedType); ok {
+		return validated, true
+	}
+
+	if wrapper, ok := aType.(MetaType); ok {
+		return AsValidatedType(wrapper.Unwrap())
+	}
+
+	return nil, false
+}
+
 func MustBeResourceType(aType Type) *ResourceType {
 	result, ok := AsResourceType(aType)
 	if !ok {

--- a/v2/tools/generator/internal/codegen/testdata/Validations/Validate_property_type.golden
+++ b/v2/tools/generator/internal/codegen/testdata/Validations/Validate_property_type.golden
@@ -53,12 +53,7 @@ func (test *Test) AssignProperties_From_Test(source *storage.Test) error {
 	}
 
 	// Duck
-	if source.Duck != nil {
-		duck := *source.Duck
-		test.Duck = &duck
-	} else {
-		test.Duck = nil
-	}
+	test.Duck = genruntime.ClonePointerToString(source.Duck)
 
 	// Moon
 	if source.Moon != nil {
@@ -69,12 +64,7 @@ func (test *Test) AssignProperties_From_Test(source *storage.Test) error {
 	}
 
 	// Sun
-	if source.Sun != nil {
-		sun := *source.Sun
-		test.Sun = &sun
-	} else {
-		test.Sun = nil
-	}
+	test.Sun = genruntime.ClonePointerToInt(source.Sun)
 
 	// No error
 	return nil
@@ -99,12 +89,7 @@ func (test *Test) AssignProperties_To_Test(destination *storage.Test) error {
 	}
 
 	// Duck
-	if test.Duck != nil {
-		duck := *test.Duck
-		destination.Duck = &duck
-	} else {
-		destination.Duck = nil
-	}
+	destination.Duck = genruntime.ClonePointerToString(test.Duck)
 
 	// Moon
 	if test.Moon != nil {
@@ -115,12 +100,7 @@ func (test *Test) AssignProperties_To_Test(destination *storage.Test) error {
 	}
 
 	// Sun
-	if test.Sun != nil {
-		sun := *test.Sun
-		destination.Sun = &sun
-	} else {
-		destination.Sun = nil
-	}
+	destination.Sun = genruntime.ClonePointerToInt(test.Sun)
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/tools/generator/internal/conversions/property_conversions.go
+++ b/v2/tools/generator/internal/conversions/property_conversions.go
@@ -1143,8 +1143,20 @@ func assignHandcraftedImplementations(
 	conversionFound := false
 	var conversion handCraftedConversion
 	for _, impl := range handCraftedConversions {
-		if astmodel.TypeEquals(sourceEndpoint.Type(), impl.fromType) &&
-			astmodel.TypeEquals(destinationEndpoint.Type(), impl.toType) {
+		sourceType := sourceEndpoint.Type()
+		if vt, ok := astmodel.AsValidatedType(sourceType); ok {
+			// If the source is a validated type, we need to use the underlying type
+			sourceType = vt.ElementType()
+		}
+
+		destinationType := destinationEndpoint.Type()
+		if vt, ok := astmodel.AsValidatedType(destinationType); ok {
+			// If the destination is a validated type, we need to use the underlying type
+			destinationType = vt.ElementType()
+		}
+
+		if astmodel.TypeEquals(sourceType, impl.fromType) &&
+			astmodel.TypeEquals(destinationType, impl.toType) {
 			conversion = impl
 			conversionFound = true
 			break


### PR DESCRIPTION
## What this PR does

In `genruntime` we have a library of general purpose value conversion functions that weren't being as widely reused as they should have been. 

This stems from the use of exact type matches, which weren't matching for validated property types.

By matching validated variants as well, we broaden the use of these methods.

Discovered while addressing #2503 

The active code change is in `property_conversions.go`, most everything else is generated code.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/AoTzzu7XUJCwM/giphy.gif?cid=790b7611h95teh0lark8cygq59hc6hcsx49n63d4iu6b2nfz&ep=v1_gifs_search&rid=giphy.gif&ct=g)
