### PR TITLE
Fix broken ASO v1 links

### DIFF
--- a/docs/hugo/content/design/secrets.md
+++ b/docs/hugo/content/design/secrets.md
@@ -164,7 +164,7 @@ intending to use this secret on a resource they have not created yet. As such, t
 
 Rollover will be supported by triggering events on the associated resource when the secret is modified. Since multiple custom resources might be using 
 the same secret, this could trigger reconciles on multiple resources. An existing pattern has been established for this in 
-[mysqlserver_controller.go](https://github.com/Azure/azure-service-operator/blob/main/controllers/mysqlserver_controller.go#L51) of ASO v1.
+[mysqlserver_controller.go](https://github.com/Azure/azure-service-operator/blob/asov1/controllers/mysqlserver_controller.go#L51) of ASO v1.
 
 When secrets are rolled over, there is a risk that applications using the secret will fail because the secret they are using is no longer valid.
 We don't need to worry about coordination or timing though. If the user asks us to update the password (by changing it in the Kubernetes secret),

--- a/docs/hugo/content/guide/asov1-asov2-migration/_index.md
+++ b/docs/hugo/content/guide/asov1-asov2-migration/_index.md
@@ -6,7 +6,7 @@ cascade:
   - type: docs
   - render: always
 ---
-ASOv1 is [deprecated](https://github.com/Azure/azure-service-operator/blob/main/README.md#aso-v1). 
+ASOv1 has been [deleted](https://github.com/Azure/azure-service-operator/blob/main/README.md#aso-v1). 
 We strongly recommend migrating to ASOv2 to continue getting new features and support.
 
 ## Assumptions
@@ -177,7 +177,7 @@ modifying the YAML, using a tool such as Kustomize, or using the `--namespace` a
 These are secrets such as storage account keys which ASOv1 has automatically exported into a Kubernetes secret.
 
 ASOv1 exports secrets from Azure according to the 
-[Secret naming](https://github.com/Azure/azure-service-operator/blob/main/docs/v1/howto/secrets.md#secret-naming)
+[Secret naming](https://github.com/Azure/azure-service-operator/blob/asov1/docs/v1/howto/secrets.md#secret-naming)
 rules. ASOv1 always exports these secrets, there is no user configuration required on either the name of the secret or its values.
 In contrast, ASOv2 requires the user to opt-in to secret export, via the `spec.operatorSpec.secrets` property.
 

--- a/docs/hugo/content/guide/asov1-asov2-migration/databaseusers.md
+++ b/docs/hugo/content/guide/asov1-asov2-migration/databaseusers.md
@@ -15,15 +15,15 @@ into the ASOv2 shape.
 
 ## Azure SQL
 
-ASOv1 `AzureSQLUser` [example](https://github.com/Azure/azure-service-operator/blob/main/config/samples/azure_v1alpha1_azuresqluser.yaml).
+ASOv1 `AzureSQLUser` [example](https://github.com/Azure/azure-service-operator/blob/asov1/config/samples/azure_v1alpha1_azuresqluser.yaml).
 
 ASOv2 `sql.azure.com/User` [example](https://github.com/Azure/azure-service-operator/blob/main/v2/samples/sql/v1api/v1api/v1_user.yaml).
 
 ## MySQL
 
-ASOv1 `MySQLUser` [example](https://github.com/Azure/azure-service-operator/blob/main/config/samples/azure_v1alpha2_mysqluser.yaml).
+ASOv1 `MySQLUser` [example](https://github.com/Azure/azure-service-operator/blob/asov1/config/samples/azure_v1alpha2_mysqluser.yaml).
 
-ASOv1 `MySQLAADUser` [example](https://github.com/Azure/azure-service-operator/blob/main/config/samples/azure_v1alpha2_mysqlaaduser.yaml).
+ASOv1 `MySQLAADUser` [example](https://github.com/Azure/azure-service-operator/blob/asov1/config/samples/azure_v1alpha2_mysqlaaduser.yaml).
 
 ASOv2 `dbformysql.azure.com/User` [example](https://github.com/Azure/azure-service-operator/blob/main/v2/samples/dbformysql/v1api/v1_user.yaml).
 
@@ -34,6 +34,6 @@ ASOv2 `dbformysql.azure.com/User` in AAD configuration [example](https://github.
 
 ## PostgreSQL
 
-ASOv1 `PostgreSQLUser` [example](https://github.com/Azure/azure-service-operator/blob/main/config/samples/azure_v1alpha1_postgresqluser.yaml).
+ASOv1 `PostgreSQLUser` [example](https://github.com/Azure/azure-service-operator/blob/asov1/config/samples/azure_v1alpha1_postgresqluser.yaml).
 
 ASOv2 `dbforpostgresql.azure.com/User` [example](https://github.com/Azure/azure-service-operator/blob/main/v2/samples/dbforpostgresql/v1api/v1_user.yaml).


### PR DESCRIPTION
## What this PR does

We have a few broken links in the ASO v2 documentation where it references the (now deleted) ASO v1 documentation and code. 

Redirecting these links to the `asov1` branch where we've kept the ASO v1 source code and documentation in case there's a need for it.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGJoempkdjgxcGMwMGZub3lvdHM2MzA1bXgxdThzZWZiM3A1d2Y3MyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Er3QVX48nt5ok/giphy.gif)

## Checklist

- [x] this PR contains documentation
