### PR TITLE
Improve error classification and add operationID to errors

### DIFF
--- a/v2/internal/errwrap/errwrap.go
+++ b/v2/internal/errwrap/errwrap.go
@@ -1,0 +1,31 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package errwrap
+
+type hideError struct {
+	err error
+	msg string
+}
+
+var _ error = &hideError{}
+
+// Hide wraps an error with a message, hiding the original error.
+// This is useful when you want to provide a user-friendly message without exposing the underlying error details.
+// The original error can still be accessed via the Unwrap method (so errors.Is and errors.As work as expected).
+func Hide(err error, msg string) error {
+	return &hideError{
+		err: err,
+		msg: msg,
+	}
+}
+
+func (w *hideError) Error() string {
+	return w.msg
+}
+
+func (w *hideError) Unwrap() error {
+	return w.err
+}

--- a/v2/internal/genericarmclient/cloud_error.go
+++ b/v2/internal/genericarmclient/cloud_error.go
@@ -7,7 +7,10 @@ package genericarmclient
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/rotisserie/eris"
 
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
@@ -38,17 +41,34 @@ func NewCloudError(err error) *CloudError {
 	}
 }
 
-func NewTestCloudError(code string, message string) *CloudError {
-	return &CloudError{
+type TestOption func(e *CloudError)
+
+func WithTestInnerError(err error) TestOption {
+	return func(e *CloudError) {
+		e.error = err
+	}
+}
+
+func NewTestCloudError(code string, message string, options ...TestOption) *CloudError {
+	result := &CloudError{
 		code:    &code,
 		message: &message,
 	}
+
+	for _, opt := range options {
+		opt(result)
+	}
+	return result
 }
 
 // Error implements the error interface for type CloudError.
 // The contents of the error text are not contractual and subject to change.
 func (e *CloudError) Error() string {
-	return e.error.Error()
+	requestID := e.RequestID()
+	if e.RequestID() == "" {
+		requestID = "unknown"
+	}
+	return fmt.Sprintf("%s, RequestID: %s", e.error.Error(), requestID)
 }
 
 // Code returns the error code from the message, if present, or UnknownErrorCode if not.
@@ -81,6 +101,25 @@ func (e *CloudError) Target() string {
 // Details returns the details of the error, if present, or an empty slice if not
 func (e *CloudError) Details() []*ErrorResponse {
 	return e.details
+}
+
+// RequestID returns the request ID (from x-ms-request-id header) of the error, if one exists.
+func (e *CloudError) RequestID() string {
+	var respErr *azcore.ResponseError
+	if !eris.As(e, &respErr) {
+		return ""
+	}
+
+	id, ok := respErr.RawResponse.Header[http.CanonicalHeaderKey("x-ms-request-id")]
+	if !ok {
+		return ""
+	}
+
+	if len(id) == 0 {
+		return ""
+	}
+
+	return id[0]
 }
 
 func (e *CloudError) UnmarshalJSON(data []byte) error {

--- a/v2/internal/genericarmclient/generic_client.go
+++ b/v2/internal/genericarmclient/generic_client.go
@@ -236,7 +236,7 @@ func (client *GenericClient) GetByID(
 		return retryAfter, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return retryAfter, runtime.NewResponseError(resp)
+		return retryAfter, client.handleError(resp)
 	}
 	return zeroDuration, client.getByIDHandleResponse(resp, resource)
 }
@@ -302,7 +302,7 @@ func (client *GenericClient) checkExistenceByIDImpl(
 		return retryAfter, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusNoContent, http.StatusNotFound) {
-		return retryAfter, runtime.NewResponseError(resp)
+		return retryAfter, client.handleError(resp)
 	}
 	return zeroDuration, nil
 }
@@ -362,7 +362,7 @@ func (p *listPageResponse[T]) NextPage(
 	}
 
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return nil, runtime.NewResponseError(resp)
+		return nil, client.handleError(resp)
 	}
 
 	newPage := listPageResponse[T]{}
@@ -479,7 +479,7 @@ func (client *GenericClient) deleteByID(ctx context.Context, resourceID string, 
 	}
 
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return nil, runtime.NewResponseError(resp)
+		return nil, client.handleError(resp)
 	}
 	return resp, nil
 }

--- a/v2/internal/reconcilers/arm/errorclassification/error_classifier.go
+++ b/v2/internal/reconcilers/arm/errorclassification/error_classifier.go
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package arm
+package errorclassification
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"

--- a/v2/internal/reconcilers/arm/errorclassification/error_classifier_test.go
+++ b/v2/internal/reconcilers/arm/errorclassification/error_classifier_test.go
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
 
-package arm_test
+package errorclassification_test
 
 import (
 	"testing"
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
-	"github.com/Azure/azure-service-operator/v2/internal/reconcilers/arm"
+	"github.com/Azure/azure-service-operator/v2/internal/reconcilers/arm/errorclassification"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/retry"
 )
@@ -36,7 +36,7 @@ func Test_NilError_IsRetryable(t *testing.T) {
 		Message:        core.UnknownErrorMessage,
 	}
 
-	g.Expect(arm.ClassifyCloudError(nil)).To(Equal(expected))
+	g.Expect(errorclassification.ClassifyCloudError(nil)).To(Equal(expected))
 }
 
 func Test_Conflict_IsRetryable(t *testing.T) {
@@ -48,7 +48,7 @@ func Test_Conflict_IsRetryable(t *testing.T) {
 		Code:           conflictError.Code(),
 		Message:        conflictError.Message(),
 	}
-	g.Expect(arm.ClassifyCloudError(conflictError)).To(Equal(expected))
+	g.Expect(errorclassification.ClassifyCloudError(conflictError)).To(Equal(expected))
 }
 
 func Test_BadRequest_IsFatal(t *testing.T) {
@@ -60,7 +60,7 @@ func Test_BadRequest_IsFatal(t *testing.T) {
 		Code:           badRequestError.Code(),
 		Message:        badRequestError.Message(),
 	}
-	g.Expect(arm.ClassifyCloudError(badRequestError)).To(Equal(expected))
+	g.Expect(errorclassification.ClassifyCloudError(badRequestError)).To(Equal(expected))
 }
 
 func Test_Locked_IsRetryableVerySlowly(t *testing.T) {
@@ -73,7 +73,7 @@ func Test_Locked_IsRetryableVerySlowly(t *testing.T) {
 		Message:        lockedError.Message(),
 		Retry:          retry.VerySlow,
 	}
-	g.Expect(arm.ClassifyCloudError(lockedError)).To(Equal(expected))
+	g.Expect(errorclassification.ClassifyCloudError(lockedError)).To(Equal(expected))
 }
 
 func Test_ResourceGroupNotFound_IsRetryable(t *testing.T) {
@@ -85,7 +85,7 @@ func Test_ResourceGroupNotFound_IsRetryable(t *testing.T) {
 		Code:           resourceGroupNotFoundError.Code(),
 		Message:        resourceGroupNotFoundError.Message(),
 	}
-	g.Expect(arm.ClassifyCloudError(resourceGroupNotFoundError)).To(Equal(expected))
+	g.Expect(errorclassification.ClassifyCloudError(resourceGroupNotFoundError)).To(Equal(expected))
 }
 
 func Test_UnknownError_IsRetryable(t *testing.T) {
@@ -97,7 +97,7 @@ func Test_UnknownError_IsRetryable(t *testing.T) {
 		Code:           unknownError.Code(),
 		Message:        unknownError.Message(),
 	}
-	g.Expect(arm.ClassifyCloudError(unknownError)).To(Equal(expected))
+	g.Expect(errorclassification.ClassifyCloudError(unknownError)).To(Equal(expected))
 }
 
 func Test_HTTP400_IsFatal(t *testing.T) {
@@ -109,5 +109,5 @@ func Test_HTTP400_IsFatal(t *testing.T) {
 		Message:        core.UnknownErrorMessage,
 	}
 
-	g.Expect(arm.ClassifyCloudError(http400Error)).To(Equal(expected))
+	g.Expect(errorclassification.ClassifyCloudError(http400Error)).To(Equal(expected))
 }

--- a/v2/internal/reconcilers/arm/errorclassification/ready_condition.go
+++ b/v2/internal/reconcilers/arm/errorclassification/ready_condition.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package errorclassification
+
+import (
+	"github.com/rotisserie/eris"
+
+	"github.com/Azure/azure-service-operator/v2/internal/errwrap"
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/retry"
+)
+
+// MakeReadyConditionImpactingErrorFromError creates a ReadyConditionImpactingError from an error.
+// It uses the provided classifier to classify the error, and returns a ReadyConditionImpactingError with the
+// appropriate severity and reason based on the classification.
+// If the error is already a ReadyConditionImpactingError, it returns it unchanged.
+func MakeReadyConditionImpactingErrorFromError(azureErr error, classifier extensions.ErrorClassifierFunc) error {
+	var readyConditionError *conditions.ReadyConditionImpactingError
+	isReadyConditionImpactingError := eris.As(azureErr, &readyConditionError)
+	if isReadyConditionImpactingError {
+		// The error has already been classified. This currently only happens in test with the go-vcr injected
+		// http client
+		return azureErr
+	}
+
+	var cloudError *genericarmclient.CloudError
+	isCloudErr := eris.As(azureErr, &cloudError)
+	if !isCloudErr {
+		// This shouldn't happen, as all errors from ARM should be in one of the shapes that CloudError supports. In case
+		// we've somehow gotten one that isn't formatted correctly, create a sensible default error
+		return conditions.NewReadyConditionImpactingError(
+			azureErr,
+			conditions.ConditionSeverityWarning,
+			conditions.MakeReason(core.UnknownErrorCode, retry.Slow))
+	}
+
+	details, err := classifier(cloudError)
+	if err != nil {
+		return eris.Wrapf(
+			err,
+			"Unable to classify cloud error (%s)",
+			cloudError.Error())
+	}
+
+	var severity conditions.ConditionSeverity
+	switch details.Classification {
+	case core.ErrorRetryable:
+		severity = conditions.ConditionSeverityWarning
+	case core.ErrorFatal:
+		severity = conditions.ConditionSeverityError
+	default:
+		return eris.Errorf(
+			"unknown error classification %q while making Ready condition",
+			details.Classification)
+
+	}
+
+	// Stick errorDetails.Message into an error so that it will be displayed as the message on the condition
+	err = errwrap.Hide(cloudError, details.Message)
+	reason := conditions.MakeReason(details.Code, details.Retry)
+	result := conditions.NewReadyConditionImpactingError(err, severity, reason)
+
+	return result
+}

--- a/v2/internal/reconcilers/arm/errorclassification/ready_condition_test.go
+++ b/v2/internal/reconcilers/arm/errorclassification/ready_condition_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package errorclassification_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/rotisserie/eris"
+
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	"github.com/Azure/azure-service-operator/v2/internal/reconcilers/arm/errorclassification"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/retry"
+)
+
+// Mock classifier function for the unknown classification test
+func mockUnknownClassifier(err *genericarmclient.CloudError) (core.CloudErrorDetails, error) {
+	return core.CloudErrorDetails{
+		Classification: "Unknown", // Not a valid classification
+		Code:           err.Code(),
+		Message:        err.Message(),
+	}, nil
+}
+
+func Test_MakeReadyConditionImpactingErrorFromError_AlreadyReadyConditionImpactingError(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	// Create a ReadyConditionImpactingError
+	originalErr := errors.New("original error")
+	reason := conditions.MakeReason("SomeCode", retry.Fast)
+	readyErr := conditions.NewReadyConditionImpactingError(originalErr, conditions.ConditionSeverityWarning, reason)
+	result := errorclassification.MakeReadyConditionImpactingErrorFromError(readyErr, errorclassification.ClassifyCloudError)
+
+	// Check that the original error is returned
+	g.Expect(result).To(MatchError(readyErr))
+}
+
+func Test_MakeReadyConditionImpactingErrorFromError_NotCloudError(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	// Create a non-CloudError
+	regularErr := errors.New("regular error")
+	result := errorclassification.MakeReadyConditionImpactingErrorFromError(regularErr, errorclassification.ClassifyCloudError)
+
+	// Check that a new ReadyConditionImpactingError is created with appropriate defaults
+	readyErr, ok := conditions.AsReadyConditionImpactingError(result)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(readyErr.Severity).To(Equal(conditions.ConditionSeverityWarning))
+	g.Expect(readyErr.Reason).To(ContainSubstring(core.UnknownErrorCode))
+}
+
+func Test_MakeReadyConditionImpactingErrorFromError_RetryableCloudError(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	// Create a CloudError using "Conflict" code which is classified as retryable
+	innerErr := fmt.Errorf("This is an inner error")
+	retryableErr := genericarmclient.NewTestCloudError("Conflict", "This is a retryable error", genericarmclient.WithTestInnerError(innerErr))
+
+	result := errorclassification.MakeReadyConditionImpactingErrorFromError(retryableErr, errorclassification.ClassifyCloudError)
+
+	// Check that a new ReadyConditionImpactingError is created with appropriate severity
+	readyErr, ok := conditions.AsReadyConditionImpactingError(result)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(readyErr.Severity).To(Equal(conditions.ConditionSeverityWarning))
+	g.Expect(readyErr.Reason).To(ContainSubstring("Conflict"))
+
+	// Verify the cause contains our original error
+	g.Expect(eris.Unwrap(readyErr.Cause())).To(Equal(retryableErr))
+	// Verify that the inner error is not included in the message
+	g.Expect(readyErr).ToNot(MatchError(ContainSubstring("This is an inner error")))
+}
+
+func Test_MakeReadyConditionImpactingErrorFromError_FatalCloudError(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	// Create a fatal CloudError using "BadRequest" code which is classified as fatal
+	innerErr := fmt.Errorf("This is an inner error")
+	fatalErr := genericarmclient.NewTestCloudError("BadRequest", "This is a fatal error", genericarmclient.WithTestInnerError(innerErr))
+
+	// Pass it to MakeReadyConditionImpactingErrorFromError with the real classifier
+	result := errorclassification.MakeReadyConditionImpactingErrorFromError(fatalErr, errorclassification.ClassifyCloudError)
+
+	// Check that a new ReadyConditionImpactingError is created with appropriate severity
+	readyErr, ok := conditions.AsReadyConditionImpactingError(result)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(readyErr.Severity).To(Equal(conditions.ConditionSeverityError))
+	g.Expect(readyErr.Reason).To(ContainSubstring("BadRequest"))
+
+	// Verify the cause contains our original error
+	g.Expect(eris.Unwrap(readyErr.Cause())).To(Equal(fatalErr))
+	// Verify that the inner error is not included in the message
+	g.Expect(readyErr).ToNot(MatchError(ContainSubstring("This is an inner error")))
+}
+
+func Test_MakeReadyConditionImpactingErrorFromError_UnknownClassification(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	// Create a CloudError
+	unknownErr := genericarmclient.NewTestCloudError("SomeCode", "This has an unknown classification")
+
+	// Pass it to MakeReadyConditionImpactingErrorFromError with a mock classifier that returns an invalid classification
+	result := errorclassification.MakeReadyConditionImpactingErrorFromError(unknownErr, mockUnknownClassifier)
+
+	// Check that this returns an error about the unknown classification
+	g.Expect(result).To(MatchError("unknown error classification \"Unknown\" while making Ready condition"))
+}


### PR DESCRIPTION
Add operationID to errors from Azure in the logs (not in the Condition as we want the condition to be "stable" and not have a rotation UUID in it).

Fix a number of bugs around error formatting and classification
* Errors were not correctly classified by the DELETE operation.
* Conditions were including too much detail unintentionally.
* Error classification was lacking testing, which made the above issues harder to notice.

Fixes #4738.


## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
