### PR TITLE
Remove URL host redaction

### DIFF
--- a/v2/internal/testcommon/vcr/redact.go
+++ b/v2/internal/testcommon/vcr/redact.go
@@ -195,14 +195,6 @@ func hideCustomKeys(s string) string {
 
 func (r *Redactor) HideURLData(s string) string {
 	s = r.hideRecordingDataWithCustomRedaction(s)
-	s = hideBaseRequestURL(s)
 
 	return s
-}
-
-// baseURLMatcher matches the base part of a URL
-var baseURLMatcher = regexp.MustCompile(`^https://[^/]+/`)
-
-func hideBaseRequestURL(s string) string {
-	return baseURLMatcher.ReplaceAllLiteralString(s, `https://management.azure.com/`)
 }


### PR DESCRIPTION
## What this PR does

Discovered while testing Entra support, we're _redacting_ URLs by forcibly changing the host to `https://management.azure.com/` - but this breaks URL lookup when doing playback of tests.

This redaction doesn't do anything to prior URLs because they already had the hostname `https://management.azure.com/` specified. 

This PR removes the redaction so that _other_ endpoints can be included in tests - like `graph.microsoft.com` for Entra.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOTVsb2UwcWNqMTU5aTA5NWo3c3d6b2pjbGNrcHB6Y2phZDl0NnJyYSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/R7m04yMaGWVeE/giphy.gif)
