### PR TITLE
Fix bug in reconcile-policy parsing

### DIFF
--- a/v2/internal/reconcilers/reconcile_policy.go
+++ b/v2/internal/reconcilers/reconcile_policy.go
@@ -28,8 +28,7 @@ func ParseReconcilePolicy(policy string, defaultReconcilePolicy annotations.Reco
 	case string(annotations.ReconcilePolicyDetachOnDelete):
 		return annotations.ReconcilePolicyDetachOnDelete, nil
 	default:
-		// Defaulting to manage.
-		return annotations.ReconcilePolicyManage, eris.Errorf("%q is not a known reconcile policy", policy)
+		return defaultReconcilePolicy, eris.Errorf("%q is not a known reconcile policy", policy)
 	}
 }
 

--- a/v2/internal/reconcilers/reconcile_policy_test.go
+++ b/v2/internal/reconcilers/reconcile_policy_test.go
@@ -38,5 +38,5 @@ func TestParseReconcilePolicy(t *testing.T) {
 	// test error in case of any other value
 	returnedPolicy, err = ParseReconcilePolicy("whatever", annotations.ReconcilePolicySkip)
 	g.Expect(err).Should(HaveOccurred())
-	g.Expect(returnedPolicy).Should(Equal(annotations.ReconcilePolicyManage))
+	g.Expect(returnedPolicy).Should(Equal(annotations.ReconcilePolicySkip))
 }


### PR DESCRIPTION
If it fails to parse the reconcile policy it should use the configured default policy, NOT default to managed always.

- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
