### PR TITLE
Add Copilot Coding Agent setup 

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,29 @@
+name: "Copilot Setup Steps"
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
+        with:
+          fetch-depth: 0 # required to access tags
+          submodules: 'true'
+
+      - name: Install Dependencies
+        run: .devcontainer/scripts/install-dependencies.sh

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           fetch-depth: 0 # required to access tags
           submodules: 'true'
+          
+      - name: Display context
+        run: |
+          pwd
+          ls -la
 
       - name: Install Dependencies
         run: .devcontainer/scripts/install-dependencies.sh

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,4 +26,4 @@ jobs:
           submodules: 'true'
 
       - name: Install Dependencies
-        run: .devcontainer/install-dependencies.sh
+        run: sudo .devcontainer/install-dependencies.sh

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,11 +24,6 @@ jobs:
         with:
           fetch-depth: 0 # required to access tags
           submodules: 'true'
-          
-      - name: Display context
-        run: |
-          pwd
-          ls -la
 
       - name: Install Dependencies
-        run: .devcontainer/scripts/install-dependencies.sh
+        run: .devcontainer/install-dependencies.sh


### PR DESCRIPTION
## What this PR does

Adds a GitHub action to [configure the workspace](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment) for the GitHub CoPilot Coding Agent so that it has all the correct tools available.

Reuses the `install-dependencies.sh` script we already use.

### Special notes

It doesn't appear that the agent can reuse the existing `.devcontainer`.
