### PR TITLE
Add build check on CRD sizes

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -122,6 +122,7 @@ tasks:
     deps: 
       - header-check
       - specifier-check
+      - controller:check-crd-size
 
   make-release-artifacts:
     desc: Produce files required for an ASOv2 release

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -733,6 +733,52 @@ tasks:
       WEBHOOK_OPTIONS: webhook output:webhook:artifacts:config={{.CONTROLLER_OUTPUT}}/webhook
       RBAC_OPTIONS: rbac:roleName=manager-role output:rbac:artifacts:config={{.CONTROLLER_OUTPUT}}/rbac
 
+  controller:check-crd-size:
+    desc: Check that generated CRDs are not too large for Kubernetes
+    deps:
+      - controller:generate-crds
+    dir: "{{.CONTROLLER_ROOT}}"
+    sources:
+      - "{{.CONTROLLER_OUTPUT}}/crd/generated/bases/*.yaml"
+    cmds:
+      - |
+        echo "Checking CRD sizes..."
+        FAILED=false
+        LIMIT_MB=1.5
+        LIMIT_BYTES=$((LIMIT_MB * 1024 * 1024))
+        CRD_DIR="{{.CONTROLLER_OUTPUT}}/crd/generated/bases"
+        
+        echo "Checking CRDs against size limit of ${LIMIT_MB}MiB (${LIMIT_BYTES} bytes)..."
+        
+        for crd_file in "$CRD_DIR"/*.yaml; do
+          if [ -f "$crd_file" ]; then
+            # Convert YAML to JSON and get size using yq
+            json_size=$(yq -o=json "$crd_file" | wc -c)
+            
+            if [ "$json_size" -gt "$LIMIT_BYTES" ]; then
+              yaml_size=$(wc -c < "$crd_file")
+              # Use python for floating point calculation
+              size_mb=$(python3 -c "print(f'{$json_size / 1024 / 1024:.2f}')")
+              echo "❌ CRD too large: $(basename "$crd_file")"
+              echo "   JSON size: ${json_size} bytes (${size_mb}MiB)"
+              echo "   YAML size: ${yaml_size} bytes"
+              echo "   Limit: ${LIMIT_BYTES} bytes (${LIMIT_MB}MiB)"
+              FAILED=true
+            else
+              # Use python for floating point calculation
+              size_mb=$(python3 -c "print(f'{$json_size / 1024 / 1024:.2f}')")
+              echo "✅ $(basename "$crd_file"): ${size_mb}MiB"
+            fi
+          fi
+        done
+        
+        if [ "$FAILED" = true ]; then
+          echo "❌ Build failed: One or more CRDs exceed the ${LIMIT_MB}MiB size limit"
+          exit 1
+        else
+          echo "✅ All CRDs are within the size limit"
+        fi
+
   controller:generate-genruntime-deepcopy:
     desc: Run controller-gen to generate {{.CONTROLLER_APP}} CRD files.
     dir: "{{.CONTROLLER_ROOT}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -751,8 +751,14 @@ tasks:
         
         echo "Checking CRDs against size limit of ${LIMIT_MB}MiB (${LIMIT_BYTES} bytes)..."
         
+        WARNING_BYTES=1048576  # 1 MiB warning threshold
+        TOTAL_CRDS=0
+        LARGE_CRDS=0
+        WARNING_CRDS=0
+        
         for crd_file in "$CRD_DIR"/*.yaml; do
           if [ -f "$crd_file" ]; then
+            TOTAL_CRDS=$((TOTAL_CRDS + 1))
             # Convert YAML to compact JSON and get size using yq
             json_size=$(yq -o=json --indent 0 "$crd_file" | wc -c)
             
@@ -760,24 +766,35 @@ tasks:
               yaml_size=$(wc -c < "$crd_file")
               # Use python for floating point calculation
               size_mb=$(python3 -c "print(f'{$json_size / 1024 / 1024:.2f}')")
-              echo "❌ CRD too large: $(basename "$crd_file")"
-              echo "   JSON size: ${json_size} bytes (${size_mb}MiB)"
-              echo "   YAML size: ${yaml_size} bytes"
-              echo "   Limit: ${LIMIT_BYTES} bytes (${LIMIT_MB}MiB)"
+              echo "[ERR] CRD too large: $(basename "$crd_file")"
+              echo "      JSON size: ${json_size} bytes (${size_mb}MiB)"
+              echo "      YAML size: ${yaml_size} bytes"
+              echo "      Limit: ${LIMIT_BYTES} bytes (${LIMIT_MB}MiB)"
               FAILED=true
-            else
+              LARGE_CRDS=$((LARGE_CRDS + 1))
+            elif [ "$json_size" -gt "$WARNING_BYTES" ]; then
               # Use python for floating point calculation
               size_mb=$(python3 -c "print(f'{$json_size / 1024 / 1024:.2f}')")
-              echo "✅ $(basename "$crd_file"): ${size_mb}MiB"
+              echo "[WRN] Large CRD (>1MiB): $(basename "$crd_file") - ${size_mb}MiB"
+              WARNING_CRDS=$((WARNING_CRDS + 1))
             fi
+            # Suppress output for CRDs under 1MiB to reduce log noise
           fi
         done
         
+        echo ""
+        echo "[INF] CRD Size Summary:"
+        echo "      Total CRDs: ${TOTAL_CRDS}"
+        echo "      Large CRDs (>1MiB): ${WARNING_CRDS}"
+        echo "      Oversized CRDs (>${LIMIT_MB}MiB): ${LARGE_CRDS}"
+        
         if [ "$FAILED" = true ]; then
-          echo "❌ Build failed: One or more CRDs exceed the ${LIMIT_MB}MiB size limit"
+          echo ""
+          echo "[ERR] Build failed: One or more CRDs exceed the ${LIMIT_MB}MiB size limit"
           exit 1
         else
-          echo "✅ All CRDs are within the size limit"
+          echo ""
+          echo "[INF] All CRDs are within the size limit"
         fi
 
   controller:generate-genruntime-deepcopy:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -745,7 +745,8 @@ tasks:
         echo "Checking CRD sizes..."
         FAILED=false
         LIMIT_MB=1.5
-        LIMIT_BYTES=$((LIMIT_MB * 1024 * 1024))
+        # Convert 1.5 MiB to bytes: 1.5 * 1024 * 1024 = 1572864
+        LIMIT_BYTES=1572864
         CRD_DIR="{{.CONTROLLER_OUTPUT}}/crd/generated/bases"
         
         echo "Checking CRDs against size limit of ${LIMIT_MB}MiB (${LIMIT_BYTES} bytes)..."

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -738,6 +738,7 @@ tasks:
     deps:
       - controller:generate-crds
     dir: "{{.CONTROLLER_ROOT}}"
+    silent: true
     sources:
       - "{{.CONTROLLER_OUTPUT}}/crd/generated/bases/*.yaml"
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -753,8 +753,8 @@ tasks:
         
         for crd_file in "$CRD_DIR"/*.yaml; do
           if [ -f "$crd_file" ]; then
-            # Convert YAML to JSON and get size using yq
-            json_size=$(yq -o=json "$crd_file" | wc -c)
+            # Convert YAML to compact JSON and get size using yq
+            json_size=$(yq -o=json --indent 0 "$crd_file" | wc -c)
             
             if [ "$json_size" -gt "$LIMIT_BYTES" ]; then
               yaml_size=$(wc -c < "$crd_file")

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -739,65 +739,10 @@ tasks:
     deps:
       - controller:generate-crds
     dir: "{{.CONTROLLER_ROOT}}"
-    silent: true
     sources:
       - "{{.CONTROLLER_OUTPUT}}/crd/generated/bases/*.yaml"
     cmds:
-      - |
-        echo "Checking CRD sizes..."
-        FAILED=false
-        LIMIT_MB=1.5
-        # Convert 1.5 MiB to bytes: 1.5 * 1024 * 1024 = 1572864
-        LIMIT_BYTES=1572864
-        CRD_DIR="{{.CONTROLLER_OUTPUT}}/crd/generated/bases"
-        
-        echo "Checking CRDs against size limit of ${LIMIT_MB}MiB (${LIMIT_BYTES} bytes)..."
-        
-        WARNING_BYTES=1048576  # 1 MiB warning threshold
-        TOTAL_CRDS=0
-        LARGE_CRDS=0
-        WARNING_CRDS=0
-        
-        for crd_file in "$CRD_DIR"/*.yaml; do
-          if [ -f "$crd_file" ]; then
-            TOTAL_CRDS=$((TOTAL_CRDS + 1))
-            # Convert YAML to compact JSON and get size using yq
-            json_size=$(yq -o=json --indent 0 "$crd_file" | wc -c)
-            
-            if [ "$json_size" -gt "$LIMIT_BYTES" ]; then
-              yaml_size=$(wc -c < "$crd_file")
-              # Use python for floating point calculation
-              size_mb=$(python3 -c "print(f'{$json_size / 1024 / 1024:.2f}')")
-              echo "[ERR] CRD too large: $(basename "$crd_file")"
-              echo "      JSON size: ${json_size} bytes (${size_mb}MiB)"
-              echo "      YAML size: ${yaml_size} bytes"
-              echo "      Limit: ${LIMIT_BYTES} bytes (${LIMIT_MB}MiB)"
-              FAILED=true
-              LARGE_CRDS=$((LARGE_CRDS + 1))
-            elif [ "$json_size" -gt "$WARNING_BYTES" ]; then
-              # Use python for floating point calculation
-              size_mb=$(python3 -c "print(f'{$json_size / 1024 / 1024:.2f}')")
-              echo "[WRN] Large CRD (>1MiB): $(basename "$crd_file") - ${size_mb}MiB"
-              WARNING_CRDS=$((WARNING_CRDS + 1))
-            fi
-            # Suppress output for CRDs under 1MiB to reduce log noise
-          fi
-        done
-        
-        echo ""
-        echo "[INF] CRD Size Summary:"
-        echo "      Total CRDs: ${TOTAL_CRDS}"
-        echo "      Large CRDs (>1MiB): ${WARNING_CRDS}"
-        echo "      Oversized CRDs (>${LIMIT_MB}MiB): ${LARGE_CRDS}"
-        
-        if [ "$FAILED" = true ]; then
-          echo ""
-          echo "[ERR] Build failed: One or more CRDs exceed the ${LIMIT_MB}MiB size limit"
-          exit 1
-        else
-          echo ""
-          echo "[INF] All CRDs are within the size limit"
-        fi
+      - "{{.SCRIPTS_ROOT}}/check-crd-size.sh {{.CONTROLLER_OUTPUT}}/crd/generated/bases"
 
   controller:generate-genruntime-deepcopy:
     desc: Run controller-gen to generate {{.CONTROLLER_APP}} CRD files.

--- a/scripts/v2/check-crd-size.sh
+++ b/scripts/v2/check-crd-size.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Check that generated CRDs are not too large for Kubernetes
+# This script validates that CRD files don't exceed the 1.5MiB size limit
+
+set -e
+
+echo "Checking CRD sizes..."
+FAILED=false
+LIMIT_MB=1.5
+# Convert 1.5 MiB to bytes: 1.5 * 1024 * 1024 = 1572864
+LIMIT_BYTES=1572864
+
+# Default CRD directory - can be overridden by passing as argument
+CRD_DIR="${1:-v2/config/crd/generated/bases}"
+
+if [ ! -d "$CRD_DIR" ]; then
+    echo "[ERR] CRD directory not found: $CRD_DIR"
+    echo "Usage: $0 [CRD_DIRECTORY]"
+    exit 1
+fi
+
+echo "Checking CRDs against size limit of ${LIMIT_MB}MiB (${LIMIT_BYTES} bytes)..."
+
+WARNING_BYTES=1048576  # 1 MiB warning threshold
+TOTAL_CRDS=0
+LARGE_CRDS=0
+WARNING_CRDS=0
+
+for crd_file in "$CRD_DIR"/*.yaml; do
+  if [ -f "$crd_file" ]; then
+    TOTAL_CRDS=$((TOTAL_CRDS + 1))
+    # Convert YAML to compact JSON and get size using yq
+    json_size=$(yq -o=json --indent 0 "$crd_file" | wc -c)
+    
+    if [ "$json_size" -gt "$LIMIT_BYTES" ]; then
+      yaml_size=$(wc -c < "$crd_file")
+      # Use python for floating point calculation
+      size_mb=$(python3 -c "print(f'{$json_size / 1024 / 1024:.2f}')")
+      echo "[ERR] CRD too large: $(basename "$crd_file")"
+      echo "      JSON size: ${json_size} bytes (${size_mb}MiB)"
+      echo "      YAML size: ${yaml_size} bytes"
+      echo "      Limit: ${LIMIT_BYTES} bytes (${LIMIT_MB}MiB)"
+      FAILED=true
+      LARGE_CRDS=$((LARGE_CRDS + 1))
+    elif [ "$json_size" -gt "$WARNING_BYTES" ]; then
+      # Use python for floating point calculation
+      size_mb=$(python3 -c "print(f'{$json_size / 1024 / 1024:.2f}')")
+      echo "[WRN] Large CRD (>1MiB): $(basename "$crd_file") - ${size_mb}MiB"
+      WARNING_CRDS=$((WARNING_CRDS + 1))
+    fi
+    # Suppress output for CRDs under 1MiB to reduce log noise
+  fi
+done
+
+echo ""
+echo "[INF] CRD Size Summary:"
+echo "      Total CRDs: ${TOTAL_CRDS}"
+echo "      Large CRDs (>1MiB): ${WARNING_CRDS}"
+echo "      Oversized CRDs (>${LIMIT_MB}MiB): ${LARGE_CRDS}"
+
+if [ "$FAILED" = true ]; then
+  echo ""
+  echo "[ERR] Build failed: One or more CRDs exceed the ${LIMIT_MB}MiB size limit"
+  exit 1
+else
+  echo ""
+  echo "[INF] All CRDs are within the size limit"
+fi


### PR DESCRIPTION
## What this PR does

Adds a size check on our generated CRD files, failing the build if any exceed the Kubernetes limit of 1.5MiB (in JSON format).

Also generates a warning for any CRDs that exceed 1MiB in file so that we don't get surprised. 

Sample output:
```
[controller:check-crd-size] Checking CRD sizes...
[controller:check-crd-size] Checking CRDs against size limit of 1.5MiB (1572864 bytes)...
[controller:check-crd-size] [WRN] Large CRD (>1MiB): containerservice.azure.com_managedclusters.yaml - 1.29MiB
[controller:check-crd-size] 
[controller:check-crd-size] [INF] CRD Size Summary:
[controller:check-crd-size]       Total CRDs: 243
[controller:check-crd-size]       Large CRDs (>1MiB): 1
[controller:check-crd-size]       Oversized CRDs (>1.5MiB): 0
[controller:check-crd-size] 
[controller:check-crd-size] [INF] All CRDs are within the size limit
```

### Special notes

Implemented using AI - while I've carefully reviewed the code, a second pair of eyes is necessary.

## How does this PR make you feel?

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNTA5NThxY29zdzNhY29sbjZtdDE5dDRpMTRxa2locnRlYW9vYTJnOCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/WJZdOtltegO76/giphy.gif)
