### PR TITLE
Use the same err and success requeue interval for envtest

### DIFF
--- a/v2/internal/reconcilers/generic/generic_reconciler.go
+++ b/v2/internal/reconcilers/generic/generic_reconciler.go
@@ -102,7 +102,7 @@ func (gr *GenericReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if err != nil {
 		err = gr.writeReadyConditionErrorOrDefault(ctx, log, metaObj, err)
 		result, err = gr.RequeueIntervalCalculator.NextInterval(req, result, err)
-		log.V(Verbose).Info("Encountered error, re-queuing...", "result", result)
+		log.V(Verbose).Info("Encountered error, re-queuing...", "result", result, "error", err)
 		return result, err
 	}
 

--- a/v2/internal/testcommon/kube_test_context_envtest.go
+++ b/v2/internal/testcommon/kube_test_context_envtest.go
@@ -178,8 +178,8 @@ func createSharedEnvTest(cfg testConfig, namespaceResources *namespaceResources)
 	maxBackoff := 1 * time.Minute
 	if cfg.Replaying {
 		requeueDelay = 10 * time.Millisecond
-		minBackoff = 5 * time.Millisecond
-		maxBackoff = 5 * time.Millisecond
+		minBackoff = 10 * time.Millisecond
+		maxBackoff = 10 * time.Millisecond
 	}
 
 	// We use a custom indexer here so that we can simulate the caching client behavior for indexing even though

--- a/v2/internal/util/interval/interval_calculator.go
+++ b/v2/internal/util/interval/interval_calculator.go
@@ -105,7 +105,6 @@ func (i *calculator) NextInterval(req ctrl.Request, result ctrl.Result, err erro
 	isRequeueing := result.Requeue || result.RequeueAfter > time.Duration(0)
 	if hasRequeueDelayOverride && isRequeueing {
 		result.RequeueAfter = i.requeueDelayOverride
-		result.Requeue = true
 	}
 	return result, nil
 }


### PR DESCRIPTION
Some small log improvements too

- [ ] this PR contains documentation
- [x] this PR contains tests
- [ ] this PR contains YAML Samples
