### PR TITLE
Add startup probe to controller manager

### DIFF
--- a/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
+++ b/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
@@ -208,7 +208,6 @@ spec:
           httpGet:
             path: /healthz
             port: 8081
-          initialDelaySeconds: 60
         name: manager
         ports:
         - containerPort: {{ .Values.webhook.port }}
@@ -224,7 +223,6 @@ spec:
           httpGet:
             path: /readyz
             port: 8081
-          initialDelaySeconds: 60
         {{- with .Values.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
@@ -233,6 +231,12 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          periodSeconds: 10
+          failureThreshold: 12
         volumeMounts:
         - mountPath: /var/run/secrets/tokens
           name: azure-identity

--- a/v2/config/manager/manager.yaml
+++ b/v2/config/manager/manager.yaml
@@ -54,16 +54,20 @@ spec:
           - containerPort: 8443
             name: metrics-port
             protocol: TCP
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          periodSeconds: 10
+          failureThreshold: 12
         livenessProbe:
           httpGet:
             path: /healthz
             port: 8081
-          initialDelaySeconds: 60
         readinessProbe:
           httpGet:
             path: /readyz
             port: 8081
-          initialDelaySeconds: 60
         image: controller:latest
         name: manager
         resources:


### PR DESCRIPTION
## What this PR does

I spend quite a bit of time spinning up CAPZ management clusters which include ASO, and I noticed that the `initialDelaySeconds` on the readiness probe is bottlenecking that process where I usually see ASO finish starting up after about 10s, then idle for an extra ~45s waiting for the first readiness probe.

I see the `initialDelaySeconds` was increased in #2844, but a startup probe should be able to account for longer startup times without holding things up if things are actually ready more quickly.

<!--  

Here are some tips:

If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. 
Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

Closes #[issue number]
-->

<!--
### Special notes

_If there's anything complex or unusual about this PR that would help us review it, let us know here. Otherwise delete this section._
-->

## How does this PR make you feel?

![gif](https://giphy.com/)

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->


