### PR TITLE
Let ASO use reconcile policy defined at namespace level for all its r…

### DIFF
--- a/docs/hugo/content/guide/aso-controller-settings-options.md
+++ b/docs/hugo/content/guide/aso-controller-settings-options.md
@@ -309,7 +309,7 @@ RATE_LIMIT_BUCKET_SIZE is the size of the bucket. This value only has an effect 
 
 ### DEFAULT_RECONCILE_POLICY
 
-DEFAULT_RECONCILE_POLICY specify which reconcile strategy to be used by the operator. If not specified, it is set to 'manage'.
+DEFAULT_RECONCILE_POLICY specifies the reconcile strategy to be used by the operator. If not specified, it is set to 'manage'.
 
 **Format:** `string`
 

--- a/v2/api/resources/v1api20200601/permissions.go
+++ b/v2/api/resources/v1api20200601/permissions.go
@@ -13,3 +13,4 @@ package v1api20200601
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch

--- a/v2/internal/reconcilers/generic/register.go
+++ b/v2/internal/reconcilers/generic/register.go
@@ -10,17 +10,24 @@ import (
 	"fmt"
 
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
+	"github.com/Azure/azure-service-operator/v2/internal/reconcilers"
 
 	"github.com/go-logr/logr"
 	"github.com/rotisserie/eris"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/Azure/azure-service-operator/v2/internal/config"
 	"github.com/Azure/azure-service-operator/v2/internal/util/interval"
@@ -94,6 +101,7 @@ func RegisterAll(
 
 	var errs []error
 	for _, obj := range objs {
+		options.LogConstructor(nil).V(Info).Info("Registering", "objectName", obj.Name)
 		// TODO: Consider pulling some of the construction of things out of register (gvk, etc), so that we can pass in just
 		// TODO: the applicable extensions rather than a map of all of them
 		if err := register(mgr, kubeClient, positiveConditions, obj, options); err != nil {
@@ -148,6 +156,8 @@ func register(
 		WithOptions(options.Options)
 	builder.Named(info.Name)
 
+	builder = builder.Watches(&corev1.Namespace{}, handler.EnqueueRequestsFromMapFunc(registerNamespaceWatcher(options, kubeClient, info.Obj, gvk)), ctrlbuilder.WithPredicates(reconcilers.ARMReconcilerAnnotationChangedPredicate()))
+
 	for _, watch := range info.Watches {
 		builder = builder.Watches(watch.Type, watch.MakeEventHandler(kubeClient, options.LogConstructor(nil).WithName(info.Name)))
 	}
@@ -158,4 +168,33 @@ func register(
 	}
 
 	return nil
+}
+
+// This registers a watcher on the namespace for the watched resource
+func registerNamespaceWatcher(options Options, kubeclient kubeclient.Client, object client.Object, gvk schema.GroupVersionKind) func(ctx context.Context, obj client.Object) []reconcile.Request {
+	options.LogConstructor(nil).V(Status).Info("Handler for resource object", "name", object.GetName(), "object.namespace", object.GetNamespace(), "object.kind", gvk.Kind)
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		reconcileRequests := []reconcile.Request{}
+
+		aList := &unstructured.UnstructuredList{}
+		aList.SetGroupVersionKind(gvk)
+		if err := kubeclient.List(ctx, aList, &client.ListOptions{Namespace: obj.GetName()}); err != nil {
+			return []reconcile.Request{}
+		}
+		// list the objects for the current kind
+		options.LogConstructor(nil).V(Verbose).Info("Detected namespace reconcile-policy annotation")
+		for _, el := range aList.Items {
+			if _, ok := el.GetAnnotations()["serviceoperator.azure.com/reconcile-policy"]; ok {
+				// If the annotation is defined for the object, there's no need to reconcile it and we skip the object
+				continue
+			}
+			if _, ok := obj.GetAnnotations()["serviceoperator.azure.com/reconcile-policy"]; ok {
+				reconcileRequests = append(reconcileRequests, reconcile.Request{NamespacedName: types.NamespacedName{
+					Name:      el.GetName(),
+					Namespace: el.GetNamespace(),
+				}})
+			}
+		}
+		return reconcileRequests
+	}
 }

--- a/v2/internal/reconcilers/generic/register.go
+++ b/v2/internal/reconcilers/generic/register.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
-	"github.com/Azure/azure-service-operator/v2/internal/reconcilers"
 
 	"github.com/go-logr/logr"
 	"github.com/rotisserie/eris"
@@ -30,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/Azure/azure-service-operator/v2/internal/config"
+	"github.com/Azure/azure-service-operator/v2/internal/reconcilers"
 	"github.com/Azure/azure-service-operator/v2/internal/util/interval"
 	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"

--- a/v2/internal/reconcilers/predicates.go
+++ b/v2/internal/reconcilers/predicates.go
@@ -8,12 +8,10 @@ package reconcilers
 import (
 	"reflect"
 
-	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/Azure/azure-service-operator/v2/internal/util/predicates"
 	"github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
-	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 )
 
 // ARMReconcilerAnnotationChangedPredicate creates a predicate that emits events when annotations
@@ -32,21 +30,6 @@ func ARMPerResourceSecretAnnotationChangedPredicate() predicate.Predicate {
 		map[string]predicates.HasAnnotationChanged{
 			annotations.PerResourceSecret: HasAnnotationChanged,
 		})
-}
-
-// GetReconcilePolicy gets the reconcile-policy from the ReconcilePolicy
-func GetReconcilePolicy(obj genruntime.MetaObject, log logr.Logger, defaultReconcilePolicy annotations.ReconcilePolicyValue) annotations.ReconcilePolicyValue {
-	policyStr := obj.GetAnnotations()[annotations.ReconcilePolicy]
-	policy, err := ParseReconcilePolicy(policyStr, defaultReconcilePolicy)
-	if err != nil {
-		log.Error(
-			err,
-			"failed to get reconcile policy. Applying default policy instead",
-			"chosenPolicy", policy,
-			"policyAnnotation", policyStr)
-	}
-
-	return policy
 }
 
 // HasAnnotationChanged returns true if the annotation has changed

--- a/v2/internal/reconcilers/reconcile_policy.go
+++ b/v2/internal/reconcilers/reconcile_policy.go
@@ -14,8 +14,8 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
 )
 
-// ParseReconcilePolicy parses the provided reconcile policy.
-// defaultPolicyValue is read from DEFAULT_RECONCILE_POLICY env variable, it set to "manage" when not specified
+// ParseReconcilePolicy parses provided reconcile policy.
+// defaultPolicyValue is read from DEFAULT_RECONCILE_POLICY env variable or set to 'manage' when missing
 func ParseReconcilePolicy(policy string, defaultReconcilePolicy annotations.ReconcilePolicyValue) (annotations.ReconcilePolicyValue, error) {
 	// policy is read from CR annotation, if it's empty it being read from defaultReconcilePolicy
 	switch policy {

--- a/v2/internal/reconcilers/reconcile_policy_test.go
+++ b/v2/internal/reconcilers/reconcile_policy_test.go
@@ -40,3 +40,18 @@ func TestParseReconcilePolicy(t *testing.T) {
 	g.Expect(err).Should(HaveOccurred())
 	g.Expect(returnedPolicy).Should(Equal(annotations.ReconcilePolicySkip))
 }
+
+func TestHasReconcilePolicyAnnotationChanged(t *testing.T) {
+	old := "detach-on-delete"
+	new := "skip"
+
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	result := HasReconcilePolicyAnnotationChanged(&old, &new)
+	g.Expect(result).Should(Equal(true))
+
+	old = "skip"
+	result = HasReconcilePolicyAnnotationChanged(&old, &new)
+	g.Expect(result).Should(Equal(false))
+}


### PR DESCRIPTION
…esources (#4600)


## What this PR does

This addressed the discussion happening in here https://github.com/Azure/azure-service-operator/issues/4600.
With this change we can specify a reconcile policy at namespace level so that all the resources will be handled according to that one, even if another value is explicitly set at resource level.

Closes #[4600]

- [x] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
