### PR TITLE
Mitigate ok-to-test failures in fork PRs

### DIFF
--- a/.github/workflows/pr-validation-fork.yml
+++ b/.github/workflows/pr-validation-fork.yml
@@ -17,40 +17,11 @@ jobs:
       packages: read
 
     steps:
-      # Update check run called "integration-tests" setting status to in_progress
-      # Note: There is no way to specify which suite the check we create goes into apparently, see:
-      # https://github.community/t/specify-check-suite-when-creating-a-checkrun/118380
-      # Also, details_url doesn't currently work when set via a GITHUB_TOKEN which is what we're using, see:
-      # https://github.community/t/create-a-check-run-details-url-is-not-being-set/166002
-      # Given the above limitations, we create a new check for the fork integration tests, and then at the end
-      # of this job we update the "integration-tests" check to be passing as well (so this single job really
-      # ends up writing the status 2 checks, 1 is "integration-tests" and one is "integration-tests-fork").
-      - name: set-check-run-in-progress
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pinned to v7.0.1
-        id: set-check-run-in-progress
-        env:
-          number: ${{ github.event.client_payload.pull_request.number }}
-          job: ${{ github.job }}
-          server_url: ${{ github.server_url }}
-          repo: ${{ github.repository }}
-          run_id: ${{ github.run_id }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const url = `${process.env.server_url}/${process.env.repo}/actions/runs/${process.env.run_id}`
-            const { data: pull } = await github.rest.pulls.get({
-              ...context.repo,
-              pull_number: process.env.number
-            });
-            const ref = pull.head.sha;
-            const { data: result } = await github.rest.checks.create({
-              ...context.repo,
-              name: process.env.job,
-              head_sha: ref,
-              status: 'in_progress',
-              details_url: url,
-            });
-            return result;
+      # Note that we now don't do anything with the integration-test check anymore
+      # due to https://github.blog/changelog/2025-02-12-notice-of-upcoming-deprecations-and-breaking-changes-for-github-actions/#changes-to-check-run-status-modification
+      # This is actually OK though because the status of that check gets set to skipped (due to PRs originating from
+      # a fork). Skipped checks count as successes. Note: that check still sets the status of this check to succeeded,
+      # as otherwise it will be left pending (which does NOT count as succeeded).
 
       - name: Fork based /ok-to-test checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
@@ -114,48 +85,3 @@ jobs:
           KIND_OIDC_STORAGE_ACCOUNT_RG: ${{ secrets.KIND_OIDC_STORAGE_ACCOUNT_RG }}
           KIND_OIDC_STORAGE_ACCOUNT: ${{ secrets.KIND_OIDC_STORAGE_ACCOUNT }}
         if: steps.check-changes.outputs.code-changed == 'true'
-
-      # Update check run called "integration-fork"
-      - name: update-integration-tests-result
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pinned to v7.0.1
-        id: update-check-run
-        if: ${{ always() }}
-        env:
-          number: ${{ github.event.client_payload.pull_request.number }}
-          job: ${{ github.job }}
-          integration_test_job: 'integration-tests' # This is the name of the job defined in pr-validation.yml
-          # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
-          conclusion: ${{ job.status }}
-          server_url: ${{ github.server_url }}
-          repo: ${{ github.repository }}
-          run_id: ${{ github.run_id }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const url = `${process.env.server_url}/${process.env.repo}/actions/runs/${process.env.run_id}`
-            const { data: pull } = await github.rest.pulls.get({
-              ...context.repo,
-              pull_number: process.env.number
-            });
-            const ref = pull.head.sha;
-            const { data: checks } = await github.rest.checks.listForRef({
-              ...context.repo,
-              ref
-            });
-            const forkCheck = checks.check_runs.filter(c => c.name === process.env.job);
-            await github.rest.checks.update({
-              ...context.repo,
-              check_run_id: forkCheck[0].id,
-              status: 'completed',
-              conclusion: process.env.conclusion,
-              details_url: url,
-            });
-            const mainCheck = checks.check_runs.filter(c => c.name === process.env.integration_test_job);
-            const { data: result } = await github.rest.checks.update({
-              ...context.repo,
-              check_run_id: mainCheck[0].id,
-              status: 'completed',
-              conclusion: process.env.conclusion,
-              details_url: url,
-            });
-            return result;


### PR DESCRIPTION
We don't need to mark the integration-test status check manually, as it's already skipped which counts as success


- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
