### PR TITLE
Minor refactoring of gopter test generation

### DIFF
--- a/v2/api/cdn/v1api20210601/arm/profiles_endpoint_spec_types_gen_test.go
+++ b/v2/api/cdn/v1api20210601/arm/profiles_endpoint_spec_types_gen_test.go
@@ -806,7 +806,8 @@ func DeliveryRuleActionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction{}), props))
 	}
 	deliveryRuleActionGenerator = gen.OneGenOf(gens...)
 
@@ -1124,7 +1125,8 @@ func DeliveryRuleConditionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), props))
 	}
 	deliveryRuleConditionGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20210601/arm/profiles_endpoint_status_types_gen_test.go
+++ b/v2/api/cdn/v1api20210601/arm/profiles_endpoint_status_types_gen_test.go
@@ -876,7 +876,8 @@ func DeliveryRuleAction_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction_STATUS{}), props))
 	}
 	deliveryRuleAction_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1194,7 +1195,8 @@ func DeliveryRuleCondition_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_STATUS{}), props))
 	}
 	deliveryRuleCondition_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20210601/profiles_endpoint_types_gen_test.go
+++ b/v2/api/cdn/v1api20210601/profiles_endpoint_types_gen_test.go
@@ -1953,7 +1953,8 @@ func DeliveryRuleActionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction{}), props))
 	}
 	deliveryRuleActionGenerator = gen.OneGenOf(gens...)
 
@@ -2088,7 +2089,8 @@ func DeliveryRuleAction_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction_STATUS{}), props))
 	}
 	deliveryRuleAction_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -2925,7 +2927,8 @@ func DeliveryRuleConditionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), props))
 	}
 	deliveryRuleConditionGenerator = gen.OneGenOf(gens...)
 
@@ -3090,7 +3093,8 @@ func DeliveryRuleCondition_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_STATUS{}), props))
 	}
 	deliveryRuleCondition_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20210601/storage/profiles_endpoint_types_gen_test.go
+++ b/v2/api/cdn/v1api20210601/storage/profiles_endpoint_types_gen_test.go
@@ -1616,7 +1616,8 @@ func DeliveryRuleActionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction{}), props))
 	}
 	deliveryRuleActionGenerator = gen.OneGenOf(gens...)
 
@@ -1751,7 +1752,8 @@ func DeliveryRuleAction_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction_STATUS{}), props))
 	}
 	deliveryRuleAction_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -2588,7 +2590,8 @@ func DeliveryRuleConditionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), props))
 	}
 	deliveryRuleConditionGenerator = gen.OneGenOf(gens...)
 
@@ -2753,7 +2756,8 @@ func DeliveryRuleCondition_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_STATUS{}), props))
 	}
 	deliveryRuleCondition_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20230501/arm/rule_spec_types_gen_test.go
+++ b/v2/api/cdn/v1api20230501/arm/rule_spec_types_gen_test.go
@@ -433,7 +433,8 @@ func DeliveryRuleActionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction{}), props))
 	}
 	deliveryRuleActionGenerator = gen.OneGenOf(gens...)
 
@@ -751,7 +752,8 @@ func DeliveryRuleConditionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), props))
 	}
 	deliveryRuleConditionGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20230501/arm/rule_status_types_gen_test.go
+++ b/v2/api/cdn/v1api20230501/arm/rule_status_types_gen_test.go
@@ -435,7 +435,8 @@ func DeliveryRuleAction_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction_STATUS{}), props))
 	}
 	deliveryRuleAction_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -753,7 +754,8 @@ func DeliveryRuleCondition_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_STATUS{}), props))
 	}
 	deliveryRuleCondition_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20230501/arm/secret_spec_types_gen_test.go
+++ b/v2/api/cdn/v1api20230501/arm/secret_spec_types_gen_test.go
@@ -272,7 +272,8 @@ func SecretParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(SecretParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(SecretParameters{}), props))
 	}
 	secretParametersGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20230501/arm/secret_status_types_gen_test.go
+++ b/v2/api/cdn/v1api20230501/arm/secret_status_types_gen_test.go
@@ -297,7 +297,8 @@ func SecretParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(SecretParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(SecretParameters_STATUS{}), props))
 	}
 	secretParameters_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20230501/arm/security_policy_spec_types_gen_test.go
+++ b/v2/api/cdn/v1api20230501/arm/security_policy_spec_types_gen_test.go
@@ -133,7 +133,8 @@ func SecurityPolicyPropertiesParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(SecurityPolicyPropertiesParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(SecurityPolicyPropertiesParameters{}), props))
 	}
 	securityPolicyPropertiesParametersGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20230501/arm/security_policy_status_types_gen_test.go
+++ b/v2/api/cdn/v1api20230501/arm/security_policy_status_types_gen_test.go
@@ -133,7 +133,8 @@ func SecurityPolicyPropertiesParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(SecurityPolicyPropertiesParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(SecurityPolicyPropertiesParameters_STATUS{}), props))
 	}
 	securityPolicyPropertiesParameters_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20230501/rule_types_gen_test.go
+++ b/v2/api/cdn/v1api20230501/rule_types_gen_test.go
@@ -1259,7 +1259,8 @@ func DeliveryRuleActionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction{}), props))
 	}
 	deliveryRuleActionGenerator = gen.OneGenOf(gens...)
 
@@ -1394,7 +1395,8 @@ func DeliveryRuleAction_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction_STATUS{}), props))
 	}
 	deliveryRuleAction_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -2231,7 +2233,8 @@ func DeliveryRuleConditionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), props))
 	}
 	deliveryRuleConditionGenerator = gen.OneGenOf(gens...)
 
@@ -2396,7 +2399,8 @@ func DeliveryRuleCondition_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_STATUS{}), props))
 	}
 	deliveryRuleCondition_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20230501/secret_types_gen_test.go
+++ b/v2/api/cdn/v1api20230501/secret_types_gen_test.go
@@ -1034,7 +1034,8 @@ func SecretParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(SecretParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(SecretParameters{}), props))
 	}
 	secretParametersGenerator = gen.OneGenOf(gens...)
 
@@ -1154,7 +1155,8 @@ func SecretParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(SecretParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(SecretParameters_STATUS{}), props))
 	}
 	secretParameters_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20230501/security_policy_types_gen_test.go
+++ b/v2/api/cdn/v1api20230501/security_policy_types_gen_test.go
@@ -358,7 +358,8 @@ func SecurityPolicyPropertiesParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(SecurityPolicyPropertiesParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(SecurityPolicyPropertiesParameters{}), props))
 	}
 	securityPolicyPropertiesParametersGenerator = gen.OneGenOf(gens...)
 
@@ -469,7 +470,8 @@ func SecurityPolicyPropertiesParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(SecurityPolicyPropertiesParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(SecurityPolicyPropertiesParameters_STATUS{}), props))
 	}
 	securityPolicyPropertiesParameters_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20230501/storage/rule_types_gen_test.go
+++ b/v2/api/cdn/v1api20230501/storage/rule_types_gen_test.go
@@ -716,7 +716,8 @@ func DeliveryRuleActionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction{}), props))
 	}
 	deliveryRuleActionGenerator = gen.OneGenOf(gens...)
 
@@ -809,7 +810,8 @@ func DeliveryRuleAction_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction_STATUS{}), props))
 	}
 	deliveryRuleAction_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1352,7 +1354,8 @@ func DeliveryRuleConditionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), props))
 	}
 	deliveryRuleConditionGenerator = gen.OneGenOf(gens...)
 
@@ -1475,7 +1478,8 @@ func DeliveryRuleCondition_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_STATUS{}), props))
 	}
 	deliveryRuleCondition_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20230501/storage/secret_types_gen_test.go
+++ b/v2/api/cdn/v1api20230501/storage/secret_types_gen_test.go
@@ -612,7 +612,8 @@ func SecretParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(SecretParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(SecretParameters{}), props))
 	}
 	secretParametersGenerator = gen.OneGenOf(gens...)
 
@@ -690,7 +691,8 @@ func SecretParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(SecretParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(SecretParameters_STATUS{}), props))
 	}
 	secretParameters_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1api20230501/storage/security_policy_types_gen_test.go
+++ b/v2/api/cdn/v1api20230501/storage/security_policy_types_gen_test.go
@@ -249,7 +249,8 @@ func SecurityPolicyPropertiesParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(SecurityPolicyPropertiesParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(SecurityPolicyPropertiesParameters{}), props))
 	}
 	securityPolicyPropertiesParametersGenerator = gen.OneGenOf(gens...)
 
@@ -318,7 +319,8 @@ func SecurityPolicyPropertiesParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(SecurityPolicyPropertiesParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(SecurityPolicyPropertiesParameters_STATUS{}), props))
 	}
 	securityPolicyPropertiesParameters_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/datafactory/v1api20180601/arm/factory_spec_types_gen_test.go
+++ b/v2/api/datafactory/v1api20180601/arm/factory_spec_types_gen_test.go
@@ -448,7 +448,8 @@ func FactoryRepoConfigurationGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(FactoryRepoConfiguration{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(FactoryRepoConfiguration{}), props))
 	}
 	factoryRepoConfigurationGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/datafactory/v1api20180601/arm/factory_status_types_gen_test.go
+++ b/v2/api/datafactory/v1api20180601/arm/factory_status_types_gen_test.go
@@ -439,7 +439,8 @@ func FactoryRepoConfiguration_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(FactoryRepoConfiguration_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(FactoryRepoConfiguration_STATUS{}), props))
 	}
 	factoryRepoConfiguration_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/datafactory/v1api20180601/factory_types_gen_test.go
+++ b/v2/api/datafactory/v1api20180601/factory_types_gen_test.go
@@ -1267,7 +1267,8 @@ func FactoryRepoConfigurationGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(FactoryRepoConfiguration{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(FactoryRepoConfiguration{}), props))
 	}
 	factoryRepoConfigurationGenerator = gen.OneGenOf(gens...)
 
@@ -1381,7 +1382,8 @@ func FactoryRepoConfiguration_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(FactoryRepoConfiguration_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(FactoryRepoConfiguration_STATUS{}), props))
 	}
 	factoryRepoConfiguration_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/datafactory/v1api20180601/storage/factory_types_gen_test.go
+++ b/v2/api/datafactory/v1api20180601/storage/factory_types_gen_test.go
@@ -761,7 +761,8 @@ func FactoryRepoConfigurationGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(FactoryRepoConfiguration{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(FactoryRepoConfiguration{}), props))
 	}
 	factoryRepoConfigurationGenerator = gen.OneGenOf(gens...)
 
@@ -833,7 +834,8 @@ func FactoryRepoConfiguration_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(FactoryRepoConfiguration_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(FactoryRepoConfiguration_STATUS{}), props))
 	}
 	factoryRepoConfiguration_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dataprotection/v1api20230101/arm/backup_vaults_backup_policy_spec_types_gen_test.go
+++ b/v2/api/dataprotection/v1api20230101/arm/backup_vaults_backup_policy_spec_types_gen_test.go
@@ -483,7 +483,8 @@ func BackupCriteriaGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria{}), props))
 	}
 	backupCriteriaGenerator = gen.OneGenOf(gens...)
 
@@ -551,7 +552,8 @@ func BackupParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters{}), props))
 	}
 	backupParametersGenerator = gen.OneGenOf(gens...)
 
@@ -830,7 +832,8 @@ func BaseBackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy{}), props))
 	}
 	baseBackupPolicyGenerator = gen.OneGenOf(gens...)
 
@@ -898,7 +901,8 @@ func BasePolicyRuleGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule{}), props))
 	}
 	basePolicyRuleGenerator = gen.OneGenOf(gens...)
 
@@ -1029,7 +1033,8 @@ func CopyOptionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption{}), props))
 	}
 	copyOptionGenerator = gen.OneGenOf(gens...)
 
@@ -1286,7 +1291,8 @@ func DeleteOptionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption{}), props))
 	}
 	deleteOptionGenerator = gen.OneGenOf(gens...)
 
@@ -1859,7 +1865,8 @@ func TriggerContextGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext{}), props))
 	}
 	triggerContextGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dataprotection/v1api20230101/arm/backup_vaults_backup_policy_status_types_gen_test.go
+++ b/v2/api/dataprotection/v1api20230101/arm/backup_vaults_backup_policy_status_types_gen_test.go
@@ -487,7 +487,8 @@ func BackupCriteria_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria_STATUS{}), props))
 	}
 	backupCriteria_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -556,7 +557,8 @@ func BackupParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters_STATUS{}), props))
 	}
 	backupParameters_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -841,7 +843,8 @@ func BaseBackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy_STATUS{}), props))
 	}
 	baseBackupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -910,7 +913,8 @@ func BasePolicyRule_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule_STATUS{}), props))
 	}
 	basePolicyRule_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1042,7 +1046,8 @@ func CopyOption_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption_STATUS{}), props))
 	}
 	copyOption_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1302,7 +1307,8 @@ func DeleteOption_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption_STATUS{}), props))
 	}
 	deleteOption_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1882,7 +1888,8 @@ func TriggerContext_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext_STATUS{}), props))
 	}
 	triggerContext_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dataprotection/v1api20230101/backup_vaults_backup_policy_types_gen_test.go
+++ b/v2/api/dataprotection/v1api20230101/backup_vaults_backup_policy_types_gen_test.go
@@ -1446,7 +1446,8 @@ func BackupCriteriaGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria{}), props))
 	}
 	backupCriteriaGenerator = gen.OneGenOf(gens...)
 
@@ -1557,7 +1558,8 @@ func BackupCriteria_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria_STATUS{}), props))
 	}
 	backupCriteria_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1667,7 +1669,8 @@ func BackupParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters{}), props))
 	}
 	backupParametersGenerator = gen.OneGenOf(gens...)
 
@@ -1778,7 +1781,8 @@ func BackupParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters_STATUS{}), props))
 	}
 	backupParameters_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -2812,7 +2816,8 @@ func BaseBackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy{}), props))
 	}
 	baseBackupPolicyGenerator = gen.OneGenOf(gens...)
 
@@ -2923,7 +2928,8 @@ func BaseBackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy_STATUS{}), props))
 	}
 	baseBackupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -3033,7 +3039,8 @@ func BasePolicyRuleGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule{}), props))
 	}
 	basePolicyRuleGenerator = gen.OneGenOf(gens...)
 
@@ -3147,7 +3154,8 @@ func BasePolicyRule_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule_STATUS{}), props))
 	}
 	basePolicyRule_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -3465,7 +3473,8 @@ func CopyOptionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption{}), props))
 	}
 	copyOptionGenerator = gen.OneGenOf(gens...)
 
@@ -3581,7 +3590,8 @@ func CopyOption_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption_STATUS{}), props))
 	}
 	copyOption_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -4317,7 +4327,8 @@ func DeleteOptionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption{}), props))
 	}
 	deleteOptionGenerator = gen.OneGenOf(gens...)
 
@@ -4428,7 +4439,8 @@ func DeleteOption_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption_STATUS{}), props))
 	}
 	deleteOption_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -6142,7 +6154,8 @@ func TriggerContextGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext{}), props))
 	}
 	triggerContextGenerator = gen.OneGenOf(gens...)
 
@@ -6256,7 +6269,8 @@ func TriggerContext_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext_STATUS{}), props))
 	}
 	triggerContext_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dataprotection/v1api20230101/storage/backup_vaults_backup_policy_types_gen_test.go
+++ b/v2/api/dataprotection/v1api20230101/storage/backup_vaults_backup_policy_types_gen_test.go
@@ -1445,7 +1445,8 @@ func BackupCriteriaGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria{}), props))
 	}
 	backupCriteriaGenerator = gen.OneGenOf(gens...)
 
@@ -1556,7 +1557,8 @@ func BackupCriteria_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria_STATUS{}), props))
 	}
 	backupCriteria_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1666,7 +1668,8 @@ func BackupParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters{}), props))
 	}
 	backupParametersGenerator = gen.OneGenOf(gens...)
 
@@ -1777,7 +1780,8 @@ func BackupParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters_STATUS{}), props))
 	}
 	backupParameters_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -2812,7 +2816,8 @@ func BaseBackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy{}), props))
 	}
 	baseBackupPolicyGenerator = gen.OneGenOf(gens...)
 
@@ -2923,7 +2928,8 @@ func BaseBackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy_STATUS{}), props))
 	}
 	baseBackupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -3033,7 +3039,8 @@ func BasePolicyRuleGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule{}), props))
 	}
 	basePolicyRuleGenerator = gen.OneGenOf(gens...)
 
@@ -3147,7 +3154,8 @@ func BasePolicyRule_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule_STATUS{}), props))
 	}
 	basePolicyRule_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -3465,7 +3473,8 @@ func CopyOptionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption{}), props))
 	}
 	copyOptionGenerator = gen.OneGenOf(gens...)
 
@@ -3581,7 +3590,8 @@ func CopyOption_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption_STATUS{}), props))
 	}
 	copyOption_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -4317,7 +4327,8 @@ func DeleteOptionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption{}), props))
 	}
 	deleteOptionGenerator = gen.OneGenOf(gens...)
 
@@ -4428,7 +4439,8 @@ func DeleteOption_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption_STATUS{}), props))
 	}
 	deleteOption_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -6084,7 +6096,8 @@ func TriggerContextGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext{}), props))
 	}
 	triggerContextGenerator = gen.OneGenOf(gens...)
 
@@ -6198,7 +6211,8 @@ func TriggerContext_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext_STATUS{}), props))
 	}
 	triggerContext_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dataprotection/v1api20231101/arm/backup_vaults_backup_instance_spec_types_gen_test.go
+++ b/v2/api/dataprotection/v1api20231101/arm/backup_vaults_backup_instance_spec_types_gen_test.go
@@ -71,7 +71,8 @@ func AuthCredentialsGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AuthCredentials{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(AuthCredentials{}), props))
 	}
 	authCredentialsGenerator = gen.OneGenOf(gens...)
 
@@ -203,7 +204,8 @@ func BackupDatasourceParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupDatasourceParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupDatasourceParameters{}), props))
 	}
 	backupDatasourceParametersGenerator = gen.OneGenOf(gens...)
 
@@ -433,7 +435,8 @@ func BaseResourcePropertiesGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseResourceProperties{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseResourceProperties{}), props))
 	}
 	baseResourcePropertiesGenerator = gen.OneGenOf(gens...)
 
@@ -564,7 +567,8 @@ func DataStoreParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DataStoreParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DataStoreParameters{}), props))
 	}
 	dataStoreParametersGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dataprotection/v1api20231101/arm/backup_vaults_backup_instance_status_types_gen_test.go
+++ b/v2/api/dataprotection/v1api20231101/arm/backup_vaults_backup_instance_status_types_gen_test.go
@@ -72,7 +72,8 @@ func AuthCredentials_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AuthCredentials_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(AuthCredentials_STATUS{}), props))
 	}
 	authCredentials_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -204,7 +205,8 @@ func BackupDatasourceParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupDatasourceParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupDatasourceParameters_STATUS{}), props))
 	}
 	backupDatasourceParameters_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -454,7 +456,8 @@ func BaseResourceProperties_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseResourceProperties_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseResourceProperties_STATUS{}), props))
 	}
 	baseResourceProperties_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -585,7 +588,8 @@ func DataStoreParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DataStoreParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DataStoreParameters_STATUS{}), props))
 	}
 	dataStoreParameters_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dataprotection/v1api20231101/arm/backup_vaults_backup_policy_spec_types_gen_test.go
+++ b/v2/api/dataprotection/v1api20231101/arm/backup_vaults_backup_policy_spec_types_gen_test.go
@@ -483,7 +483,8 @@ func BackupCriteriaGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria{}), props))
 	}
 	backupCriteriaGenerator = gen.OneGenOf(gens...)
 
@@ -551,7 +552,8 @@ func BackupParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters{}), props))
 	}
 	backupParametersGenerator = gen.OneGenOf(gens...)
 
@@ -830,7 +832,8 @@ func BaseBackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy{}), props))
 	}
 	baseBackupPolicyGenerator = gen.OneGenOf(gens...)
 
@@ -898,7 +901,8 @@ func BasePolicyRuleGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule{}), props))
 	}
 	basePolicyRuleGenerator = gen.OneGenOf(gens...)
 
@@ -1029,7 +1033,8 @@ func CopyOptionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption{}), props))
 	}
 	copyOptionGenerator = gen.OneGenOf(gens...)
 
@@ -1286,7 +1291,8 @@ func DeleteOptionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption{}), props))
 	}
 	deleteOptionGenerator = gen.OneGenOf(gens...)
 
@@ -1859,7 +1865,8 @@ func TriggerContextGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext{}), props))
 	}
 	triggerContextGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dataprotection/v1api20231101/arm/backup_vaults_backup_policy_status_types_gen_test.go
+++ b/v2/api/dataprotection/v1api20231101/arm/backup_vaults_backup_policy_status_types_gen_test.go
@@ -487,7 +487,8 @@ func BackupCriteria_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria_STATUS{}), props))
 	}
 	backupCriteria_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -556,7 +557,8 @@ func BackupParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters_STATUS{}), props))
 	}
 	backupParameters_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -841,7 +843,8 @@ func BaseBackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy_STATUS{}), props))
 	}
 	baseBackupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -910,7 +913,8 @@ func BasePolicyRule_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule_STATUS{}), props))
 	}
 	basePolicyRule_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1042,7 +1046,8 @@ func CopyOption_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption_STATUS{}), props))
 	}
 	copyOption_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1302,7 +1307,8 @@ func DeleteOption_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption_STATUS{}), props))
 	}
 	deleteOption_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1882,7 +1888,8 @@ func TriggerContext_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext_STATUS{}), props))
 	}
 	triggerContext_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dataprotection/v1api20231101/backup_vaults_backup_instance_types_gen_test.go
+++ b/v2/api/dataprotection/v1api20231101/backup_vaults_backup_instance_types_gen_test.go
@@ -114,7 +114,8 @@ func AuthCredentialsGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AuthCredentials{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(AuthCredentials{}), props))
 	}
 	authCredentialsGenerator = gen.OneGenOf(gens...)
 
@@ -225,7 +226,8 @@ func AuthCredentials_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AuthCredentials_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(AuthCredentials_STATUS{}), props))
 	}
 	authCredentials_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -545,7 +547,8 @@ func BackupDatasourceParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupDatasourceParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupDatasourceParameters{}), props))
 	}
 	backupDatasourceParametersGenerator = gen.OneGenOf(gens...)
 
@@ -659,7 +662,8 @@ func BackupDatasourceParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupDatasourceParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupDatasourceParameters_STATUS{}), props))
 	}
 	backupDatasourceParameters_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1522,7 +1526,8 @@ func BaseResourcePropertiesGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseResourceProperties{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseResourceProperties{}), props))
 	}
 	baseResourcePropertiesGenerator = gen.OneGenOf(gens...)
 
@@ -1633,7 +1638,8 @@ func BaseResourceProperties_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseResourceProperties_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseResourceProperties_STATUS{}), props))
 	}
 	baseResourceProperties_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1952,7 +1958,8 @@ func DataStoreParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DataStoreParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DataStoreParameters{}), props))
 	}
 	dataStoreParametersGenerator = gen.OneGenOf(gens...)
 
@@ -2063,7 +2070,8 @@ func DataStoreParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DataStoreParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DataStoreParameters_STATUS{}), props))
 	}
 	dataStoreParameters_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dataprotection/v1api20231101/backup_vaults_backup_policy_types_gen_test.go
+++ b/v2/api/dataprotection/v1api20231101/backup_vaults_backup_policy_types_gen_test.go
@@ -1445,7 +1445,8 @@ func BackupCriteriaGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria{}), props))
 	}
 	backupCriteriaGenerator = gen.OneGenOf(gens...)
 
@@ -1556,7 +1557,8 @@ func BackupCriteria_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria_STATUS{}), props))
 	}
 	backupCriteria_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1666,7 +1668,8 @@ func BackupParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters{}), props))
 	}
 	backupParametersGenerator = gen.OneGenOf(gens...)
 
@@ -1777,7 +1780,8 @@ func BackupParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters_STATUS{}), props))
 	}
 	backupParameters_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -2811,7 +2815,8 @@ func BaseBackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy{}), props))
 	}
 	baseBackupPolicyGenerator = gen.OneGenOf(gens...)
 
@@ -2922,7 +2927,8 @@ func BaseBackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy_STATUS{}), props))
 	}
 	baseBackupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -3032,7 +3038,8 @@ func BasePolicyRuleGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule{}), props))
 	}
 	basePolicyRuleGenerator = gen.OneGenOf(gens...)
 
@@ -3146,7 +3153,8 @@ func BasePolicyRule_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule_STATUS{}), props))
 	}
 	basePolicyRule_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -3464,7 +3472,8 @@ func CopyOptionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption{}), props))
 	}
 	copyOptionGenerator = gen.OneGenOf(gens...)
 
@@ -3580,7 +3589,8 @@ func CopyOption_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption_STATUS{}), props))
 	}
 	copyOption_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -4316,7 +4326,8 @@ func DeleteOptionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption{}), props))
 	}
 	deleteOptionGenerator = gen.OneGenOf(gens...)
 
@@ -4427,7 +4438,8 @@ func DeleteOption_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption_STATUS{}), props))
 	}
 	deleteOption_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -6141,7 +6153,8 @@ func TriggerContextGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext{}), props))
 	}
 	triggerContextGenerator = gen.OneGenOf(gens...)
 
@@ -6255,7 +6268,8 @@ func TriggerContext_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext_STATUS{}), props))
 	}
 	triggerContext_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dataprotection/v1api20231101/storage/backup_vaults_backup_instance_types_gen_test.go
+++ b/v2/api/dataprotection/v1api20231101/storage/backup_vaults_backup_instance_types_gen_test.go
@@ -71,7 +71,8 @@ func AuthCredentialsGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AuthCredentials{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(AuthCredentials{}), props))
 	}
 	authCredentialsGenerator = gen.OneGenOf(gens...)
 
@@ -140,7 +141,8 @@ func AuthCredentials_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AuthCredentials_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(AuthCredentials_STATUS{}), props))
 	}
 	authCredentials_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -334,7 +336,8 @@ func BackupDatasourceParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupDatasourceParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupDatasourceParameters{}), props))
 	}
 	backupDatasourceParametersGenerator = gen.OneGenOf(gens...)
 
@@ -406,7 +409,8 @@ func BackupDatasourceParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupDatasourceParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupDatasourceParameters_STATUS{}), props))
 	}
 	backupDatasourceParameters_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -921,7 +925,8 @@ func BaseResourcePropertiesGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseResourceProperties{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseResourceProperties{}), props))
 	}
 	baseResourcePropertiesGenerator = gen.OneGenOf(gens...)
 
@@ -990,7 +995,8 @@ func BaseResourceProperties_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseResourceProperties_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseResourceProperties_STATUS{}), props))
 	}
 	baseResourceProperties_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1183,7 +1189,8 @@ func DataStoreParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DataStoreParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DataStoreParameters{}), props))
 	}
 	dataStoreParametersGenerator = gen.OneGenOf(gens...)
 
@@ -1252,7 +1259,8 @@ func DataStoreParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DataStoreParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DataStoreParameters_STATUS{}), props))
 	}
 	dataStoreParameters_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dataprotection/v1api20231101/storage/backup_vaults_backup_policy_types_gen_test.go
+++ b/v2/api/dataprotection/v1api20231101/storage/backup_vaults_backup_policy_types_gen_test.go
@@ -898,7 +898,8 @@ func BackupCriteriaGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria{}), props))
 	}
 	backupCriteriaGenerator = gen.OneGenOf(gens...)
 
@@ -967,7 +968,8 @@ func BackupCriteria_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupCriteria_STATUS{}), props))
 	}
 	backupCriteria_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1035,7 +1037,8 @@ func BackupParametersGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters{}), props))
 	}
 	backupParametersGenerator = gen.OneGenOf(gens...)
 
@@ -1104,7 +1107,8 @@ func BackupParameters_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupParameters_STATUS{}), props))
 	}
 	backupParameters_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1718,7 +1722,8 @@ func BaseBackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy{}), props))
 	}
 	baseBackupPolicyGenerator = gen.OneGenOf(gens...)
 
@@ -1787,7 +1792,8 @@ func BaseBackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BaseBackupPolicy_STATUS{}), props))
 	}
 	baseBackupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1855,7 +1861,8 @@ func BasePolicyRuleGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule{}), props))
 	}
 	basePolicyRuleGenerator = gen.OneGenOf(gens...)
 
@@ -1927,7 +1934,8 @@ func BasePolicyRule_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BasePolicyRule_STATUS{}), props))
 	}
 	basePolicyRule_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -2119,7 +2127,8 @@ func CopyOptionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption{}), props))
 	}
 	copyOptionGenerator = gen.OneGenOf(gens...)
 
@@ -2193,7 +2202,8 @@ func CopyOption_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(CopyOption_STATUS{}), props))
 	}
 	copyOption_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -2635,7 +2645,8 @@ func DeleteOptionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption{}), props))
 	}
 	deleteOptionGenerator = gen.OneGenOf(gens...)
 
@@ -2704,7 +2715,8 @@ func DeleteOption_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeleteOption_STATUS{}), props))
 	}
 	deleteOption_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -3730,7 +3742,8 @@ func TriggerContextGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext{}), props))
 	}
 	triggerContextGenerator = gen.OneGenOf(gens...)
 
@@ -3802,7 +3815,8 @@ func TriggerContext_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(TriggerContext_STATUS{}), props))
 	}
 	triggerContext_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dbformariadb/v1api20180601/arm/server_spec_types_gen_test.go
+++ b/v2/api/dbformariadb/v1api20180601/arm/server_spec_types_gen_test.go
@@ -72,7 +72,8 @@ func ServerPropertiesForCreateGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(ServerPropertiesForCreate{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(ServerPropertiesForCreate{}), props))
 	}
 	serverPropertiesForCreateGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dbformariadb/v1api20180601/server_types_gen_test.go
+++ b/v2/api/dbformariadb/v1api20180601/server_types_gen_test.go
@@ -912,7 +912,8 @@ func ServerPropertiesForCreateGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(ServerPropertiesForCreate{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(ServerPropertiesForCreate{}), props))
 	}
 	serverPropertiesForCreateGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dbformariadb/v1api20180601/storage/server_types_gen_test.go
+++ b/v2/api/dbformariadb/v1api20180601/storage/server_types_gen_test.go
@@ -523,7 +523,8 @@ func ServerPropertiesForCreateGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(ServerPropertiesForCreate{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(ServerPropertiesForCreate{}), props))
 	}
 	serverPropertiesForCreateGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1api20210515/arm/database_account_spec_types_gen_test.go
+++ b/v2/api/documentdb/v1api20210515/arm/database_account_spec_types_gen_test.go
@@ -192,7 +192,8 @@ func BackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), props))
 	}
 	backupPolicyGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1api20210515/arm/database_account_status_types_gen_test.go
+++ b/v2/api/documentdb/v1api20210515/arm/database_account_status_types_gen_test.go
@@ -194,7 +194,8 @@ func BackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), props))
 	}
 	backupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1api20210515/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1api20210515/database_account_types_gen_test.go
@@ -526,7 +526,8 @@ func BackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), props))
 	}
 	backupPolicyGenerator = gen.OneGenOf(gens...)
 
@@ -640,7 +641,8 @@ func BackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), props))
 	}
 	backupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1api20210515/storage/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1api20210515/storage/database_account_types_gen_test.go
@@ -526,7 +526,8 @@ func BackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), props))
 	}
 	backupPolicyGenerator = gen.OneGenOf(gens...)
 
@@ -640,7 +641,8 @@ func BackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), props))
 	}
 	backupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1api20231115/arm/database_account_spec_types_gen_test.go
+++ b/v2/api/documentdb/v1api20231115/arm/database_account_spec_types_gen_test.go
@@ -196,7 +196,8 @@ func BackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), props))
 	}
 	backupPolicyGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1api20231115/arm/database_account_status_types_gen_test.go
+++ b/v2/api/documentdb/v1api20231115/arm/database_account_status_types_gen_test.go
@@ -326,7 +326,8 @@ func BackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), props))
 	}
 	backupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1api20231115/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1api20231115/database_account_types_gen_test.go
@@ -637,7 +637,8 @@ func BackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), props))
 	}
 	backupPolicyGenerator = gen.OneGenOf(gens...)
 
@@ -969,7 +970,8 @@ func BackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), props))
 	}
 	backupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1api20231115/storage/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1api20231115/storage/database_account_types_gen_test.go
@@ -628,7 +628,8 @@ func BackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), props))
 	}
 	backupPolicyGenerator = gen.OneGenOf(gens...)
 
@@ -952,7 +953,8 @@ func BackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), props))
 	}
 	backupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1api20240815/arm/database_account_spec_types_gen_test.go
+++ b/v2/api/documentdb/v1api20240815/arm/database_account_spec_types_gen_test.go
@@ -199,7 +199,8 @@ func BackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), props))
 	}
 	backupPolicyGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1api20240815/arm/database_account_status_types_gen_test.go
+++ b/v2/api/documentdb/v1api20240815/arm/database_account_status_types_gen_test.go
@@ -329,7 +329,8 @@ func BackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), props))
 	}
 	backupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1api20240815/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1api20240815/database_account_types_gen_test.go
@@ -642,7 +642,8 @@ func BackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), props))
 	}
 	backupPolicyGenerator = gen.OneGenOf(gens...)
 
@@ -974,7 +975,8 @@ func BackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), props))
 	}
 	backupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1api20240815/storage/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1api20240815/storage/database_account_types_gen_test.go
@@ -375,7 +375,8 @@ func BackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), props))
 	}
 	backupPolicyGenerator = gen.OneGenOf(gens...)
 
@@ -573,7 +574,8 @@ func BackupPolicy_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_STATUS{}), props))
 	}
 	backupPolicy_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1api20200601/arm/domain_spec_types_gen_test.go
+++ b/v2/api/eventgrid/v1api20200601/arm/domain_spec_types_gen_test.go
@@ -286,7 +286,8 @@ func InputSchemaMappingGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(InputSchemaMapping{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(InputSchemaMapping{}), props))
 	}
 	inputSchemaMappingGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1api20200601/arm/domain_status_types_gen_test.go
+++ b/v2/api/eventgrid/v1api20200601/arm/domain_status_types_gen_test.go
@@ -302,7 +302,8 @@ func InputSchemaMapping_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(InputSchemaMapping_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(InputSchemaMapping_STATUS{}), props))
 	}
 	inputSchemaMapping_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1api20200601/arm/event_subscription_spec_types_gen_test.go
+++ b/v2/api/eventgrid/v1api20200601/arm/event_subscription_spec_types_gen_test.go
@@ -71,7 +71,8 @@ func AdvancedFilterGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), props))
 	}
 	advancedFilterGenerator = gen.OneGenOf(gens...)
 
@@ -374,7 +375,8 @@ func DeadLetterDestinationGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeadLetterDestination{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeadLetterDestination{}), props))
 	}
 	deadLetterDestinationGenerator = gen.OneGenOf(gens...)
 
@@ -579,7 +581,8 @@ func EventSubscriptionDestinationGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), props))
 	}
 	eventSubscriptionDestinationGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1api20200601/arm/event_subscription_status_types_gen_test.go
+++ b/v2/api/eventgrid/v1api20200601/arm/event_subscription_status_types_gen_test.go
@@ -72,7 +72,8 @@ func AdvancedFilter_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter_STATUS{}), props))
 	}
 	advancedFilter_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -375,7 +376,8 @@ func DeadLetterDestination_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeadLetterDestination_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeadLetterDestination_STATUS{}), props))
 	}
 	deadLetterDestination_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -580,7 +582,8 @@ func EventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination_STATUS{}), props))
 	}
 	eventSubscriptionDestination_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1api20200601/domain_types_gen_test.go
+++ b/v2/api/eventgrid/v1api20200601/domain_types_gen_test.go
@@ -823,7 +823,8 @@ func InputSchemaMappingGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(InputSchemaMapping{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(InputSchemaMapping{}), props))
 	}
 	inputSchemaMappingGenerator = gen.OneGenOf(gens...)
 
@@ -934,7 +935,8 @@ func InputSchemaMapping_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(InputSchemaMapping_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(InputSchemaMapping_STATUS{}), props))
 	}
 	inputSchemaMapping_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1api20200601/event_subscription_types_gen_test.go
+++ b/v2/api/eventgrid/v1api20200601/event_subscription_types_gen_test.go
@@ -114,7 +114,8 @@ func AdvancedFilterGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), props))
 	}
 	advancedFilterGenerator = gen.OneGenOf(gens...)
 
@@ -258,7 +259,8 @@ func AdvancedFilter_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter_STATUS{}), props))
 	}
 	advancedFilter_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -823,7 +825,8 @@ func DeadLetterDestinationGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeadLetterDestination{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeadLetterDestination{}), props))
 	}
 	deadLetterDestinationGenerator = gen.OneGenOf(gens...)
 
@@ -934,7 +937,8 @@ func DeadLetterDestination_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeadLetterDestination_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeadLetterDestination_STATUS{}), props))
 	}
 	deadLetterDestination_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1398,7 +1402,8 @@ func EventSubscriptionDestinationGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), props))
 	}
 	eventSubscriptionDestinationGenerator = gen.OneGenOf(gens...)
 
@@ -1527,7 +1532,8 @@ func EventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination_STATUS{}), props))
 	}
 	eventSubscriptionDestination_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1api20200601/storage/domain_types_gen_test.go
+++ b/v2/api/eventgrid/v1api20200601/storage/domain_types_gen_test.go
@@ -480,7 +480,8 @@ func InputSchemaMappingGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(InputSchemaMapping{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(InputSchemaMapping{}), props))
 	}
 	inputSchemaMappingGenerator = gen.OneGenOf(gens...)
 
@@ -549,7 +550,8 @@ func InputSchemaMapping_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(InputSchemaMapping_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(InputSchemaMapping_STATUS{}), props))
 	}
 	inputSchemaMapping_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1api20200601/storage/event_subscription_types_gen_test.go
+++ b/v2/api/eventgrid/v1api20200601/storage/event_subscription_types_gen_test.go
@@ -71,7 +71,8 @@ func AdvancedFilterGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), props))
 	}
 	advancedFilterGenerator = gen.OneGenOf(gens...)
 
@@ -173,7 +174,8 @@ func AdvancedFilter_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter_STATUS{}), props))
 	}
 	advancedFilter_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -528,7 +530,8 @@ func DeadLetterDestinationGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeadLetterDestination{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeadLetterDestination{}), props))
 	}
 	deadLetterDestinationGenerator = gen.OneGenOf(gens...)
 
@@ -597,7 +600,8 @@ func DeadLetterDestination_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeadLetterDestination_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeadLetterDestination_STATUS{}), props))
 	}
 	deadLetterDestination_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -850,7 +854,8 @@ func EventSubscriptionDestinationGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), props))
 	}
 	eventSubscriptionDestinationGenerator = gen.OneGenOf(gens...)
 
@@ -937,7 +942,8 @@ func EventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination_STATUS{}), props))
 	}
 	eventSubscriptionDestination_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/insights/v1api20180301/arm/metric_alert_spec_types_gen_test.go
+++ b/v2/api/insights/v1api20180301/arm/metric_alert_spec_types_gen_test.go
@@ -286,7 +286,8 @@ func MetricAlertCriteriaGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(MetricAlertCriteria{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(MetricAlertCriteria{}), props))
 	}
 	metricAlertCriteriaGenerator = gen.OneGenOf(gens...)
 
@@ -826,7 +827,8 @@ func MultiMetricCriteriaGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(MultiMetricCriteria{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(MultiMetricCriteria{}), props))
 	}
 	multiMetricCriteriaGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/insights/v1api20180301/arm/metric_alert_status_types_gen_test.go
+++ b/v2/api/insights/v1api20180301/arm/metric_alert_status_types_gen_test.go
@@ -287,7 +287,8 @@ func MetricAlertCriteria_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(MetricAlertCriteria_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(MetricAlertCriteria_STATUS{}), props))
 	}
 	metricAlertCriteria_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -833,7 +834,8 @@ func MultiMetricCriteria_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(MultiMetricCriteria_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(MultiMetricCriteria_STATUS{}), props))
 	}
 	multiMetricCriteria_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/insights/v1api20180301/metric_alert_types_gen_test.go
+++ b/v2/api/insights/v1api20180301/metric_alert_types_gen_test.go
@@ -942,7 +942,8 @@ func MetricAlertCriteriaGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(MetricAlertCriteria{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(MetricAlertCriteria{}), props))
 	}
 	metricAlertCriteriaGenerator = gen.OneGenOf(gens...)
 
@@ -1059,7 +1060,8 @@ func MetricAlertCriteria_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(MetricAlertCriteria_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(MetricAlertCriteria_STATUS{}), props))
 	}
 	metricAlertCriteria_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -2481,7 +2483,8 @@ func MultiMetricCriteriaGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(MultiMetricCriteria{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(MultiMetricCriteria{}), props))
 	}
 	multiMetricCriteriaGenerator = gen.OneGenOf(gens...)
 
@@ -2595,7 +2598,8 @@ func MultiMetricCriteria_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(MultiMetricCriteria_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(MultiMetricCriteria_STATUS{}), props))
 	}
 	multiMetricCriteria_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/insights/v1api20180301/storage/metric_alert_types_gen_test.go
+++ b/v2/api/insights/v1api20180301/storage/metric_alert_types_gen_test.go
@@ -552,7 +552,8 @@ func MetricAlertCriteriaGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(MetricAlertCriteria{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(MetricAlertCriteria{}), props))
 	}
 	metricAlertCriteriaGenerator = gen.OneGenOf(gens...)
 
@@ -627,7 +628,8 @@ func MetricAlertCriteria_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(MetricAlertCriteria_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(MetricAlertCriteria_STATUS{}), props))
 	}
 	metricAlertCriteria_STATUSGenerator = gen.OneGenOf(gens...)
 
@@ -1526,7 +1528,8 @@ func MultiMetricCriteriaGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(MultiMetricCriteria{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(MultiMetricCriteria{}), props))
 	}
 	multiMetricCriteriaGenerator = gen.OneGenOf(gens...)
 
@@ -1598,7 +1601,8 @@ func MultiMetricCriteria_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(MultiMetricCriteria_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(MultiMetricCriteria_STATUS{}), props))
 	}
 	multiMetricCriteria_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20210701/arm/workspaces_compute_spec_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20210701/arm/workspaces_compute_spec_types_gen_test.go
@@ -640,7 +640,8 @@ func ComputeGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), props))
 	}
 	computeGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20210701/arm/workspaces_compute_status_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20210701/arm/workspaces_compute_status_types_gen_test.go
@@ -1193,7 +1193,8 @@ func Compute_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_STATUS{}), props))
 	}
 	compute_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20210701/storage/workspaces_compute_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20210701/storage/workspaces_compute_types_gen_test.go
@@ -1940,7 +1940,8 @@ func ComputeGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), props))
 	}
 	computeGenerator = gen.OneGenOf(gens...)
 
@@ -3200,7 +3201,8 @@ func Compute_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_STATUS{}), props))
 	}
 	compute_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20210701/workspaces_compute_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20210701/workspaces_compute_types_gen_test.go
@@ -1955,7 +1955,8 @@ func ComputeGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), props))
 	}
 	computeGenerator = gen.OneGenOf(gens...)
 
@@ -3251,7 +3252,8 @@ func Compute_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_STATUS{}), props))
 	}
 	compute_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20240401/arm/workspace_spec_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20240401/arm/workspace_spec_types_gen_test.go
@@ -658,7 +658,8 @@ func OutboundRuleGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(OutboundRule{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(OutboundRule{}), props))
 	}
 	outboundRuleGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20240401/arm/workspace_status_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20240401/arm/workspace_status_types_gen_test.go
@@ -817,7 +817,8 @@ func OutboundRule_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(OutboundRule_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(OutboundRule_STATUS{}), props))
 	}
 	outboundRule_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20240401/arm/workspaces_compute_spec_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20240401/arm/workspaces_compute_spec_types_gen_test.go
@@ -702,7 +702,8 @@ func ComputeGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), props))
 	}
 	computeGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20240401/arm/workspaces_compute_status_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20240401/arm/workspaces_compute_status_types_gen_test.go
@@ -1817,7 +1817,8 @@ func Compute_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_STATUS{}), props))
 	}
 	compute_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20240401/arm/workspaces_connection_spec_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20240401/arm/workspaces_connection_spec_types_gen_test.go
@@ -2725,7 +2725,8 @@ func WorkspaceConnectionPropertiesV2Generator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(WorkspaceConnectionPropertiesV2{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(WorkspaceConnectionPropertiesV2{}), props))
 	}
 	workspaceConnectionPropertiesV2Generator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20240401/arm/workspaces_connection_status_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20240401/arm/workspaces_connection_status_types_gen_test.go
@@ -2810,7 +2810,8 @@ func WorkspaceConnectionPropertiesV2_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(WorkspaceConnectionPropertiesV2_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(WorkspaceConnectionPropertiesV2_STATUS{}), props))
 	}
 	workspaceConnectionPropertiesV2_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20240401/storage/workspace_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20240401/storage/workspace_types_gen_test.go
@@ -1388,7 +1388,8 @@ func OutboundRuleGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(OutboundRule{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(OutboundRule{}), props))
 	}
 	outboundRuleGenerator = gen.OneGenOf(gens...)
 
@@ -1463,7 +1464,8 @@ func OutboundRule_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(OutboundRule_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(OutboundRule_STATUS{}), props))
 	}
 	outboundRule_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20240401/storage/workspaces_compute_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20240401/storage/workspaces_compute_types_gen_test.go
@@ -1348,7 +1348,8 @@ func ComputeGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), props))
 	}
 	computeGenerator = gen.OneGenOf(gens...)
 
@@ -2901,7 +2902,8 @@ func Compute_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_STATUS{}), props))
 	}
 	compute_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20240401/storage/workspaces_connection_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20240401/storage/workspaces_connection_types_gen_test.go
@@ -2899,7 +2899,8 @@ func WorkspaceConnectionPropertiesV2Generator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(WorkspaceConnectionPropertiesV2{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(WorkspaceConnectionPropertiesV2{}), props))
 	}
 	workspaceConnectionPropertiesV2Generator = gen.OneGenOf(gens...)
 
@@ -3001,7 +3002,8 @@ func WorkspaceConnectionPropertiesV2_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(WorkspaceConnectionPropertiesV2_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(WorkspaceConnectionPropertiesV2_STATUS{}), props))
 	}
 	workspaceConnectionPropertiesV2_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20240401/workspace_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20240401/workspace_types_gen_test.go
@@ -2279,7 +2279,8 @@ func OutboundRuleGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(OutboundRule{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(OutboundRule{}), props))
 	}
 	outboundRuleGenerator = gen.OneGenOf(gens...)
 
@@ -2396,7 +2397,8 @@ func OutboundRule_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(OutboundRule_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(OutboundRule_STATUS{}), props))
 	}
 	outboundRule_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20240401/workspaces_compute_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20240401/workspaces_compute_types_gen_test.go
@@ -2161,7 +2161,8 @@ func ComputeGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), props))
 	}
 	computeGenerator = gen.OneGenOf(gens...)
 
@@ -4694,7 +4695,8 @@ func Compute_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_STATUS{}), props))
 	}
 	compute_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1api20240401/workspaces_connection_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1api20240401/workspaces_connection_types_gen_test.go
@@ -7070,7 +7070,8 @@ func WorkspaceConnectionPropertiesV2Generator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(WorkspaceConnectionPropertiesV2{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(WorkspaceConnectionPropertiesV2{}), props))
 	}
 	workspaceConnectionPropertiesV2Generator = gen.OneGenOf(gens...)
 
@@ -7214,7 +7215,8 @@ func WorkspaceConnectionPropertiesV2_STATUSGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(WorkspaceConnectionPropertiesV2_STATUS{}), map[string]gopter.Gen{propName: propGen}))
+		props := map[string]gopter.Gen{propName: propGen}
+		gens = append(gens, gen.Struct(reflect.TypeOf(WorkspaceConnectionPropertiesV2_STATUS{}), props))
 	}
 	workspaceConnectionPropertiesV2_STATUSGenerator = gen.OneGenOf(gens...)
 

--- a/v2/tools/generator/internal/astbuilder/statements.go
+++ b/v2/tools/generator/internal/astbuilder/statements.go
@@ -58,6 +58,11 @@ func Statements(statements ...any) []dst.Stmt {
 	// Clone everything to avoid sharing nodes
 	result := make([]dst.Stmt, 0, len(stmts))
 	for _, st := range stmts {
+		if st == nil {
+			// Skip nils
+			continue
+		}
+
 		result = append(result, dst.Clone(st).(dst.Stmt))
 	}
 


### PR DESCRIPTION
## What this PR does

Slightly changes the structure of generated gopter tests to make it easier to generate tests for `kusto` that pass.

The biggest change is in the way the generator has been refactored - see `json_serialization_test_case.go`.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMHdrMGc5bmliYnhxajRmM3N0M2VuMmRqemFjcTBrOWFqYzFnNHd5MCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/eenzqB2MsGKbK/giphy.gif)

## Checklist

- [x] this PR contains tests
