### PR TITLE
Retry ScopeLocked errors at a slower rate

### DIFF
--- a/v2/cmd/controller/app/setup.go
+++ b/v2/cmd/controller/app/setup.go
@@ -477,6 +477,13 @@ func makeControllerOptions(log logr.Logger, cfg config.Values) generic.Options {
 			})
 	}
 
+	// If sync period isn't set, set verySlow delay at 24h, otherwise set it
+	// to the sync period.
+	verySlowDelay := 24 * time.Hour
+	if cfg.SyncPeriod != nil {
+		verySlowDelay = *cfg.SyncPeriod
+	}
+
 	return generic.Options{
 		Config: cfg,
 		Options: controller.Options{
@@ -497,11 +504,12 @@ func makeControllerOptions(log logr.Logger, cfg config.Values) generic.Options {
 			// These rate limits are primarily for ReadyConditionImpactingError's
 			interval.CalculatorParameters{
 				//nolint:gosec // do not want cryptographic randomness here
-				Rand:              rand.New(lockedrand.NewSource(time.Now().UnixNano())),
-				ErrorBaseDelay:    1 * time.Second,
-				ErrorMaxFastDelay: 30 * time.Second,
-				ErrorMaxSlowDelay: 3 * time.Minute,
-				SyncPeriod:        cfg.SyncPeriod,
+				Rand:               rand.New(lockedrand.NewSource(time.Now().UnixNano())),
+				ErrorBaseDelay:     1 * time.Second,
+				ErrorMaxFastDelay:  30 * time.Second,
+				ErrorMaxSlowDelay:  3 * time.Minute,
+				ErrorVerySlowDelay: verySlowDelay,
+				SyncPeriod:         cfg.SyncPeriod,
 			}),
 	}
 }

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/merger"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/retry"
 )
 
 type azureDeploymentReconcilerInstance struct {
@@ -118,7 +119,7 @@ func (r *azureDeploymentReconcilerInstance) MakeReadyConditionImpactingErrorFrom
 		return conditions.NewReadyConditionImpactingError(
 			azureErr,
 			conditions.ConditionSeverityWarning,
-			conditions.MakeReason(core.UnknownErrorCode))
+			conditions.MakeReason(core.UnknownErrorCode, retry.Slow))
 	}
 
 	apiVersion, verr := r.GetAPIVersion()
@@ -151,7 +152,7 @@ func (r *azureDeploymentReconcilerInstance) MakeReadyConditionImpactingErrorFrom
 
 	// Stick errorDetails.Message into an error so that it will be displayed as the message on the condition
 	err = eris.Wrap(cloudError, details.Message)
-	reason := conditions.MakeReason(details.Code)
+	reason := conditions.MakeReason(details.Code, details.Retry)
 	result := conditions.NewReadyConditionImpactingError(err, severity, reason)
 
 	return result

--- a/v2/internal/testcommon/kube_test_context_envtest.go
+++ b/v2/internal/testcommon/kube_test_context_envtest.go
@@ -243,6 +243,7 @@ func createSharedEnvTest(cfg testConfig, namespaceResources *namespaceResources)
 				ErrorBaseDelay:       minBackoff,
 				ErrorMaxFastDelay:    maxBackoff,
 				ErrorMaxSlowDelay:    maxBackoff,
+				ErrorVerySlowDelay:   maxBackoff,
 				RequeueDelayOverride: requeueDelay,
 			}),
 	}

--- a/v2/internal/util/interval/interval_calculator.go
+++ b/v2/internal/util/interval/interval_calculator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
 	"github.com/Azure/azure-service-operator/v2/internal/util/randextensions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/retry"
 )
 
 // Calculator calculates an interval
@@ -25,10 +26,18 @@ type Calculator interface {
 }
 
 type CalculatorParameters struct {
-	Rand                 *rand.Rand
-	ErrorBaseDelay       time.Duration
-	ErrorMaxFastDelay    time.Duration
-	ErrorMaxSlowDelay    time.Duration
+	Rand *rand.Rand
+	// ErrorBaseDelay is the base delay for exponential backoff of errors.
+	ErrorBaseDelay time.Duration
+	// ErrorMaxFastDelay is the maximum delay duration (computed via exponential backoff) for retry.Fast errors.
+	ErrorMaxFastDelay time.Duration
+	// ErrorMaxSlowDelay is the maximum delay duration (computed via exponential backoff) for retry.Slow errors.
+	ErrorMaxSlowDelay time.Duration
+	// ErrorVerySlowDelay is the retry.VerySlow error delay. These errors do not follow an exponential backoff and
+	// instead jump straight to this delay, with some jitter to avoid retry storms.
+	ErrorVerySlowDelay time.Duration
+	// SyncPeriod is the duration after which to re-sync healthy (non-error) requests. If omitted, requests are not
+	// re-synced periodically.
 	SyncPeriod           *time.Duration
 	RequeueDelayOverride time.Duration
 }
@@ -38,6 +47,7 @@ func NewCalculator(params CalculatorParameters) Calculator {
 	return &calculator{
 		failures:             make(map[ctrl.Request]int),
 		errorBaseDelay:       params.ErrorBaseDelay,
+		errorVerySlowDelay:   params.ErrorVerySlowDelay,
 		errorMaxSlowDelay:    params.ErrorMaxSlowDelay,
 		errorMaxFastDelay:    params.ErrorMaxFastDelay,
 		syncPeriod:           params.SyncPeriod,
@@ -51,9 +61,10 @@ type calculator struct {
 	failures     map[ctrl.Request]int
 
 	// Used only if there is an error
-	errorBaseDelay    time.Duration
-	errorMaxSlowDelay time.Duration
-	errorMaxFastDelay time.Duration
+	errorBaseDelay     time.Duration
+	errorMaxSlowDelay  time.Duration
+	errorMaxFastDelay  time.Duration
+	errorVerySlowDelay time.Duration
 
 	// Used only if there is not an error
 	syncPeriod           *time.Duration
@@ -130,13 +141,18 @@ func (i *calculator) failureResult(req ctrl.Request, err error) (ctrl.Result, er
 		return ctrl.Result{}, nil
 	case conditions.ConditionSeverityWarning:
 		switch readyErr.RetryClassification {
-		case conditions.RetrySlow:
+		case retry.VerySlow:
+			// For VerySlow, we don't start at baseDelay and go up via exponential, instead
+			// we jump straight to the slow delay interval w/ jitter
+			delay := i.delayWithJitter(i.errorVerySlowDelay)
+			return ctrl.Result{RequeueAfter: delay}, nil
+		case retry.Slow:
 			delay := i.calculateExponentialDelay(i.errorBaseDelay, exp, i.errorMaxSlowDelay)
 			return ctrl.Result{RequeueAfter: delay}, nil
-		case conditions.RetryFast:
+		case retry.Fast:
 			delay := i.calculateExponentialDelay(i.errorBaseDelay, exp, i.errorMaxFastDelay)
 			return ctrl.Result{RequeueAfter: delay}, nil
-		case conditions.RetryNone:
+		case retry.None:
 			// This shouldn't happen, return an error
 			return ctrl.Result{}, eris.New("didn't expect RetryNone classification for error")
 		default:
@@ -157,10 +173,15 @@ func (i *calculator) makeSuccessResult() ctrl.Result {
 	// potential drift from the state in Azure. Note that we cannot use mgr.Options.SyncPeriod for this because we filter
 	// our events by predicate.GenerationChangedPredicate and the generation will not have changed.
 	if i.syncPeriod != nil {
-		result.RequeueAfter = randextensions.Jitter(i.rand, *i.syncPeriod, 0.25)
+		result.RequeueAfter = i.delayWithJitter(*i.syncPeriod)
 	}
 
 	return result
+}
+
+// calculateSyncPeriodDelay calculates a delay from the syncPeriod, with some jitter applied
+func (i *calculator) delayWithJitter(delay time.Duration) time.Duration {
+	return randextensions.Jitter(i.rand, delay, 0.25)
 }
 
 func (i *calculator) calculateExponentialDelay(base time.Duration, exp int, max time.Duration) time.Duration {

--- a/v2/pkg/genruntime/conditions/errors.go
+++ b/v2/pkg/genruntime/conditions/errors.go
@@ -10,6 +10,8 @@ import (
 	"io"
 
 	"github.com/rotisserie/eris"
+
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/retry"
 )
 
 // ReadyConditionImpactingError is an error that requires notification in the Ready condition
@@ -17,7 +19,7 @@ type ReadyConditionImpactingError struct {
 	Severity            ConditionSeverity
 	Reason              string
 	cause               error
-	RetryClassification RetryClassification
+	RetryClassification retry.Classification
 }
 
 // NewReadyConditionImpactingError creates a new ReadyConditionImpactingError
@@ -41,7 +43,7 @@ func AsReadyConditionImpactingError(err error) (*ReadyConditionImpactingError, b
 	return nil, false
 }
 
-func (e *ReadyConditionImpactingError) WithRetryClassification(classification RetryClassification) *ReadyConditionImpactingError {
+func (e *ReadyConditionImpactingError) WithRetryClassification(classification retry.Classification) *ReadyConditionImpactingError {
 	e.RetryClassification = classification
 	return e
 }

--- a/v2/pkg/genruntime/core/cloud_error_details.go
+++ b/v2/pkg/genruntime/core/cloud_error_details.go
@@ -5,8 +5,18 @@ Licensed under the MIT license.
 
 package core
 
+import (
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/retry"
+)
+
 type CloudErrorDetails struct {
+	// Classification specifies if the error is fatal or transient
 	Classification ErrorClassification
-	Code           string
-	Message        string
+	// Retry defines the speed at which the error should be retried. If this is not set,
+	// the default is retry.Slow.
+	Retry retry.Classification
+	// Code is the error code
+	Code string
+	// Message is the error message
+	Message string
 }

--- a/v2/pkg/genruntime/extensions/error_classifier.go
+++ b/v2/pkg/genruntime/extensions/error_classifier.go
@@ -62,6 +62,7 @@ func CreateErrorClassifier(
 		log.V(Status).Info(
 			"CloudError classified",
 			"Classification", result.Classification,
+			"Retry", result.Retry,
 			"Code", result.Code,
 			"Message", result.Message)
 

--- a/v2/pkg/genruntime/retry/retry_classification.go
+++ b/v2/pkg/genruntime/retry/retry_classification.go
@@ -1,0 +1,16 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package retry
+
+type Classification string
+
+const (
+	// None means that this classification is not expected to ever retry. It should only be set for fatal errors
+	None     = Classification("None")
+	Fast     = Classification("RetryFast")
+	Slow     = Classification("RetrySlow")
+	VerySlow = Classification("RetryVerySlow")
+)


### PR DESCRIPTION
* Adds the ability to retry at a slower rate for certain errors.

Fixes #4666.

- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
