### PR TITLE
Allow GOMEMLIMIT to be unset

### DIFF
--- a/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
+++ b/v2/charts/azure-service-operator/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
@@ -70,8 +70,10 @@ spec:
         - --json-logging
         {{- end }}
         env:
+        {{- if .Values.go.memLimit }}
         - name: GOMEMLIMIT
           value: {{ .Values.go.memLimit }}
+        {{- end }}
         - name: AZURE_CLIENT_ID
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## What this PR does

Allows to unset GOMEMLIMIT environment variable if helm value is set to null. 
This is especially needed if you use a VPA to avoid conflict between the POD memory that will change thanks to the VPA and this go memory limit fixed value.

Alternative would be to rely on dynamic configuration as provided by https://github.com/KimMachineGun/automemlimit
