### PR TITLE
Add readme for v1 charts

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,8 @@
+# Charts for ASO v1
+
+This directory contains Helm charts for deploying Azure Service Operator v1 (ASOv1).
+
+> **ASO v1 has been deprecated and is no longer being maintained.**  
+> **New users should use [ASO v2](https://azure.github.io/azure-service-operator/), which is actively maintained and includes many improvements over v1.**
+
+If you're looking for charts for ASO v2, see [v2/charts](../v2/charts/).


### PR DESCRIPTION
## What this PR does

We saw [on Slack](https://kubernetes.slack.com/archives/C046DEVLAQM/p1744610768869099?thread_ts=1744383458.097009&cid=C046DEVLAQM) someone who thought ASO was unmaintained because they were looking at the v1 charts.

Adding a README to that folder to redirect people to the v2 charts.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/bh4jzePjmd9iE/giphy.gif?cid=ecf05e47kbilhhicsifbjt9suq4gelhpuecb3np4zuempevj&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## Checklist

- [x] this PR contains documentation
