### PR TITLE
Fix the Kusto Database extension to allow owners referenced by armID

### DIFF
--- a/v2/api/containerservice/customizations/managed_cluster_extensions.go
+++ b/v2/api/containerservice/customizations/managed_cluster_extensions.go
@@ -166,13 +166,13 @@ var nonBlockingManagedClusterProvisioningStates = set.Make(
 )
 
 func (ext *ManagedClusterExtension) PreReconcileCheck(
-	_ context.Context,
+	ctx context.Context,
 	obj genruntime.MetaObject,
-	_ genruntime.MetaObject,
-	_ *resolver.Resolver,
-	_ *genericarmclient.GenericClient,
-	_ logr.Logger,
-	_ extensions.PreReconcileCheckFunc,
+	owner genruntime.MetaObject,
+	resourceResolver *resolver.Resolver,
+	armClient *genericarmclient.GenericClient,
+	log logr.Logger,
+	next extensions.PreReconcileCheckFunc,
 ) (extensions.PreReconcileCheckResult, error) {
 	// This has to be the current hub storage version. It will need to be updated
 	// if the hub storage version changes.
@@ -197,7 +197,7 @@ func (ext *ManagedClusterExtension) PreReconcileCheck(
 			nil
 	}
 
-	return extensions.ProceedWithReconcile(), nil
+	return next(ctx, obj, owner, resourceResolver, armClient, log)
 }
 
 func clusterProvisioningStateBlocksReconciliation(provisioningState *string) bool {

--- a/v2/api/dbforpostgresql/customizations/flexible_server_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_server_extensions.go
@@ -99,13 +99,13 @@ var nonBlockingFlexibleServerStates = set.Make(
 )
 
 func (ext *FlexibleServerExtension) PreReconcileCheck(
-	_ context.Context,
+	ctx context.Context,
 	obj genruntime.MetaObject,
-	_ genruntime.MetaObject,
-	_ *resolver.Resolver,
-	_ *genericarmclient.GenericClient,
-	_ logr.Logger,
-	_ extensions.PreReconcileCheckFunc,
+	owner genruntime.MetaObject,
+	resourceResolver *resolver.Resolver,
+	armClient *genericarmclient.GenericClient,
+	log logr.Logger,
+	next extensions.PreReconcileCheckFunc,
 ) (extensions.PreReconcileCheckResult, error) {
 	// This has to be the current hub storage version. It will need to be updated
 	// if the hub storage version changes.
@@ -127,7 +127,7 @@ func (ext *FlexibleServerExtension) PreReconcileCheck(
 				*state)), nil
 	}
 
-	return extensions.ProceedWithReconcile(), nil
+	return next(ctx, obj, owner, resourceResolver, armClient, log)
 }
 
 func flexibleServerStateBlocksReconciliation(state string) bool {

--- a/v2/api/dbforpostgresql/customizations/flexible_servers_firewall_rule_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_servers_firewall_rule_extensions.go
@@ -29,20 +29,17 @@ func (ext *FlexibleServersFirewallRuleExtension) PreReconcileCheck(
 	log logr.Logger,
 	next extensions.PreReconcileCheckFunc,
 ) (extensions.PreReconcileCheckResult, error) {
-	if owner == nil {
-		// TODO: Check from ARM instead?
-		return extensions.ProceedWithReconcile(), nil
-	}
-
 	// Check to see if our owning server is ready for the database to be reconciled
 	// Owner nil can happen if the server/owner of the firewall rule is referenced by armID
-	if server, ok := owner.(*postgresql.FlexibleServer); ok {
-		serverState := server.Status.State
-		if serverState != nil && flexibleServerStateBlocksReconciliation(*serverState) {
-			return extensions.BlockReconcile(
-				fmt.Sprintf(
-					"Owning FlexibleServer is in provisioning state %q",
-					*serverState)), nil
+	if owner != nil {
+		if server, ok := owner.(*postgresql.FlexibleServer); ok {
+			serverState := server.Status.State
+			if serverState != nil && flexibleServerStateBlocksReconciliation(*serverState) {
+				return extensions.BlockReconcile(
+					fmt.Sprintf(
+						"Owning FlexibleServer is in provisioning state %q",
+						*serverState)), nil
+			}
 		}
 	}
 

--- a/v2/api/dbforpostgresql/customizations/flexible_servers_firewall_rule_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_servers_firewall_rule_extensions.go
@@ -21,13 +21,13 @@ import (
 var _ extensions.PreReconciliationChecker = &FlexibleServersFirewallRuleExtension{}
 
 func (ext *FlexibleServersFirewallRuleExtension) PreReconcileCheck(
-	_ context.Context,
-	_ genruntime.MetaObject,
+	ctx context.Context,
+	obj genruntime.MetaObject,
 	owner genruntime.MetaObject,
-	_ *resolver.Resolver,
-	_ *genericarmclient.GenericClient,
-	_ logr.Logger,
-	_ extensions.PreReconcileCheckFunc,
+	resourceResolver *resolver.Resolver,
+	armClient *genericarmclient.GenericClient,
+	log logr.Logger,
+	next extensions.PreReconcileCheckFunc,
 ) (extensions.PreReconcileCheckResult, error) {
 	if owner == nil {
 		// TODO: Check from ARM instead?
@@ -35,6 +35,7 @@ func (ext *FlexibleServersFirewallRuleExtension) PreReconcileCheck(
 	}
 
 	// Check to see if our owning server is ready for the database to be reconciled
+	// Owner nil can happen if the server/owner of the firewall rule is referenced by armID
 	if server, ok := owner.(*postgresql.FlexibleServer); ok {
 		serverState := server.Status.State
 		if serverState != nil && flexibleServerStateBlocksReconciliation(*serverState) {
@@ -45,5 +46,5 @@ func (ext *FlexibleServersFirewallRuleExtension) PreReconcileCheck(
 		}
 	}
 
-	return extensions.ProceedWithReconcile(), nil
+	return next(ctx, obj, owner, resourceResolver, armClient, log)
 }

--- a/v2/api/kusto/customizations/cluster_extensions.go
+++ b/v2/api/kusto/customizations/cluster_extensions.go
@@ -38,13 +38,13 @@ var clusterTerminalStates = set.Make(
 // new state out of hand; so there's no point in even trying. This is true even if the PUT we're
 // doing will have no effect on the state of the cluster.
 func (ext *ClusterExtension) PreReconcileCheck(
-	_ context.Context,
+	ctx context.Context,
 	obj genruntime.MetaObject,
-	_ genruntime.MetaObject,
-	_ *resolver.Resolver,
-	_ *genericarmclient.GenericClient,
-	_ logr.Logger,
-	_ extensions.PreReconcileCheckFunc,
+	owner genruntime.MetaObject,
+	resourceResolver *resolver.Resolver,
+	armClient *genericarmclient.GenericClient,
+	log logr.Logger,
+	next extensions.PreReconcileCheckFunc,
 ) (extensions.PreReconcileCheckResult, error) {
 	// This has to be the current hub storage version. It will need to be updated
 	// if the hub storage version changes.
@@ -69,7 +69,7 @@ func (ext *ClusterExtension) PreReconcileCheck(
 			nil
 	}
 
-	return extensions.ProceedWithReconcile(), nil
+	return next(ctx, obj, owner, resourceResolver, armClient, log)
 }
 
 func clusterProvisioningStateBlocksReconciliation(provisioningState *string) bool {

--- a/v2/api/kusto/customizations/database_extensions.go
+++ b/v2/api/kusto/customizations/database_extensions.go
@@ -34,7 +34,7 @@ func (ext *DatabaseExtension) PreReconcileCheck(
 ) (extensions.PreReconcileCheckResult, error) {
 	// Check to see if the owning cluster is in a state that will block us from reconciling
 	// Owner nil can happen if the owner of the database is referenced by armID
-	if owner == nil {
+	if owner != nil {
 		if cluster, ok := owner.(*kusto.Cluster); ok {
 			// If our owning *cluster* is in a state that will reject any PUT, then we should skip
 			// reconciliation of the database as there's no point in even trying.

--- a/v2/api/kusto/customizations/database_extensions.go
+++ b/v2/api/kusto/customizations/database_extensions.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/rotisserie/eris"
-	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	kusto "github.com/Azure/azure-service-operator/v2/api/kusto/v1api20230815/storage"
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
@@ -26,39 +24,34 @@ var _ extensions.PreReconciliationChecker = &ClusterExtension{}
 // is in a state that will allow reconciliation to proceed.
 // We can't try to create/update a Database unless the cluster is in a state that allows it.
 func (ext *DatabaseExtension) PreReconcileCheck(
-	_ context.Context,
+	ctx context.Context,
 	obj genruntime.MetaObject,
 	owner genruntime.MetaObject,
-	_ *resolver.Resolver,
-	_ *genericarmclient.GenericClient,
-	_ logr.Logger,
-	_ extensions.PreReconcileCheckFunc,
+	resourceResolver *resolver.Resolver,
+	armClient_ *genericarmclient.GenericClient,
+	log logr.Logger,
+	next extensions.PreReconcileCheckFunc,
 ) (extensions.PreReconcileCheckResult, error) {
-	// This has to be the current hub storage version. It will need to be updated
-	// if the hub storage version changes.
-	cluster, ok := owner.(*kusto.Cluster)
-	if !ok {
-		return extensions.PreReconcileCheckResult{},
-			eris.Errorf("cannot run on unknown resource type %T, expected owner to be *kusto.Cluster", owner)
+	// Check to see if the owning cluster is in a state that will block us from reconciling
+	// Owner nil can happen if the owner of the database is referenced by armID
+	if owner == nil {
+		if cluster, ok := owner.(*kusto.Cluster); ok {
+			// If our owning *cluster* is in a state that will reject any PUT, then we should skip
+			// reconciliation of the database as there's no point in even trying.
+			// One way this can happen is when we reconcile the cluster, putting it into an `Updating`
+			// state for a period. While it's in that state, we can't even try to reconcile the database as
+			// the operation will fail with a `Conflict` error.
+			// Checking the state of our owning cluster allows us to "play nice with others" and not use up
+			// request quota attempting to make changes when we already know those attempts will fail.
+			state := cluster.Status.ProvisioningState
+			if state != nil && clusterProvisioningStateBlocksReconciliation(state) {
+				return extensions.BlockReconcile(
+						fmt.Sprintf("Owning cluster is in provisioning state %q", *state)),
+					nil
+			}
+
+		}
 	}
 
-	// Type assert that we are the hub type. This will fail to compile if
-	// the hub type has been changed but this extension has not
-	var _ conversion.Hub = cluster
-
-	// If our owning *cluster* is in a state that will reject any PUT, then we should skip
-	// reconciliation of the database as there's no point in even trying.
-	// One way this can happen is when we reconcile the cluster, putting it into an `Updating`
-	// state for a period. While it's in that state, we can't even try to reconcile the database as
-	// the operation will fail with a `Conflict` error.
-	// Checking the state of our owning cluster allows us to "play nice with others" and not use up
-	// request quota attempting to make changes when we already know those attempts will fail.
-	state := cluster.Status.ProvisioningState
-	if state != nil && clusterProvisioningStateBlocksReconciliation(state) {
-		return extensions.BlockReconcile(
-				fmt.Sprintf("Owning cluster is in provisioning state %q", *state)),
-			nil
-	}
-
-	return extensions.ProceedWithReconcile(), nil
+	return next(ctx, obj, owner, resourceResolver, armClient_, log)
 }


### PR DESCRIPTION
## What this PR does

Fixes the PreReconcileCheck extension for kusto.Database resources to allow their owner to be referenced by armID.

Note: We can only do the prerequisite check for Kusto Clusters that are managed by ASO, so users will end up with _conflict_ messages in their logs.

Closes #4712 

### Special notes

Also fixes up other implementations of `extensions.PreReconciliationChecker` to properly call the `next()` function, bringing them into alignment with the design of the extension.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcDN2aWQwam8zbHZ2djlkajlmOHF4MWU1NTY0ZXNsZjl1bnRsbXlrdiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/AbYxDs20DECQw/giphy.gif)
